### PR TITLE
Activate `collision_test`

### DIFF
--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -40,22 +40,6 @@ class CollisionTest(parameterized.TestCase):
           </worldbody>
         </mujoco>
       """,
-    "box_mesh": """
-        <mujoco>
-          <asset>
-            <mesh name="boxmesh" scale="0.1 0.1 0.1"
-                  vertex="-1 -1 -1 1 -1 -1 1 1 -1 1 1 1
-                           1 -1 1 -1 1 -1 -1 1 1 -1 -1 1"/>
-          </asset>
-          <worldbody>
-            <geom pos="0 0 -0.1" type="box" size="0.5 0.5 0.1"/>
-            <body pos="0 0 .099">
-              <joint type="free"/>
-              <geom type="mesh" mesh="boxmesh"/>
-            </body>
-          </worldbody>
-        </mujoco>
-      """,
     "plane_sphere": """
         <mujoco>
           <worldbody>
@@ -242,6 +226,24 @@ class CollisionTest(parameterized.TestCase):
         </mujoco>
         """,
   }
+
+  # Temporarily disabled
+  #  "box_mesh": """
+  #      <mujoco>
+  #        <asset>
+  #          <mesh name="boxmesh" scale="0.1 0.1 0.1"
+  #                vertex="-1 -1 -1 1 -1 -1 1 1 -1 1 1 1
+  #                         1 -1 1 -1 1 -1 -1 1 1 -1 -1 1"/>
+  #        </asset>
+  #        <worldbody>
+  #          <geom pos="0 0 -0.1" type="box" size="0.5 0.5 0.1"/>
+  #          <body pos="0 0 .099">
+  #            <joint type="free"/>
+  #            <geom type="mesh" mesh="boxmesh"/>
+  #          </body>
+  #        </worldbody>
+  #      </mujoco>
+  #    """,
 
   @parameterized.parameters(_FIXTURES.keys())
   def test_collision(self, fixture):

--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -246,7 +246,10 @@ class CollisionTest(parameterized.TestCase):
   @parameterized.parameters(_FIXTURES.keys())
   def test_collision(self, fixture):
     """Tests convex collision with different geometries."""
-    _, mjd, _, d = test_util.fixture(xml=self._FIXTURES[fixture])
+    mjm, mjd, m, d = test_util.fixture(xml=self._FIXTURES[fixture])
+
+    mujoco.mj_collision(mjm, mjd)
+    mjwarp.collision(m, d)
 
     for i in range(mjd.ncon):
       actual_dist = mjd.contact.dist[i]

--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -27,9 +27,6 @@ from .types import vec5
 
 wp.set_module_options({"enable_backward": False})
 
-wp.set_module_options({"enable_backward": False})
-
-
 @wp.struct
 class Geom:
   pos: wp.vec3

--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -27,6 +27,7 @@ from .types import vec5
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.struct
 class Geom:
   pos: wp.vec3


### PR DESCRIPTION
The `collision_driver_test.test_collision` test case misses a collision step. This causes it to pass regardless of the collision pipeline. This change runs the collision pipeline and temporarily disables the `boxmesh` test fixture that now fails. It also removes a duplicate statement.