### PR TITLE
update contact constraints

### DIFF
--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -224,7 +224,7 @@ def _efc_contact_pyramidal(
 
   if condim == 1 and dimid > 0:
     return
-  elif dimid >= 2 * (condim - 1):
+  elif condim > 1 and dimid >= 2 * (condim - 1):
     return
 
   includemargin = d.contact.includemargin[conid]
@@ -310,18 +310,7 @@ def _efc_contact_elliptic(
 
   condim = d.contact.dim[conid]
 
-  if condim == 1 and dimid > 0:
-    return
-
-  if condim == 3 and dimid > 2:
-    return
-
-  # TODO(team): condim=4
-  if condim == 4:
-    return
-
-  # TODO(team): condim=6
-  if condim == 6:
+  if dimid > condim - 1:
     return
 
   includemargin = d.contact.includemargin[conid]
@@ -346,10 +335,15 @@ def _efc_contact_elliptic(
     for i in range(m.nv):
       J = float(0.0)
       for xyz in range(3):
-        jac1p, _ = _jac(m, d, cpos, xyz, body1, i, worldid)
-        jac2p, _ = _jac(m, d, cpos, xyz, body2, i, worldid)
-        jac_dif = jac2p - jac1p
-        J += frame[dimid, xyz] * jac_dif
+        jac1p, jac1r = _jac(m, d, cpos, xyz, body1, i, worldid)
+        jac2p, jac2r = _jac(m, d, cpos, xyz, body2, i, worldid)
+
+        if dimid < 3:
+          jac_dif = jac2p - jac1p
+          J += frame[dimid, xyz] * jac_dif
+        else:
+          jac_dif = jac2r - jac1r
+          J += frame[dimid - 3, xyz] * jac_dif
 
       d.efc.J[efcid, i] = J
       Jqvel += J * d.qvel[worldid, i]
@@ -426,11 +420,10 @@ def make_constraint(m: types.Model, d: types.Data):
       if m.opt.cone == types.ConeType.PYRAMIDAL.value:
         wp.launch(
           _efc_contact_pyramidal,
-          dim=(d.nconmax, 2 * (m.condim_max - 1)),
+          dim=(d.nconmax, 2 * (m.condim_max - 1) if m.condim_max > 1 else 1),
           inputs=[m, d, refsafe],
         )
       elif m.opt.cone == types.ConeType.ELLIPTIC.value:
-        wp.launch(_efc_contact_elliptic, dim=(d.nconmax, 3), inputs=[m, d, refsafe])
-
-        # TODO(team): condim=4
-        # TODO(team): condim=6
+        wp.launch(
+          _efc_contact_elliptic, dim=(d.nconmax, m.condim_max), inputs=[m, d, refsafe]
+        )

--- a/mujoco_warp/_src/constraint_test.py
+++ b/mujoco_warp/_src/constraint_test.py
@@ -22,6 +22,7 @@ from absl.testing import parameterized
 
 import mujoco_warp as mjwarp
 
+from .types import ConeType
 from . import test_util
 
 # tolerance for difference between MuJoCo and MJWarp constraint calculations,
@@ -36,66 +37,53 @@ def _assert_eq(a, b, name):
 
 
 class ConstraintTest(parameterized.TestCase):
-  def test_condim(self):
+  @parameterized.parameters(
+    (ConeType.PYRAMIDAL, 1, 1),
+    (ConeType.PYRAMIDAL, 1, 3),
+    (ConeType.PYRAMIDAL, 1, 4),
+    (ConeType.PYRAMIDAL, 1, 6),
+    (ConeType.PYRAMIDAL, 3, 3),
+    (ConeType.PYRAMIDAL, 3, 4),
+    (ConeType.PYRAMIDAL, 3, 6),
+    (ConeType.PYRAMIDAL, 4, 4),
+    (ConeType.PYRAMIDAL, 4, 6),
+    (ConeType.PYRAMIDAL, 6, 6),
+    (ConeType.ELLIPTIC, 1, 1),
+    (ConeType.ELLIPTIC, 1, 3),
+    (ConeType.ELLIPTIC, 1, 4),
+    (ConeType.ELLIPTIC, 1, 6),
+    (ConeType.ELLIPTIC, 3, 3),
+    (ConeType.ELLIPTIC, 3, 4),
+    (ConeType.ELLIPTIC, 3, 6),
+    (ConeType.ELLIPTIC, 4, 4),
+    (ConeType.ELLIPTIC, 4, 6),
+    (ConeType.ELLIPTIC, 6, 6),
+  )
+  def test_condim(self, cone, condim1, condim2):
     """Test condim."""
-    xml = """
+    xml = f"""
       <mujoco>
         <worldbody>
-          <body pos="0 0 0">
-            <joint type="slide"/>
-            <geom type="sphere" size=".1" condim="1"/>
+          <body pos="0.0 0 0">
+            <freejoint/>
+            <geom type="sphere" size=".1" condim="{condim1}"/>
           </body>
-          <body pos="1 0 0">
-            <joint type="slide"/>
-            <geom type="sphere" size=".1" condim="1"/>
-          </body>
-          <body pos="2 0 0">
-            <joint type="slide"/>
-            <geom type="sphere" size=".1" condim="3"/>
-          </body>
-          <body pos="3 0 0">
-            <joint type="slide"/>
-            <geom type="sphere" size=".1" condim="3"/>
-          </body>
-          <body pos="4 0 0">
-            <joint type="slide"/>
-            <geom type="sphere" size=".1" condim="4"/>
-          </body>
-          <body pos="5 0 0">
-            <joint type="slide"/>
-            <geom type="sphere" size=".1" condim="4"/>
-          </body>
-          <body pos="6 0 0">
-            <joint type="slide"/>
-            <geom type="sphere" size=".1" condim="6"/>
-          </body>
-          <body pos="7 0 0">
-            <joint type="slide"/>
-            <geom type="sphere" size=".1" condim="6"/>
+          <body pos="0.05 0 0">
+            <freejoint/>
+            <geom type="sphere" size=".1" condim="{condim2}"/>
           </body>
         </worldbody>
-        <keyframe>
-          <key qpos='0 0 0 0 0 0 0 0'/>
-          <key qpos='0 .01 .02 .03 .04 .05 .06 .07'/>
-          <key qpos='0 0 1 2 3 4 5 6'/>
-          <key qpos='1 2 0 0 3 4 5 6'/>
-          <key qpos='1 2 3 4 0 0 5 6'/>
-          <key qpos='1 2 3 4 5 6 0 0'/>
-        </keyframe>
       </mujoco>
     """
 
-    # TODO(team): test elliptic friction cone
+    _, mjd, m, d = test_util.fixture(xml=xml, cone=cone)
+    mjwarp.make_constraint(m, d)
 
-    for keyframe in range(6):
-      _, mjd, m, d = test_util.fixture(xml=xml, keyframe=keyframe)
-      mjwarp.make_constraint(m, d)
-
-      _assert_eq(d.efc.J.numpy()[: mjd.nefc, :].reshape(-1), mjd.efc_J, "efc_J")
-      _assert_eq(d.efc.D.numpy()[: mjd.nefc], mjd.efc_D, "efc_D")
-      _assert_eq(d.efc.aref.numpy()[: mjd.nefc], mjd.efc_aref, "efc_aref")
-      _assert_eq(d.efc.pos.numpy()[: mjd.nefc], mjd.efc_pos, "efc_pos")
-      _assert_eq(d.efc.margin.numpy()[: mjd.nefc], mjd.efc_margin, "efc_margin")
+    _assert_eq(d.efc.J.numpy()[: mjd.nefc, :].reshape(-1), mjd.efc_J, "efc_J")
+    _assert_eq(d.efc.D.numpy()[: mjd.nefc], mjd.efc_D, "efc_D")
+    _assert_eq(d.efc.aref.numpy()[: mjd.nefc], mjd.efc_aref, "efc_aref")
+    _assert_eq(d.efc.pos.numpy()[: mjd.nefc], mjd.efc_pos, "efc_pos")
+    _assert_eq(d.efc.margin.numpy()[: mjd.nefc], mjd.efc_margin, "efc_margin")
 
   @parameterized.parameters(
     mujoco.mjtCone.mjCONE_PYRAMIDAL,


### PR DESCRIPTION
- update `_efc_contact_elliptic` kernel to add `condim`=4 and `condim`=6 support for elliptic friction cones
- fix launch for `_efc_contact_pyramidal` kernel when `condim_max`=1
- fix `_efc_contact_pyramidal` return logic
- update `constraint_test.test_condim` to test `cone` and `condim` combinations