### PR TITLE
Clean up tests to use fixture loading.

### DIFF
--- a/mujoco_warp/_src/broad_phase_test.py
+++ b/mujoco_warp/_src/broad_phase_test.py
@@ -15,7 +15,6 @@
 
 """Tests for broadphase functions."""
 
-import mujoco
 import numpy as np
 import warp as wp
 from absl.testing import absltest
@@ -23,19 +22,7 @@ from absl.testing import absltest
 import mujoco_warp as mjwarp
 
 from . import collision_driver
-
-
-def _load_from_string(xml: str, keyframe: int = -1):
-  mjm = mujoco.MjModel.from_xml_string(xml)
-  mjd = mujoco.MjData(mjm)
-  if keyframe > -1:
-    mujoco.mj_resetDataKeyframe(mjm, mjd, keyframe)
-  mujoco.mj_forward(mjm, mjd)
-
-  m = mjwarp.put_model(mjm)
-  d = mjwarp.put_data(mjm, mjd)
-
-  return mjm, mjd, m, d
+from . import test_util
 
 
 class BroadphaseTest(absltest.TestCase):
@@ -97,7 +84,7 @@ class BroadphaseTest(absltest.TestCase):
       (6, 7),
     ]
 
-    _, _, m, d = _load_from_string(_SAP_MODEL)
+    _, _, m, d = test_util.fixture(xml=_SAP_MODEL)
 
     mjwarp.sap_broadphase(m, d)
 
@@ -184,12 +171,12 @@ class BroadphaseTest(absltest.TestCase):
       </mujoco>
     """
     # one world and zero collisions
-    mjm, _, m, d0 = _load_from_string(_NXN_MODEL, keyframe=0)
+    mjm, _, m, d0 = test_util.fixture(xml=_NXN_MODEL, keyframe=0)
     collision_driver.nxn_broadphase(m, d0)
     np.testing.assert_allclose(d0.ncollision.numpy()[0], 0)
 
     # one world and one collision
-    _, mjd1, _, d1 = _load_from_string(_NXN_MODEL, keyframe=1)
+    _, mjd1, _, d1 = test_util.fixture(xml=_NXN_MODEL, keyframe=1)
     collision_driver.nxn_broadphase(m, d1)
 
     np.testing.assert_allclose(d1.ncollision.numpy()[0], 1)
@@ -197,7 +184,7 @@ class BroadphaseTest(absltest.TestCase):
     np.testing.assert_allclose(d1.collision_pair.numpy()[0][1], 1)
 
     # one world and three collisions
-    _, mjd2, _, d2 = _load_from_string(_NXN_MODEL, keyframe=2)
+    _, mjd2, _, d2 = test_util.fixture(xml=_NXN_MODEL, keyframe=2)
     collision_driver.nxn_broadphase(m, d2)
     np.testing.assert_allclose(d2.ncollision.numpy()[0], 3)
     np.testing.assert_allclose(d2.collision_pair.numpy()[0][0], 0)
@@ -228,7 +215,7 @@ class BroadphaseTest(absltest.TestCase):
     np.testing.assert_allclose(d3.collision_pair.numpy()[3][1], 2)
 
     # one world and zero collisions: contype and conaffinity incompatibility
-    _, _, m4, d4 = _load_from_string(_NXN_MODEL, keyframe=1)
+    _, _, m4, d4 = test_util.fixture(xml=_NXN_MODEL, keyframe=1)
     m4.geom_contype = wp.array(
       np.array(np.repeat(0, m.geom_type.shape)), dtype=wp.int32
     )
@@ -240,7 +227,7 @@ class BroadphaseTest(absltest.TestCase):
     np.testing.assert_allclose(d4.ncollision.numpy()[0], 0)
 
     # one world and one collision: geomtype ordering
-    _, _, _, d5 = _load_from_string(_NXN_MODEL, keyframe=3)
+    _, _, _, d5 = test_util.fixture(xml=_NXN_MODEL, keyframe=3)
     collision_driver.nxn_broadphase(m, d5)
     np.testing.assert_allclose(d5.ncollision.numpy()[0], 1)
     np.testing.assert_allclose(d5.collision_pair.numpy()[0][0], 3)

--- a/mujoco_warp/_src/constraint_test.py
+++ b/mujoco_warp/_src/constraint_test.py
@@ -38,7 +38,7 @@ def _assert_eq(a, b, name):
 class ConstraintTest(parameterized.TestCase):
   def test_condim(self):
     """Test condim."""
-    mjm = mujoco.MjModel.from_xml_string("""
+    xml = """
       <mujoco>
         <worldbody>
           <body pos="0 0 0">
@@ -83,20 +83,12 @@ class ConstraintTest(parameterized.TestCase):
           <key qpos='1 2 3 4 5 6 0 0'/>
         </keyframe>
       </mujoco>
-    """)
-
-    mjm.opt.cone = mujoco.mjtCone.mjCONE_PYRAMIDAL
+    """
 
     # TODO(team): test elliptic friction cone
 
-    mjd = mujoco.MjData(mjm)
-
-    for keyframe in range(mjm.nkey):
-      mujoco.mj_resetDataKeyframe(mjm, mjd, keyframe)
-      mujoco.mj_forward(mjm, mjd)
-
-      m = mjwarp.put_model(mjm)
-      d = mjwarp.put_data(mjm, mjd)
+    for keyframe in range(6):
+      _, mjd, m, d = test_util.fixture(xml=xml, keyframe=keyframe)
       mjwarp.make_constraint(m, d)
 
       _assert_eq(d.efc.J.numpy()[: mjd.nefc, :].reshape(-1), mjd.efc_J, "efc_J")
@@ -111,7 +103,7 @@ class ConstraintTest(parameterized.TestCase):
   )
   def test_constraints(self, cone):
     """Test constraints."""
-    mjm, mjd, _, _ = test_util.fixture("constraints.xml", sparse=False, cone=cone)
+    mjm, mjd, _, _ = test_util.fixture("constraints.xml", cone=cone)
 
     for key in range(3):
       mujoco.mj_resetDataKeyframe(mjm, mjd, key)

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -19,9 +19,10 @@ import mujoco
 import numpy as np
 import warp as wp
 from absl.testing import absltest
-from etils import epath
 
 import mujoco_warp as mjwarp
+
+from . import test_util
 
 
 class IOTest(absltest.TestCase):
@@ -122,11 +123,9 @@ class IOTest(absltest.TestCase):
       mjwarp.put_model(mjm)
 
   def test_dense(self):
-    path = epath.resource_path("mujoco_warp") / "test_data/humanoid/n_humanoids.xml"
-    mjm = mujoco.MjModel.from_xml_path(path.as_posix())
-
     with self.assertRaises(ValueError):
-      mjwarp.put_model(mjm)
+      # dense not supported yet for large nv
+      test_util.fixture("humanoid/n_humanoids.xml")
 
   def test_actuator_trntype(self):
     mjm = mujoco.MjModel.from_xml_string("""

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -41,7 +41,8 @@ def _assert_eq(a, b, name):
 class SensorTest(parameterized.TestCase):
   def test_sensor(self):
     """Test sensors."""
