### PR TITLE
Avoid zeroing the constraint jacobian upfront

### DIFF
--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -245,6 +245,7 @@ def _efc_equality_connect(
 @wp.kernel
 def _efc_equality_joint(
   # Model:
+  nv: int,
   opt_timestep: float,
   qpos0: wp.array2d(dtype=float),
   jnt_qposadr: wp.array(dtype=int),
@@ -291,6 +292,9 @@ def _efc_equality_joint(
     return
 
   efc_worldid_out[efcid] = worldid
+
+  for i in range(nv):
+    efc_J_out[efcid, i] = 0.0
 
   jntid_1 = eq_obj1id[i_eq]
   jntid_2 = eq_obj2id[i_eq]
@@ -460,6 +464,7 @@ def _efc_equality_tendon(
 @wp.kernel
 def _efc_friction_dof(
   # Model:
+  nv: int,
   opt_timestep: float,
   dof_invweight0: wp.array2d(dtype=float),
   dof_frictionloss: wp.array2d(dtype=float),
@@ -493,6 +498,9 @@ def _efc_friction_dof(
 
   if efcid >= njmax_in:
     return
+  
+  for i in range(nv):
+    efc_J_out[efcid, i] = 0.0
 
   wp.atomic_add(nf_out, 0, 1)
   efc_worldid_out[efcid] = worldid
@@ -797,6 +805,7 @@ def _efc_equality_weld(
 @wp.kernel
 def _efc_limit_slide_hinge(
   # Model:
+  nv: int,
   opt_timestep: float,
   jnt_qposadr: wp.array(dtype=int),
   jnt_dofadr: wp.array(dtype=int),
@@ -843,6 +852,10 @@ def _efc_limit_slide_hinge(
     if efcid >= njmax_in:
       return
 
+    for i in range(nv):
+      efc_J_out[efcid, i] = 0.0
+
+
     efc_worldid_out[efcid] = worldid
 
     dofadr = jnt_dofadr[jntid]
@@ -879,6 +892,7 @@ def _efc_limit_slide_hinge(
 @wp.kernel
 def _efc_limit_ball(
   # Model:
+  nv: int,
   opt_timestep: float,
   jnt_qposadr: wp.array(dtype=int),
   jnt_dofadr: wp.array(dtype=int),
@@ -929,6 +943,9 @@ def _efc_limit_ball(
 
     if efcid >= njmax_in:
       return
+    
+    for i in range(nv):
+      efc_J_out[efcid, i] = 0.0
 
     efc_worldid_out[efcid] = worldid
 
@@ -1022,6 +1039,9 @@ def _efc_limit_tendon(
       return
 
     efc_worldid_out[efcid] = worldid
+
+    for i in range(nv):
+      efc_J_out[efcid, i] = 0.0
 
     Jqvel = float(0.0)
     scl = float(dist_min < dist_max) * 2.0 - 1.0
@@ -1433,7 +1453,6 @@ def make_constraint(m: types.Model, d: types.Data):
   d.nl.zero_()
 
   if not (m.opt.disableflags & types.DisableBit.CONSTRAINT.value):
-    d.efc.J.zero_()
 
     refsafe = m.opt.disableflags & types.DisableBit.REFSAFE
 
@@ -1533,6 +1552,7 @@ def make_constraint(m: types.Model, d: types.Data):
         _efc_equality_joint,
         dim=(d.nworld, m.eq_jnt_adr.size),
         inputs=[
+          m.nv,
           m.opt.timestep,
           m.qpos0,
           m.jnt_qposadr,
@@ -1627,6 +1647,7 @@ def make_constraint(m: types.Model, d: types.Data):
         _efc_friction_dof,
         dim=(d.nworld, m.nv),
         inputs=[
+          m.nv,
           m.opt.timestep,
           m.dof_invweight0,
           m.dof_frictionloss,
@@ -1690,6 +1711,7 @@ def make_constraint(m: types.Model, d: types.Data):
           _efc_limit_ball,
           dim=(d.nworld, m.jnt_limited_ball_adr.size),
           inputs=[
+            m.nv,
             m.opt.timestep,
             m.jnt_qposadr,
             m.jnt_dofadr,
@@ -1726,6 +1748,7 @@ def make_constraint(m: types.Model, d: types.Data):
           _efc_limit_slide_hinge,
           dim=(d.nworld, m.jnt_limited_slide_hinge_adr.size),
           inputs=[
+            m.nv,
             m.opt.timestep,
             m.jnt_qposadr,
             m.jnt_dofadr,

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -498,7 +498,7 @@ def _efc_friction_dof(
 
   if efcid >= njmax_in:
     return
-  
+
   for i in range(nv):
     efc_J_out[efcid, i] = 0.0
 
@@ -855,7 +855,6 @@ def _efc_limit_slide_hinge(
     for i in range(nv):
       efc_J_out[efcid, i] = 0.0
 
-
     efc_worldid_out[efcid] = worldid
 
     dofadr = jnt_dofadr[jntid]
@@ -943,7 +942,7 @@ def _efc_limit_ball(
 
     if efcid >= njmax_in:
       return
-    
+
     for i in range(nv):
       efc_J_out[efcid, i] = 0.0
 
@@ -1453,7 +1452,6 @@ def make_constraint(m: types.Model, d: types.Data):
   d.nl.zero_()
 
   if not (m.opt.disableflags & types.DisableBit.CONSTRAINT.value):
-
     refsafe = m.opt.disableflags & types.DisableBit.REFSAFE
 
     if not (m.opt.disableflags & types.DisableBit.EQUALITY.value):

--- a/mujoco_warp/_src/constraint_test.py
+++ b/mujoco_warp/_src/constraint_test.py
@@ -17,6 +17,7 @@
 
 import mujoco
 import numpy as np
+import warp as wp
 from absl.testing import absltest
 from absl.testing import parameterized
 
@@ -79,13 +80,15 @@ class ConstraintTest(parameterized.TestCase):
     _, mjd, m, d = test_util.fixture(xml=xml, cone=cone)
 
     for arr in (
-      d.efc.J,
       d.efc.D,
       d.efc.aref,
       d.efc.pos,
       d.efc.margin,
     ):
       arr.zero_()
+
+    # fill with nan to check whether we are not reading uninitialized values
+    d.efc.J.fill_(wp.nan)
 
     mjwarp.make_constraint(m, d)
 
@@ -105,7 +108,6 @@ class ConstraintTest(parameterized.TestCase):
       mjm, mjd, m, d = test_util.fixture("constraints.xml", sparse=False, cone=cone, keyframe=key)
 
       for arr in (
-        d.efc.J,
         d.efc.D,
         d.efc.aref,
         d.efc.pos,
@@ -116,6 +118,8 @@ class ConstraintTest(parameterized.TestCase):
         d.nl,
       ):
         arr.zero_()
+
+      d.efc.J.fill_(wp.nan)
 
       mjwarp.make_constraint(m, d)
 

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -243,7 +243,7 @@ class SolverTest(parameterized.TestCase):
         ineq_J0,
         ineq_J1,
         ineq_J2,  # All inequality constraints
-        np.zeros((nefc_fill, mjm.nv)),  # Padding
+        np.full((nefc_fill, mjm.nv), np.nan),  # Padding
       ]
     )
 


### PR DESCRIPTION
We do end up writing into all of the relevant memory right now afterwards anyway. For the kitchen benchmark, we clear 10 GB of VRAM which takes around 8ms on my RTX 6000 Pro Blackwell.

This change does require us to be a bit more careful about how we're initializing all the constraints, but the win is that we can do things in one go, writing the relevant data and clearing some of the nearby data that is assumed to be zero. Another upside is that we only need to clear nefc number of entries, compared to njmax.

This started showing up in the kitchen benchmark with @Kenny-Vilella 's linesearch optimizations. Still need to combine these 2 - I don't see any regressions on trunk so I think this is worthwhile without a big number right now.