### PR TITLE
Camlight

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -34,6 +34,7 @@ from ._src.io import put_data as put_data
 from ._src.io import put_model as put_model
 from ._src.passive import passive as passive
 from ._src.smooth import com_pos as com_pos
+from ._src.smooth import camlight as camlight
 from ._src.smooth import com_vel as com_vel
 from ._src.smooth import crb as crb
 from ._src.smooth import factor_m as factor_m

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -411,7 +411,7 @@ def fwd_position(m: Model, d: Data):
 
   smooth.kinematics(m, d)
   smooth.com_pos(m, d)
-  # TODO(team): smooth.camlight
+  smooth.camlight(m, d)
   # TODO(team): smooth.tendon
   smooth.crb(m, d)
   smooth.factor_m(m, d)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -77,6 +77,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.ngeom = mjm.ngeom
   m.nsite = mjm.nsite
   m.ncam = mjm.ncam
+  m.nlight = mjm.nlight
   m.nmocap = mjm.nmocap
   m.nM = mjm.nM
   m.nlsp = mjm.opt.ls_iterations  # TODO(team): how to set nlsp?
@@ -362,6 +363,14 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.cam_poscom0 = wp.array(mjm.cam_poscom0, dtype=wp.vec3, ndim=1)
   m.cam_pos0 = wp.array(mjm.cam_pos0, dtype=wp.vec3, ndim=1)
   m.cam_mat0 = wp.array(mjm.cam_mat0.reshape(-1, 3, 3), dtype=wp.mat33, ndim=1)
+  m.light_mode = wp.array(mjm.light_mode, dtype=wp.int32, ndim=1)
+  m.light_bodyid = wp.array(mjm.light_bodyid, dtype=wp.int32, ndim=1)
+  m.light_targetbodyid = wp.array(mjm.light_targetbodyid, dtype=wp.int32, ndim=1)
+  m.light_pos = wp.array(mjm.light_pos, dtype=wp.vec3, ndim=1)
+  m.light_dir = wp.array(mjm.light_dir, dtype=wp.vec3, ndim=1)
+  m.light_poscom0 = wp.array(mjm.light_poscom0, dtype=wp.vec3, ndim=1)
+  m.light_pos0 = wp.array(mjm.light_pos0, dtype=wp.vec3, ndim=1)
+  m.light_dir0 = wp.array(mjm.light_dir0, dtype=wp.vec3, ndim=1)
   m.dof_bodyid = wp.array(mjm.dof_bodyid, dtype=wp.int32, ndim=1)
   m.dof_jntid = wp.array(mjm.dof_jntid, dtype=wp.int32, ndim=1)
   m.dof_parentid = wp.array(mjm.dof_parentid, dtype=wp.int32, ndim=1)
