### PR TITLE
Optimization: launch fewer threads and loop over nv in init_qfrc_constraint

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1732,33 +1732,6 @@ def update_constraint_zero_qfrc_constraint(
 
 @wp.kernel
 def update_constraint_init_qfrc_constraint(
-  # Data in:
-  nefc_in: wp.array(dtype=int),
-  efc_worldid_in: wp.array(dtype=int),
-  efc_J_in: wp.array2d(dtype=float),
-  efc_force_in: wp.array(dtype=float),
-  efc_done_in: wp.array(dtype=bool),
-  # Data out:
-  qfrc_constraint_out: wp.array2d(dtype=float),
-):
-  dofid, efcid = wp.tid()
-
-  if efcid >= nefc_in[0]:
-    return
-
-  worldid = efc_worldid_in[efcid]
-
-  if efc_done_in[worldid]:
-    return
-
-  wp.atomic_add(
-    qfrc_constraint_out[worldid],
-    dofid,
-    efc_J_in[efcid, dofid] * efc_force_in[efcid],
-  )
-
-@wp.kernel
-def update_constraint_init_qfrc_constraintv2(
   # Model in:
   nv: int,
   # Data in:
@@ -1924,17 +1897,10 @@ def _update_constraint(m: types.Model, d: types.Data):
     outputs=[d.qfrc_constraint],
   )
 
-  #wp.launch(
-  #  update_constraint_init_qfrc_constraint,
-  #  dim=(m.nv, d.njmax),
-  #  inputs=[d.nefc, d.efc.worldid, d.efc.J, d.efc.force, d.efc.done],
-  #  outputs=[d.qfrc_constraint],
-  #)
-
   wp.launch(
-    update_constraint_init_qfrc_constraintv2,
+    update_constraint_init_qfrc_constraint,
     dim=(d.njmax),
-    inputs=[m.nv,d.nefc, d.efc.worldid, d.efc.J, d.efc.force, d.efc.done],
+    inputs=[m.nv, d.nefc, d.efc.worldid, d.efc.J, d.efc.force, d.efc.done],
     outputs=[d.qfrc_constraint],
   )
 


### PR DESCRIPTION
Seems to have a good effect on many assets, especially if you look at low-level traces. Makes sense if you think about it - we only need to load the force once.

Total time spent in this kernel for some assets (main -> this):
humanoid: 4.4ms -> 1.9ms
n_humanoids: 333ms -> 29.8ms
internal asset with nv==70: 94ms -> 14.58ms
Ant: 2.7s -> 294ms
cartpole: 693ms -> 286ms