-    mjm = mujoco.MjModel.from_xml_string("""
+    mjm, mjd, m, d = test_util.fixture(
+      xml="""
       <mujoco>
         <worldbody>
           <body name="body0" pos="0.1 0.2 0.3" quat=".05 .1 .15 .2">
@@ -113,14 +114,8 @@ class SensorTest(parameterized.TestCase):
           <key qpos="1 .1 .2 .3 .4 1 1 1 1 0 0 0 .25 .35" qvel="2 .2 -.1 .4 .25 .35 .45 -0.1 -0.2 -0.3 .1 -.2" ctrl="3"/>
         </keyframe>
       </mujoco>
-    """)
-
-    mjd = mujoco.MjData(mjm)
-    mujoco.mj_resetDataKeyframe(mjm, mjd, 0)
-    mujoco.mj_forward(mjm, mjd)
-
-    m = mjwarp.put_model(mjm)
-    d = mjwarp.put_data(mjm, mjd)
+    """
+    )
 
     d.sensordata.zero_()
 

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -211,7 +211,8 @@ class SmoothTest(parameterized.TestCase):
 
   def test_fixed_tendon(self):
     """Tests fixed tendon."""
-    _FIXED_TENDON = """
+    mjm, mjd, m, d = test_util.fixture(
+      xml="""
       <mujoco>
         <worldbody>
           <body>
@@ -238,15 +239,9 @@ class SmoothTest(parameterized.TestCase):
           <key qpos=".2 .4 .6"/>
         </keyframe>
       </mujoco>
-    """
-    mjm = mujoco.MjModel.from_xml_string(_FIXED_TENDON)
-    mjm.opt.jacobian = mujoco.mjtJacobian.mjJAC_DENSE
-    mjd = mujoco.MjData(mjm)
-    mujoco.mj_resetDataKeyframe(mjm, mjd, 0)
-    mujoco.mj_forward(mjm, mjd)
-
-    m = mjwarp.put_model(mjm)
-    d = mjwarp.put_data(mjm, mjd)
+    """,
+      keyframe=0,
+    )
 
     for arr in (d.ten_length, d.ten_J):
       arr.zero_()

--- a/mujoco_warp/_src/support_test.py
+++ b/mujoco_warp/_src/support_test.py
@@ -74,7 +74,7 @@ class SupportTest(parameterized.TestCase):
 
   def test_make_put_data(self):
     """Tests that make_put_data and put_data are producing the same shapes for all warp arrays."""
-    mjm, mjd, m, d = test_util.fixture("pendula.xml")
+    mjm, _, _, d = test_util.fixture("pendula.xml")
     md = mjwarp.make_data(mjm)
 
     # same number of fields


### PR DESCRIPTION
Ensure all tests load fixtures the same way - this is helpful for code portability.

Also changed the parameterized tests in `collision_driver_test.py` to have fixture names for parameters instead of the fixture XMLs themselves.  This improves test output that otherwise prints large strings for test names.

Fixes #133 