### PR TITLE
Speed up tests by reducing kernel loads in test fixtures.

### DIFF
--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -295,7 +295,8 @@ class CollisionTest(parameterized.TestCase):
     # generate contact
     m = mjwarp.put_model(mjm)
     d = mjwarp.make_data(mjm)
-    mjwarp.forward(m, d)
+    mjwarp.kinematics(m, d)
+    mjwarp.collision(m, d)
 
     self.assertEqual(d.ncon.numpy()[0], 1)
     self.assertEqual(d.contact.includemargin.numpy()[0], -1)
@@ -333,7 +334,8 @@ class CollisionTest(parameterized.TestCase):
     # generate contact
     m = mjwarp.put_model(mjm)
     d = mjwarp.make_data(mjm)
-    mjwarp.forward(m, d)
+    mjwarp.kinematics(m, d)
+    mjwarp.collision(m, d)
 
     self.assertEqual(d.ncon.numpy()[0], 1)
     self.assertEqual(d.contact.includemargin.numpy()[0], -1)
@@ -372,7 +374,8 @@ class CollisionTest(parameterized.TestCase):
     # generate contact
     m = mjwarp.put_model(mjm)
     d = mjwarp.make_data(mjm)
-    mjwarp.forward(m, d)
+    mjwarp.kinematics(m, d)
+    mjwarp.collision(m, d)
 
     self.assertEqual(d.ncon.numpy()[0], 1)
     self.assertEqual(d.contact.includemargin.numpy()[0], -1)
@@ -415,7 +418,8 @@ class CollisionTest(parameterized.TestCase):
     # generate contact
     m = mjwarp.put_model(mjm)
     d = mjwarp.make_data(mjm)
