### PR TITLE
RK4 integrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following features are implemented:
 | Geom              | `PLANE`, `SPHERE`, `CAPSULE`       |
 | Constraint        | `LIMIT_JOINT`, `CONTACT_PYRAMIDAL` |
 | Equality          | Not yet implemented                |
-| Integrator        | `EULER`, `IMPLICITFAST`            |
+| Integrator        | `EULER`, `IMPLICITFAST`, `RK4`     |
 | Cone              | `PYRAMIDAL`                        |
 | Condim            | 3                                  |
 | Solver            | `CG`, `NEWTON`                     |

--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -21,6 +21,7 @@ from ._src.collision_driver import sap_broadphase as sap_broadphase
 from ._src.collision_primitive import primitive_narrowphase as primitive_narrowphase
 from ._src.constraint import make_constraint as make_constraint
 from ._src.forward import euler as euler
+from ._src.forward import rungekutta4 as rungekutta4
 from ._src.forward import forward as forward
 from ._src.forward import fwd_acceleration as fwd_acceleration
 from ._src.forward import fwd_actuation as fwd_actuation

--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -21,13 +21,13 @@ from ._src.collision_driver import sap_broadphase as sap_broadphase
 from ._src.collision_primitive import primitive_narrowphase as primitive_narrowphase
 from ._src.constraint import make_constraint as make_constraint
 from ._src.forward import euler as euler
-from ._src.forward import rungekutta4 as rungekutta4
 from ._src.forward import forward as forward
 from ._src.forward import fwd_acceleration as fwd_acceleration
 from ._src.forward import fwd_actuation as fwd_actuation
 from ._src.forward import fwd_position as fwd_position
 from ._src.forward import fwd_velocity as fwd_velocity
 from ._src.forward import implicit as implicit
+from ._src.forward import rungekutta4 as rungekutta4
 from ._src.forward import step as step
 from ._src.io import get_data_into as get_data_into
 from ._src.io import make_data as make_data
@@ -37,8 +37,8 @@ from ._src.passive import passive as passive
 from ._src.sensor import sensor_acc as sensor_acc
 from ._src.sensor import sensor_pos as sensor_pos
 from ._src.sensor import sensor_vel as sensor_vel
-from ._src.smooth import com_pos as com_pos
 from ._src.smooth import camlight as camlight
+from ._src.smooth import com_pos as com_pos
 from ._src.smooth import com_vel as com_vel
 from ._src.smooth import crb as crb
 from ._src.smooth import factor_m as factor_m

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -145,7 +145,7 @@ class ForwardTest(parameterized.TestCase):
     np.testing.assert_allclose(d.qvel.numpy()[0], 1 + mjm.opt.timestep)
 
   def test_rungekutta4(self):
-    # `forward` kernel dispatch is very slow
+    # slower than other tests because `forward` compilation
     mjm = mujoco.MjModel.from_xml_string("""
         <mujoco>
           <option integrator="RK4">

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -164,7 +164,7 @@ class ForwardTest(parameterized.TestCase):
           </worldbody>
         </mujoco>
         """)
-    
+
     mjd = mujoco.MjData(mjm)
     mjd.qvel[:] = np.array([0.2, -0.1])
     mujoco.mj_step(mjm, mjd, 10)
@@ -179,6 +179,7 @@ class ForwardTest(parameterized.TestCase):
     _assert_eq(d.qvel.numpy()[0], mjd.qvel, "qvel")
     _assert_eq(d.act.numpy()[0], mjd.act, "act")
     _assert_eq(d.time, mjd.time, "time")
+
 
 class ImplicitIntegratorTest(parameterized.TestCase):
   def _load(self, fname: str, disableFlags: int):

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -179,6 +179,7 @@ class ForwardTest(parameterized.TestCase):
     _assert_eq(d.qvel.numpy()[0], mjd.qvel, "qvel")
     _assert_eq(d.act.numpy()[0], mjd.act, "act")
     _assert_eq(d.time, mjd.time, "time")
