### PR TITLE
Optimization: loop over nv in solve_init_jaref

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1418,7 +1418,7 @@ def solve_init_jaref(
 
   if efcid >= nefc_in[0]:
     return
-  
+
   worldid = efc_worldid_in[efcid]
   jaref = float(0.0)
   for i in range(nv):


### PR DESCRIPTION
This has the positive effect of also removing the float division, as well as removing the memset.

I tried the same 2-stage decision process I did in linesearch_jv_fused, but turns out just looping was faster for nv up 120. I think we can revisit this if it ever becomes a problem.

No big-time numbers yet on main, this has also been showing up on after Kenny's linesearch optimizations. For kitchen + G1 (8k worlds, 10steps) and parallel linesearch, this goes from 78ms total to 2ms. Avg kernel runtime from 7ms down to 160us. So it essentially disappears.