### PR TITLE
Optimization for geom_local_to_global

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -755,6 +755,7 @@ def make_data(mjm: mujoco.MjModel, nworld: int = 1, nconmax: int = -1, njmax: in
     ximat=wp.zeros((nworld, mjm.nbody), dtype=wp.mat33),
     xanchor=wp.zeros((nworld, mjm.njnt), dtype=wp.vec3),
     xaxis=wp.zeros((nworld, mjm.njnt), dtype=wp.vec3),
+    geom_sameframe=wp.zeros(mjm.ngeom, dtype=int),  # warp only
     geom_xpos=wp.zeros((nworld, mjm.ngeom), dtype=wp.vec3),
     geom_xmat=wp.zeros((nworld, mjm.ngeom), dtype=wp.mat33),
     site_xpos=wp.zeros((nworld, mjm.nsite), dtype=wp.vec3),
@@ -1074,6 +1075,7 @@ def put_data(
     ximat=tile(mjd.ximat, dtype=wp.mat33),
     xanchor=tile(mjd.xanchor, dtype=wp.vec3),
     xaxis=tile(mjd.xaxis, dtype=wp.vec3),
+    geom_sameframe=wp.zeros(mjm.ngeom, dtype=int),  # warp only
     geom_xpos=tile(mjd.geom_xpos, dtype=wp.vec3),
     geom_xmat=tile(mjd.geom_xmat, dtype=wp.mat33),
     site_xpos=tile(mjd.site_xpos, dtype=wp.vec3),

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -755,7 +755,7 @@ def make_data(mjm: mujoco.MjModel, nworld: int = 1, nconmax: int = -1, njmax: in
     ximat=wp.zeros((nworld, mjm.nbody), dtype=wp.mat33),
     xanchor=wp.zeros((nworld, mjm.njnt), dtype=wp.vec3),
     xaxis=wp.zeros((nworld, mjm.njnt), dtype=wp.vec3),
-    geom_sameframe=wp.zeros(mjm.ngeom, dtype=int),  # warp only
+    geom_skip=wp.zeros(mjm.ngeom, dtype=bool),  # warp only
     geom_xpos=wp.zeros((nworld, mjm.ngeom), dtype=wp.vec3),
     geom_xmat=wp.zeros((nworld, mjm.ngeom), dtype=wp.mat33),
     site_xpos=wp.zeros((nworld, mjm.nsite), dtype=wp.vec3),
@@ -1075,7 +1075,7 @@ def put_data(
     ximat=tile(mjd.ximat, dtype=wp.mat33),
     xanchor=tile(mjd.xanchor, dtype=wp.vec3),
     xaxis=tile(mjd.xaxis, dtype=wp.vec3),
-    geom_sameframe=wp.zeros(mjm.ngeom, dtype=int),  # warp only
+    geom_skip=wp.zeros(mjm.ngeom, dtype=bool),  # warp only
     geom_xpos=tile(mjd.geom_xpos, dtype=wp.vec3),
     geom_xmat=tile(mjd.geom_xmat, dtype=wp.mat33),
     site_xpos=tile(mjd.site_xpos, dtype=wp.vec3),

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -158,14 +158,14 @@ def _geom_local_to_global(
   # Data in:
   xpos_in: wp.array2d(dtype=wp.vec3),
   xquat_in: wp.array2d(dtype=wp.quat),
-  geom_sameframe_in: wp.array(dtype=int),
   # Data out:
+  geom_sameframe_out: wp.array(dtype=int),
   geom_xpos_out: wp.array2d(dtype=wp.vec3),
   geom_xmat_out: wp.array2d(dtype=wp.mat33),
 ):
   worldid, geomid = wp.tid()
   bodyid = geom_bodyid[geomid]
-  if geom_sameframe_in[geomid] == 0:
+  if geom_sameframe_out[geomid] == 0:
     # Calculate only if necessary
     xpos = xpos_in[worldid, bodyid]
     xquat = xquat_in[worldid, bodyid]
@@ -174,7 +174,7 @@ def _geom_local_to_global(
 
     if bodyid == 0:
       # static geom pose are calculated only once
-      geom_sameframe_in[geomid] = 1
+      geom_sameframe_out[geomid] = 1
 
 
 @wp.kernel
@@ -317,8 +317,8 @@ def kinematics(m: Model, d: Data):
   wp.launch(
     _geom_local_to_global,
     dim=(d.nworld, m.ngeom),
-    inputs=[m.geom_bodyid, m.geom_pos, m.geom_quat, d.xpos, d.xquat, d.geom_sameframe],
-    outputs=[d.geom_xpos, d.geom_xmat],
+    inputs=[m.geom_bodyid, m.geom_pos, m.geom_quat, d.xpos, d.xquat],
+    outputs=[d.geom_sameframe, d.geom_xpos, d.geom_xmat],
   )
 
   wp.launch(

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -156,9 +156,9 @@ def _geom_local_to_global(
   geom_pos: wp.array2d(dtype=wp.vec3),
   geom_quat: wp.array2d(dtype=wp.quat),
   # Data in:
-  geom_sameframe_in: wp.array(dtype=int),
   xpos_in: wp.array2d(dtype=wp.vec3),
   xquat_in: wp.array2d(dtype=wp.quat),
+  geom_sameframe_in: wp.array(dtype=int),
   # Data out:
   geom_xpos_out: wp.array2d(dtype=wp.vec3),
   geom_xmat_out: wp.array2d(dtype=wp.mat33),
@@ -166,12 +166,14 @@ def _geom_local_to_global(
   worldid, geomid = wp.tid()
   bodyid = geom_bodyid[geomid]
   if geom_sameframe_in[geomid] == 0:
+    # Calculate only if necessary
     xpos = xpos_in[worldid, bodyid]
     xquat = xquat_in[worldid, bodyid]
     geom_xpos_out[worldid, geomid] = xpos + math.rot_vec_quat(geom_pos[worldid, geomid], xquat)
     geom_xmat_out[worldid, geomid] = math.quat_to_mat(math.mul_quat(xquat, geom_quat[worldid, geomid]))
 
     if bodyid == 0:
+      # static geom pose are calculated only once
       geom_sameframe_in[geomid] = 1
 
 
@@ -315,7 +317,7 @@ def kinematics(m: Model, d: Data):
   wp.launch(
     _geom_local_to_global,
     dim=(d.nworld, m.ngeom),
-    inputs=[m.geom_bodyid, m.geom_pos, m.geom_quat, d.geom_sameframe, d.xpos, d.xquat],
+    inputs=[m.geom_bodyid, m.geom_pos, m.geom_quat, d.xpos, d.xquat, d.geom_sameframe],
     outputs=[d.geom_xpos, d.geom_xmat],
   )
 

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1441,6 +1441,7 @@ class Data:
   ximat: wp.array2d(dtype=wp.mat33)
   xanchor: wp.array2d(dtype=wp.vec3)
   xaxis: wp.array2d(dtype=wp.vec3)
+  geom_sameframe: wp.array(dtype=int)  # warp only
   geom_xpos: wp.array2d(dtype=wp.vec3)
   geom_xmat: wp.array2d(dtype=wp.mat33)
   site_xpos: wp.array2d(dtype=wp.vec3)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1315,7 +1315,8 @@ class Data:
     ximat: Cartesian orientation of body inertia                (nworld, nbody, 3, 3)
     xanchor: Cartesian position of joint anchor                 (nworld, njnt, 3)
     xaxis: Cartesian joint axis                                 (nworld, njnt, 3)
-    geom_sameframe: Indicate whether to compute geom pose       (ngeom,)
+    geom_skip: skip calculating `geom_xpos` and `geom_xmat`     (ngeom,)
+               during step, reuse previous value
     geom_xpos: Cartesian geom position                          (nworld, ngeom, 3)
     geom_xmat: Cartesian geom orientation                       (nworld, ngeom, 3, 3)
     site_xpos: Cartesian site position                          (nworld, nsite, 3)
@@ -1442,7 +1443,7 @@ class Data:
   ximat: wp.array2d(dtype=wp.mat33)
   xanchor: wp.array2d(dtype=wp.vec3)
   xaxis: wp.array2d(dtype=wp.vec3)
-  geom_sameframe: wp.array(dtype=int)  # warp only
+  geom_skip: wp.array(dtype=bool)  # warp only
   geom_xpos: wp.array2d(dtype=wp.vec3)
   geom_xmat: wp.array2d(dtype=wp.mat33)
   site_xpos: wp.array2d(dtype=wp.vec3)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1315,6 +1315,7 @@ class Data:
     ximat: Cartesian orientation of body inertia                (nworld, nbody, 3, 3)
     xanchor: Cartesian position of joint anchor                 (nworld, njnt, 3)
     xaxis: Cartesian joint axis                                 (nworld, njnt, 3)
+    geom_sameframe: Indicate whether to compute geom pose       (ngeom,)
     geom_xpos: Cartesian geom position                          (nworld, ngeom, 3)
     geom_xmat: Cartesian geom orientation                       (nworld, ngeom, 3, 3)
     site_xpos: Cartesian site position                          (nworld, nsite, 3)


### PR DESCRIPTION
Currently, the function geom_local_to_global is slowing down the apptronik apollo benchmark because we have a lot of geom composing the ground.
We recalculate at each timestep their position while it is unnecessary.
This change aim to skip unnecessary calculation.

Benchmark on a L40:
`python mujoco_warp/testspeed.py --function=step --mjcf=/home/horde/Documents/optimization/mujoco_warp/benchmark/apptronik_apollo/scene_terrain.xml --batch_size=8192 --nstep=1000`

Trunk:
```
 Total JIT time: 1.40 s
 Total simulation time: 2.39 s
 Total steps per second: 342,123
 Total realtime factor: 1,710.61 x
 Total time per step: 2922.93 ns
```

This branch:
```
 Total JIT time: 1.56 s
 Total simulation time: 20.52 s
 Total steps per second: 399,152
 Total realtime factor: 1,995.76 x
 Total time per step: 2505.31 ns
```

