### PR TITLE
Fix issues with missing files in wheel (#142)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ select = [
 force-single-line = true
 single-line-exclusions = ["typing"]
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
-include = ["mujoco_warp"]
-exclude = ["contrib*"]
+include = ["mujoco_warp*"]


### PR DESCRIPTION
This MR tries to fix some `setuptools` configuration options in `pyproject.toml` that were preventing a wheel file being made that included the contents of the `mujoco_warp` directory.

Without this change, the wheel only contains the files in the `mujoco_warp` directory, which are `__init__.py`, `testspeed.py`, and `viewer.py`.

Fixes #142 