### PR TITLE
dtype fixes for numpy 1.26.0

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -832,7 +832,7 @@ def put_data(
         dtype = wp.int32
       elif np.issubdtype(x.dtype, np.floating):
         dtype = wp.float32
-      elif np.issubdtype(x.dtype, np.bool):
+      elif np.issubdtype(x.dtype, bool):
         dtype = wp.bool
       else:
         raise ValueError(f"Unsupported dtype: {x.dtype}")
@@ -853,10 +853,10 @@ def put_data(
     njmax=njmax,
     ncon=arr([mjd.ncon * nworld]),
     ne=arr([mjd.ne * nworld]),
-    ne_connect=arr([3 * nworld * np.sum((mjm.eq_type == mujoco.mjtEq.mjEQ_CONNECT) & mjd.eq_active)]),
-    ne_weld=arr([6 * nworld * np.sum((mjm.eq_type == mujoco.mjtEq.mjEQ_WELD) & mjd.eq_active)]),
-    ne_jnt=arr([nworld * np.sum((mjm.eq_type == mujoco.mjtEq.mjEQ_JOINT) & mjd.eq_active)]),
-    ne_ten=arr([nworld * np.sum((mjm.eq_type == mujoco.mjtEq.mjEQ_TENDON) & mjd.eq_active)]),
+    ne_connect=arr([3 * nworld * np.sum((mjm.eq_type == mujoco.mjtEq.mjEQ_CONNECT) & mjd.eq_active, dtype=int)]),
+    ne_weld=arr([6 * nworld * np.sum((mjm.eq_type == mujoco.mjtEq.mjEQ_WELD) & mjd.eq_active, dtype=int)]),
+    ne_jnt=arr([nworld * np.sum((mjm.eq_type == mujoco.mjtEq.mjEQ_JOINT) & mjd.eq_active, dtype=int)]),
+    ne_ten=arr([nworld * np.sum((mjm.eq_type == mujoco.mjtEq.mjEQ_TENDON) & mjd.eq_active, dtype=int)]),
     nf=arr([mjd.nf * nworld]),
     nl=arr([mjd.nl * nworld]),
     nefc=arr([mjd.nefc * nworld]),


### PR DESCRIPTION
This makes MjWarp work with numpy 1.26.0 (which is not that old, from sept 2023..) I think these changes are generally ok, so I would like to merge them if possible.

Otherwise we need to be explicit about only supporting numpy 2.0+