### PR TITLE
test cuda graph capture

### DIFF
--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -25,8 +25,6 @@ import mujoco_warp as mjwarp
 
 from . import test_util
 
-wp.config.verify_cuda = True
-
 # tolerance for difference between MuJoCo and mjwarp smooth calculations - mostly
 # due to float precision
 _TOLERANCE = 5e-5
@@ -146,6 +144,18 @@ class ForwardTest(parameterized.TestCase):
     _assert_eq(d.act.numpy()[0], mjd.act, "act")
     _assert_eq(d.time.numpy()[0], mjd.time, "time")
     _assert_eq(d.xpos.numpy()[0], mjd.xpos, "xpos")
+
+  def test_graph_capture(self):
+    # TODO(team): pytest flag for wp.config.verify_cuda
+    if wp.get_device().is_cuda and wp.config.verify_cuda == False:
+      _, _, m, d = test_util.fixture("humanoid/humanoid.xml")
+
+      with wp.ScopedCapture() as capture:
+        mjwarp.step(m, d)
+
+      wp.capture_launch(capture.graph)
+
+      self.assertTrue(d.time.numpy()[0] > 0.0)
 
 
 class ImplicitIntegratorTest(parameterized.TestCase):

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -208,9 +208,13 @@ class ForwardTest(parameterized.TestCase):
     _assert_eq(d.qpos.numpy()[0], mjd.qpos, "qpos")
     _assert_eq(d.act.numpy()[0], mjd.act, "act")
 
-  def test_graph_capture(self):
+  @parameterized.parameters(
+    "humanoid/humanoid.xml", "pendula.xml", "constraints.xml", "collision.xml"
+  )
+  def test_graph_capture(self, xml):
+    # TODO(team): test more environments
     if wp.get_device().is_cuda and wp.config.verify_cuda == False:
-      _, _, m, d = test_util.fixture("humanoid/humanoid.xml")
+      _, _, m, d = test_util.fixture(xml)
 
       with wp.ScopedCapture() as capture:
         mjwarp.step(m, d)

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -25,8 +25,6 @@ import mujoco_warp as mjwarp
 
 from . import test_util
 
-wp.config.verify_cuda = True
-
 # tolerance for difference between MuJoCo and MJWarp calculations - mostly
 # due to float precision
 _TOLERANCE = 5e-5

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -25,8 +25,6 @@ import mujoco_warp as mjwarp
 
 from . import test_util
 
-wp.config.verify_cuda = True
-
 # tolerance for difference between MuJoCo and MJWarp smooth calculations - mostly
 # due to float precision
 _TOLERANCE = 5e-5

--- a/mujoco_warp/_src/support_test.py
+++ b/mujoco_warp/_src/support_test.py
@@ -27,8 +27,6 @@ from . import test_util
 from .support import contact_force_kernel
 from .types import ConeType
 
-wp.config.verify_cuda = True
-
 # tolerance for difference between MuJoCo and MJWarp support calculations - mostly
 # due to float precision
 _TOLERANCE = 5e-5


### PR DESCRIPTION
add test for cuda graph capture

a pytest option for `wp.config.verify_cuda`, similar to #200, can be added in a future pr