### PR TITLE
Optimization: fuse linesearch_zero_jv and linesarch_init_jv

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1282,7 +1282,10 @@ def _linesearch(m: types.Model, d: types.Data):
 
   # jv = efc_J @ search
   # TODO(team): is there a better way of doing batched matmuls with dynamic array sizes?
-  dofs_per_thread = 50
+  if m.nv > 50:
+    dofs_per_thread = 20
+  else:
+    dofs_per_thread = 50
 
   threads_per_efc = ceil(m.nv / dofs_per_thread)
   # we need to clear the jv array if we're doing atomic adds.

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1064,31 +1064,6 @@ def linesearch_zero_jv(
   efc_jv_out[efcid] = 0.0
 
 
-@wp.kernel
-def linesearch_init_jv(
-  # Data in:
-  nefc_in: wp.array(dtype=int),
-  efc_worldid_in: wp.array(dtype=int),
-  efc_J_in: wp.array2d(dtype=float),
-  efc_search_in: wp.array2d(dtype=float),
-  efc_done_in: wp.array(dtype=bool),
-  # Data out:
-  efc_jv_out: wp.array(dtype=float),
-):
-  efcid, dofid = wp.tid()
-
-  if efcid >= nefc_in[0]:
-    return
-
-  worldid = efc_worldid_in[efcid]
-
-  if efc_done_in[worldid]:
-    return
-
-  j = efc_J_in[efcid, dofid]
-  search = efc_search_in[worldid, dofid]
-  wp.atomic_add(efc_jv_out, efcid, j * search)
-
 def linesearch_jv_fused(nv: int, dofs_per_thread: int):
   @nested_kernel # nested_kernel here is a 15ns perf penalty per step.
   def kernel(

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1066,7 +1066,7 @@ def linesearch_zero_jv(
 
 
 def linesearch_jv_fused(nv: int, dofs_per_thread: int):
-  @nested_kernel 
+  @nested_kernel
   def kernel(
     # Data in:
     nefc_in: wp.array(dtype=int),

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1066,7 +1066,7 @@ def linesearch_zero_jv(
 
 
 def linesearch_jv_fused(nv: int, dofs_per_thread: int):
-  @nested_kernel  # nested_kernel here is a 15ns perf penalty per step.
+  @nested_kernel 
   def kernel(
     # Data in:
     nefc_in: wp.array(dtype=int),

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1159,35 +1159,6 @@ def linesearch_init_quad_gauss(
   wp.atomic_add(efc_quad_gauss_out, worldid, quad_gauss)
 
 @wp.kernel
-def linesearch_quad_gauss_fused(
-  # Model:
-  nv: int,
-  # Data in:
-  qfrc_smooth_in: wp.array2d(dtype=float),
-  efc_Ma_in: wp.array2d(dtype=float),
-  efc_search_in: wp.array2d(dtype=float),
-  efc_gauss_in: wp.array(dtype=float),
-  efc_mv_in: wp.array2d(dtype=float),
-  efc_done_in: wp.array(dtype=bool),
-  # Data out:
-  efc_quad_gauss_out: wp.array(dtype=wp.vec3),
-):
-  worldid = wp.tid()
-  if efc_done_in[worldid]:
-    return
-
-  quad_gauss = wp.vec3(0.0)
-
-  for i in range(nv):
-    search = efc_search_in[worldid, i]
-    quad_gauss[0] = efc_gauss_in[worldid] / float(nv)
-    quad_gauss[1] = search * (efc_Ma_in[worldid, i] - qfrc_smooth_in[worldid, i])
-    quad_gauss[2] = 0.5 * search * efc_mv_in[worldid, i]
-
-  efc_quad_gauss_out[worldid] = quad_gauss
-
-
-@wp.kernel
 def linesearch_init_quad(
   # Data in:
   nefc_in: wp.array(dtype=int),
@@ -1347,30 +1318,23 @@ def _linesearch(m: types.Model, d: types.Data):
       outputs=[d.efc.jv],
     )
 
-  if m.nv < 50:
-    wp.launch(
-      linesearch_quad_gauss_fused,
-      dim=(d.nworld),
-      inputs=[m.nv, d.qfrc_smooth, d.efc.Ma, d.efc.search, d.efc.gauss, d.efc.mv, d.efc.done],
-      outputs=[d.efc.quad_gauss],
-    )
-  else:
-    # prepare quadratics
-    # quad_gauss = [gauss, search.T @ Ma - search.T @ qfrc_smooth, 0.5 * search.T @ mv]
-    # TOOD(team): is zero_() better here?
-    wp.launch(
-      linesearch_zero_quad_gauss,
-      dim=(d.nworld),
-      inputs=[d.efc.done],
-      outputs=[d.efc.quad_gauss],
-    )
 
-    wp.launch(
-      linesearch_init_quad_gauss,
-      dim=(d.nworld, m.nv),
-      inputs=[m.nv, d.qfrc_smooth, d.efc.Ma, d.efc.search, d.efc.gauss, d.efc.mv, d.efc.done],
-      outputs=[d.efc.quad_gauss],
-    )
+  # prepare quadratics
+  # quad_gauss = [gauss, search.T @ Ma - search.T @ qfrc_smooth, 0.5 * search.T @ mv]
+  # TOOD(team): is zero_() better here?
+  wp.launch(
+    linesearch_zero_quad_gauss,
+    dim=(d.nworld),
+    inputs=[d.efc.done],
+    outputs=[d.efc.quad_gauss],
+  )
+
+  wp.launch(
+    linesearch_init_quad_gauss,
+    dim=(d.nworld, m.nv),
+    inputs=[m.nv, d.qfrc_smooth, d.efc.Ma, d.efc.search, d.efc.gauss, d.efc.mv, d.efc.done],
+    outputs=[d.efc.quad_gauss],
+  )
 
   # quad = [0.5 * Jaref * Jaref * efc_D, jv * Jaref * efc_D, 0.5 * jv * jv * efc_D]
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1318,7 +1318,6 @@ def _linesearch(m: types.Model, d: types.Data):
       outputs=[d.efc.jv],
     )
 
-
   # prepare quadratics
   # quad_gauss = [gauss, search.T @ Ma - search.T @ qfrc_smooth, 0.5 * search.T @ mv]
   # TOOD(team): is zero_() better here?

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1282,6 +1282,10 @@ def _linesearch(m: types.Model, d: types.Data):
 
   # jv = efc_J @ search
   # TODO(team): is there a better way of doing batched matmuls with dynamic array sizes?
+  
+  # if we are only using 1 thread, it makes sense to do more dofs as we can also skip the 
+  # init kernel. If we use more than 1 thread, dofs_per_thread is lower for better load balancing.
+
   if m.nv > 50:
     dofs_per_thread = 20
   else:

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1176,9 +1176,10 @@ def linesearch_quad_gauss_fused(
   if efc_done_in[worldid]:
     return
 
+  quad_gauss = wp.vec3(0.0)
+
   for i in range(nv):
     search = efc_search_in[worldid, i]
-    quad_gauss = wp.vec3()
     quad_gauss[0] = efc_gauss_in[worldid] / float(nv)
     quad_gauss[1] = search * (efc_Ma_in[worldid, i] - qfrc_smooth_in[worldid, i])
     quad_gauss[2] = 0.5 * search * efc_mv_in[worldid, i]


### PR DESCRIPTION
For humanoid, but I'm seeing good stuff for many other things as well. This is a tiny piece of an effort to work on all of these tiny kernels, so sometimes it might not even show up in the overall runtime. But looking at low-level traces, there is a big difference.

Time spent in the 2 kernels before/after for 8k humanoids: 11ms -> 1.5ms.

main:

```
Summary for 8192 parallel rollouts

 Total JIT time: 1.18 s
 Total simulation time: 0.16 s
 Total steps per second: 2,555,648
 Total realtime factor: 12,778.24 x
 Total time per step: 391.29 ns

```
this:

```
Summary for 8192 parallel rollouts

 Total JIT time: 1.12 s
 Total simulation time: 0.15 s
 Total steps per second: 2,773,893
 Total realtime factor: 13,869.46 x
 Total time per step: 360.50 ns

```

