### PR TITLE
Small set of follow-up optimizations for _JTDAJ

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -253,7 +253,7 @@ def _update_gradient(m: types.Model, d: types.Data):
   # of SMs on the GPU. We can now query the SM count:
   # https://github.com/NVIDIA/warp/commit/f3814e7e5459e5fd13032cf0fddb3daddd510f30
 
-  # AD: make dim_x and nblocks_perblock static arguments for _JTDAJ to allow unrolling the loop
+  # make dim_x and nblocks_perblock static arguments for _JTDAJ to allow unrolling the loop
   if wp.get_device().is_cuda:
     sm_count = wp.get_device().sm_count
 
@@ -263,7 +263,7 @@ def _update_gradient(m: types.Model, d: types.Data):
     # simultaneously run on the SM. TODO: This factor can be tuned further.
     dim_x = int((sm_count * 6 * 256) / m.dof_tri_row.size)
   else:
-    dim_x = d.njmax  # fall back
+    dim_x = d.njmax  # fall back for CPU
 
   nblocks_perblock = int((d.njmax + dim_x - 1) / dim_x)
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -246,8 +246,29 @@ def _update_gradient(m: types.Model, d: types.Data):
       colid = m.dof_tri_col[elementid]
       d.efc.h[worldid, rowid, colid] = d.qM[worldid, rowid, colid]
 
+  # Optimization: launching _JTDAJ with limited number of blocks on a GPU.
+  # Profiling suggests that only a fraction of blocks out of the original
+  # d.njmax blocks do the actual work. It aims to minimize #CTAs with no
+  # effective work. It launches with #blocks that's proportional to the number
+  # of SMs on the GPU. We can now query the SM count:
+  # https://github.com/NVIDIA/warp/commit/f3814e7e5459e5fd13032cf0fddb3daddd510f30
+
+  # AD: make dim_x and nblocks_perblock static arguments for _JTDAJ to allow unrolling the loop
+  if wp.get_device().is_cuda:
+    sm_count = wp.get_device().sm_count
+
+    # Here we assume one block has 256 threads. We use a factor of 6, which
+    # can be change in future to fine-tune the perf. The optimal factor will
+    # depend on the kernel's occupancy, which determines how many blocks can
+    # simultaneously run on the SM. TODO: This factor can be tuned further.
+    dim_x = int((sm_count * 6 * 256) / m.dof_tri_row.size)
+  else:
+    dim_x = d.njmax  # fall back
+
+  nblocks_perblock = int((d.njmax + dim_x - 1) / dim_x)
+
   @kernel
-  def _JTDAJ(m: types.Model, d: types.Data, nblocks_perblock: int, dim_x: int):
+  def _JTDAJ(m: types.Model, d: types.Data):
     # TODO(team): static m?
     efcid_temp, elementid = wp.tid()
 
@@ -277,11 +298,7 @@ def _update_gradient(m: types.Model, d: types.Data):
       # TODO(team): sparse efc_J
       value = d.efc.J[efcid, dofi] * d.efc.J[efcid, dofj] * efc_D
       if value != 0.0:
-        wp.atomic_add(
-          d.efc.h[worldid, dofi],
-          dofj,
-          value
-        )
+        wp.atomic_add(d.efc.h[worldid, dofi], dofj, value)
 
   @kernel
   def _cholesky(d: types.Data):
@@ -315,27 +332,10 @@ def _update_gradient(m: types.Model, d: types.Data):
     else:
       wp.launch(_copy_lower_triangle, dim=(d.nworld, m.dof_tri_row.size), inputs=[m, d])
 
-    # Optimization: launching _JTDAJ with limited number of blocks on a GPU.
-    # Profiling suggests that only a fraction of blocks out of the original
-    # d.njmax blocks do the actual work. It aims to minimize #CTAs with no
-    # effective work. It launches with #blocks that's proportional to the number
-    # of SMs on the GPU. We can now query the SM count:
-    # https://github.com/NVIDIA/warp/commit/f3814e7e5459e5fd13032cf0fddb3daddd510f30
-    if wp.get_device().is_cuda:
-      sm_count = wp.get_device().sm_count
-
-      # Here we assume one block has 256 threads. We use a factor of 6, which
-      # can be change in future to fine-tune the perf. The optimal factor will
-      # depend on the kernel's occupancy, which determines how many blocks can
-      # simultaneously run on the SM. TODO: This factor can be tuned further.
-      dim_x = int((sm_count * 6 * 256) / m.dof_tri_row.size)
-    else:
-      dim_x = d.njmax  # fall back
-
     wp.launch(
       _JTDAJ,
       dim=(dim_x, m.dof_tri_row.size),
-      inputs=[m, d, int((d.njmax + dim_x - 1) / dim_x), dim_x],
+      inputs=[m, d],
     )
 
     wp.launch_tiled(_cholesky, dim=(d.nworld,), inputs=[d], block_dim=32)

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -265,13 +265,14 @@ def _update_gradient(m: types.Model, d: types.Data):
         if d.efc.done[worldid]:
           continue
 
-      dofi = m.dof_tri_row[elementid]
-      dofj = m.dof_tri_col[elementid]
-
       efc_D = d.efc.D[efcid]
       active = d.efc.active[efcid]
-      if efc_D == 0.0 or active == 0:
+
+      if efc_D * float(active) == 0.0:
         continue
+
+      dofi = m.dof_tri_row[elementid]
+      dofj = m.dof_tri_col[elementid]
 
       # TODO(team): sparse efc_J
       value = d.efc.J[efcid, dofi] * d.efc.J[efcid, dofj] * efc_D


### PR DESCRIPTION
* value-gating the atomic add for 0 values
* move nefc lookup out of the loop
* make dim_X and nblocks_per_block static to enable unrolling the loop

Difficult to tell the effect of individual parts here, but mostly better codegen and overall some perf gains (humanoid.xml):

before:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.66 s
 Total simulation time: 4.46 s
 Total steps per second: 1,834,768
 Total realtime factor: 9,173.84 x
 Total time per step: 545.03 ns
```

after: 
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.66 s
 Total simulation time: 4.35 s
 Total steps per second: 1,884,647
 Total realtime factor: 9,423.23 x
 Total time per step: 530.60 ns
```
