### PR TITLE
[WIP] API changes to address multiple issues.

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -31,8 +31,11 @@ from ._src.forward import rungekutta4 as rungekutta4
 from ._src.forward import step as step
 from ._src.io import get_data_into as get_data_into
 from ._src.io import make_data as make_data
+from ._src.io import make_data_new as make_data_new
 from ._src.io import put_data as put_data
+from ._src.io import put_data_new as put_data_new
 from ._src.io import put_model as put_model
+from ._src.io import put_model_new as put_model_new
 from ._src.passive import passive as passive
 from ._src.sensor import sensor_acc as sensor_acc
 from ._src.sensor import sensor_pos as sensor_pos
@@ -43,6 +46,7 @@ from ._src.smooth import com_vel as com_vel
 from ._src.smooth import crb as crb
 from ._src.smooth import factor_m as factor_m
 from ._src.smooth import kinematics as kinematics
+from ._src.smooth import kinematics_new as kinematics_new
 from ._src.smooth import rne as rne
 from ._src.smooth import rne_postconstraint as rne_postconstraint
 from ._src.smooth import solve_m as solve_m

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -60,6 +60,30 @@ class SmoothTest(parameterized.TestCase):
     _assert_eq(d.site_xpos.numpy()[0], mjd.site_xpos, "site_xpos")
     _assert_eq(d.site_xmat.numpy()[0], mjd.site_xmat.reshape((-1, 3, 3)), "site_xmat")
 
+  def test_new_kinematics(self):
+    """Tests kinematics."""
+    mjm, mjd, _, _ = test_util.fixture("pendula.xml")
+
+    m = mjwarp.put_model_new(mjm)
+    d = mjwarp.put_data_new(mjm, mjd)
+
+    for arr in (d.xanchor, d.xaxis, d.xquat, d.xpos):
+      arr.zero_()
+
+    mjwarp.kinematics_new(m, d)
+
+    _assert_eq(d.xanchor.numpy()[0], mjd.xanchor, "xanchor")
+    _assert_eq(d.xaxis.numpy()[0], mjd.xaxis, "xaxis")
+    _assert_eq(d.xpos.numpy()[0], mjd.xpos, "xpos")
+    _assert_eq(d.xquat.numpy()[0], mjd.xquat, "xquat")
+    _assert_eq(d.xmat.numpy()[0], mjd.xmat.reshape((-1, 3, 3)), "xmat")
+    _assert_eq(d.xipos.numpy()[0], mjd.xipos, "xipos")
+    _assert_eq(d.ximat.numpy()[0], mjd.ximat.reshape((-1, 3, 3)), "ximat")
+    _assert_eq(d.geom_xpos.numpy()[0], mjd.geom_xpos, "geom_xpos")
+    _assert_eq(d.geom_xmat.numpy()[0], mjd.geom_xmat.reshape((-1, 3, 3)), "geom_xmat")
+    _assert_eq(d.site_xpos.numpy()[0], mjd.site_xpos, "site_xpos")
+    _assert_eq(d.site_xmat.numpy()[0], mjd.site_xmat.reshape((-1, 3, 3)), "site_xmat")
+
   def test_com_pos(self):
     """Tests com_pos."""
     _, mjd, m, d = test_util.fixture("pendula.xml")

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1132,6 +1132,7 @@ class Data:
   # sensors
   sensordata: wp.array(dtype=wp.float32, ndim=2)
 
+
 @dataclasses.dataclass
 class NewData:
   """Dynamic state that updates each step.
@@ -1151,6 +1152,7 @@ class NewData:
     site_xpos: Cartesian site position                          (nworld, nsite, 3)
     site_xmat: Cartesian site orientation                       (nworld, nsite, 3, 3)
   """
+
   nworld: int
 
   qpos: wp.array2d(dtype=float)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import dataclasses
 import enum
 
 import mujoco
@@ -837,6 +838,70 @@ class Model:
   sensor_acc_adr: wp.array(dtype=wp.int32, ndim=1)  # warp only
 
 
