### PR TITLE
connect equalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following features are implemented:
 | Geom              | `PLANE`, `SPHERE`, `CAPSULE`       |
 | Constraint        | `LIMIT_JOINT`, `CONTACT_PYRAMIDAL` |
 |                   | `CONTACT_ELLIPTIC`                 |
-| Equality          | `JOINT`                            |
+| Equality          | `CONNECT`, `JOINT`                 |
 | Integrator        | `EULER`, `IMPLICITFAST`, `RK4`     |
 | Cone              | `PYRAMIDAL`, `ELLIPTIC`            |
 | Condim            | (1, 3, 4, 6), (1, 3)               |

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -25,6 +25,7 @@ from .types import Model
 from .types import vec5
 from .warp_util import event_scope
 
+wp.set_module_options({"enable_backward": False})
 
 @wp.func
 def _geom_filter(m: Model, geom1: int, geom2: int, filterparent: bool) -> bool:

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -27,6 +27,7 @@ from .warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.func
 def _geom_filter(m: Model, geom1: int, geom2: int, filterparent: bool) -> bool:
   bodyid1 = m.geom_bodyid[geom1]

--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -25,6 +25,7 @@ from .types import Model
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.struct
 class Geom:
   pos: wp.vec3

--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -23,6 +23,7 @@ from .types import Data
 from .types import GeomType
 from .types import Model
 
+wp.set_module_options({"enable_backward": False})
 
 @wp.struct
 class Geom:

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -101,7 +101,7 @@ def _jac(
   cdof_ang = wp.spatial_top(cdof)
   cdof_lin = wp.spatial_bottom(cdof)
 
-  jacp = (cdof_lin + wp.cross(cdof_ang, offset))
+  jacp = cdof_lin + wp.cross(cdof_ang, offset)
   jacr = cdof_ang
 
   return jacp, jacr

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -79,11 +79,10 @@ def _jac(
   m: types.Model,
   d: types.Data,
   point: wp.vec3,
-  xyz: wp.int32,
   bodyid: wp.int32,
   dofid: wp.int32,
   worldid: wp.int32,
-) -> Tuple[wp.float32, wp.float32]:
+) -> Tuple[wp.vec3f, wp.vec3f]:
   dof_bodyid = m.dof_bodyid[dofid]
   in_tree = int(dof_bodyid == 0)
   parentid = bodyid
