### PR TITLE
WIP SDF collisions

### DIFF
--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -20,6 +20,7 @@ import warp as wp
 from .collision_box import box_box_narrowphase
 from .collision_convex import gjk_narrowphase
 from .collision_primitive import primitive_narrowphase
+from .collision_sdf import sdf_narrowphase
 from .types import MJ_MAXVAL
 from .types import Data
 from .types import DisableBit
@@ -446,4 +447,5 @@ def collision(m: Model, d: Data):
   # TODO(team) switch between collision functions and GJK/EPA here
   gjk_narrowphase(m, d)
   primitive_narrowphase(m, d)
-  box_box_narrowphase(m, d)
+  sdf_narrowphase(m, d)
+#  box_box_narrowphase(m, d)

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -448,4 +448,6 @@ def collision(m: Model, d: Data):
   gjk_narrowphase(m, d)
   primitive_narrowphase(m, d)
   sdf_narrowphase(m, d)
+
+
 #  box_box_narrowphase(m, d)

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -447,7 +447,6 @@ def collision(m: Model, d: Data):
   # TODO(team) switch between collision functions and GJK/EPA here
   gjk_narrowphase(m, d)
   primitive_narrowphase(m, d)
+  box_box_narrowphase(m, d)
   sdf_narrowphase(m, d)
 
-
-#  box_box_narrowphase(m, d)

