### PR TITLE
Specify data files a different way

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ force-single-line = true
 single-line-exclusions = ["typing"]
 
 [tool.setuptools]
-include-package-data = true
+package-data = { "mujoco_warp" = ["test_data/**"] }
 
 [tool.setuptools.packages.find]
 include = ["mujoco_warp*"]


### PR DESCRIPTION
I was having problems installing the `mujoco_warp` dependency in our pipelines because the files in the `test_data` directory was not being included for some reason.

This change should fix things (tested on my fork).