### PR TITLE
Ignore equality constraints in rne postconstraint test.

### DIFF
--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -157,7 +157,6 @@ class SmoothTest(parameterized.TestCase):
   @parameterized.parameters(True, False)
   def test_rne_postconstraint(self, gravity):
     """Tests rne_postconstraint."""
-    # TODO(team): test equality constraints
     mjm, mjd, m, d = test_util.fixture("pendula.xml", gravity=gravity)
 
     mjd.xfrc_applied = np.random.uniform(
@@ -179,7 +178,8 @@ class SmoothTest(parameterized.TestCase):
     _assert_eq(d.cfrc_ext.numpy()[0], mjd.cfrc_ext, "cfrc_ext")
 
     # test contact
-    mjm, mjd, m, d = test_util.fixture("constraints.xml", keyframe=1)
+    # TODO(team): test equality constraints once its implemented
+    mjm, mjd, m, d = test_util.fixture("constraints.xml", keyframe=1, equality=False)
 
     mujoco.mj_rnePostConstraint(mjm, mjd)
 

--- a/mujoco_warp/_src/test_util.py
+++ b/mujoco_warp/_src/test_util.py
@@ -38,6 +38,7 @@ def fixture(
   keyframe: int = -1,
   contact: bool = True,
   constraint: bool = True,
+  equality: bool = True,
   gravity: bool = True,
   cone: Optional[ConeType] = None,
   solver: Optional[SolverType] = None,
@@ -60,6 +61,8 @@ def fixture(
     mjm.opt.disableflags |= DisableBit.CONTACT
   if not constraint:
     mjm.opt.disableflags |= DisableBit.CONSTRAINT
+  if not equality:
+    mjm.opt.disableflags |= DisableBit.EQUALITY
   if not gravity:
     mjm.opt.disableflags |= DisableBit.GRAVITY
   if cone is not None:


### PR DESCRIPTION
Fixes a recent PR merge that broke tests, because a test fixture was changed a different PR.