--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -29,7 +29,7 @@ class CollisionTest(parameterized.TestCase):
   """Tests the collision contact functions."""
 
   _SDF_SDF = {
-      "_NUT_NUT": """
+    "_NUT_NUT": """
 <mujoco>
   <extension>
     <plugin plugin="mujoco.sdf.nut">

--- a/mujoco_warp/_src/collision_sdf.py
+++ b/mujoco_warp/_src/collision_sdf.py
@@ -554,7 +554,7 @@ def _sdf_narrowphase(
 
 def sdf_narrowphase(m: Model, d: Data):
   wp.launch(
-    _sdf_narrowphase8,
+    _sdf_narrowphase,
     dim=d.nconmax,
     inputs=[
       m.geom_type,

--- a/mujoco_warp/_src/collision_sdf.py
+++ b/mujoco_warp/_src/collision_sdf.py
@@ -1,0 +1,706 @@
+# Copyright 2025 The Physics-Next Project Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import warp as wp
+from .types import GeomType
+from .collision_primitive import Geom
+from .collision_primitive import _geom
+from .collision_primitive import contact_params
+from .collision_primitive import write_contact
+from .types import Data
+from .types import Model
+from .types import vec5
+from .math import make_frame
+from . import math
+
+@wp.struct
+class GradientState:
+  dist: float
+  x: wp.vec3
+
+@wp.struct
+class OptimizationParams:
+  rel_mat: wp.mat33
+  rel_pos: wp.vec3
+  size1: wp.vec3
+  size2: wp.vec3
+
+@wp.struct
+class AABB:
+  min: wp.vec3
+  max: wp.vec3
+
+@wp.func
+def transform_aabb(
+  aabb_pos: wp.vec3, aabb_size: wp.vec3, pos: wp.vec3, ori: wp.mat33
+) -> AABB:
+  aabb = AABB()
+  aabb.max = wp.vec3(-1000000000.0, -1000000000.0, -1000000000.0)
+  aabb.min = wp.vec3(1000000000.0, 1000000000.0, 1000000000.0)
+
+  for i in range(8):
+    corner = wp.vec3(aabb_size.x, aabb_size.y, aabb_size.z)
+    if i % 2 == 0:
+      corner.x = -corner.x
+    if (i // 2) % 2 == 0:
+      corner.y = -corner.y
+    if i < 4:
+      corner.z = -corner.z
+    corner_world = ori * (corner + aabb_pos) + pos
+    aabb.max = wp.max(aabb.max, corner_world)
+    aabb.min = wp.min(aabb.min, corner_world)
+
+  return aabb
+
+@wp.func
+def sphere(p: wp.vec3, size: wp.vec3) -> float:
+  return wp.length(p) - size[0]
+
+@wp.func
+def ellipsoid(p: wp.vec3, size: wp.vec3) -> float:
+  scaled_p = wp.vec3(p[0] / size[0], p[1] / size[1], p[2] / size[2])
+  k0 = wp.length(scaled_p)
+  k1 = wp.length(
+    wp.vec3(p[0] / (size[0] ** 2.0), p[1] / (size[1] ** 2.0), p[2] / (size[2] ** 2.0))
+  )
+  if k1 != 0.0:
+    denom = k1
+  else:
+    denom = 1e-12
+  return k0 * (k0 - 1.0) / denom
+
+@wp.func
+def nut(p: wp.vec3) -> float:
+    screw = 12.0
+    radius2 = wp.sqrt(p[0]*p[0] + p[1]*p[1]) - 0.27 #todo
+    sqrt12 = wp.sqrt(2.0)/2.0
+
+    azimuth = wp.atan2(p[1], p[0])
+    triangle = wp.abs((p[2] * screw - azimuth/(wp.pi*2.0)) - wp.floor(p[2] * screw - azimuth/(wp.pi*2.0)) - 0.5)
+    thread2 = (radius2 - triangle / screw) * sqrt12
+
+    cone2 = (p[2] - radius2) * sqrt12
+    hole = wp.min(thread2, cone2 + 0.5 * sqrt12)
+    hole = wp.min(hole, -cone2 - 0.05 * sqrt12)
+
+    k = 6.0 / wp.pi / 2.0
+    angle = -wp.floor((wp.atan2(p[1], p[0])) * k + 0.5) / k
+    s = wp.vec2(wp.sin(angle), wp.sin(angle + wp.pi * 0.5))
+    rot_point = wp.vec2(s.y * p.x - s.x * p.y, 
+                        s.x * p.x + s.y * p.y)
+
+    head = rot_point[0] - 0.5
+    head = wp.max(head, wp.abs(rot_point[1] + 0.25) - 0.25)
+    head = wp.max(head, (rot_point[1] + radius2 - 0.22) * sqrt12)
+    
+    return wp.max(head, -hole)
+
+
+@wp.func
+def grad_sphere(p: wp.vec3) -> wp.vec3:
+  c = wp.length(p)
+  if c > 1e-9:
+    return p / c
+  else:
+    wp.vec3(0.0)
+
+
+@wp.func
+def grad_ellipsoid(p: wp.vec3, size: wp.vec3) -> wp.vec3:
+  a = wp.vec3(p[0] / size[0], p[1] / size[1], p[2] / size[2])
+
+  b = wp.vec3(a[0] / size[0], a[1] / size[1], a[2] / size[2])
+  k0 = wp.length(a)
+  k1 = wp.length(b)
+  invK0 = 1.0 / k0
+  invK1 = 1.0 / k1
+
+  gk0 = b * invK0
+  gk1 = wp.vec3(
+    b[0] * invK1 / (size[0] * size[0]),
+    b[1] * invK1 / (size[1] * size[1]),
+    b[2] * invK1 / (size[2] * size[2]),
+  )
+  df_dk0 = (2.0 * k0 - 1.0) * invK1
+  df_dk1 = k0 * (k0 - 1.0) * invK1 * invK1
+
+  raw_grad = gk0 * df_dk0 - gk1 * df_dk1
+  return raw_grad / wp.length(raw_grad)
+
+
+@wp.func
+def grad_nut(
+    x: wp.vec3,
+) -> wp.vec3:
+    grad = wp.vec3()
+    eps = 1e-4
+    
+    f_original =  nut(x)
+    x_plus = wp.vec3(x[0] + eps, x[1], x[2])
+    f_plus =  nut(x_plus)
+    grad[0] = (f_plus - f_original) / eps
+
+    x_plus = wp.vec3(x[0], x[1] + eps, x[2])
+    f_plus =  nut(x_plus)
+    grad[1] = (f_plus - f_original) / eps
+
+    x_plus = wp.vec3(x[0], x[1], x[2] + eps)
+    f_plus =  nut(x_plus)
+    grad[2] = (f_plus - f_original) / eps
+    return grad
+
+def sdf(type: int):
+  @wp.func
+  def _sdf(p: wp.vec3, size: wp.vec3) -> float:
+    if wp.static(type == GeomType.SPHERE.value):
+        return sphere(p, size)
+    elif wp.static(type == GeomType.ELLIPSOID.value):
+        return ellipsoid(p, size)
+    elif wp.static(type == GeomType.SDF.value):
+        return nut(p)
+    else:
+      wp.printf("not supported")
+  return _sdf
+
+def sdf_grad(type: int):
+  @wp.func
+  def _sdf_grad(p: wp.vec3, size: wp.vec3) -> wp.vec3:
+    if wp.static(type == GeomType.SPHERE.value):
+        return grad_sphere(p)
+    elif wp.static(type == GeomType.ELLIPSOID.value):
+        return grad_ellipsoid(p, size)
+    elif wp.static(type == GeomType.SDF.value):
+        return grad_nut(p)
+    else:
+      wp.printf("not supported")
+  return _sdf_grad
+
+def clearance(type1: int, type2: int, sfd_intersection: bool = False):
+    @wp.func
+    def _clearance(p1: wp.vec3, p2: wp.vec3, s1: wp.vec3, s2: wp.vec3) -> float:
+        s = wp.static(sdf(type1))(p1, s1)
+        e = wp.static(sdf(type2))(p2, s2)
+        if sfd_intersection:
+            return wp.max(s, e)
+        else:
+            return s + e + wp.abs(wp.max(s, e))
+    return _clearance
+
+def compute_grad(type1: int, type2: int, sfd_intersection: bool = False):
+    @wp.func
+    def _compute_grad(
+        p1: wp.vec3, p2: wp.vec3, params: OptimizationParams
+    ) -> wp.vec3:
+        A = wp.static(sdf(type1))(p1, params.size1)
+        B = wp.static(sdf(type2))(p2, params.size2)
+        grad1 = wp.static(sdf_grad(type1))(p1, params.size1)
+        grad2 = wp.static(sdf_grad(type2))(p2, params.size2)
+        grad1_transformed = params.rel_mat * grad1
+        if sfd_intersection:
+            # Only return the gradient of the maximum SDF
+            if A > B:
+                return grad1_transformed
+            else:
+                return grad2
+        else:
+            gradient = grad2 + grad1_transformed
+            max_val = wp.max(A, B)
+            if A > B:
+                max_grad = grad1_transformed
+            else:
+                max_grad = grad2
+            sign = wp.sign(max_val)
+            gradient += max_grad * sign
+            return gradient
+    return _compute_grad
+
+def gradient_step(type1: int, type2: int, sfd_intersection: bool = False):
+    @wp.func
+    def _gradient_step(
+        state: GradientState,
+        params: OptimizationParams,
+    ) -> GradientState:
+        amin = 1e-4
+        rho = 0.5
+        c = 0.1
+        alpha = float(2.0)
+
+        x0 = state.x
+        x1 = params.rel_mat * x0 + params.rel_pos
+        grad = wp.static(compute_grad(type1, type2, sfd_intersection))(x1, x0, params)
+        dist0 = wp.static(clearance(type1, type2, sfd_intersection))(
+            x1, x0, params.size1, params.size2
+        )
+        grad_dot = wp.dot(grad, grad)
+
+        if grad_dot < 1e-12:
+            return GradientState(dist0, x0)
+
+        wolfe = -c * alpha * grad_dot
+        best_candidate = x0
+        best_value = dist0
+
+        while True:
+            alpha *= rho
+            wolfe *= rho
+
+            candidate = x0 - grad * alpha
+            x1_candidate = params.rel_mat * candidate + params.rel_pos
+            value = wp.static(clearance(type1, type2, sfd_intersection))(
+                x1_candidate, candidate, params.size1, params.size2
+            )
+
+            if alpha <= amin or (value - dist0) <= wolfe:
+                best_candidate = candidate
+                best_value = value
+                break
+
+        if best_value < dist0:
+            new_state = GradientState()
+            new_state.dist = best_value
+            new_state.x = best_candidate
+            return new_state
+        else:
+            original_state = GradientState()
+            original_state.dist = dist0
+            original_state.x = x0
+            return original_state
+    return _gradient_step
+
+def gradient_descent(type1: int, type2: int):
+  @wp.func
+  def _gradient_descent(
+    x: wp.vec3,
+    niter: int,
+    params: OptimizationParams,
+  ):
+
+    state = GradientState(1e10, x)
+
+    for _ in range(niter):
+      state = wp.static(gradient_step(type1, type2))(state, params)
+      #todo early break
+
+    state = wp.static(gradient_step(type1, type2, True))(state, params)
+    return state.dist, state.x
+
+  return _gradient_descent
+
+@wp.func
+def sphere_ellipsoid(
+   # Data in:
+  nconmax_in: int,
+  # In:
+  s: Geom,
+  e: Geom,
+  aabb1: AABB,
+  aabb2: AABB,
+  worldid: int,
+  margin: float,
+  gap: float,
+  condim: int,
+  friction: vec5,
+  solref: wp.vec2f,
+  solreffriction: wp.vec2f,
+  solimp: vec5,
+  geoms: wp.vec2i,
+  # Data out:
+  ncon_out: wp.array(dtype=int),
+  contact_dist_out: wp.array(dtype=float),
+  contact_pos_out: wp.array(dtype=wp.vec3),
+  contact_frame_out: wp.array(dtype=wp.mat33),
+  contact_includemargin_out: wp.array(dtype=float),
+  contact_friction_out: wp.array(dtype=vec5),
+  contact_solref_out: wp.array(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array(dtype=wp.vec2),
+  contact_solimp_out: wp.array(dtype=vec5),
+  contact_dim_out: wp.array(dtype=int),
+  contact_geom_out: wp.array(dtype=wp.vec2i),
+  contact_worldid_out: wp.array(dtype=int),): 
+    
+    
+    params = OptimizationParams()
+    static_type1 =  wp.static(GeomType.SPHERE.value)
+    static_type2 =  wp.static(GeomType.ELLIPSOID.value)
+    params.rel_mat = wp.transpose(s.rot) * e.rot
+    params.rel_pos = wp.transpose(s.rot) * (e.pos - s.pos)
+    params.size1 = s.size #todo
+    params.size2 = e.size
+
+    # min of the first AABB
+    x1 = aabb1.min
+    # min of the second AABB
+    x2 = aabb2.min
+    # min of the intersection
+    x = wp.vec3(wp.max(x1[0], x2[0]),wp.max(x1[1], x2[1]),wp.max(x1[2], x2[2])
+                )
+    x0_transformed = wp.transpose(e.rot) * (x - e.pos)
+    dist, pos = wp.static(gradient_descent(static_type1, static_type2))(x0_transformed, 10, params)
+
+    pos_s = params.rel_mat * pos + params.rel_pos
+    grad1 = wp.static(sdf_grad(static_type1))(pos_s, params.size1)
+    grad2 = wp.static(sdf_grad(static_type1))(pos, params.size2) 
+    n = grad1 - grad2
+    pos = e.rot * pos + e.pos
+    n = e.rot * n
+    f = wp.normalize(n)
+    pos3 = pos - f* dist/2.0
+    write_contact(
+    nconmax_in,
+    dist,
+    pos3,
+    make_frame(n),
+    margin,
+    gap,
+    condim,
+    friction,
+    solref,
+    solreffriction,
+    solimp,
+    geoms,
+    worldid,
+    ncon_out,
+    contact_dist_out,
+    contact_pos_out,
+    contact_frame_out,
+    contact_includemargin_out,
+    contact_friction_out,
+    contact_solref_out,
+    contact_solreffriction_out,
+    contact_solimp_out,
+    contact_dim_out,
+    contact_geom_out,
+    contact_worldid_out,
+  )
+
+@wp.func
+def sdf_sdf (
+   # Data in:
+  nconmax_in: int,
+  # In:
+  s1: Geom,
+  s2: Geom,
+  aabb1: AABB,
+  aabb2:AABB,
+  geom_pos1: wp.vec3,
+  geom_mat1: wp.mat33,
+  geom_pos2: wp.vec3,
+  geom_mat2: wp.mat33,
+  worldid: int,
+  margin: float,
+  gap: float,
+  condim: int,
+  friction: vec5,
+  solref: wp.vec2f,
+  solreffriction: wp.vec2f,
+  solimp: vec5,
+  geoms: wp.vec2i,
+  # Data out:
+  ncon_out: wp.array(dtype=int),
+  contact_dist_out: wp.array(dtype=float),
+  contact_pos_out: wp.array(dtype=wp.vec3),
+  contact_frame_out: wp.array(dtype=wp.mat33),
+  contact_includemargin_out: wp.array(dtype=float),
+  contact_friction_out: wp.array(dtype=vec5),
+  contact_solref_out: wp.array(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array(dtype=wp.vec2),
+  contact_solimp_out: wp.array(dtype=vec5),
+  contact_dim_out: wp.array(dtype=int),
+  contact_geom_out: wp.array(dtype=wp.vec2i),
+  contact_worldid_out: wp.array(dtype=int),):
+
+    rot1 = math.mul(s1.rot, math.transpose(geom_mat1))
+    pos1 = wp.sub(s1.pos, math.mul(rot1, geom_pos1))
+    rot2 = math.mul(s2.rot, math.transpose(geom_mat2))
+    pos2 = wp.sub(s2.pos, math.mul(rot2, geom_pos2))
+   
+    params = OptimizationParams()
+    params.rel_mat = wp.transpose(rot1) * rot2
+    params.rel_pos = wp.transpose(rot1) * (pos2 - pos1)
+    params.size1 = s1.size
+    params.size2 = s2.size
+    static_type1 = wp.static(GeomType.SDF.value)
+    static_type2 =  wp.static(GeomType.SDF.value)
+    x1 = aabb1.min
+    x2 = aabb2.min
+    x = wp.vec3(wp.max(x1[0], x2[0]),wp.max(x1[1], x2[1]),wp.max(x1[2], x2[2]))
+    x0_transformed = wp.transpose(rot2) * (x - pos2)
+    dist, pos = wp.static(gradient_descent(static_type1, static_type2))(x0_transformed, 10, params)
+    pos_s = params.rel_mat * pos + params.rel_pos
+    grad1 = wp.static(sdf_grad(static_type1))(pos_s, params.size1)
+    grad2 = wp.static(sdf_grad(static_type1))(pos, params.size2) 
+    n = grad1 - grad2
+    pos = rot2 * pos + pos2
+    n = rot2 * n
+    f = wp.normalize(n)
+    pos3 = pos - f* dist/2.0 #todo
+
+    write_contact(
+    nconmax_in,
+    dist,
+    pos3,
+    make_frame(n),
+    margin,
+    gap,
+    condim,
+    friction,
+    solref,
+    solreffriction,
+    solimp,
+    geoms,
+    worldid,
+    ncon_out,
+    contact_dist_out,
+    contact_pos_out,
+    contact_frame_out,
+    contact_includemargin_out,
+    contact_friction_out,
+    contact_solref_out,
+    contact_solreffriction_out,
+    contact_solimp_out,
+    contact_dim_out,
+    contact_geom_out,
+    contact_worldid_out,
+  )
+
+@wp.kernel
+def _sdf_narrowphase(
+  # Model:
+  geom_type: wp.array(dtype=int),
+  geom_condim: wp.array(dtype=int),
+  geom_dataid: wp.array(dtype=int),
+  geom_priority: wp.array(dtype=int),
+  geom_solmix: wp.array(dtype=float),
+  geom_solref: wp.array(dtype=wp.vec2),
+  geom_solimp: wp.array(dtype=vec5),
+  geom_size: wp.array(dtype=wp.vec3),
+  geom_friction: wp.array(dtype=wp.vec3),
+  geom_margin: wp.array(dtype=float),
+  geom_gap: wp.array(dtype=float),
+  mesh_vertadr: wp.array(dtype=int),
+  mesh_vertnum: wp.array(dtype=int),
+  pair_dim: wp.array(dtype=int),
+  pair_solref: wp.array(dtype=wp.vec2),
+  pair_solreffriction: wp.array(dtype=wp.vec2),
+  pair_solimp: wp.array(dtype=vec5),
+  pair_margin: wp.array(dtype=float),
+  pair_gap: wp.array(dtype=float),
+  pair_friction: wp.array(dtype=vec5),
+  geom_aabb : wp.array2d(dtype=wp.vec3),
+  geom_pos: wp.array(dtype=wp.vec3),
+  geom_quat: wp.array(dtype=wp.quat),
+
+  # Data in:
+  nconmax_in: int,
+  geom_xpos_in: wp.array2d(dtype=wp.vec3),
+  geom_xmat_in: wp.array2d(dtype=wp.mat33),
+  collision_pair_in: wp.array(dtype=wp.vec2i),
+  collision_pairid_in: wp.array(dtype=int),
+  collision_worldid_in: wp.array(dtype=int),
+  ncollision_in: wp.array(dtype=int),
+  # Data out:
+  ncon_out: wp.array(dtype=int),
+  contact_dist_out: wp.array(dtype=float),
+  contact_pos_out: wp.array(dtype=wp.vec3),
+  contact_frame_out: wp.array(dtype=wp.mat33),
+  contact_includemargin_out: wp.array(dtype=float),
+  contact_friction_out: wp.array(dtype=vec5),
+  contact_solref_out: wp.array(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array(dtype=wp.vec2),
+  contact_solimp_out: wp.array(dtype=vec5),
+  contact_dim_out: wp.array(dtype=int),
+  contact_geom_out: wp.array(dtype=wp.vec2i),
+  contact_worldid_out: wp.array(dtype=int),
+):
+  tid = wp.tid()
+  if tid >= ncollision_in[0]:
+    return
+  geoms, margin, gap, condim, friction, solref, solreffriction, solimp = contact_params(
+    geom_condim,
+    geom_priority,
+    geom_solmix,
+    geom_solref,
+    geom_solimp,
+    geom_friction,
+    geom_margin,
+    geom_gap,
+    pair_dim,
+    pair_solref,
+    pair_solreffriction,
+    pair_solimp,
+    pair_margin,
+    pair_gap,
+    pair_friction,
+    collision_pair_in,
+    collision_pairid_in,
+    tid,
+  )
+  g1 = geoms[0]
+  g2 = geoms[1]
+
+  worldid = collision_worldid_in[tid]
+
+  geom1 = _geom(
+    geom_dataid,
+    geom_size,
+    mesh_vertadr,
+    mesh_vertnum,
+    geom_xpos_in,
+    geom_xmat_in,
+    worldid,
+    g1,
+  )
+  geom2 = _geom(
+    geom_dataid,
+    geom_size,
+    mesh_vertadr,
+    mesh_vertnum,
+    geom_xpos_in,
+    geom_xmat_in,
+    worldid,
+    g2,
+  )
+
+  type1 = geom_type[g1]
+  type2 = geom_type[g2]
+
+  aabb_pos = geom_aabb[g1, 0]
+  aabb_size = geom_aabb[g1, 1]
+  aabb1 = transform_aabb(aabb_pos, aabb_size, geom1.pos, geom1.rot)
+  aabb_pos = geom_aabb[g2, 0]
+  aabb_size = geom_aabb[g2, 1]
+  aabb2 = transform_aabb(aabb_pos, aabb_size, geom2.pos, geom2.rot)
+  pos1 = geom_pos[g1]
+  quat1 = geom_quat[g1]
+  rot1 = math.quat_to_mat(quat1)
+  pos2 = geom_pos[g2]
+  quat2 = geom_quat[g2]
+  rot2 = math.quat_to_mat(quat2)
+
+
+  if type1 == int(GeomType.SPHERE.value) and type2 == int(GeomType.ELLIPSOID.value):
+    sphere_ellipsoid(
+      nconmax_in,
+      geom1,
+      geom2,
+      aabb1,
+      aabb2,
+      worldid,
+      margin,
+      gap,
+      condim,
+      friction,
+      solref,
+      solreffriction,
+      solimp,
+      geoms,
+      ncon_out,
+      contact_dist_out,
+      contact_pos_out,
+      contact_frame_out,
+      contact_includemargin_out,
+      contact_friction_out,
+      contact_solref_out,
+      contact_solreffriction_out,
+      contact_solimp_out,
+      contact_dim_out,
+      contact_geom_out,
+      contact_worldid_out,
+    )
+  elif type1 == int(GeomType.SDF.value) and type2 == int(GeomType.SDF.value):
+    sdf_sdf(
+      nconmax_in,
+      geom1,
+      geom2,
+      aabb1,
+      aabb2,
+      pos1,
+      rot1,
+      pos2, 
+      rot2,
+      worldid,
+      margin,
+      gap,
+      condim,
+      friction,
+      solref,
+      solreffriction,
+      solimp,
+      geoms,
+      ncon_out,
+      contact_dist_out,
+      contact_pos_out,
+      contact_frame_out,
+      contact_includemargin_out,
+      contact_friction_out,
+      contact_solref_out,
+      contact_solreffriction_out,
+      contact_solimp_out,
+      contact_dim_out,
+      contact_geom_out,
+      contact_worldid_out,
+    )
+
+def sdf_narrowphase(m: Model, d: Data):
+  wp.launch(
+    _sdf_narrowphase,
+    dim=d.nconmax,
+    inputs=[
+      m.geom_type,
+      m.geom_condim,
+      m.geom_dataid,
+      m.geom_priority,
+      m.geom_solmix,
+      m.geom_solref,
+      m.geom_solimp,
+      m.geom_size,
+      m.geom_friction,
+      m.geom_margin,
+      m.geom_gap,
+      m.mesh_vertadr,
+      m.mesh_vertnum,
+      m.pair_dim,
+      m.pair_solref,
+      m.pair_solreffriction,
+      m.pair_solimp,
+      m.pair_margin,
+      m.pair_gap,
+      m.pair_friction,
+      m.geom_aabb,
+      m.geom_pos,
+      m.geom_quat,
+      d.nconmax,
+      d.geom_xpos,
+      d.geom_xmat,
+      d.collision_pair,
+      d.collision_pairid,
+      d.collision_worldid,
+      d.ncollision,
+    ],
+    outputs=[
+      d.ncon,
+      d.contact.dist,
+      d.contact.pos,
+      d.contact.frame,
+      d.contact.includemargin,
+      d.contact.friction,
+      d.contact.solref,
+      d.contact.solreffriction,
+      d.contact.solimp,
+      d.contact.dim,
+      d.contact.geom,
+      d.contact.worldid,
+    ],
+  )

--- a/mujoco_warp/_src/collision_sdf.py
+++ b/mujoco_warp/_src/collision_sdf.py
@@ -57,7 +57,7 @@ def transform_aabb(aabb_pos: wp.vec3, aabb_size: wp.vec3, pos: wp.vec3, ori: wp.
     c = corner + aabb_pos
     aabb.max = wp.max(aabb.max, c)
     aabb.min = wp.min(aabb.min, c)
-  aabb.min =  ori * aabb.min + pos
+  aabb.min = ori * aabb.min + pos
 
   return aabb
 
@@ -78,72 +78,78 @@ def ellipsoid(p: wp.vec3, size: wp.vec3) -> float:
     denom = 1e-12
   return k0 * (k0 - 1.0) / denom
 
+
 @wp.func
 def Fract(x: float) -> float:
-    return x - wp.floor(x)
+  return x - wp.floor(x)
+
+
 @wp.func
 def Subtraction(a: float, b: float) -> float:
-    return wp.max(a, -b)
+  return wp.max(a, -b)
+
+
 @wp.func
 def Union(a: float, b: float) -> float:
-    return wp.min(a, b)
+  return wp.min(a, b)
+
+
 @wp.func
 def Intersection(a: float, b: float) -> float:
-    return wp.max(a, b)
+  return wp.max(a, b)
+
+
 @wp.func
-def nut(p: wp.vec3,  attr: wp.vec3) -> float:
-    screw = 12.0
-    radius2 = wp.sqrt(p[0]*p[0] + p[1]*p[1]) - attr[0]
-    sqrt12 = wp.sqrt(2.0)/2.0
-    azimuth = wp.atan2(p[1], p[0])
-    triangle = wp.abs(Fract(p[2] * screw - azimuth / (wp.pi * 2.0)) - 0.5)
-    thread2 = (radius2 - triangle / screw) * sqrt12
-    cone2 = (p[2] - radius2) * sqrt12
-    hole = Subtraction(thread2, cone2 + 0.5 * sqrt12)
-    hole = Union(hole, -cone2 - 0.05 * sqrt12)
-    k = 6.0 / wp.pi / 2.0
-    angle = -wp.floor((wp.atan2(p[1], p[0])) * k + 0.5) / k
-    s0 = wp.sin(angle)
-    s1 = wp.sin(angle + wp.pi * 0.5)
-    res0 = s1 * p[0] - s0 * p[1]
-    res1 = s0 * p[0] + s1 * p[1]
-    point3D0 = res0
-    point3D1 = res1
-    point3D2 = p[2]
-    head = point3D0 - 0.5
-    head = Intersection(head, wp.abs(point3D2 + 0.25) - 0.25)
-    head = Intersection(head, (point3D2 + radius2 - 0.22) * sqrt12)
-    return Subtraction(head, hole)
+def nut(p: wp.vec3, attr: wp.vec3) -> float:
+  screw = 12.0
+  radius2 = wp.sqrt(p[0] * p[0] + p[1] * p[1]) - attr[0]
+  sqrt12 = wp.sqrt(2.0) / 2.0
+  azimuth = wp.atan2(p[1], p[0])
+  triangle = wp.abs(Fract(p[2] * screw - azimuth / (wp.pi * 2.0)) - 0.5)
+  thread2 = (radius2 - triangle / screw) * sqrt12
+  cone2 = (p[2] - radius2) * sqrt12
+  hole = Subtraction(thread2, cone2 + 0.5 * sqrt12)
+  hole = Union(hole, -cone2 - 0.05 * sqrt12)
+  k = 6.0 / wp.pi / 2.0
+  angle = -wp.floor((wp.atan2(p[1], p[0])) * k + 0.5) / k
+  s0 = wp.sin(angle)
+  s1 = wp.sin(angle + wp.pi * 0.5)
+  res0 = s1 * p[0] - s0 * p[1]
+  res1 = s0 * p[0] + s1 * p[1]
+  point3D0 = res0
+  point3D1 = res1
+  point3D2 = p[2]
+  head = point3D0 - 0.5
+  head = Intersection(head, wp.abs(point3D2 + 0.25) - 0.25)
+  head = Intersection(head, (point3D2 + radius2 - 0.22) * sqrt12)
+  return Subtraction(head, hole)
 
 
 @wp.func
 def bolt(p: wp.vec3, attr: wp.vec3) -> float:
-    screw = 12.0
-    radius = wp.sqrt(p[0]*p[0] + p[1]*p[1]) - attr[0]
-    sqrt12 = wp.sqrt(2.0) / 2.0
+  screw = 12.0
+  radius = wp.sqrt(p[0] * p[0] + p[1] * p[1]) - attr[0]
+  sqrt12 = wp.sqrt(2.0) / 2.0
 
-    azimuth = wp.atan2(p[1], p[0])
-    triangle = wp.abs((p[2] * screw - azimuth / (wp.pi * 2.0)) 
-               - wp.floor(p[2] * screw - azimuth / (wp.pi * 2.0)) - 0.5)
-    thread = (radius - triangle / screw) * sqrt12
+  azimuth = wp.atan2(p[1], p[0])
+  triangle = wp.abs((p[2] * screw - azimuth / (wp.pi * 2.0)) - wp.floor(p[2] * screw - azimuth / (wp.pi * 2.0)) - 0.5)
+  thread = (radius - triangle / screw) * sqrt12
 
-    bolt = thread - (0.5 - wp.abs(p[2] + 0.5))
-    cone = (p[2] - radius) * sqrt12
-    bolt = wp.max(bolt, -(cone + 1.0 * sqrt12))
+  bolt = thread - (0.5 - wp.abs(p[2] + 0.5))
+  cone = (p[2] - radius) * sqrt12
+  bolt = wp.max(bolt, -(cone + 1.0 * sqrt12))
 
-    k = 6.0 / (wp.pi * 2.0)
-    angle = -wp.floor((wp.atan2(p[1], p[0])) * k + 0.5) / k
-    s = wp.vec2(wp.sin(angle), wp.sin(angle + wp.pi * 0.5))
-    rot_point = wp.vec2(
-        s[1] * p[0] - s[0] * p[1],
-        s[0] * p[0] + s[1] * p[1]
-    )
+  k = 6.0 / (wp.pi * 2.0)
+  angle = -wp.floor((wp.atan2(p[1], p[0])) * k + 0.5) / k
+  s = wp.vec2(wp.sin(angle), wp.sin(angle + wp.pi * 0.5))
+  rot_point = wp.vec2(s[1] * p[0] - s[0] * p[1], s[0] * p[0] + s[1] * p[1])
 
-    head = rot_point[0] - 0.5
-    head = wp.max(head, wp.abs(rot_point[1] + 0.25) - 0.25)
-    head = wp.max(head, (rot_point[1] + radius - 0.22) * sqrt12)
+  head = rot_point[0] - 0.5
+  head = wp.max(head, wp.abs(rot_point[1] + 0.25) - 0.25)
+  head = wp.max(head, (rot_point[1] + radius - 0.22) * sqrt12)
 
-    return wp.max(bolt, head)
+  return wp.max(bolt, head)
+
 
 @wp.func
 def grad_sphere(p: wp.vec3) -> wp.vec3:
@@ -329,7 +335,7 @@ def gradient_descent(type1: int, type2: int, sdf_type1: int = 0, sdf_type2: int 
     grad1 = params.rel_mat * grad1
     grad1 = wp.normalize(grad1)
     grad2 = wp.normalize(grad2)
-    n =  grad2 - grad1
+    n = grad2 - grad1
     pos = rot2 * x + pos2
     n = rot2 * n
     n = wp.normalize(n)

--- a/mujoco_warp/_src/collision_sdf.py
+++ b/mujoco_warp/_src/collision_sdf.py
@@ -26,11 +26,6 @@ from .math import make_frame
 from . import math
 
 @wp.struct
-class GradientState:
-  dist: float
-  x: wp.vec3
-
-@wp.struct
 class OptimizationParams:
   rel_mat: wp.mat33
   rel_pos: wp.vec3
@@ -257,9 +252,9 @@ def gradient_step(type1: int, type2: int,  sdf_type1: int, sdf_type2: int, niter
               )
 
               if alpha <= amin or (dist - dist0) <= wolfe:
-                  if dist > dist0:
-                     return dist, x
-                  break       
+                  break  
+          if dist > dist0:
+                  return dist, x
         return dist, x
     return _gradient_step
 
@@ -456,7 +451,7 @@ def sdf_sdf(type1: int, type2: int, sdf_type1: int = 0, sdf_type2: int = 0):
   return _sdf_sdf
 
 @wp.kernel
-def _sdf_narrowphase5(
+def _sdf_narrowphase6(
   # Model:
   geom_type: wp.array(dtype=int),
   sdf_type: wp.array(dtype=int),
@@ -646,7 +641,7 @@ def _sdf_narrowphase5(
 
 def sdf_narrowphase(m: Model, d: Data):
   wp.launch(
-    _sdf_narrowphase5,
+    _sdf_narrowphase6,
     dim=d.nconmax,
     inputs=[
       m.geom_type,

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -38,6 +38,8 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     if unsupported.any():
       raise NotImplementedError(f"{field_str} {field[unsupported]} not supported.")
 
+  sdf_types = np.zeros_like(mjm.geom_type)
+  attr = np.zeros((mjm.geom_type.shape[0], 3), dtype=float)
   if mjm.nplugin > 0:
     sdf_types = []
     attr = []
@@ -62,7 +64,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
                     current.append(v)
             # Pad with zeros if less than 3
             attr_values += [0.0] * (3 - len(attr_values))
-            attr.append(attr_values[:3])  # Ensure only 3 elements
+            attr.append(attr_values[:3])
     sdf_types = np.array(sdf_types)
     attr = np.array(attr)
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -44,27 +44,27 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     sdf_types = []
     attr = []
     for i in mjm.geom_plugin:
-        if i == -1:
-            sdf_types.append(-1)
-            attr.append([0.0, 0.0, 0.0])
-        else:
-            sdf_types.append(mjm.plugin[i])
-            start = mjm.plugin_attradr[i]
-            end = mjm.plugin_attradr[i + 1] if i + 1 < mjm.nplugin else len(mjm.plugin_attr)
-            values = mjm.plugin_attr[start:end]
-            attr_values = []
-            current = []
-            for v in values:
-                if v == 0:
-                    if current:
-                        s = ''.join(chr(int(x)) for x in current)
-                        attr_values.append(float(s))
-                        current = []
-                else:
-                    current.append(v)
-            # Pad with zeros if less than 3
-            attr_values += [0.0] * (3 - len(attr_values))
-            attr.append(attr_values[:3])
+      if i == -1:
+        sdf_types.append(-1)
+        attr.append([0.0, 0.0, 0.0])
+      else:
+        sdf_types.append(mjm.plugin[i])
+        start = mjm.plugin_attradr[i]
+        end = mjm.plugin_attradr[i + 1] if i + 1 < mjm.nplugin else len(mjm.plugin_attr)
+        values = mjm.plugin_attr[start:end]
+        attr_values = []
+        current = []
+        for v in values:
+          if v == 0:
+            if current:
+              s = "".join(chr(int(x)) for x in current)
+              attr_values.append(float(s))
+              current = []
+          else:
+            current.append(v)
+        # Pad with zeros if less than 3
+        attr_values += [0.0] * (3 - len(attr_values))
+        attr.append(attr_values[:3])
     sdf_types = np.array(sdf_types)
     attr = np.array(attr)
 
@@ -397,8 +397,8 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     dof_tri_row=wp.array(dof_tri_row, dtype=int),
     dof_tri_col=wp.array(dof_tri_col, dtype=int),
     geom_type=wp.array(mjm.geom_type, dtype=int),
-    geom_sdf_plugin_type = wp.array(sdf_types, dtype=int),
-    geom_sdf_plugin_attr = wp.array(attr, dtype=wp.vec3f),
+    geom_sdf_plugin_type=wp.array(sdf_types, dtype=int),
+    geom_sdf_plugin_attr=wp.array(attr, dtype=wp.vec3f),
     geom_contype=wp.array(mjm.geom_contype, dtype=int),
     geom_conaffinity=wp.array(mjm.geom_conaffinity, dtype=int),
     geom_condim=wp.array(mjm.geom_condim, dtype=int),

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -38,8 +38,8 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     if unsupported.any():
       raise NotImplementedError(f"{field_str} {field[unsupported]} not supported.")
 
-  if mjm.nplugin > 0:
-    raise NotImplementedError("Plugins are unsupported.")
+  #if mjm.nplugin > 0:
+  #  raise NotImplementedError("Plugins are unsupported.")
 
   if mjm.nflex > 0:
     raise NotImplementedError("Flex is unsupported.")
@@ -370,6 +370,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     dof_tri_row=wp.array(dof_tri_row, dtype=int),
     dof_tri_col=wp.array(dof_tri_col, dtype=int),
     geom_type=wp.array(mjm.geom_type, dtype=int),
+    geom_sdf_plugin_type = wp.zeros(mjm.geom_type.shape, dtype=int),
     geom_contype=wp.array(mjm.geom_contype, dtype=int),
     geom_conaffinity=wp.array(mjm.geom_conaffinity, dtype=int),
     geom_condim=wp.array(mjm.geom_condim, dtype=int),

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -219,9 +219,12 @@ class GeomType(enum.IntEnum):
   CYLINDER = mujoco.mjtGeom.mjGEOM_CYLINDER
   BOX = mujoco.mjtGeom.mjGEOM_BOX
   MESH = mujoco.mjtGeom.mjGEOM_MESH
+  SDF = mujoco.mjtGeom.mjGEOM_SDF
   # unsupported: HFIELD,
   # NGEOMTYPES, ARROW*, LINE, SKIN, LABEL, NONE
 
+class SDFType(enum.IntEnum):
+  NUT = 0
 
 class SolverType(enum.IntEnum):
   """Constraint solver algorithm.
@@ -867,6 +870,7 @@ class Model:
   dof_tri_row: wp.array(dtype=int)  # warp only
   dof_tri_col: wp.array(dtype=int)  # warp only
   geom_type: wp.array(dtype=int)
+  geom_sdf_plugin_type: wp.array(dtype=int)
   geom_contype: wp.array(dtype=int)
   geom_conaffinity: wp.array(dtype=int)
   geom_condim: wp.array(dtype=int)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -224,7 +224,12 @@ class GeomType(enum.IntEnum):
   # NGEOMTYPES, ARROW*, LINE, SKIN, LABEL, NONE
 
 class SDFType(enum.IntEnum):
-  NUT = 0
+  BOLT = 3
+  BOWL = 4
+  GEAR = 5
+  NUT = 6
+  TORUS= 7
+
 
 class SolverType(enum.IntEnum):
   """Constraint solver algorithm.
@@ -871,6 +876,7 @@ class Model:
   dof_tri_col: wp.array(dtype=int)  # warp only
   geom_type: wp.array(dtype=int)
   geom_sdf_plugin_type: wp.array(dtype=int)
+  geom_sdf_plugin_attr: wp.array(dtype=wp.vec3f)
   geom_contype: wp.array(dtype=int)
   geom_conaffinity: wp.array(dtype=int)
   geom_condim: wp.array(dtype=int)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -223,12 +223,13 @@ class GeomType(enum.IntEnum):
   # unsupported: HFIELD,
   # NGEOMTYPES, ARROW*, LINE, SKIN, LABEL, NONE
 
+
 class SDFType(enum.IntEnum):
   BOLT = 3
   BOWL = 4
   GEAR = 5
   NUT = 6
-  TORUS= 7
+  TORUS = 7
 
 
 class SolverType(enum.IntEnum):


### PR DESCRIPTION
This MR is a starting point for SDF collisions.  In Mujoco SDF collisions are performed when at least 1 geometry is of SDF type and there is a plugin which implements distance and gradient method.  Mujoco already contains a couple of sdf plugins and offers a possibility to add more. So far I ported the general sdf collision logic and some distance and gradient functions of convex and non-convex shapes e.g.  from nut and bolt plugins.

But, thats not flexible enough and does not generalize to other non convex shapes. How do we proceed from here ? Do we intend to extend the plugin mechanism to warp?