### PR TITLE
Update README.md to also tell user to install MuJoCo nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ source env/bin/activate
 pip install --upgrade pip
 ```
 
-During early development, MJWarp is on the bleeding edge - you should install Warp nightly:
+During early development, MJWarp is on the bleeding edge - you should install Warp and MuJoCo nightly:
 
 ```bash
 pip install warp-lang --pre --upgrade -f https://pypi.nvidia.com/warp-lang/
+pip install mujoco --pre --upgrade -f https://py.mujoco.org/
 ```
 
 Then install MJWarp in editable mode for local development:


### PR DESCRIPTION
Environment:

- Ubuntu 24.04
- 4090, CUDA 12.8, 570 open driver 
- Conda python 3.12


Quick reasoning:

- Installed on a fresh Conda environment (python 3.12) following exactly instructions on readme (except venv)
- pytest failed with "172 failed, 80 passed in 9.35s"
- Checked CI and it ran successfully. Compared difference in setup and it came down to: pip install mujoco --pre -f https://py.mujoco.org/
- Doing so (with the update flag) yields: 252 passed in 188.05s (0:03:08)