### PR TITLE
rearrange geom types in GJK/EPA to be in order

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -131,20 +131,20 @@ def _gjk_support(
 
 
 convex_collision_functions = {
-  (GeomType.ELLIPSOID.value, GeomType.SPHERE.value),
-  (GeomType.ELLIPSOID.value, GeomType.BOX.value),
-  (GeomType.ELLIPSOID.value, GeomType.MESH.value),
+  (GeomType.SPHERE.value, GeomType.ELLIPSOID.value),
+  (GeomType.SPHERE.value, GeomType.MESH.value),
+  (GeomType.CAPSULE.value, GeomType.CYLINDER.value),
+  (GeomType.CAPSULE.value, GeomType.ELLIPSOID.value),
+  (GeomType.CAPSULE.value, GeomType.MESH.value),
   (GeomType.ELLIPSOID.value, GeomType.ELLIPSOID.value),
   (GeomType.ELLIPSOID.value, GeomType.CYLINDER.value),
-  (GeomType.ELLIPSOID.value, GeomType.CAPSULE.value),
-  (GeomType.MESH.value, GeomType.SPHERE.value),
-  (GeomType.MESH.value, GeomType.BOX.value),
-  (GeomType.MESH.value, GeomType.CAPSULE.value),
-  (GeomType.MESH.value, GeomType.CYLINDER.value),
-  (GeomType.MESH.value, GeomType.MESH.value),
-  (GeomType.CYLINDER.value, GeomType.BOX.value),
+  (GeomType.ELLIPSOID.value, GeomType.BOX.value),
+  (GeomType.ELLIPSOID.value, GeomType.MESH.value),
   (GeomType.CYLINDER.value, GeomType.CYLINDER.value),
-  (GeomType.CYLINDER.value, GeomType.CAPSULE.value),
+  (GeomType.CYLINDER.value, GeomType.BOX.value),
+  (GeomType.CYLINDER.value, GeomType.MESH.value),
+  (GeomType.BOX.value, GeomType.MESH.value),
+  (GeomType.MESH.value, GeomType.MESH.value),
 }
 
 

--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -40,6 +40,22 @@ class CollisionTest(parameterized.TestCase):
           </worldbody>
         </mujoco>
       """,
+    "box_mesh": """
+        <mujoco>
+          <asset>
+            <mesh name="boxmesh" scale="0.1 0.1 0.1"
+                  vertex="-1 -1 -1 1 -1 -1 1 1 -1 1 1 1
+                           1 -1 1 -1 1 -1 -1 1 1 -1 -1 1"/>
+          </asset>
+          <worldbody>
+            <geom pos="0 0 -0.1" type="box" size="0.5 0.5 0.1"/>
+            <body pos="0 0 .099">
+              <joint type="free"/>
+              <geom type="mesh" mesh="boxmesh"/>
+            </body>
+          </worldbody>
+        </mujoco>
+      """,
     "plane_sphere": """
         <mujoco>
           <worldbody>


### PR DESCRIPTION
Fixes bug where certain geoms won't collide in GJK/EPA (e.g. box-mesh collisions).