+@dataclasses.dataclass
+class NewModel:
+  """Model definition and parameters.
+
+  Attributes:
+    nq: number of generalized coordinates = dim              ()
+    nv: number of degrees of freedom = dim                   ()
+    nbody: number of bodies                                  ()
+    njnt: number of joints                                   ()
+    ngeom: number of geoms                                   ()
+    nsite: number of sites                                   ()
+    qpos0: qpos values at default pose                       (nq,)
+
+    tree_bodyids: bodyids grouped by tree level
+    body_parentid: id of body's parent                       (nbody,)
+    body_rootid: id of root above body                       (nbody,)
+    body_jntnum: number of joints for this body              (nbody,)
+    body_jntadr: start addr of joints; -1: no joints         (nbody,)
+    body_pos: position offset rel. to parent body            (nbody, 3)
+    body_quat: orientation offset rel. to parent body        (nbody, 4)
+    body_ipos: local position of center of mass              (nbody, 3)
+    body_iquat: local orientation of inertia ellipsoid       (nbody, 4)
+    jnt_type: type of joint (mjtJoint)                       (njnt,)
+    jnt_qposadr: start addr in 'qpos' for joint's data       (njnt,)
+    jnt_bodyid: id of joint's body                           (njnt,)
+    jnt_pos: local anchor position                           (njnt, 3)
+    jnt_axis: local joint axis                               (njnt, 3)
+    geom_bodyid: id of geom's body                           (ngeom,)
+    geom_pos: local position offset rel. to body             (ngeom, 3)
+    geom_quat: local orientation offset rel. to body         (ngeom, 4)
+    site_bodyid: id of site's body                           (nsite,)
+    site_pos: local position offset rel. to body             (nsite, 3)
+    site_quat: local orientation offset rel. to body         (nsite, 4)
+  """
+
+  nq: int
+  nv: int
+  nbody: int
+  njnt: int
+  ngeom: int
+  nsite: int
+  qpos0: wp.array(dtype=float)
+
+  tree_bodyids: tuple[wp.array(dtype=int), ...]
+  body_parentid: wp.array(dtype=int)
+  body_jntnum: wp.array(dtype=int)
+  body_jntadr: wp.array(dtype=int)
+  body_pos: wp.array(dtype=wp.vec3)
+  body_quat: wp.array(dtype=wp.quat)
+  body_ipos: wp.array(dtype=wp.vec3)
+  body_iquat: wp.array(dtype=wp.quat)
+  jnt_type: wp.array(dtype=int)
+  jnt_qposadr: wp.array(dtype=int)
+  jnt_bodyid: wp.array(dtype=int)
+  jnt_pos: wp.array(dtype=wp.vec3)
+  jnt_axis: wp.array(dtype=wp.vec3)
+  geom_bodyid: wp.array(dtype=int)
+  geom_pos: wp.array(dtype=wp.vec3)
+  geom_quat: wp.array(dtype=wp.quat)
+  site_bodyid: wp.array(dtype=int)
+  site_pos: wp.array(dtype=wp.vec3)
+  site_quat: wp.array(dtype=wp.quat)
+
+
 @wp.struct
 class Contact:
   """Contact data.
@@ -1066,3 +1131,37 @@ class Data:
 
   # sensors
   sensordata: wp.array(dtype=wp.float32, ndim=2)
+
+@dataclasses.dataclass
+class NewData:
+  """Dynamic state that updates each step.
+
+  Attributes:
+    nworld: number of worlds                                    ()
+    qpos: position                                              (nworld, nq)
+    xpos: Cartesian position of body frame                      (nworld, nbody, 3)
+    xquat: Cartesian orientation of body frame                  (nworld, nbody, 4)
+    xmat: Cartesian orientation of body frame                   (nworld, nbody, 3, 3)
+    xipos: Cartesian position of body com                       (nworld, nbody, 3)
+    ximat: Cartesian orientation of body inertia                (nworld, nbody, 3, 3)
+    xanchor: Cartesian position of joint anchor                 (nworld, njnt, 3)
+    xaxis: Cartesian joint axis                                 (nworld, njnt, 3)
+    geom_xpos: Cartesian geom position                          (nworld, ngeom, 3)
+    geom_xmat: Cartesian geom orientation                       (nworld, ngeom, 3, 3)
+    site_xpos: Cartesian site position                          (nworld, nsite, 3)
+    site_xmat: Cartesian site orientation                       (nworld, nsite, 3, 3)
+  """
+  nworld: int
+
+  qpos: wp.array2d(dtype=float)
+  xpos: wp.array2d(dtype=wp.vec3)
+  xquat: wp.array2d(dtype=wp.quat)
+  xmat: wp.array2d(dtype=wp.mat33)
+  xipos: wp.array2d(dtype=wp.vec3)
+  ximat: wp.array2d(dtype=wp.mat33)
+  xanchor: wp.array2d(dtype=wp.vec3)
+  xaxis: wp.array2d(dtype=wp.vec3)
+  geom_xpos: wp.array2d(dtype=wp.vec3)
+  geom_xmat: wp.array2d(dtype=wp.mat33)
+  site_xpos: wp.array2d(dtype=wp.vec3)
+  site_xmat: wp.array2d(dtype=wp.mat33)


### PR DESCRIPTION
Here are some proposed API changes, right now only applied to `kinematics` as a preview - once we work out the kinks we'll roll this out to the rest of the codebase.

Summary of changes:

* Moving kernel functions to the module level as my understanding is this is better for the warp cache (is this still the case?)
* Give kernel functions explicit in/out params, even if the params are duplicated (e.g. `xpos_in`, `xpos_out`).  This is helpful for:
  * Moving towards making MJWarp differentiable
  * Easier integration into JAX that wants control of providing separate in/out arrays.
* Changing `Model` and `Data` from `wp.struct` to `dataclasses.dataclass`
  * Should address the kernel parameter size issue we're hitting (4kb for older CUDA versions, 32kb for CUDA 12.8)
  * One ergonomic improvement is we can simplify tree-nested arrays, e.g. the tree bodyids is now a simple tuple field and easier to process.

The downside of this change is that the kernel signatures are much more verbose, and explicitly writing out the kernel parameters is slow and could be a vector for bugs.  I wonder if we should consider helper classes or some kind of code automation to make it easier to write bug-free kernels.

Would love any and all thoughts on these changes, very experimental still and I want everyone to be on board before we apply this change to the rest of the repo.