-    mjwarp.forward(m, d)
+    mjwarp.kinematics(m, d)
+    mjwarp.collision(m, d)
 
     self.assertEqual(d.ncon.numpy()[0], 2)
     self.assertEqual(d.contact.includemargin.numpy()[1], -1)

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -148,7 +148,7 @@ class ForwardTest(parameterized.TestCase):
     mjm, mjd, m, d = test_util.fixture(
       xml="""
         <mujoco>
-          <option integrator="RK4">
+          <option integrator="RK4" iterations="4" ls_iterations="4">
             <flag constraint="disable"/>
           </option>
           <worldbody>

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -41,7 +41,7 @@ def _assert_eq(a, b, name):
 
 class SolverTest(parameterized.TestCase):
   @parameterized.parameters(
-    (ConeType.PYRAMIDAL, SolverType.CG, 25, 5, False, False),
+    (ConeType.PYRAMIDAL, SolverType.CG, 5, 5, False, False),
     (ConeType.PYRAMIDAL, SolverType.NEWTON, 2, 4, False, False),
     (ConeType.PYRAMIDAL, SolverType.NEWTON, 2, 4, True, True),
   )
@@ -355,18 +355,18 @@ class SolverTest(parameterized.TestCase):
       world2_forces = np.concatenate([world2_eq_forces, world2_ineq_forces])
       _assert_eq(world2_forces, mjd2.efc_force, "efc_force2")
 
-  def test_frictionloss(self):
+  @parameterized.parameters(1, 2)
+  def test_frictionloss(self, keyframe):
     """Tests solver with frictionloss."""
     # TODO(team): test tendon frictionloss
     # TODO(team): test keyframe 2
-    for keyframe in range(2):
-      _, mjd, m, d = test_util.fixture("constraints.xml", keyframe=keyframe)
-      mjwarp.solve(m, d)
+    _, mjd, m, d = test_util.fixture("constraints.xml", keyframe=keyframe)
+    mjwarp.solve(m, d)
 
-      _assert_eq(d.nf.numpy()[0], mjd.nf, "nf")
-      _assert_eq(d.qacc.numpy()[0], mjd.qacc, "qacc")
-      _assert_eq(d.qfrc_constraint.numpy()[0], mjd.qfrc_constraint, "qfrc_constraint")
-      _assert_eq(d.efc.force.numpy()[: mjd.nefc], mjd.efc_force, "efc_force")
+    _assert_eq(d.nf.numpy()[0], mjd.nf, "nf")
+    _assert_eq(d.qacc.numpy()[0], mjd.qacc, "qacc")
+    _assert_eq(d.qfrc_constraint.numpy()[0], mjd.qfrc_constraint, "qfrc_constraint")
+    _assert_eq(d.efc.force.numpy()[: mjd.nefc], mjd.efc_force, "efc_force")
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/test_data/actuation/actuation.xml
+++ b/mujoco_warp/test_data/actuation/actuation.xml
@@ -1,4 +1,5 @@
 <mujoco>
+  <option iterations="4" ls_iterations="4"/>
   <worldbody>
     <body pos="0 0 0">
       <joint name="hinge0" type="hinge" axis="1 0 0"/>

--- a/mujoco_warp/test_data/actuation/actuators.xml
+++ b/mujoco_warp/test_data/actuation/actuators.xml
@@ -1,4 +1,5 @@
 <mujoco>
+  <option iterations="4" ls_iterations="4"/>
   <worldbody>
     <body>
       <joint name="hinge" type="hinge"/>

--- a/mujoco_warp/test_data/constraints.xml
+++ b/mujoco_warp/test_data/constraints.xml
@@ -4,7 +4,7 @@
 * solref, solimp
 -->
 <mujoco>
-  <option timestep="0.015" impratio="1.5"/>
+  <option timestep="0.015" impratio="1.5" iterations="4" ls_iterations="4"/>
 
   <default>
     <default class="box">


### PR DESCRIPTION
Currently, default `iterations` and `ls_iterations` is 50 and 50.  Generally this is OK, but one implication is that kernels inside linesearch are loaded 50 x 50 = 2500 times, which even when cached can be slow to do for a physics step.

Probably after #78 lands we should revisit what our `iterations` and `ls_iterations` defaults should be, whether we should turn on parallel linesearch by default, or whether there's some other way to reduce the cost of 2500 kernel cache hits.

For the time being this PR removes the places in our tests where we were hitting these large kernel cache hits, it lowers test times on my machine from 82s (after cache is fully populated) to 11s.

Output of `pytest --durations=10` before this PR:

```
========================================================================================================= slowest 10 durations ==========================================================================================================
34.68s call     mujoco_warp/_src/solver_test.py::SolverTest::test_frictionloss
18.44s call     mujoco_warp/_src/collision_driver_test.py::CollisionTest::test_contact_pair
13.53s call     mujoco_warp/_src/forward_test.py::ForwardTest::test_rungekutta4
4.81s call     mujoco_warp/_src/forward_test.py::ForwardTest::test_actuation1
3.56s call     mujoco_warp/_src/solver_test.py::SolverTest::test_solve0
1.19s call     mujoco_warp/_src/solver_test.py::SolverTest::test_solve_batch0
0.46s call     mujoco_warp/_src/solver_test.py::SolverTest::test_solve1
0.42s call     mujoco_warp/_src/broad_phase_test.py::BroadphaseTest::test_nxn_broadphase
0.41s call     mujoco_warp/_src/solver_test.py::SolverTest::test_solve2
0.40s call     mujoco_warp/_src/collision_driver_test.py::CollisionTest::test_collision_disableflags0
==================================================================================================== 118 passed in 82.17s (0:01:22) =====================================================================================================
```

And after this PR:

```
========================================================================================================= slowest 10 durations ==========================================================================================================
1.04s call     mujoco_warp/_src/solver_test.py::SolverTest::test_solve_batch0
0.84s call     mujoco_warp/_src/solver_test.py::SolverTest::test_frictionloss0
0.84s call     mujoco_warp/_src/solver_test.py::SolverTest::test_solve0
0.79s call     mujoco_warp/_src/solver_test.py::SolverTest::test_frictionloss1
0.76s call     mujoco_warp/_src/forward_test.py::ForwardTest::test_rungekutta4
0.52s call     mujoco_warp/_src/solver_test.py::SolverTest::test_solve2
0.52s call     mujoco_warp/_src/solver_test.py::SolverTest::test_solve1
0.46s call     mujoco_warp/_src/forward_test.py::ImplicitIntegratorTest::test_implicit0
0.41s call     mujoco_warp/_src/broad_phase_test.py::BroadphaseTest::test_nxn_broadphase
0.40s call     mujoco_warp/_src/forward_test.py::ForwardTest::test_actuation1
========================================================================================================= 119 passed in 11.03s ==========================================================================================================
```