### PR TITLE
Avoid out-of-bounds accesses if nconmax and njmax are exceeded.

### DIFF
--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -308,7 +308,7 @@ def get_contact_solver_params_kernel(
 ):
   tid = wp.tid()
 
-  n_contact_pts = d.ncon[0]
+  n_contact_pts = min(d.ncon[0], d.nconmax)
   if tid >= n_contact_pts:
     return
 

--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -18,9 +18,10 @@ import mujoco
 import numpy as np
 from absl.testing import absltest
 from absl.testing import parameterized
-from . import test_util
 
 import mujoco_warp as mjwarp
+
+from . import test_util
 
 # tolerance for difference between MuJoCo and MJWarp calculations - mostly
 # due to float precision

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -149,7 +149,7 @@ def _efc_contact_pyramidal(
 ):
   conid, dimid = wp.tid()
 
-  if conid >= d.ncon[0]:
+  if conid >= min(d.ncon[0], d.nconmax):
     return
 
   if d.contact.dim[conid] != 3:

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -37,7 +37,7 @@ def _create_context(m: types.Model, d: types.Data, grad: bool = True):
   def _jaref(m: types.Model, d: types.Data):
     efcid, dofid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -89,7 +89,7 @@ def _update_constraint(m: types.Model, d: types.Data):
   def _efc_kernel(d: types.Data):
     efcid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -128,7 +128,7 @@ def _update_constraint(m: types.Model, d: types.Data):
   def _qfrc_constraint(d: types.Data):
     dofid, efcid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -251,7 +251,7 @@ def _update_gradient(m: types.Model, d: types.Data):
     # TODO(team): static m?
     efcid, elementid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -367,7 +367,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data):
   def _init_p0(p0: wp.array(dtype=wp.vec3), d: types.Data):
     efcid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -409,7 +409,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data):
   ):
     efcid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -503,7 +503,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data):
   ):
     efcid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -683,7 +683,7 @@ def _linesearch_parallel(m: types.Model, d: types.Data):
     # TODO(team): static m?
     efcid, alphaid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -752,7 +752,7 @@ def _linesearch(m: types.Model, d: types.Data):
   def _jv(d: types.Data):
     efcid, dofid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -795,7 +795,7 @@ def _linesearch(m: types.Model, d: types.Data):
   def _init_quad(d: types.Data):
     efcid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]
@@ -829,7 +829,7 @@ def _linesearch(m: types.Model, d: types.Data):
   def _jaref(d: types.Data):
     efcid = wp.tid()
 
-    if efcid >= d.nefc[0]:
+    if efcid >= min(d.nefc[0], d.njmax):
       return
 
     worldid = d.efc.worldid[efcid]


### PR DESCRIPTION
We should probably find a way to correct the count once and avoid all the min() calls for nefc, but I couldn't find a good place for it. This at least fixes all the errors.