### PR TITLE
sensor_subtree_vel and sensor_rne_postconstraint

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -602,6 +602,20 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     ndim=1,
   )
 
+  m.sensor_subtree_vel = np.isin(
+    mjm.sensor_type,
+    [mujoco.mjtSensor.mjSENS_SUBTREELINVEL, mujoco.mjtSensor.mjSENS_SUBTREEANGMOM],
+  ).any()
+  m.sensor_rne_postconstraint = np.isin(
+    mjm.sensor_type,
+    [
+      mujoco.mjtSensor.mjSENS_ACCELEROMETER,
+      mujoco.mjtSensor.mjSENS_FORCE,
+      mujoco.mjtSensor.mjSENS_TORQUE,
+      mujoco.mjtSensor.mjSENS_FRAMELINACC,
+      mujoco.mjtSensor.mjSENS_FRAMEANGACC,
+    ],
+  ).any()
   return m
 
 

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -473,11 +473,7 @@ def sensor_vel(m: Model, d: Data):
   if (m.sensor_vel_adr.size == 0) or (m.opt.disableflags & DisableBit.SENSOR):
     return
 
-  if wp.static(
-    np.isin(
-      m.sensor_type.numpy(), [SensorType.SUBTREELINVEL, SensorType.SUBTREEANGMOM]
-    ).any()
-  ):
+  if m.sensor_subtree_vel:
     smooth.subtree_vel(m, d)
 
   wp.launch(_sensor_vel, dim=(d.nworld, m.sensor_vel_adr.size), inputs=[m, d])
@@ -623,12 +619,7 @@ def sensor_acc(m: Model, d: Data):
   if (m.sensor_acc_adr.size == 0) or (m.opt.disableflags & DisableBit.SENSOR):
     return
 
-  if wp.static(
-    np.isin(
-      m.sensor_type.numpy(),
-      [SensorType.ACCELEROMETER, SensorType.FORCE, SensorType.TORQUE],
-    ).any()
-  ):
+  if m.sensor_rne_postconstraint:
     smooth.rne_postconstraint(m, d)
 
   wp.launch(_sensor_acc, dim=(d.nworld, m.sensor_acc_adr.size), inputs=[m, d])

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -737,6 +737,8 @@ class Model:
     sensor_pos_adr: addresses for position sensors           (<=nsensor,)
     sensor_vel_adr: addresses for velocity sensors           (<=nsensor,)
     sensor_acc_adr: addresses for acceleration sensors       (<=nsensor,)
+    sensor_subtree_vel: evaluate subtree_vel
+    sensor_rne_postconstraint: evaluate rne_postconstraint
   """
 
   nq: int
@@ -949,6 +951,8 @@ class Model:
   sensor_pos_adr: wp.array(dtype=wp.int32, ndim=1)  # warp only
   sensor_vel_adr: wp.array(dtype=wp.int32, ndim=1)  # warp only
   sensor_acc_adr: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  sensor_subtree_vel: bool  # warp only
+  sensor_rne_postconstraint: bool  # warp only
 
 
 @wp.struct


### PR DESCRIPTION
the current logic for calling `subtree_vel` or `rne_postconstraint` by sensor functions is not compatible with cuda graph capture.

this pr add fields `sensor_subtree_vel` and `sensor_rne_postconstraint` to `Model` that determine if `subtree_vel` or `rne_postconstraint`, respectively, are required by sensors. these fields are compute in `io.put_model`.

this update makes the relevant sensors compatible with cuda graph capture. 