### PR TITLE
Update .gitignore to ignore generated benchmark data for kitchen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,14 @@ MUJOCO_LOG.TXT
 ## Cloned repositories
 ## -------------------
 
-mujoco_warp/test_data/mujoco_menagerie
+benchmark/mujoco_menagerie/
+
 
 ## Created directories
 ## --------------------
 
-mujoco_warp/test_data/kitchen/combined_assets/
+benchmark/kitchen/combined_assets/
+benchmark/kitchen/kitchen_robot.xml
 
 # Language-specific files
 # =======================

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ benchmark/mujoco_menagerie/
 ## --------------------
 
 benchmark/kitchen/combined_assets/
-benchmark/kitchen/kitchen_robot.xml
+kitchen_robot.xml
 
 # Language-specific files
 # =======================


### PR DESCRIPTION
Seems like the paths were still pointing at an older version.