@@ -94,7 +93,7 @@ def _jac(
     parentid = m.body_parentid[parentid]
 
   if not in_tree:
-    return 0.0, 0.0
+    return wp.vec3f(0.0, 0.0, 0.0), wp.vec3f(0.0, 0.0, 0.0)
 
   offset = point - wp.vec3(d.subtree_com[worldid, m.body_rootid[bodyid]])
 
@@ -102,10 +101,76 @@ def _jac(
   cdof_ang = wp.spatial_top(cdof)
   cdof_lin = wp.spatial_bottom(cdof)
 
-  jacp_xyz = (cdof_lin + wp.cross(cdof_ang, offset))[xyz]
-  jacr_xyz = cdof_ang[xyz]
+  jacp = (cdof_lin + wp.cross(cdof_ang, offset))
+  jacr = cdof_ang
 
-  return jacp_xyz, jacr_xyz
+  return jacp, jacr
+
+
+@wp.kernel
+def _efc_equality_connect(
+  m: types.Model,
+  d: types.Data,
+  refsafe: bool,
+):
+  """Calculates constraint rows for connect equality constraints."""
+
+  worldid, i_eq_connect_adr = wp.tid()
+  i_eq = m.eq_connect_adr[i_eq_connect_adr]  # TODO
+  if not d.eq_active[worldid, i_eq]:  # TODO: not there.
+    return
+
+  efcid = wp.atomic_add(d.nefc, 0, 3)
+  wp.atomic_add(d.ne, 0, 3)
+  d.efc.worldid[efcid] = worldid
+
+  data = m.eq_data[i_eq]
+  anchor1 = wp.vec3f(data[0], data[1], data[2])
+  anchor2 = wp.vec3f(data[3], data[4], data[5])
+
+  if m.nsite and m.eq_objtype[i_eq] == wp.static(types.ObjType.SITE.value):
+    # body1id stores the index of site_bodyid.
+    body1id = m.site_bodyid[m.eq_obj1id[i_eq]]
+    body2id = m.site_bodyid[m.eq_obj2id[i_eq]]
+    pos1 = d.site_xpos[worldid, m.eq_obj1id[i_eq]]
+    pos2 = d.site_xpos[worldid, m.eq_obj2id[i_eq]]
+  else:
+    body1id = m.eq_obj1id[i_eq]
+    body2id = m.eq_obj2id[i_eq]
+    pos1 = d.xpos[worldid, body1id] + d.xmat[worldid, body1id] @ anchor1
+    pos2 = d.xpos[worldid, body2id] + d.xmat[worldid, body2id] @ anchor2
+
+  # error is difference in global positions
+  pos = pos1 - pos2
+
+  # compute Jacobian difference (opposite of contact: 0 - 1)
+  Jqvel = wp.vec3f(0.0, 0.0, 0.0)
+  for dofid in range(m.nv):  # TODO: parallelize
+    jacp1, _ = _jac(m, d, pos1, body1id, dofid, worldid)
+    jacp2, _ = _jac(m, d, pos2, body2id, dofid, worldid)
+    j1mj2 = jacp1 - jacp2
+    d.efc.J[efcid, dofid] = j1mj2[0]
+    d.efc.J[efcid + 1, dofid] = j1mj2[1]
+    d.efc.J[efcid + 2, dofid] = j1mj2[2]
+    Jqvel += j1mj2 * d.qvel[worldid, dofid]
+
+  invweight = m.body_invweight0[body1id, 0] + m.body_invweight0[body2id, 0]
+  pos_imp = wp.length(pos)
+
+  for i in range(3):
+    _update_efc_row(
+      m,
+      d,
+      efcid + i,
+      pos[i],
+      pos_imp,
+      invweight,
+      m.eq_solref[i_eq],
+      m.eq_solimp[i_eq],
+      wp.float32(0.0),
+      refsafe,
+      Jqvel[i],
+    )
 
 
 @wp.kernel
@@ -259,19 +324,17 @@ def _efc_contact_pyramidal(
     for i in range(m.nv):
       J = float(0.0)
       Ji = float(0.0)
+      jac1p, jac1r = _jac(m, d, con_pos, body1, i, worldid)
+      jac2p, jac2r = _jac(m, d, con_pos, body2, i, worldid)
+      jacp_dif = jac2p - jac1p
       for xyz in range(3):
-        jac1p, jac1r = _jac(m, d, con_pos, xyz, body1, i, worldid)
-        jac2p, jac2r = _jac(m, d, con_pos, xyz, body2, i, worldid)
-        jacp_dif = jac2p - jac1p
-
-        J += frame[0, xyz] * jacp_dif
+        J += frame[0, xyz] * jacp_dif[xyz]
 
         if condim > 1:
           if dimid2 < 3:
-            Ji += frame[dimid2, xyz] * jacp_dif
+            Ji += frame[dimid2, xyz] * jacp_dif[xyz]
           else:
-            jacr_dif = jac2r - jac1r
-            Ji += frame[dimid2 - 3, xyz] * jacr_dif
+            Ji += frame[dimid2 - 3, xyz] * (jac2r[xyz] - jac1r[xyz])
 
       if condim > 1:
         if dimid % 2 == 0:
@@ -345,11 +408,11 @@ def _efc_contact_elliptic(
     Jqvel = float(0.0)
     for i in range(m.nv):
       J = float(0.0)
+      jac1p, _ = _jac(m, d, cpos, body1, i, worldid)
+      jac2p, _ = _jac(m, d, cpos, body2, i, worldid)
+      jac_dif = jac2p - jac1p
       for xyz in range(3):
-        jac1p, _ = _jac(m, d, cpos, xyz, body1, i, worldid)
-        jac2p, _ = _jac(m, d, cpos, xyz, body2, i, worldid)
-        jac_dif = jac2p - jac1p
-        J += frame[dimid, xyz] * jac_dif
+        J += frame[dimid, xyz] * jac_dif[xyz]
 
       d.efc.J[efcid, i] = J
       Jqvel += J * d.qvel[worldid, i]
@@ -406,6 +469,11 @@ def make_constraint(m: types.Model, d: types.Data):
     refsafe = not m.opt.disableflags & types.DisableBit.REFSAFE.value
 
     if not (m.opt.disableflags & types.DisableBit.EQUALITY.value):
+      wp.launch(
+        _efc_equality_connect,
+        dim=(d.nworld, m.eq_connect_adr.size),
+        inputs=[m, d, refsafe],
+      )
       wp.launch(
         _efc_equality_joint,
         dim=(d.nworld, m.eq_jnt_adr.size),

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -149,11 +149,10 @@ def _efc_equality_connect(
     jacp1, _ = _jac(m, d, pos1, body1id, dofid, worldid)
     jacp2, _ = _jac(m, d, pos2, body2id, dofid, worldid)
     j1mj2 = jacp1 - jacp2
-    if j1mj2[0] + j1mj2[1] + j1mj2[2] != 0.0:
-      d.efc.J[efcid, dofid] = j1mj2[0]
-      d.efc.J[efcid + 1, dofid] = j1mj2[1]
-      d.efc.J[efcid + 2, dofid] = j1mj2[2]
-      Jqvel += j1mj2 * d.qvel[worldid, dofid]
+    d.efc.J[efcid, dofid] = j1mj2[0]
+    d.efc.J[efcid + 1, dofid] = j1mj2[1]
+    d.efc.J[efcid + 2, dofid] = j1mj2[2]
+    Jqvel += j1mj2 * d.qvel[worldid, dofid]
 
   invweight = m.body_invweight0[body1id, 0] + m.body_invweight0[body2id, 0]
   pos_imp = wp.length(pos)

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -116,8 +116,8 @@ def _efc_equality_connect(
   """Calculates constraint rows for connect equality constraints."""
 
   worldid, i_eq_connect_adr = wp.tid()
-  i_eq = m.eq_connect_adr[i_eq_connect_adr]  # TODO
-  if not d.eq_active[worldid, i_eq]:  # TODO: not there.
+  i_eq = m.eq_connect_adr[i_eq_connect_adr]
+  if not d.eq_active[worldid, i_eq]:
     return
 
   efcid = wp.atomic_add(d.nefc, 0, 3)

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -149,10 +149,11 @@ def _efc_equality_connect(
     jacp1, _ = _jac(m, d, pos1, body1id, dofid, worldid)
     jacp2, _ = _jac(m, d, pos2, body2id, dofid, worldid)
     j1mj2 = jacp1 - jacp2
-    d.efc.J[efcid, dofid] = j1mj2[0]
-    d.efc.J[efcid + 1, dofid] = j1mj2[1]
-    d.efc.J[efcid + 2, dofid] = j1mj2[2]
-    Jqvel += j1mj2 * d.qvel[worldid, dofid]
+    if j1mj2[0] + j1mj2[1] + j1mj2[2] != 0.0:
+      d.efc.J[efcid, dofid] = j1mj2[0]
+      d.efc.J[efcid + 1, dofid] = j1mj2[1]
+      d.efc.J[efcid + 2, dofid] = j1mj2[2]
+      Jqvel += j1mj2 * d.qvel[worldid, dofid]
 
   invweight = m.body_invweight0[body1id, 0] + m.body_invweight0[body2id, 0]
   pos_imp = wp.length(pos)

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -40,6 +40,8 @@ from .warp_util import event_scope
 from .warp_util import kernel
 from .warp_util import kernel_copy
 
+wp.set_module_options({"enable_backward": False})
+
 # RK4 tableau
 _RK4_A = [
   [0.5, 0.0, 0.0],

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -384,7 +384,6 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.cam_quat = wp.array(mjm.cam_quat, dtype=wp.quat, ndim=1)
   m.cam_poscom0 = wp.array(mjm.cam_poscom0, dtype=wp.vec3, ndim=1)
   m.cam_pos0 = wp.array(mjm.cam_pos0, dtype=wp.vec3, ndim=1)
-  m.cam_mat0 = wp.array(mjm.cam_mat0.reshape(-1, 3, 3), dtype=wp.mat33, ndim=1)
   m.light_mode = wp.array(mjm.light_mode, dtype=wp.int32, ndim=1)
   m.light_bodyid = wp.array(mjm.light_bodyid, dtype=wp.int32, ndim=1)
   m.light_targetbodyid = wp.array(mjm.light_targetbodyid, dtype=wp.int32, ndim=1)
@@ -392,7 +391,6 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.light_dir = wp.array(mjm.light_dir, dtype=wp.vec3, ndim=1)
   m.light_poscom0 = wp.array(mjm.light_poscom0, dtype=wp.vec3, ndim=1)
   m.light_pos0 = wp.array(mjm.light_pos0, dtype=wp.vec3, ndim=1)
-  m.light_dir0 = wp.array(mjm.light_dir0, dtype=wp.vec3, ndim=1)
   m.dof_bodyid = wp.array(mjm.dof_bodyid, dtype=wp.int32, ndim=1)
   m.dof_jntid = wp.array(mjm.dof_jntid, dtype=wp.int32, ndim=1)
   m.dof_parentid = wp.array(mjm.dof_parentid, dtype=wp.int32, ndim=1)
@@ -423,6 +421,9 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   # pre-compute indices of joint equalities
   m.eq_jnt_adr = wp.array(
     np.nonzero(mjm.eq_type == types.EqType.JOINT.value)[0], dtype=wp.int32, ndim=1
+  )
+  m.eq_connect_adr = wp.array(
+    np.nonzero(mjm.eq_type == types.EqType.CONNECT.value)[0], dtype=wp.int32, ndim=1
   )
 
   # short-circuiting here allows us to skip a lot of code in implicit integration

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -28,6 +28,7 @@ from .warp_util import kernel
 
 wp.set_module_options({"enable_backward": False})
 
+
 def is_sparse(m: mujoco.MjModel):
   if m.opt.jacobian == mujoco.mjtJacobian.mjJAC_AUTO:
     return m.nv >= 60

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -26,6 +26,7 @@ from .types import vec5
 from .warp_util import event_scope
 from .warp_util import kernel
 
+wp.set_module_options({"enable_backward": False})
 
 def is_sparse(m: mujoco.MjModel):
   if m.opt.jacobian == mujoco.mjtJacobian.mjJAC_AUTO:

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -279,15 +279,37 @@ class ObjType(enum.IntEnum):
   # unsupported: CAMERA
 
 
+class ObjType(enum.IntEnum):
+  """Type of object.
+
+  Members:
+    UNKNOWN: unknown object type
+    BODY: body
+    XBODY: body, used to access regular frame instead of i-frame
+    GEOM: geom
+    SITE: site
+    CAMERA: camera
+  """
+
+  UNKNOWN = mujoco.mjtObj.mjOBJ_UNKNOWN
+  BODY = mujoco.mjtObj.mjOBJ_BODY
+  XBODY = mujoco.mjtObj.mjOBJ_XBODY
+  GEOM = mujoco.mjtObj.mjOBJ_GEOM
+  SITE = mujoco.mjtObj.mjOBJ_SITE
+  CAMERA = mujoco.mjtObj.mjOBJ_CAMERA
+
+
 class EqType(enum.IntEnum):
   """Type of equality constraint.
 
   Members:
+    CONNECT: connect two bodies at a point (ball joint)
     JOINT: couple the values of two scalar joints with cubic
   """
 
+  CONNECT = mujoco.mjtEq.mjEQ_CONNECT
   JOINT = mujoco.mjtEq.mjEQ_JOINT
-  # unsupported: CONNECT, WELD, TENDON, FLEX, DISTANCE
+  # unsupported: WELD, TENDON, FLEX, DISTANCE
 
 
 class WrapType(enum.IntEnum):
@@ -598,7 +620,6 @@ class Model:
     cam_quat: orientation rel. to body frame                 (ncam, 4)
     cam_poscom0: global position rel. to sub-com in qpos0    (ncam, 3)
     cam_pos0: Cartesian camera position                      (nworld, ncam, 3)
-    cam_mat0: Cartesian camera orientation                   (nworld, ncam, 3, 3)
     light_mode: light tracking mode (mjtCamLight)            (nlight,)
     light_bodyid: id of light's body                         (nlight,)
     light_targetbodyid: id of targeted body; -1: none        (nlight,)
@@ -606,7 +627,6 @@ class Model:
     light_dir: direction rel. to body frame                  (nlight, 3)
     light_poscom0: global position rel. to sub-com in qpos0  (nlight, 3)
     light_pos0: global position rel. to body in qpos0        (nworld, nlight, 3)
-    light_dir0: global direction in qpos0                    (nworld, nlight, 3)
     mesh_vertadr: first vertex address                       (nmesh,)
     mesh_vertnum: number of vertices                         (nmesh,)
     mesh_vert: vertex positions for all meshes               (nmeshvert, 3)
@@ -618,7 +638,8 @@ class Model:
     eq_solref: constraint solver reference                   (neq, mjNREF)
     eq_solimp: constraint solver impedance                   (neq, mjNIMP)
     eq_data: numeric data for constraint                     (neq, mjNEQDATA)
-    eq_jnt_adr: which addresses of eq_* are type `JOINT`
+    eq_jnt_adr: eq_* addresses of type `JOINT`
+    eq_connect_adr: eq_* addresses of type `CONNECT`
     actuator_trntype: transmission type (mjtTrn)             (nu,)
     actuator_dyntype: dynamics type (mjtDyn)                 (nu,)
     actuator_gaintype: gain type (mjtGain)                   (nu,)
@@ -776,7 +797,6 @@ class Model:
   cam_quat: wp.array(dtype=wp.quat, ndim=1)
   cam_poscom0: wp.array(dtype=wp.vec3, ndim=1)
   cam_pos0: wp.array(dtype=wp.vec3, ndim=1)
-  cam_mat0: wp.array(dtype=wp.mat33, ndim=1)
   light_mode: wp.array(dtype=wp.int32, ndim=1)
   light_bodyid: wp.array(dtype=wp.int32, ndim=1)
   light_targetbodyid: wp.array(dtype=wp.int32, ndim=1)
@@ -784,7 +804,6 @@ class Model:
   light_dir: wp.array(dtype=wp.vec3, ndim=1)
   light_poscom0: wp.array(dtype=wp.vec3, ndim=1)
   light_pos0: wp.array(dtype=wp.vec3, ndim=1)
-  light_dir0: wp.array(dtype=wp.vec3, ndim=1)
   mesh_vertadr: wp.array(dtype=wp.int32, ndim=1)
   mesh_vertnum: wp.array(dtype=wp.int32, ndim=1)
   mesh_vert: wp.array(dtype=wp.vec3, ndim=1)
@@ -797,6 +816,7 @@ class Model:
   eq_solimp: wp.array(dtype=vec5, ndim=1)
   eq_data: wp.array(dtype=vec11, ndim=1)
   eq_jnt_adr: wp.array(dtype=wp.int32, ndim=1)
+  eq_connect_adr: wp.array(dtype=wp.int32, ndim=1)
   actuator_trntype: wp.array(dtype=wp.int32, ndim=1)
   actuator_dyntype: wp.array(dtype=wp.int32, ndim=1)
   actuator_gaintype: wp.array(dtype=wp.int32, ndim=1)

--- a/mujoco_warp/test_data/constraints.xml
+++ b/mujoco_warp/test_data/constraints.xml
@@ -78,6 +78,8 @@
   </worldbody>
 
   <equality>
+    <connect name="c_site"   site1="site0"      site2="site1"/>
+    <connect name="connect"  body1="anchor1"    body2="beam1"   anchor="1 0 -1" />
     <joint   name="joint"    joint1="joint3"    joint2="joint4" polycoef="0.5 -1 0.1 0.15 0.2" />
   </equality>
 

--- a/mujoco_warp/test_data/humanoid/humanoid.xml
+++ b/mujoco_warp/test_data/humanoid/humanoid.xml
@@ -196,10 +196,6 @@
       <joint joint="knee_left" coef="-.5"/>
     </fixed>
   </tendon> -->
-  <equality>
-    <connect name="joint1" body1="hand_right" body2="hand_left" anchor="0 0 0"/>
-    <connect name="joint2" body1="foot_right" body2="foot_left" anchor="0 0 0"/>
-  </equality>
 
   <actuator>
     <motor name="abdomen_y"       gear="40"  joint="abdomen_y"/>

--- a/mujoco_warp/test_data/humanoid/humanoid.xml
+++ b/mujoco_warp/test_data/humanoid/humanoid.xml
@@ -196,6 +196,10 @@
       <joint joint="knee_left" coef="-.5"/>
     </fixed>
   </tendon> -->
+  <equality>
+    <connect name="joint1" body1="hand_right" body2="hand_left" anchor="0 0 0"/>
+    <connect name="joint2" body1="foot_right" body2="foot_left" anchor="0 0 0"/>
+  </equality>
 
   <actuator>
     <motor name="abdomen_y"       gear="40"  joint="abdomen_y"/>


### PR DESCRIPTION
~~**WIP**. Passes all tests, but I'm still working on making it faster.~~

#### Before; no connect equalities
(added `wp.set_module_options({"enable_backward": False})` to collision_driver.py, forward.py, collision_primitive.py, support.py so that testspeed runs)
```
mjwarp-testspeed --function=step --mjcf=test_data/humanoid/humanoid.xml --batch_size=8192 --event_trace=True

Summary for 8192 parallel rollouts

 Total JIT time: 5.36 s
 Total simulation time: 9.79 s
 Total steps per second: 836,892
 Total realtime factor: 4,184.46 x
 Total time per step: 1194.90 ns

Event trace:

step: 1193.22
  forward: 1189.60
    fwd_position: 206.42
      kinematics: 46.02
      com_pos: 14.79
      camlight: 3.36
      crb: 44.21
      factor_m: 28.98
      collision: 24.50
      make_constraint: 35.97
      transmission: 7.36
    sensor_pos: 0.14
    fwd_velocity: 53.21
      com_vel: 19.66
      passive: 1.76
      rne: 19.70
    sensor_vel: 0.13
    fwd_actuation: 14.99
    fwd_acceleration: 27.49
      xfrc_accumulate: 9.02
      solve_m: 16.56
    sensor_acc: 0.14
    solve: 885.80
      mul_m: 15.50
      _linesearch: [ 74.45, 43.45, 30.16, 27.18, 25.79, 25.14, 24.74, 24.44, 24.22, 24.14 ]
        mul_m: [ 15.75, 3.36, 1.86, 1.66, 1.64, 1.64, 1.65, 1.65, 1.65, 1.65 ]
  euler: 3.22
```
#### After; no connect equalities
```
mjwarp-testspeed --function=step --
mjcf=test_data/humanoid/humanoid.xml --batch_size=8192 --event_trace=True

Summary for 8192 parallel rollouts

 Total JIT time: 5.70 s
 Total simulation time: 9.74 s
 Total steps per second: 841,284
 Total realtime factor: 4,206.42 x
 Total time per step: 1188.66 ns

Event trace:

step: 1187.00
  forward: 1183.38
    fwd_position: 199.34
      kinematics: 46.21
      com_pos: 14.82
      camlight: 3.32
      crb: 44.26
      factor_m: 29.01
      collision: 24.52
      make_constraint: 28.63
      transmission: 7.35
    sensor_pos: 0.13
    fwd_velocity: 53.31
      com_vel: 19.70
      passive: 1.76
      rne: 19.71
    sensor_vel: 0.14
    fwd_actuation: 15.02
    fwd_acceleration: 27.54
      xfrc_accumulate: 9.05
      solve_m: 16.57
    sensor_acc: 0.14
    solve: 886.48
      mul_m: 15.49
      _linesearch: [ 74.39, 43.43, 30.14, 27.19, 25.74, 25.11, 24.74, 24.43, 24.23, 24.14 ]
        mul_m: [ 15.72, 3.33, 1.83, 1.63, 1.60, 1.61, 1.61, 1.61, 1.60, 1.61 ]
  euler: 3.22
```

#### After, with connect equalities
Add to humanoid.xml:
```xml
  <equality>
    <connect name="joint1" body1="hand_right" body2="hand_left" anchor="0 0 0"/>
    <connect name="joint2" body1="foot_right" body2="foot_left" anchor="0 0 0"/>
  </equality>
```

```
mjwarp-testspeed --function=step --
mjcf=test_data/humanoid/humanoid.xml --batch_size=8192 --event_trace=True

Summary for 8192 parallel rollouts

 Total JIT time: 2.71 s
 Total simulation time: 16.18 s
 Total steps per second: 506,404
 Total realtime factor: 2,532.02 x
 Total time per step: 1974.71 ns

Event trace:

step: 1973.03
  forward: 1969.35
    fwd_position: 218.87
      kinematics: 46.76
      com_pos: 14.88
      camlight: 3.34
      crb: 44.20
      factor_m: 29.00
      collision: 24.50
      make_constraint: 46.88
      transmission: 8.08
    sensor_pos: 0.14
    fwd_velocity: 53.04
      com_vel: 19.50
      passive: 1.74
      rne: 19.69
    sensor_vel: 0.14
    fwd_actuation: 14.95
    fwd_acceleration: 28.06
      xfrc_accumulate: 9.22
      solve_m: 16.87
    sensor_acc: 0.14
    solve: 1652.73
      mul_m: 15.53
      _linesearch: [ 95.88, 84.73, 68.61, 54.28, 45.96, 42.42, 40.87, 40.00, 39.41, 39.06 ]
        mul_m: [ 17.50, 14.70, 7.71, 4.36, 3.37, 3.10, 2.99, 2.96, 2.94, 2.92 ]
  euler: 3.28
```