### PR TITLE
height field maxconpair check

### DIFF
--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -22,6 +22,7 @@ from absl.testing import parameterized
 import mujoco_warp as mjwarp
 
 from . import test_util
+from . import types
 
 
 class CollisionTest(parameterized.TestCase):
@@ -664,6 +665,31 @@ class CollisionTest(parameterized.TestCase):
     mjwarp.collision(m, d)
 
     self.assertEqual(d.ncon.numpy()[0], mjd.ncon)
+
+  def test_hfield_maxconpair(self):
+    _XML = f"""
+    <mujoco>
+      <asset>
+        <hfield name="hfield" nrow="10" ncol="10" size="1e-6 1e-6 1 1"/>
+      </asset>
+      <worldbody>
+        <body>
+          <joint type="slide" axis="0 0 1"/>
+          <geom type="sphere" size=".1"/>
+        </body>
+        <geom type="hfield" hfield="hfield"/>
+      </worldbody>
+      <keyframe>
+        <key qpos=".0999"/>
+      </keyframe>
+    </mujoco>
+    """
+
+    _, _, m, d = test_util.fixture(xml=_XML, keyframe=0)
+
+    mjwarp.collision(m, d)
+
+    np.testing.assert_equal(d.ncon.numpy()[0], types.MJ_MAXCONPAIR)
 
   # TODO(team): test contact parameter mixing
 

--- a/mujoco_warp/_src/collision_hfield.py
+++ b/mujoco_warp/_src/collision_hfield.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import warp as wp
 
+from .types import MJ_MAXCONPAIR
 from .types import Data
 from .types import GeomType
 from .types import Model
@@ -329,7 +330,7 @@ def _hfield_midphase(
   ncol = hfield_ncol[dataid]
 
   # Loop through grid cells and add pairs for all triangles
-  # TODO(vreutskyy): propose a way to limit the number of contacts between a hfield and the other geom
+  count = int(0)
   for j in range(min_j, max_j + 1):
     for i in range(min_i, max_i + 1):
       # Each grid cell contains two triangles
@@ -351,6 +352,10 @@ def _hfield_midphase(
         collision_hftri_index_out[new_pairid] = base_idx + t
         collision_pairid_out[new_pairid] = pair_id
         collision_worldid_out[new_pairid] = worldid
+
+        count += 1
+        if count >= MJ_MAXCONPAIR:
+          return
 
 
 def hfield_midphase(m: Model, d: Data):


### PR DESCRIPTION
limits the number of contacts with a height field to `mjMAXCONPAIR`

depends on #307

mujoco reference: https://github.com/google-deepmind/mujoco/blob/568620dd2f0f661dae2baafe3c5dee6d1d9f88ae/src/engine/engine_collision_convex.c#L1327