### PR TITLE
Fix bug where rk temporary variables not reset

### DIFF
--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -267,6 +267,11 @@ def rungekutta4(m: Model, d: Data):
 
   wp.copy(d.qpos_t0, d.qpos)
   wp.copy(d.qvel_t0, d.qvel)
+
+  d.qvel_rk = wp.zeros_like(d.qvel_rk)
+  d.qacc_rk = wp.zeros_like(d.qacc_rk)
+  d.act_dot_rk = wp.zeros_like(d.act_dot_rk)
+
   if m.na:
     wp.copy(d.act_t0, d.act)
 

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -268,9 +268,9 @@ def rungekutta4(m: Model, d: Data):
   wp.copy(d.qpos_t0, d.qpos)
   wp.copy(d.qvel_t0, d.qvel)
 
-  d.qvel_rk = wp.zeros_like(d.qvel_rk)
-  d.qacc_rk = wp.zeros_like(d.qacc_rk)
-  d.act_dot_rk = wp.zeros_like(d.act_dot_rk)
+  d.qvel_rk.zero_()
+  d.qacc_rk.zero_()
+  d.act_dot_rk.zero_()
 
   if m.na:
     wp.copy(d.act_t0, d.act)

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -182,7 +182,7 @@ class ForwardTest(parameterized.TestCase):
       d.act = wp.ones_like(d.act)
       mjwarp.rungekutta4(m, d)
       return d.qpos
-  
+
     _assert_eq(rk_step().numpy()[0], rk_step().numpy()[0], "qpos")
 
 

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -175,6 +175,16 @@ class ForwardTest(parameterized.TestCase):
     _assert_eq(d.time.numpy()[0], mjd.time, "time")
     _assert_eq(d.xpos.numpy()[0], mjd.xpos, "xpos")
 
+    # test rungekutta determinism
+    def rk_step() -> wp.array(dtype=wp.float32, ndim=2):
+      d.qpos = wp.ones_like(d.qpos)
+      d.qvel = wp.ones_like(d.qvel)
+      d.act = wp.ones_like(d.act)
+      mjwarp.rungekutta4(m, d)
+      return d.qpos
+  
+    _assert_eq(rk_step().numpy()[0], rk_step().numpy()[0], "qpos")
+
 
 class ImplicitIntegratorTest(parameterized.TestCase):
   @parameterized.parameters(


### PR DESCRIPTION
Fix bug where Runge-Kutta  temporary variables were not reset causing non-determinism. 

Add test to `forward_test.py` 