@@ -658,6 +667,8 @@ def put_data(
   d.site_xmat = wp.array(tile(mjd.site_xmat), dtype=wp.mat33, ndim=2)
   d.cam_xpos = wp.array(tile(mjd.cam_xpos), dtype=wp.vec3, ndim=2)
   d.cam_xmat = wp.array(tile(mjd.cam_xmat.reshape(-1, 3, 3)), dtype=wp.mat33, ndim=2)
+  d.light_xpos = wp.array(tile(mjd.light_xpos), dtype=wp.vec3, ndim=2)
+  d.light_xdir = wp.array(tile(mjd.light_xdir), dtype=wp.vec3, ndim=2)
   d.cinert = wp.array(tile(mjd.cinert), dtype=types.vec10, ndim=2)
   d.cdof = wp.array(tile(mjd.cdof), dtype=wp.spatial_vector, ndim=2)
   d.crb = wp.array(tile(mjd.crb), dtype=types.vec10, ndim=2)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -506,6 +506,10 @@ def make_data(
   d.geom_xmat = wp.zeros((nworld, mjm.ngeom), dtype=wp.mat33)
   d.site_xpos = wp.zeros((nworld, mjm.nsite), dtype=wp.vec3)
   d.site_xmat = wp.zeros((nworld, mjm.nsite), dtype=wp.mat33)
+  d.cam_xpos = wp.zeros((nworld, mjm.ncam), dtype=wp.vec3)
+  d.cam_xmat = wp.zeros((nworld, mjm.ncam), dtype=wp.mat33)
+  d.light_xpos = wp.zeros((nworld, mjm.nlight), dtype=wp.vec3)
+  d.light_xdir = wp.zeros((nworld, mjm.nlight), dtype=wp.vec3)
   d.cinert = wp.zeros((nworld, mjm.nbody), dtype=types.vec10)
   d.cdof = wp.zeros((nworld, mjm.nv), dtype=wp.spatial_vector)
   d.ctrl = wp.zeros((nworld, mjm.nu), dtype=wp.float32)
@@ -849,6 +853,10 @@ def get_data_into(
   result.geom_xmat = d.geom_xmat.numpy().reshape((-1, 9))
   result.site_xpos = d.site_xpos.numpy()[0]
   result.site_xmat = d.site_xmat.numpy().reshape((-1, 9))
+  result.cam_xpos = d.cam_xpos.numpy()[0]
+  result.cam_xmat = d.cam_xmat.numpy().reshape((-1, 9))
+  result.light_xpos = d.light_xpos.numpy()[0]
+  result.light_xdir = d.light_xdir.numpy()[0]
   result.cinert = d.cinert.numpy()[0]
   result.cdof = d.cdof.numpy()[0]
   result.crb = d.crb.numpy()[0]

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -75,6 +75,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.njnt = mjm.njnt
   m.ngeom = mjm.ngeom
   m.nsite = mjm.nsite
+  m.ncam = mjm.ncam
   m.nmocap = mjm.nmocap
   m.nM = mjm.nM
   m.nlsp = mjm.opt.ls_iterations  # TODO(team): how to set nlsp?
@@ -352,6 +353,14 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.site_pos = wp.array(mjm.site_pos, dtype=wp.vec3, ndim=1)
   m.site_quat = wp.array(mjm.site_quat, dtype=wp.quat, ndim=1)
   m.site_bodyid = wp.array(mjm.site_bodyid, dtype=wp.int32, ndim=1)
+  m.cam_mode = wp.array(mjm.cam_mode, dtype=wp.int32, ndim=1)
+  m.cam_bodyid = wp.array(mjm.cam_bodyid, dtype=wp.int32, ndim=1)
+  m.cam_targetbodyid = wp.array(mjm.cam_targetbodyid, dtype=wp.int32, ndim=1)
+  m.cam_pos = wp.array(mjm.cam_pos, dtype=wp.vec3, ndim=1)
+  m.cam_quat = wp.array(mjm.cam_quat, dtype=wp.quat, ndim=1)
+  m.cam_poscom0 = wp.array(mjm.cam_poscom0, dtype=wp.vec3, ndim=1)
+  m.cam_pos0 = wp.array(mjm.cam_pos0, dtype=wp.vec3, ndim=1)
+  m.cam_mat0 = wp.array(mjm.cam_mat0.reshape(-1, 3, 3), dtype=wp.mat33, ndim=1)
   m.dof_bodyid = wp.array(mjm.dof_bodyid, dtype=wp.int32, ndim=1)
   m.dof_jntid = wp.array(mjm.dof_jntid, dtype=wp.int32, ndim=1)
   m.dof_parentid = wp.array(mjm.dof_parentid, dtype=wp.int32, ndim=1)
@@ -646,6 +655,8 @@ def put_data(
   d.geom_xmat = wp.array(tile(mjd.geom_xmat), dtype=wp.mat33, ndim=2)
   d.site_xpos = wp.array(tile(mjd.site_xpos), dtype=wp.vec3, ndim=2)
   d.site_xmat = wp.array(tile(mjd.site_xmat), dtype=wp.mat33, ndim=2)
+  d.cam_xpos = wp.array(tile(mjd.cam_xpos), dtype=wp.vec3, ndim=2)
+  d.cam_xmat = wp.array(tile(mjd.cam_xmat.reshape(-1, 3, 3)), dtype=wp.mat33, ndim=2)
   d.cinert = wp.array(tile(mjd.cinert), dtype=types.vec10, ndim=2)
   d.cdof = wp.array(tile(mjd.cdof), dtype=wp.spatial_vector, ndim=2)
   d.crb = wp.array(tile(mjd.crb), dtype=types.vec10, ndim=2)

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -122,7 +122,7 @@ class IOTest(absltest.TestCase):
 
     with self.assertRaises(ValueError):
       mjwarp.put_model(mjm)
-      
+
   def test_actuator_trntype(self):
     mjm = mujoco.MjModel.from_xml_string("""
       <mujoco>

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -293,17 +293,13 @@ def camlight(m: Model, d: Data):
       # xaxis: orthogonal to zaxis and to (0,0,1)
       mat_1 = wp.normalize(wp.cross(wp.vec3(0.0, 0.0, 1.0), mat_3))
       mat_2 = wp.normalize(wp.cross(mat_3, mat_1))
+      # fmt: off
       d.cam_xmat[worldid, camid] = wp.mat33(
-        mat_1[0],
-        mat_2[0],
-        mat_3[0],
-        mat_1[1],
-        mat_2[1],
-        mat_3[1],
-        mat_1[2],
-        mat_2[2],
-        mat_3[2],
+        mat_1[0], mat_2[0], mat_3[0],
+        mat_1[1], mat_2[1], mat_3[1],
+        mat_1[2], mat_2[2], mat_3[2]
       )
+      # fmt: on
 
   wp.launch(fn, dim=(d.nworld, m.ncam), inputs=[m, d])
 

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -18,6 +18,7 @@ import warp as wp
 from packaging import version
 
 from . import math
+from .types import CamLightType
 from .types import Data
 from .types import DisableBit
 from .types import JointType
@@ -245,6 +246,66 @@ def com_pos(m: Model, d: Data):
   wp.launch(subtree_div, dim=(d.nworld, m.nbody), inputs=[m, d])
   wp.launch(cinert, dim=(d.nworld, m.nbody), inputs=[m, d])
   wp.launch(cdof, dim=(d.nworld, m.njnt), inputs=[m, d])
+
+
+@event_scope
+def camlight(m: Model, d: Data):
+  """Computes camera and light positions and orientations."""
+
+  @kernel
+  def cam_local_to_global(m: Model, d: Data):
+    """Fixed cameras."""
+    worldid, camid = wp.tid()
+    bodyid = m.cam_bodyid[camid]
+    xpos = d.xpos[worldid, bodyid]
+    xquat = d.xquat[worldid, bodyid]
+    d.cam_xpos[worldid, camid] = xpos + math.rot_vec_quat(m.cam_pos[camid], xquat)
+    d.cam_xmat[worldid, camid] = math.quat_to_mat(
+      math.mul_quat(xquat, m.cam_quat[camid])
+    )
+
+  wp.launch(cam_local_to_global, dim=(d.nworld, m.ncam), inputs=[m, d])
+
+  @kernel
+  def fn(m: Model, d: Data):
+    worldid, camid = wp.tid()
+    is_target_cam = (m.cam_mode[camid] == wp.static(CamLightType.TARGETBODY.value)) or (
+      m.cam_mode[camid] == wp.static(CamLightType.TARGETBODYCOM.value)
+    )
+    invalid_target = is_target_cam and (m.cam_targetbodyid[camid] < 0)
+    if invalid_target:
+      return
+    elif m.cam_mode[camid] == wp.static(CamLightType.TRACK.value):
+      body_xpos = d.xpos[worldid, m.cam_bodyid[camid]]
+      d.cam_xpos[worldid, camid] = body_xpos + m.cam_pos0[camid]
+    elif m.cam_mode[camid] == wp.static(CamLightType.TRACKCOM.value):
+      d.cam_xpos[worldid, camid] = (
+        d.subtree_com[worldid, m.cam_bodyid[camid]] + m.cam_poscom0[camid]
+      )
+    elif m.cam_mode[camid] == wp.static(CamLightType.TARGETBODY.value) or m.cam_mode[
+      camid
+    ] == wp.static(CamLightType.TARGETBODYCOM.value):
+      pos = d.xpos[worldid, m.cam_targetbodyid[camid]]
+      if m.cam_mode[camid] == wp.static(CamLightType.TARGETBODYCOM.value):
+        pos = d.subtree_com[worldid, m.cam_targetbodyid[camid]]
+      # zaxis = -desired camera direction, in global frame
+      mat_3 = wp.normalize(d.cam_xpos[worldid, camid] - pos)
+      # xaxis: orthogonal to zaxis and to (0,0,1)
+      mat_1 = wp.normalize(wp.cross(wp.vec3(0.0, 0.0, 1.0), mat_3))
+      mat_2 = wp.normalize(wp.cross(mat_3, mat_1))
+      d.cam_xmat[worldid, camid] = wp.mat33(
+        mat_1[0],
+        mat_2[0],
+        mat_3[0],
+        mat_1[1],
+        mat_2[1],
+        mat_3[1],
+        mat_1[2],
+        mat_2[2],
+        mat_3[2],
+      )
+
+  wp.launch(fn, dim=(d.nworld, m.ncam), inputs=[m, d])
 
 
 @event_scope

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -72,8 +72,20 @@ class SmoothTest(parameterized.TestCase):
     _assert_eq(d.cinert.numpy()[0], mjd.cinert, "cinert")
     _assert_eq(d.cdof.numpy()[0], mjd.cdof, "cdof")
 
+  def test_camlight(self):
+    """Tests camlight."""
+    _, mjd, m, d = test_util.fixture("pendula.xml")
+
+    d.cam_xpos.zero_()
+    d.cam_xmat.zero_()
+
+    mjwarp.camlight(m, d)
+    _assert_eq(d.cam_xpos.numpy()[0], mjd.cam_xpos, "cam_xpos")
+    _assert_eq(d.cam_xmat.numpy()[0], mjd.cam_xmat.reshape((-1, 3, 3)), "cam_xmat")
+
   @parameterized.parameters(True, False)
   def test_crb(self, sparse: bool):
+    """Tests crb."""
     """Tests crb."""
     mjm, mjd, m, d = test_util.fixture("pendula.xml", sparse=sparse)
 

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -86,7 +86,6 @@ class SmoothTest(parameterized.TestCase):
   @parameterized.parameters(True, False)
   def test_crb(self, sparse: bool):
     """Tests crb."""
-    """Tests crb."""
     mjm, mjd, m, d = test_util.fixture("pendula.xml", sparse=sparse)
 
     d.crb.zero_()

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -78,10 +78,15 @@ class SmoothTest(parameterized.TestCase):
 
     d.cam_xpos.zero_()
     d.cam_xmat.zero_()
+    d.light_xpos.zero_()
+    d.light_xdir.zero_()
 
     mjwarp.camlight(m, d)
     _assert_eq(d.cam_xpos.numpy()[0], mjd.cam_xpos, "cam_xpos")
+    # import ipdb; ipdb.set_trace()
     _assert_eq(d.cam_xmat.numpy()[0], mjd.cam_xmat.reshape((-1, 3, 3)), "cam_xmat")
+    _assert_eq(d.light_xpos.numpy()[0], mjd.light_xpos, "light_xpos")
+    _assert_eq(d.light_xdir.numpy()[0], mjd.light_xdir, "light_xdir")
 
   @parameterized.parameters(True, False)
   def test_crb(self, sparse: bool):

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -24,6 +24,24 @@ MJ_NREF = mujoco.mjNREF
 MJ_NIMP = mujoco.mjNIMP
 
 
+class CamLightType(enum.IntEnum):
+  """Type of camera light.
+
+  Members:
+    FIXED: pos and rot fixed in body
+    TRACK: pos tracks body, rot fixed in global
+    TRACKCOM: pos tracks subtree com, rot fixed in body
+    TARGETBODY: pos fixed in body, rot tracks target body
+    TARGETBODYCOM: pos fixed in body, rot tracks target subtree com
+  """
+
+  FIXED = mujoco.mjtCamLight.mjCAMLIGHT_FIXED
+  TRACK = mujoco.mjtCamLight.mjCAMLIGHT_TRACK
+  TRACKCOM = mujoco.mjtCamLight.mjCAMLIGHT_TRACKCOM
+  TARGETBODY = mujoco.mjtCamLight.mjCAMLIGHT_TARGETBODY
+  TARGETBODYCOM = mujoco.mjtCamLight.mjCAMLIGHT_TARGETBODYCOM
+
+
 class DisableBit(enum.IntFlag):
   """Disable default feature bitflags.
 
@@ -376,6 +394,7 @@ class Model:
     njnt: number of joints                                   ()
     ngeom: number of geoms                                   ()
     nsite: number of sites                                   ()
+    ncam: number of cameras                                  ()
     nexclude: number of excluded geom pairs                  ()
     nmocap: number of mocap bodies                           ()
     nM: number of non-zeros in sparse inertia matrix         ()
@@ -471,6 +490,14 @@ class Model:
     site_bodyid: id of site's body                           (nsite,)
     site_pos: local position offset rel. to body             (nsite, 3)
     site_quat: local orientation offset rel. to body         (nsite, 4)
+    cam_mode: camera tracking mode (mjtCamLight)             (ncam,)
+    cam_bodyid: id of camera's body                          (ncam,)
+    cam_targetbodyid: id of targeted body; -1: none          (ncam,)
+    cam_pos: position rel. to body frame                     (ncam, 3)
+    cam_quat: orientation rel. to body frame                 (ncam, 4)
+    cam_poscom0: global position rel. to sub-com in qpos0    (ncam, 3)
+    cam_pos0: Cartesian camera position                      (nworld, ncam, 3)
+    cam_mat0: Cartesian camera orientation                   (nworld, ncam, 3, 3)
     mesh_vertadr: first vertex address                       (nmesh,)
     mesh_vertnum: number of vertices                         (nmesh,)
     mesh_vert: vertex positions for all meshes               (nmeshvert, 3)
@@ -502,6 +529,7 @@ class Model:
   njnt: int
   ngeom: int
   nsite: int
+  ncam: int
   nexclude: int
   nmocap: int
   nM: int
@@ -597,6 +625,14 @@ class Model:
   site_bodyid: wp.array(dtype=wp.int32, ndim=1)
   site_pos: wp.array(dtype=wp.vec3, ndim=1)
   site_quat: wp.array(dtype=wp.quat, ndim=1)
+  cam_mode: wp.array(dtype=wp.int32, ndim=1)
+  cam_bodyid: wp.array(dtype=wp.int32, ndim=1)
+  cam_targetbodyid: wp.array(dtype=wp.int32, ndim=1)
+  cam_pos: wp.array(dtype=wp.vec3, ndim=1)
+  cam_quat: wp.array(dtype=wp.quat, ndim=1)
+  cam_poscom0: wp.array(dtype=wp.vec3, ndim=1)
+  cam_pos0: wp.array(dtype=wp.vec3, ndim=1)
+  cam_mat0: wp.array(dtype=wp.mat33, ndim=1)
   mesh_vertadr: wp.array(dtype=wp.int32, ndim=1)
   mesh_vertnum: wp.array(dtype=wp.int32, ndim=1)
   mesh_vert: wp.array(dtype=wp.vec3, ndim=1)
@@ -684,6 +720,8 @@ class Data:
     geom_xmat: Cartesian geom orientation                       (nworld, ngeom, 3, 3)
     site_xpos: Cartesian site position                          (nworld, nsite, 3)
     site_xmat: Cartesian site orientation                       (nworld, nsite, 3, 3)
+    cam_xpos: Cartesian camera position                         (nworld, ncam, 3)
+    cam_xmat: Cartesian camera orientation                      (nworld, ncam, 3, 3)
     subtree_com: center of mass of each subtree                 (nworld, nbody, 3)
     cdof: com-based motion axis of each dof (rot:lin)           (nworld, nv, 6)
     cinert: com-based body inertia and mass                     (nworld, nbody, 10)
@@ -758,6 +796,8 @@ class Data:
   geom_xmat: wp.array(dtype=wp.mat33, ndim=2)
   site_xpos: wp.array(dtype=wp.vec3, ndim=2)
   site_xmat: wp.array(dtype=wp.mat33, ndim=2)
+  cam_xpos: wp.array(dtype=wp.vec3, ndim=2)
+  cam_xmat: wp.array(dtype=wp.mat33, ndim=2)
   subtree_com: wp.array(dtype=wp.vec3, ndim=2)
   cdof: wp.array(dtype=wp.spatial_vector, ndim=2)
   cinert: wp.array(dtype=vec10, ndim=2)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -395,6 +395,7 @@ class Model:
     ngeom: number of geoms                                   ()
     nsite: number of sites                                   ()
     ncam: number of cameras                                  ()
+    nlight: number of lights                                 ()
     nexclude: number of excluded geom pairs                  ()
     nmocap: number of mocap bodies                           ()
     nM: number of non-zeros in sparse inertia matrix         ()
@@ -498,6 +499,14 @@ class Model:
     cam_poscom0: global position rel. to sub-com in qpos0    (ncam, 3)
     cam_pos0: Cartesian camera position                      (nworld, ncam, 3)
     cam_mat0: Cartesian camera orientation                   (nworld, ncam, 3, 3)
+    light_mode: light tracking mode (mjtCamLight)            (nlight,)
+    light_bodyid: id of light's body                         (nlight,)
+    light_targetbodyid: id of targeted body; -1: none        (nlight,)
+    light_pos: position rel. to body frame                   (nlight, 3)
+    light_dir: direction rel. to body frame                  (nlight, 3)
+    light_poscom0: global position rel. to sub-com in qpos0  (nlight, 3)
+    light_pos0: global position rel. to body in qpos0        (nworld, nlight, 3)
+    light_dir0: global direction in qpos0                    (nworld, nlight, 3)
     mesh_vertadr: first vertex address                       (nmesh,)
     mesh_vertnum: number of vertices                         (nmesh,)
     mesh_vert: vertex positions for all meshes               (nmeshvert, 3)
@@ -530,6 +539,7 @@ class Model:
   ngeom: int
   nsite: int
   ncam: int
+  nlight: int
   nexclude: int
   nmocap: int
   nM: int
@@ -633,6 +643,14 @@ class Model:
   cam_poscom0: wp.array(dtype=wp.vec3, ndim=1)
   cam_pos0: wp.array(dtype=wp.vec3, ndim=1)
   cam_mat0: wp.array(dtype=wp.mat33, ndim=1)
+  light_mode: wp.array(dtype=wp.int32, ndim=1)
+  light_bodyid: wp.array(dtype=wp.int32, ndim=1)
+  light_targetbodyid: wp.array(dtype=wp.int32, ndim=1)
+  light_pos: wp.array(dtype=wp.vec3, ndim=1)
+  light_dir: wp.array(dtype=wp.vec3, ndim=1)
+  light_poscom0: wp.array(dtype=wp.vec3, ndim=1)
+  light_pos0: wp.array(dtype=wp.vec3, ndim=1)
+  light_dir0: wp.array(dtype=wp.vec3, ndim=1)
   mesh_vertadr: wp.array(dtype=wp.int32, ndim=1)
   mesh_vertnum: wp.array(dtype=wp.int32, ndim=1)
   mesh_vert: wp.array(dtype=wp.vec3, ndim=1)
@@ -722,6 +740,8 @@ class Data:
     site_xmat: Cartesian site orientation                       (nworld, nsite, 3, 3)
     cam_xpos: Cartesian camera position                         (nworld, ncam, 3)
     cam_xmat: Cartesian camera orientation                      (nworld, ncam, 3, 3)
+    light_xpos: Cartesian light position                        (nworld, nlight, 3)
+    light_xdir: Cartesian light direction                       (nworld, nlight, 3)
     subtree_com: center of mass of each subtree                 (nworld, nbody, 3)
     cdof: com-based motion axis of each dof (rot:lin)           (nworld, nv, 6)
     cinert: com-based body inertia and mass                     (nworld, nbody, 10)
@@ -798,6 +818,8 @@ class Data:
   site_xmat: wp.array(dtype=wp.mat33, ndim=2)
   cam_xpos: wp.array(dtype=wp.vec3, ndim=2)
   cam_xmat: wp.array(dtype=wp.mat33, ndim=2)
+  light_xpos: wp.array(dtype=wp.vec3, ndim=2)
+  light_xdir: wp.array(dtype=wp.vec3, ndim=2)
   subtree_com: wp.array(dtype=wp.vec3, ndim=2)
   cdof: wp.array(dtype=wp.spatial_vector, ndim=2)
   cinert: wp.array(dtype=vec10, ndim=2)

--- a/mujoco_warp/test_data/pendula.xml
+++ b/mujoco_warp/test_data/pendula.xml
@@ -20,15 +20,22 @@
   <worldbody>
     <site name="origin"/>
     <camera pos="0 1.5 0.8" xyaxes="-1 0 0 0 -0.2 .8"/>
+    <light pos="0 1.5 0.8" dir="0.1 -0.9 0"/>
     <camera mode="targetbodycom" pos="1 -1 2"/>
+    <light mode="targetbodycom" pos="1 -1 2"/>
     <camera mode="targetbodycom" target="body" pos="0 -1 2"/>
+    <light mode="targetbodycom" target="body" pos="0 -1 2"/>
     <camera mode="targetbody" target="body" pos="0 -1 -2"/>
+    <light mode="targetbody" target="body" pos="0 -1 -2"/>
 
     <!-- a single free body -->
     <body pos="0 0 0">
       <camera mode="fixed" pos="0 0.1 0.1" euler="2.7 0 0"/>
+      <light mode="fixed" pos="0 0.1 0.1" dir="0 0.02 -0.98"/>
       <camera pos="-3 0 1" xyaxes="0 -1 0 1 0 2" mode="trackcom"/>
+      <light pos="-3 0 1" dir="0 -1 0" mode="trackcom"/>
       <camera pos="-3 0 1" xyaxes="0 -1 0 1 0 2" mode="track"/>
+      <light pos="-3 0 1" dir="0 -1 0" mode="track"/>
       <freejoint/>
       <geom/>
     </body>


### PR DESCRIPTION
Adds around 0.3% overhead to step. Currently a straight-forward implementation of [mjx's version](https://github.com/google-deepmind/mujoco/blob/0abf184d49b7e3c45fb403a2dc0f6b38cd388090/mjx/mujoco/mjx/_src/smooth.py#L209), with a copy-paste for the lights. Tried factoring out commonalities between cameras and lights to a wp.func but the # of args required made it not worth it.

On my RTX4060Ti:

```
mjwarp-testspeed --function=step --mjcf=test_data/humanoid/humanoid.xml --batch_size=8192 --event_trace=True

Summary for 8192 parallel rollouts

 Total JIT time: 12.31 s
 Total simulation time: 9.85 s
 Total steps per second: 831,960
 Total realtime factor: 4,159.80 x
 Total time per step: 1201.98 ns

Event trace:

step: 1200.44
  forward: 1196.80
    fwd_position: 191.79
      kinematics: 46.50
      com_pos: 14.86
      camlight: 3.34
      crb: 44.25
      factor_m: 29.07
      collision: 14.69
      make_constraint: 30.38
      transmission: 7.47
    fwd_velocity: 53.37
      com_vel: 19.71
      passive: 1.75
      rne: 19.73
    fwd_actuation: 14.95
    fwd_acceleration: 27.55
      xfrc_accumulate: 8.96
      solve_m: 16.58
    solve: 908.27
      mul_m: 15.53
      _linesearch: [ 74.49, 43.05, 29.85, 26.91, 25.57, 25.01, 24.63, 24.35, 24.18, 24.09 ]
        mul_m: [ 16.16, 3.34, 1.85, 1.66, 1.62, 1.63, 1.63, 1.63, 1.63, 1.63 ]
  euler: 3.24
```

Passes correctness tests on pendula.xml, which has all camera and light types.