### PR TITLE
Add pendula.xml to jax_test.

### DIFF
--- a/mujoco_warp/_src/jax_test.py
+++ b/mujoco_warp/_src/jax_test.py
@@ -22,6 +22,8 @@ from absl.testing import parameterized
 import mujoco_warp as mjwarp
 from mujoco_warp._src.test_util import fixture
 
+# TODO(team): JAX test is temporary, remove after we land MJX:Warp
+
 
 class JAXTest(parameterized.TestCase):
   @parameterized.parameters("humanoid/humanoid.xml", "pendula.xml")
@@ -84,6 +86,7 @@ class JAXTest(parameterized.TestCase):
       warp_step,
       num_outputs=2,
       output_dims={"qpos_out": (NWORLDS, mjm.nq), "qvel_out": (NWORLDS, mjm.nv)},
+      graph_compatible=True,
     )
 
     jax_qpos = jp.tile(jp.array(m.qpos0.numpy()), (NWORLDS, 1))


### PR DESCRIPTION
pendula.xml does not work with JAX interop:

```
Warp CUDA error 900: operation not permitted when stream is capturing (in function cuda_unload_module, /builds/omniverse/warp/warp/native/warp.cu:3929)
2025-06-10 09:26:38.685489: E external/xla/xla/stream_executor/cuda/cuda_command_buffer.cc:715] CUDA error: Failed to destroy CUDA graph: CUDA_ERROR_INVALID_VALUE: invalid argument
E0610 09:26:38.685546  359201 pjrt_stream_executor_client.cc:3077] Execution of replica 0 failed: INTERNAL: CUDA error: Failed to end stream capture: CUDA_ERROR_STREAM_CAPTURE_INVALIDATED: operation failed due to a previous error during capture
...
XlaRuntimeError: INTERNAL: CUDA error: Failed to end stream capture: CUDA_ERROR_STREAM_CAPTURE_INVALIDATED: operation failed due to a previous error during capture
```


```
pip freeze | grep jax
jax==0.6.1
jax-cuda12-pjrt==0.6.1
jax-cuda12-plugin==0.6.1
jaxlib==0.6.1
```