### PR TITLE
Add nC for dim of mapM2M.

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -301,6 +301,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     nmocap=mjm.nmocap,
     ngravcomp=mjm.ngravcomp,
     nM=mjm.nM,
+    nC=mjm.nC,
     ntendon=mjm.ntendon,
     nwrap=mjm.nwrap,
     nsensor=mjm.nsensor,

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -952,7 +952,7 @@ def _factor_i_sparse(m: Model, d: Data, M: wp.array3d(dtype=float), L: wp.array3
   if version.parse(mujoco.__version__) <= version.parse("3.2.7"):
     return _factor_i_sparse_legacy(m, d, M, L, D)
 
-  wp.launch(_copy_CSR, dim=(d.nworld, m.nM), inputs=[m.mapM2M, M], outputs=[L])
+  wp.launch(_copy_CSR, dim=(d.nworld, m.nC), inputs=[m.mapM2M, M], outputs=[L])
 
   for i in reversed(range(len(m.qLD_updates))):
     qLD_updates = m.qLD_updates[i]

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -619,6 +619,7 @@ class Model:
     nmocap: number of mocap bodies                           ()
     ngravcomp: number of bodies with nonzero gravcomp        ()
     nM: number of non-zeros in sparse inertia matrix         ()
+    nC: number of non-zeros in sparse reduced dof-dof matrix ()
     ntendon: number of tendons                               ()
     nwrap: number of wrap objects in all tendon paths        ()
     nsensor: number of sensors                               ()
@@ -644,7 +645,7 @@ class Model:
     M_rownnz: number of non-zeros in each row of qM             (nv,)
     M_rowadr: index of each row in qM                           (nv,)
     M_colind: column indices of non-zeros in qM                 (nM,)
-    mapM2M: index mapping from M (legacy) to M (CSR)            (nM)
+    mapM2M: index mapping from M (legacy) to M (CSR)            (nC)
     qM_tiles: tiling configuration
     body_tree: list of body ids by tree level
     body_parentid: id of body's parent                       (nbody,)
@@ -873,6 +874,7 @@ class Model:
   nmocap: int
   ngravcomp: int
   nM: int
+  nC: int
   ntendon: int
   nwrap: int
   nsensor: int


### PR DESCRIPTION
This fixes 700 errors invalid memory access errors in certain models.