### PR TITLE
solver warmstart

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -346,7 +346,9 @@ def _constraint(mjm: mujoco.MjModel, nworld: int, njmax: int) -> types.Constrain
   efc.worldid = wp.zeros((njmax,), dtype=wp.int32)
 
   efc.Jaref = wp.empty(shape=(njmax,), dtype=wp.float32)
+  efc.Jaref_warmstart = wp.empty(shape=(njmax,), dtype=wp.float32)
   efc.Ma = wp.empty(shape=(nworld, mjm.nv), dtype=wp.float32)
+  efc.Ma_warmstart = wp.empty(shape=(nworld, mjm.nv), dtype=wp.float32)
   efc.grad = wp.empty(shape=(nworld, mjm.nv), dtype=wp.float32)
   efc.grad_dot = wp.empty(shape=(nworld,), dtype=wp.float32)
   efc.Mgrad = wp.empty(shape=(nworld, mjm.nv), dtype=wp.float32)
@@ -354,6 +356,7 @@ def _constraint(mjm: mujoco.MjModel, nworld: int, njmax: int) -> types.Constrain
   efc.search_dot = wp.empty(shape=(nworld,), dtype=wp.float32)
   efc.gauss = wp.empty(shape=(nworld,), dtype=wp.float32)
   efc.cost = wp.empty(shape=(nworld,), dtype=wp.float32)
+  efc.cost_warmstart = wp.empty(shape=(nworld,), dtype=wp.float32)
   efc.prev_cost = wp.empty(shape=(nworld,), dtype=wp.float32)
   efc.solver_niter = wp.empty(shape=(nworld,), dtype=wp.int32)
   efc.active = wp.empty(shape=(njmax,), dtype=wp.int32)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -67,6 +67,8 @@ class SolverTest(parameterized.TestCase):
     d = mjwarp.put_data(mjm, mjd, nworld=nworld, njmax=njmax)
     return mjm, mjd, m, d
 
+  # TODO(team): test disableflags warmstart
+
   @parameterized.parameters(
     (mujoco.mjtCone.mjCONE_PYRAMIDAL, mujoco.mjtSolver.mjSOL_CG, 25, 5, False, False),
     (

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -46,11 +46,12 @@ class DisableBit(enum.IntFlag):
   PASSIVE = mujoco.mjtDisableBit.mjDSBL_PASSIVE
   GRAVITY = mujoco.mjtDisableBit.mjDSBL_GRAVITY
   CLAMPCTRL = mujoco.mjtDisableBit.mjDSBL_CLAMPCTRL
+  WARMSTART = mujoco.mjtDisableBit.mjDSBL_WARMSTART
   ACTUATION = mujoco.mjtDisableBit.mjDSBL_ACTUATION
   REFSAFE = mujoco.mjtDisableBit.mjDSBL_REFSAFE
   EULERDAMP = mujoco.mjtDisableBit.mjDSBL_EULERDAMP
   FILTERPARENT = mujoco.mjtDisableBit.mjDSBL_FILTERPARENT
-  # unsupported: EQUALITY, FRICTIONLOSS, MIDPHASE, WARMSTART, SENSOR
+  # unsupported: EQUALITY, FRICTIONLOSS, MIDPHASE, SENSOR
 
 
 class TrnType(enum.IntEnum):
@@ -274,7 +275,9 @@ class Constraint:
     aref: reference pseudo-acceleration               (njmax,)
     force: constraint force in constraint space       (njmax,)
     Jaref: Jac*qacc - aref                            (njmax,)
+    Jaref_warmstart: Jac*qacc_warmstart - aref        (njmax,)
     Ma: M*qacc                                        (nworld, nv)
+    Ma_warmstart: M*qacc_warmstart                    (nworld, nv)
     grad: gradient of master cost                     (nworld, nv)
     grad_dot: dot(grad, grad)                         (nworld,)
     Mgrad: M / grad                                   (nworld, nv)
@@ -282,6 +285,7 @@ class Constraint:
     search_dot: dot(search, search)                   (nworld,)
     gauss: gauss Cost                                 (nworld,)
     cost: constraint + Gauss cost                     (nworld,)
+    cost_warmstart: constraint + Gauss cost           (nworld,)
     prev_cost: cost from previous iter                (nworld,)
     solver_niter: number of solver iterations         (nworld,)
     active: active (quadratic) constraints            (njmax,)
@@ -322,7 +326,9 @@ class Constraint:
   aref: wp.array(dtype=wp.float32, ndim=1)
   force: wp.array(dtype=wp.float32, ndim=1)
   Jaref: wp.array(dtype=wp.float32, ndim=1)
+  Jaref_warmstart: wp.array(dtype=wp.float32, ndim=1)
   Ma: wp.array(dtype=wp.float32, ndim=2)
+  Ma_warmstart: wp.array(dtype=wp.float32, ndim=2)
   grad: wp.array(dtype=wp.float32, ndim=2)
   grad_dot: wp.array(dtype=wp.float32, ndim=1)
   Mgrad: wp.array(dtype=wp.float32, ndim=2)
@@ -330,6 +336,7 @@ class Constraint:
   search_dot: wp.array(dtype=wp.float32, ndim=1)
   gauss: wp.array(dtype=wp.float32, ndim=1)
   cost: wp.array(dtype=wp.float32, ndim=1)
+  cost_warmstart: wp.array(dtype=wp.float32, ndim=1)
   prev_cost: wp.array(dtype=wp.float32, ndim=1)
   solver_niter: wp.array(dtype=wp.int32, ndim=1)
   active: wp.array(dtype=wp.int32, ndim=1)


### PR DESCRIPTION
the existing solver implementation initializes `qacc` with `qacc_warmstart`. 

this pr:
- if the warmstart `disableflags` option is not set, `solve` compares the costs associated with `qacc_smooth` and `qacc_warmstart` in order to determine the initialization for `qacc`
- if the warmstart `disableflags` option is set, `qacc` is initialized with `qacc_smooth`

benchmarking:
```
mjwarp-testspeed --function=solve --mjcf=humanoid/humanoid.xml --batch_size=8192 --iterations=1 --ls_iterations=5 --solver=newton
```

this pr:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.15 s
 Total simulation time: 8.48 s
 Total steps per second: 966,092
 Total realtime factor: 4,830.46 x
 Total time per step: 1035.10 ns
```

main:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.14 s
 Total simulation time: 7.91 s
 Total steps per second: 1,036,164
 Total realtime factor: 5,180.82 x
 Total time per step: 965.10 ns
```