### PR TITLE
CI: move continue-on-error to job metadata to avoid false negatives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,12 @@ jobs:
       - name: Format with Ruff
         run: |
           ruff format --check .
+        condition: always()
       - name: Lint with Ruff
         run: |
           ruff check --output-format=github .
+        condition: always()
       - name: Test with pytest
         run: |
           pytest
+        condition: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,12 @@ jobs:
       - name: Format with Ruff
         run: |
           ruff format --check .
+        if: always()
       - name: Lint with Ruff
         run: |
           ruff check --output-format=github .
+        if: always()
       - name: Test with pytest
         run: |
           pytest
+        if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         python-version: ["3.12"]
 
+    continue-on-error: true
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +35,6 @@ jobs:
       - name: Lint with Ruff
         run: |
           ruff check --output-format=github .
-        continue-on-error: true
       - name: Test with pytest
         run: |
           pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,9 @@ jobs:
       - name: Format with Ruff
         run: |
           ruff format --check .
-        condition: always()
       - name: Lint with Ruff
         run: |
           ruff check --output-format=github .
-        condition: always()
       - name: Test with pytest
         run: |
           pytest
-        condition: always()

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -18,10 +18,9 @@ import warp as wp
 from .collision_box import box_box_narrowphase
 from .collision_primitive import primitive_narrowphase
 from .types import MJ_MINVAL
-from .types import Model
-
 from .types import Data
 from .types import DisableBit
+from .types import Model
 from .types import vec5
 from .warp_util import event_scope
 

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -18,9 +18,10 @@ import warp as wp
 from .collision_box import box_box_narrowphase
 from .collision_primitive import primitive_narrowphase
 from .types import MJ_MINVAL
+from .types import Model
+
 from .types import Data
 from .types import DisableBit
-from .types import Model
 from .types import vec5
 from .warp_util import event_scope
 


### PR DESCRIPTION
Compared to before, this change should now give you a red icon if any of the stages failed. Before linter failures would not show up on the PR overview because a successful pytest run (which happens afterwards) would give this a green icon.