### PR TITLE
rne_postconstraint

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -39,6 +39,7 @@ from ._src.smooth import crb as crb
 from ._src.smooth import factor_m as factor_m
 from ._src.smooth import kinematics as kinematics
 from ._src.smooth import rne as rne
+from ._src.smooth import rne_postconstraint as rne_postconstraint
 from ._src.smooth import solve_m as solve_m
 from ._src.smooth import transmission as transmission
 from ._src.solver import solve as solve

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -529,10 +529,6 @@ def make_data(
   d.qfrc_smooth = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
   d.qfrc_constraint = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
   d.qacc_smooth = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
-
-  d.rne_cacc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
-  d.rne_cfrc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
-
   d.xfrc_applied = wp.zeros((nworld, mjm.nbody), dtype=wp.spatial_vector)
 
   # internal tmp arrays
@@ -557,6 +553,11 @@ def make_data(
   d.collision_pair = wp.empty(nconmax, dtype=wp.vec2i, ndim=1)
   d.collision_worldid = wp.empty(nconmax, dtype=wp.int32, ndim=1)
   d.ncollision = wp.zeros(1, dtype=wp.int32, ndim=1)
+
+  # rne_postconstraint
+  d.cacc = wp.zeros((nworld, mjm.nbody), dtype=wp.spatial_vector, ndim=2)
+  d.cfrc_int = wp.zeros((nworld, mjm.nbody), dtype=wp.spatial_vector, ndim=2)
+  d.cfrc_ext = wp.zeros((nworld, mjm.nbody), dtype=wp.spatial_vector, ndim=2)
 
   return d
 
@@ -752,9 +753,6 @@ def put_data(
   d.contact.efc_address = wp.array(con_efc_address, dtype=wp.int32, ndim=1)
   d.contact.worldid = wp.array(con_worldid, dtype=wp.int32, ndim=1)
 
-  d.rne_cacc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
-  d.rne_cfrc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
-
   d.efc = _constraint(mjm, d.nworld, d.njmax)
   d.efc.J = wp.array(efc_J_fill, dtype=wp.float32, ndim=2)
   d.efc.D = wp.array(efc_D_fill, dtype=wp.float32, ndim=1)
@@ -788,6 +786,12 @@ def put_data(
   d.collision_pair = wp.empty(nconmax, dtype=wp.vec2i, ndim=1)
   d.collision_worldid = wp.empty(nconmax, dtype=wp.int32, ndim=1)
   d.ncollision = wp.zeros(1, dtype=wp.int32, ndim=1)
+
+  # rne_postconstraint
+  d.cacc = wp.array(tile(mjd.cacc), dtype=wp.spatial_vector, ndim=2)
+  d.cfrc_int = wp.array(tile(mjd.cfrc_int), dtype=wp.spatial_vector, ndim=2)
+  d.cfrc_ext = wp.array(tile(mjd.cfrc_ext), dtype=wp.spatial_vector, ndim=2)
+
   return d
 
 
@@ -893,5 +897,9 @@ def get_data_into(
   result.efc_aref[:] = d.efc.aref.numpy()[:nefc]
   result.efc_force[:] = d.efc.force.numpy()[:nefc]
   result.efc_margin[:] = d.efc.margin.numpy()[:nefc]
+
+  result.cacc[:] = d.cacc.numpy()[0]
+  result.cfrc_int[:] = d.cfrc_int.numpy()[0]
+  result.cfrc_ext[:] = d.cfrc_ext.numpy()[0]
 
   # TODO: other efc_ fields, anything else missing

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -122,7 +122,7 @@ class IOTest(absltest.TestCase):
 
     with self.assertRaises(ValueError):
       mjwarp.put_model(mjm)
-      
+
   def test_actuator_trntype(self):
     mjm = mujoco.MjModel.from_xml_string("""
       <mujoco>

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -487,7 +487,7 @@ def _rne_cfrc(m: Model, d: Data, flg_cfrc_ext: bool = False):
   @kernel
   def _cfrc(d: Data):
     worldid, bodyid = wp.tid()
-    bodyid += 1
+    bodyid += 1  # skip world body
     cacc = d.cacc[worldid, bodyid]
     cinert = d.cinert[worldid, bodyid]
     cvel = d.cvel[worldid, bodyid]

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -18,6 +18,7 @@ import warp as wp
 from packaging import version
 
 from . import math
+from . import support
 from .types import Data
 from .types import DisableBit
 from .types import JointType
@@ -444,17 +445,21 @@ def factor_m(m: Model, d: Data):
   factor_i(m, d, d.qM, d.qLD, d.qLDiagInv)
 
 
-@event_scope
-def rne(m: Model, d: Data):
-  """Computes inverse dynamics using Newton-Euler algorithm."""
-
+def _rne_cacc_world(m: Model, d: Data):
   @kernel
-  def cacc_gravity(m: Model, d: Data):
+  def _cacc_world(m: Model, d: Data):
     worldid = wp.tid()
-    d.rne_cacc[worldid, 0] = wp.spatial_vector(wp.vec3(0.0), -m.opt.gravity)
+    d.cacc[worldid, 0] = wp.spatial_vector(wp.vec3(0.0), -m.opt.gravity)
 
+  if m.opt.disableflags & DisableBit.GRAVITY:
+    d.cacc.zero_()
+  else:
+    wp.launch(_cacc_world, dim=[d.nworld], inputs=[m, d])
+
+
+def _rne_cacc_forward(m: Model, d: Data, flg_acc: bool = False):
   @kernel
-  def cacc_level(
+  def _cacc(
     m: Model,
     d: Data,
     leveladr: int,
@@ -464,55 +469,108 @@ def rne(m: Model, d: Data):
     dofnum = m.body_dofnum[bodyid]
     pid = m.body_parentid[bodyid]
     dofadr = m.body_dofadr[bodyid]
-    local_cacc = d.rne_cacc[worldid, pid]
+    local_cacc = d.cacc[worldid, pid]
     for i in range(dofnum):
       local_cacc += d.cdof_dot[worldid, dofadr + i] * d.qvel[worldid, dofadr + i]
-    d.rne_cacc[worldid, bodyid] = local_cacc
+      if flg_acc:
+        local_cacc += d.cdof[worldid, dofadr + i] * d.qacc[worldid, dofadr + i]
+    d.cacc[worldid, bodyid] = local_cacc
 
+  body_treeadr = m.body_treeadr.numpy()
+  for i in range(len(body_treeadr)):
+    beg = body_treeadr[i]
+    end = m.nbody if i == len(body_treeadr) - 1 else body_treeadr[i + 1]
+    wp.launch(_cacc, dim=(d.nworld, end - beg), inputs=[m, d, beg])
+
+
+def _rne_cfrc(m: Model, d: Data, flg_cfrc_ext: bool = False):
   @kernel
-  def frc_fn(d: Data):
+  def _cfrc(d: Data):
     worldid, bodyid = wp.tid()
-    frc = math.inert_vec(d.cinert[worldid, bodyid], d.rne_cacc[worldid, bodyid])
-    frc += math.motion_cross_force(
-      d.cvel[worldid, bodyid],
-      math.inert_vec(d.cinert[worldid, bodyid], d.cvel[worldid, bodyid]),
-    )
-    d.rne_cfrc[worldid, bodyid] = frc
+    bodyid += 1
+    cacc = d.cacc[worldid, bodyid]
+    cinert = d.cinert[worldid, bodyid]
+    cvel = d.cvel[worldid, bodyid]
+    frc = math.inert_vec(cinert, cacc)
+    frc += math.motion_cross_force(cvel, math.inert_vec(cinert, cvel))
 
+    if flg_cfrc_ext:
+      frc -= d.cfrc_ext[worldid, bodyid]
+
+    d.cfrc_int[worldid, bodyid] = frc
+
+  wp.launch(_cfrc, dim=[d.nworld, m.nbody - 1], inputs=[d])
+
+
+def _rne_cfrc_backward(m: Model, d: Data):
   @kernel
-  def cfrc_fn(m: Model, d: Data, leveladr: int):
+  def _cfrc(m: Model, d: Data, leveladr: int):
     worldid, nodeid = wp.tid()
     bodyid = m.body_tree[leveladr + nodeid]
     pid = m.body_parentid[bodyid]
-    wp.atomic_add(d.rne_cfrc[worldid], pid, d.rne_cfrc[worldid, bodyid])
+    if bodyid != 0:
+      wp.atomic_add(d.cfrc_int[worldid], pid, d.cfrc_int[worldid, bodyid])
+
+  body_treeadr = m.body_treeadr.numpy()
+  for i in reversed(range(len(body_treeadr))):
+    beg = body_treeadr[i]
+    end = m.nbody if i == len(body_treeadr) - 1 else body_treeadr[i + 1]
+    wp.launch(_cfrc, dim=[d.nworld, end - beg], inputs=[m, d, beg])
+
+
+@event_scope
+def rne(m: Model, d: Data, flg_acc: bool = False):
+  """Computes inverse dynamics using Newton-Euler algorithm."""
 
   @kernel
   def qfrc_bias(m: Model, d: Data):
     worldid, dofid = wp.tid()
     bodyid = m.dof_bodyid[dofid]
     d.qfrc_bias[worldid, dofid] = wp.dot(
-      d.cdof[worldid, dofid], d.rne_cfrc[worldid, bodyid]
+      d.cdof[worldid, dofid], d.cfrc_int[worldid, bodyid]
     )
 
-  if m.opt.disableflags & DisableBit.GRAVITY:
-    d.rne_cacc.zero_()
-  else:
-    wp.launch(cacc_gravity, dim=[d.nworld], inputs=[m, d])
-
-  body_treeadr = m.body_treeadr.numpy()
-  for i in range(len(body_treeadr)):
-    beg = body_treeadr[i]
-    end = m.nbody if i == len(body_treeadr) - 1 else body_treeadr[i + 1]
-    wp.launch(cacc_level, dim=(d.nworld, end - beg), inputs=[m, d, beg])
-
-  wp.launch(frc_fn, dim=[d.nworld, m.nbody], inputs=[d])
-
-  for i in reversed(range(len(body_treeadr))):
-    beg = body_treeadr[i]
-    end = m.nbody if i == len(body_treeadr) - 1 else body_treeadr[i + 1]
-    wp.launch(cfrc_fn, dim=[d.nworld, end - beg], inputs=[m, d, beg])
+  _rne_cacc_world(m, d)
+  _rne_cacc_forward(m, d, flg_acc=flg_acc)
+  _rne_cfrc(m, d)
+  _rne_cfrc_backward(m, d)
 
   wp.launch(qfrc_bias, dim=[d.nworld, m.nv], inputs=[m, d])
+
+
+@event_scope
+def rne_postconstraint(m: Model, d: Data):
+  """RNE with complete data: compute cacc, cfrc_ext, cfrc_int."""
+
+  # cfrc_ext = perturb
+  @kernel
+  def _cfrc_ext(m: Model, d: Data):
+    worldid, bodyid = wp.tid()
+
+    if bodyid == 0:
+      d.cfrc_ext[worldid, 0] = wp.spatial_vector(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    else:
+      xfrc_applied = d.xfrc_applied[worldid, bodyid]
+      subtree_com = d.subtree_com[worldid, m.body_rootid[bodyid]]
+      xipos = d.xipos[worldid, bodyid]
+      d.cfrc_ext[worldid, bodyid] = support.transform_force(
+        xfrc_applied, subtree_com - xipos
+      )
+
+  wp.launch(_cfrc_ext, dim=(d.nworld, m.nbody), inputs=[m, d])
+
+  # TODO(team): cfrc_ext += contacts
+  # TODO(team): cfrc_ext += equality
+
+  # forward pass over bodies: compute cacc, cfrc_int
+  _rne_cacc_world(m, d)
+  _rne_cacc_forward(m, d, flg_acc=True)
+
+  # cfrc_body = cinert * cacc + cvel x (cinert * cvel)
+  _rne_cfrc(m, d, flg_cfrc_ext=True)
+
+  # backward pass over bodies: accumulate cfrc_int from children
+  _rne_cfrc_backward(m, d)
 
 
 @event_scope

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -137,6 +137,30 @@ class SmoothTest(parameterized.TestCase):
 
     # TODO(team): test DisableBit.GRAVITY
 
+  @parameterized.parameters(True, False)
+  def test_rne_postconstraint(self, gravity):
+    """Tests rne_postconstraint."""
+    # TODO(team): test: contact, equality constraints
+    mjm, mjd, m, d = test_util.fixture("pendula.xml", gravity=gravity)
+
+    mjd.xfrc_applied = np.random.uniform(
+      low=-0.01, high=0.01, size=mjd.xfrc_applied.shape
+    )
+    d.xfrc_applied = wp.array(
+      np.expand_dims(mjd.xfrc_applied, axis=0), dtype=wp.spatial_vector
+    )
+
+    mujoco.mj_rnePostConstraint(mjm, mjd)
+
+    for arr in (d.cacc, d.cfrc_int, d.cfrc_ext):
+      arr.zero_()
+
+    mjwarp.rne_postconstraint(m, d)
+
+    _assert_eq(d.cacc.numpy()[0], mjd.cacc, "cacc")
+    _assert_eq(d.cfrc_int.numpy()[0][1:], mjd.cfrc_int[1:], "cfrc_int")
+    _assert_eq(d.cfrc_ext.numpy()[0], mjd.cfrc_ext, "cfrc_ext")
+
   def test_com_vel(self):
     """Tests com_vel."""
     _, mjd, m, d = test_util.fixture("pendula.xml")

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -200,3 +200,18 @@ def mat33_from_rows(a: wp.vec3, b: wp.vec3, c: wp.vec3):
 @wp.func
 def mat33_from_cols(a: wp.vec3, b: wp.vec3, c: wp.vec3):
   return wp.mat33(a.x, b.x, c.x, a.y, b.y, c.y, a.z, b.z, c.z)
+
+
+@wp.func
+def transform_force(
+  force: wp.vec3, torque: wp.vec3, offset: wp.vec3
+) -> wp.spatial_vector:
+  torque -= wp.cross(offset, force)
+  return wp.spatial_vector(torque, force)
+
+
+@wp.func
+def transform_force(frc: wp.spatial_vector, offset: wp.vec3) -> wp.spatial_vector:
+  force = wp.spatial_top(frc)
+  torque = wp.spatial_bottom(frc)
+  return transform_force(force, torque, offset)

--- a/mujoco_warp/_src/test_util.py
+++ b/mujoco_warp/_src/test_util.py
@@ -29,9 +29,19 @@ from .types import Data
 from .types import Model
 
 
-def fixture(fname: str, keyframe: int = -1, sparse: bool = True):
+def fixture(
+  fname: str,
+  keyframe: int = -1,
+  sparse: bool = True,
+  contact: bool = True,
+  gravity: bool = True,
+):
   path = epath.resource_path("mujoco_warp") / "test_data" / fname
   mjm = mujoco.MjModel.from_xml_path(path.as_posix())
+  if not contact:
+    mjm.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+  if not gravity:
+    mjm.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_GRAVITY
   mjm.opt.jacobian = sparse
   mjd = mujoco.MjData(mjm)
   if keyframe > -1:

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -710,8 +710,6 @@ class Data:
     nworld: number of worlds                                    ()
     nconmax: maximum number of contacts                         ()
     njmax: maximum number of constraints                        ()
-    rne_cacc: arrays used for smooth.rne                        (nworld, nbody, 6)
-    rne_cfrc: arrays used for smooth.rne                        (nworld, nbody, 6)
     qfrc_integration: temporary array for integration           (nworld, nv)
     qacc_integration: temporary array for integration           (nworld, nv)
     act_vel_integration: temporary array for integration        (nworld, nu)
@@ -730,6 +728,9 @@ class Data:
     collision_type: collision types from broadphase             (nconmax,)
     collision_worldid: collision world ids from broadphase      (nconmax,)
     ncollision: collision count from broadphase                 ()
+    cacc: com-based acceleration                                (nworld, nbody, 6)
+    cfrc_int: com-based interaction force with parent           (nworld, nbody, 6)
+    cfrc_ext: com-based external force on body                  (nworld, nbody, 6)
   """
 
   ncon: wp.array(dtype=wp.int32, ndim=1)
@@ -784,8 +785,6 @@ class Data:
   nworld: int
   nconmax: int
   njmax: int
-  rne_cacc: wp.array(dtype=wp.spatial_vector, ndim=2)
-  rne_cfrc: wp.array(dtype=wp.spatial_vector, ndim=2)
   qfrc_integration: wp.array(dtype=wp.float32, ndim=2)
   qacc_integration: wp.array(dtype=wp.float32, ndim=2)
   act_vel_integration: wp.array(dtype=wp.float32, ndim=2)
@@ -806,3 +805,8 @@ class Data:
   collision_pair: wp.array(dtype=wp.vec2i, ndim=1)
   collision_worldid: wp.array(dtype=wp.int32, ndim=1)
   ncollision: wp.array(dtype=wp.int32, ndim=1)
+
+  # rne_postconstraint
+  cacc: wp.array(dtype=wp.spatial_vector, ndim=2)
+  cfrc_int: wp.array(dtype=wp.spatial_vector, ndim=2)
+  cfrc_ext: wp.array(dtype=wp.spatial_vector, ndim=2)


### PR DESCRIPTION
implementation of `mj_rnePostConstraint`. this routine is called by accelerometer, force, and torque sensors.

future prs will add support for contacts and equality constraints.