### PR TITLE
Add missing dependency, packaging, to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "etils[epath]",
     "mujoco",
     "numpy",
+    "packaging",
     "warp-lang",
 ]
 


### PR DESCRIPTION
In smooth.py, `packaging.version` is imported, but it's not declared as a package dependency.