### PR TITLE
Migrate from M_* to C_* for sparse M addressing.

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -67,7 +67,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   # calculate some fields that cannot be easily computed inline
   nlsp = mjm.opt.ls_iterations  # TODO(team): how to set nlsp?
 
-  # unfortunately we must create Data in order to get some model fields like M_rownnz
+  # unfortunately we must create Data in order to get some model fields like C_rownnz
   mjd = mujoco.MjData(mjm)
 
   # dof lower triangle row and column indices (used in solver)
@@ -108,7 +108,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   for k in range(mjm.nv):
     dof_depth[k] = dof_depth[mjm.dof_parentid[k]] + 1
     i = mjm.dof_parentid[k]
-    diag_k = mjd.M_rowadr[k] + mjd.M_rownnz[k] - 1
+    diag_k = mjd.C_rowadr[k] + mjd.C_rownnz[k] - 1
     Madr_ki = diag_k - 1
     while i > -1:
       qLD_updates.setdefault(dof_depth[i], []).append((i, k, Madr_ki))
@@ -305,10 +305,10 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     qM_mulm_j=wp.array(qM_mulm_j, dtype=int),
     qM_madr_ij=wp.array(qM_madr_ij, dtype=int),
     qLD_updates=qLD_updates,
-    M_rownnz=wp.array(mjd.M_rownnz, dtype=int),
-    M_rowadr=wp.array(mjd.M_rowadr, dtype=int),
-    M_colind=wp.array(mjd.M_colind, dtype=int),
-    mapM2M=wp.array(mjd.mapM2M, dtype=int),
+    C_rownnz=wp.array(mjd.C_rownnz, dtype=int),
+    C_rowadr=wp.array(mjd.C_rowadr, dtype=int),
+    C_colind=wp.array(mjd.C_colind, dtype=int),
+    mapM2C=wp.array(mjd.mapM2C, dtype=int),
     qM_tiles=qM_tiles,
     body_tree=body_tree,
     body_parentid=wp.array(mjm.body_parentid, dtype=int),

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -609,10 +609,10 @@ class Model:
     qM_madr_ij: sparse mass matrix addressing
     qLD_update_tree: dof tree ordering for qLD updates
     qLD_update_treeadr: index of each dof tree level
-    M_rownnz: number of non-zeros in each row of qM             (nv,)
-    M_rowadr: index of each row in qM                           (nv,)
-    M_colind: column indices of non-zeros in qM                 (nM,)
-    mapM2M: index mapping from M (legacy) to M (CSR)            (nM)
+    C_rownnz: number of non-zeros in each row of qM             (nv,)
+    C_rowadr: index of each row in qM                           (nv,)
+    C_colind: column indices of non-zeros in qM                 (nM,)
+    mapM2C: index mapping from M (legacy) to C (CSR)            (nC)
     qM_tiles: tiling configuration
     body_tree: list of body ids by tree level
     body_parentid: id of body's parent                       (nbody,)
@@ -830,10 +830,10 @@ class Model:
   qM_mulm_j: wp.array(dtype=int)  # warp only
   qM_madr_ij: wp.array(dtype=int)  # warp only
   qLD_updates: tuple[wp.array(dtype=wp.vec3i), ...]  # warp only
-  M_rownnz: wp.array(dtype=int)
-  M_rowadr: wp.array(dtype=int)
-  M_colind: wp.array(dtype=int)
-  mapM2M: wp.array(dtype=int)
+  C_rownnz: wp.array(dtype=int)
+  C_rowadr: wp.array(dtype=int)
+  C_colind: wp.array(dtype=int)
+  mapM2C: wp.array(dtype=int)
   qM_tiles: tuple[TileSet, ...]
   body_tree: tuple[wp.array(dtype=int), ...]
   body_parentid: wp.array(dtype=int)


### PR DESCRIPTION
`M_` matrix structure fields have been removed in MuJoCo as of https://github.com/google-deepmind/mujoco/commit/1e02d66c3d431aadb3e5fbe3c7bf5ac642ac9e90

Migrate to `C_` fields to avoid breakage.