+    _assert_eq(d.xpos.numpy()[0], mjd.xpos, "xpos")
 
 
 class ImplicitIntegratorTest(parameterized.TestCase):

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -144,6 +144,41 @@ class ForwardTest(parameterized.TestCase):
 
     np.testing.assert_allclose(d.qvel.numpy()[0], 1 + mjm.opt.timestep)
 
+  def test_rungekutta4(self):
+    # `forward` kernel dispatch is very slow
+    mjm = mujoco.MjModel.from_xml_string("""
+        <mujoco>
+          <option integrator="RK4">
+            <flag constraint="disable"/>
+          </option>
+          <worldbody>
+            <geom type="plane" size="1 1 .01" pos="0 0 -1"/>
+            <body pos="0.15 0 0">
+              <joint type="hinge" axis="0 1 0"/>
+              <geom type="capsule" size="0.02" fromto="0 0 0 .1 0 0"/>
+              <body pos="0.1 0 0">
+                <joint type="slide" axis="1 0 0" stiffness="200"/>
+                <geom type="capsule" size="0.015" fromto="-.1 0 0 .1 0 0"/>
+              </body>
+            </body>
+          </worldbody>
+        </mujoco>
+        """)
+    
+    mjd = mujoco.MjData(mjm)
+    mjd.qvel[:] = np.array([0.2, -0.1])
+    mujoco.mj_step(mjm, mjd, 10)
+    mujoco.mj_forward(mjm, mjd)
+
+    m = mjwarp.put_model(mjm)
+    d = mjwarp.put_data(mjm, mjd)
+    mjwarp.rungekutta4(m, d)
+    mujoco.mj_RungeKutta(mjm, mjd, 4)
+
+    _assert_eq(d.qpos.numpy()[0], mjd.qpos, "qpos")
+    _assert_eq(d.qvel.numpy()[0], mjd.qvel, "qvel")
+    _assert_eq(d.act.numpy()[0], mjd.act, "act")
+    _assert_eq(d.time, mjd.time, "time")
 
 class ImplicitIntegratorTest(parameterized.TestCase):
   def _load(self, fname: str, disableFlags: int):

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -542,6 +542,12 @@ def make_data(
   d.qLD_integration = wp.zeros_like(d.qLD)
   d.qLDiagInv_integration = wp.zeros_like(d.qLDiagInv)
   d.act_vel_integration = wp.zeros_like(d.ctrl)
+  d.qpos_t0 = wp.zeros((nworld, mjm.nq), dtype=wp.float32)
+  d.qvel_t0 = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
+  d.act_t0 = wp.zeros((nworld, mjm.na), dtype=wp.float32)
+  d.qvel_rk = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
+  d.qacc_rk = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
+  d.act_dot_rk = wp.zeros((nworld, mjm.na), dtype=wp.float32)
 
   # sweep-and-prune broadphase
   d.sap_geom_sort = wp.zeros((nworld, mjm.ngeom), dtype=wp.vec4)
@@ -773,6 +779,12 @@ def put_data(
   d.qLD_integration = wp.zeros_like(d.qLD)
   d.qLDiagInv_integration = wp.zeros_like(d.qLDiagInv)
   d.act_vel_integration = wp.zeros_like(d.ctrl)
+  d.qpos_t0 = wp.zeros((nworld, mjm.nq), dtype=wp.float32)
+  d.qvel_t0 = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
+  d.act_t0 = wp.zeros((nworld, mjm.na), dtype=wp.float32)
+  d.qvel_rk = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
+  d.qacc_rk = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
+  d.act_dot_rk = wp.zeros((nworld, mjm.na), dtype=wp.float32)
 
   # broadphase sweep and prune
   d.sap_geom_sort = wp.zeros((nworld, mjm.ngeom), dtype=wp.vec4)

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -122,7 +122,7 @@ class IOTest(absltest.TestCase):
 
     with self.assertRaises(ValueError):
       mjwarp.put_model(mjm)
-      
+
   def test_actuator_trntype(self):
     mjm = mujoco.MjModel.from_xml_string("""
       <mujoco>

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -148,7 +148,8 @@ class IntegratorType(enum.IntEnum):
 
   EULER = mujoco.mjtIntegrator.mjINT_EULER
   IMPLICITFAST = mujoco.mjtIntegrator.mjINT_IMPLICITFAST
-  # unsupported: RK4, IMPLICIT
+  RK4 = mujoco.mjtIntegrator.mjINT_RK4
+  # unsupported: IMPLICIT
 
 
 class GeomType(enum.IntEnum):
@@ -712,6 +713,12 @@ class Data:
     njmax: maximum number of constraints                        ()
     rne_cacc: arrays used for smooth.rne                        (nworld, nbody, 6)
     rne_cfrc: arrays used for smooth.rne                        (nworld, nbody, 6)
+    qpos_t0: temporary array for rk4                            (nworld, nq)
+    qvel_t0: temporary array for rk4                            (nworld, nv)
+    act_t0: temporary array for rk4                             (nworld, na)
+    qvel_rk: temporary array for rk4                            (nworld, nv)
+    qacc_rk: temporary array for rk4                            (nworld, nv)
+    act_dot_rk: temporary array for rk4                         (nworld, na)
     qfrc_integration: temporary array for integration           (nworld, nv)
     qacc_integration: temporary array for integration           (nworld, nv)
     act_vel_integration: temporary array for integration        (nworld, nu)
@@ -786,6 +793,12 @@ class Data:
   njmax: int
   rne_cacc: wp.array(dtype=wp.spatial_vector, ndim=2)
   rne_cfrc: wp.array(dtype=wp.spatial_vector, ndim=2)
+  qpos_t0: wp.array(dtype=wp.float32, ndim=2)
+  qvel_t0: wp.array(dtype=wp.float32, ndim=2)
+  act_t0: wp.array(dtype=wp.float32, ndim=2)
+  qvel_rk: wp.array(dtype=wp.float32, ndim=2)
+  qacc_rk: wp.array(dtype=wp.float32, ndim=2)
+  act_dot_rk: wp.array(dtype=wp.float32, ndim=2)
   qfrc_integration: wp.array(dtype=wp.float32, ndim=2)
   qacc_integration: wp.array(dtype=wp.float32, ndim=2)
   act_vel_integration: wp.array(dtype=wp.float32, ndim=2)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -143,12 +143,13 @@ class IntegratorType(enum.IntEnum):
 
   Members:
     EULER: semi-implicit Euler
+    RK4: 4th-order Runge Kutta
     IMPLICITFAST: implicit in velocity, no rne derivative
   """
 
   EULER = mujoco.mjtIntegrator.mjINT_EULER
-  IMPLICITFAST = mujoco.mjtIntegrator.mjINT_IMPLICITFAST
   RK4 = mujoco.mjtIntegrator.mjINT_RK4
+  IMPLICITFAST = mujoco.mjtIntegrator.mjINT_IMPLICITFAST
   # unsupported: IMPLICIT
 
 


### PR DESCRIPTION
## Notes
1. This PR currently doesn't set the time in the intermediate steps, [unlike in cmujoco](https://github.com/google-deepmind/mujoco/blob/0abf184d49b7e3c45fb403a2dc0f6b38cd388090/src/engine/engine_forward.c#L908), because it doesn't seem to do anything. I can add this back in if it does.
2. Due to kernel loading, the new test (test_rungekutta4) is quite slow, taking about 9 seconds whereas the other tests in forward_test.py are instant.

## Speed
#### Euler (default)
```
mjwarp-testspeed --function=step --mjcf=test_data/humanoid/humanoid.xml --batch_size=1024 --event_trace=True

Summary for 1024 parallel rollouts

 Total JIT time: 0.45 s
 Total simulation time: 2.72 s
 Total steps per second: 377,154
 Total realtime factor: 1,885.77 x
 Total time per step: 2651.44 ns

Event trace:

step: 2639.15
  forward: 2627.89
    fwd_position: 292.25
      kinematics: 75.39
      com_pos: 26.55
      crb: 51.29
      factor_m: 25.87
      collision: 26.13
      make_constraint: 71.69
      transmission: 6.21
    fwd_velocity: 109.43
      com_vel: 35.62
      passive: 6.49
      rne: 43.24
    fwd_actuation: 14.06
    fwd_acceleration: 40.29
      xfrc_accumulate: 15.13
      solve_m: 18.08
    solve: 2164.86
      mul_m: 16.29
      _linesearch: [ 206.28, 170.60, 152.00, 137.90, 126.04, 120.00, 114.55, 109.53, 106.25, 104.79 ]
        mul_m: [ 16.27, 9.63, 9.26, 8.99, 8.56, 8.61, 8.43, 8.07, 7.88, 7.86 ]
  euler: 7.95
```
#### RK4

Subtracting the intermediate forward calls, RK4 takes 40.8 ns.

```
mjwarp-testspeed --function=step --mjcf=test_data/humanoid/humanoid.xml --batch_size=1024 --event_trace=True

Summary for 1024 parallel rollouts

 Total JIT time: 1.48 s
 Total simulation time: 10.02 s
 Total steps per second: 102,183
 Total realtime factor: 510.92 x
 Total time per step: 9786.35 ns

Event trace:

step: 9763.19
  forward: 2429.37
    fwd_position: 223.03
      kinematics: 74.48
      com_pos: 26.41
      crb: 50.79
      factor_m: 25.81
      collision: 16.00
      make_constraint: 14.37
      transmission: 6.51
    fwd_velocity: 108.68
      com_vel: 35.31
      passive: 6.47
      rne: 42.91
    fwd_actuation: 13.86
    fwd_acceleration: 44.82
      xfrc_accumulate: 15.31
      solve_m: 22.42
    solve: 2032.10
      mul_m: 16.36
      _linesearch: [ 116.55, 116.04, 115.32, 114.88, 114.49, 114.27, 113.81, 113.68, 113.44, 113.24 ]
        mul_m: [ 16.16, 16.21, 16.07, 16.02, 15.98, 16.05, 15.94, 15.98, 15.97, 15.93 ]
  rungekutta4: 7330.62
    forward: [ 2432.05, 2424.35, 2433.46 ]
      fwd_position: [ 223.76, 224.40, 224.25 ]
        kinematics: [ 74.57, 74.31, 74.81 ]
        com_pos: [ 26.52, 26.24, 26.49 ]
        crb: [ 50.44, 50.79, 50.45 ]
        factor_m: [ 25.83, 25.95, 25.88 ]
        collision: [ 16.12, 16.76, 16.16 ]
        make_constraint: [ 14.95, 14.96, 14.85 ]
        transmission: [ 6.57, 6.34, 6.82 ]
      fwd_velocity: [ 109.25, 108.98, 109.76 ]
        com_vel: [ 35.32, 35.28, 35.34 ]
        passive: [ 6.55, 6.61, 6.59 ]
        rne: [ 42.97, 42.93, 43.07 ]
      fwd_actuation: [ 13.96, 13.88, 14.01 ]
      fwd_acceleration: [ 44.31, 44.48, 44.84 ]
        xfrc_accumulate: [ 14.90, 15.11, 14.92 ]
        solve_m: [ 22.38, 22.35, 22.40 ]
      solve: [ 2034.24, 2025.97, 2034.05 ]
        mul_m: [ 16.29, 16.36, 16.29 ]
        _linesearch: [ 116.36, 116.14, 115.41, 115.00, 114.56, 114.19, 113.68, 113.60, 113.50, 113.25, 116.25, 115.72, 114.78, 114.49, 114.11, 113.80, 113.54, 113.40, 113.24, 113.07, 116.80, 116.11, 115.69, 115.01, 114.41, 114.06, 113.78, 113.43, 113.29, 113.10 ]
          mul_m: [ 16.16, 16.16, 16.08, 16.04, 16.00, 15.98, 15.95, 15.99, 16.02, 15.91, 16.17, 16.18, 16.02, 15.93, 15.99, 16.00, 15.98, 16.03, 15.95, 15.96, 16.17, 16.16, 16.09, 16.13, 15.95, 15.97, 15.96, 15.97, 15.96, 15.88 ]
```
