### PR TITLE
Use ceil for computing dim_x.

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2322,7 +2322,7 @@ def _update_gradient(m: types.Model, d: types.Data):
       # can be change in future to fine-tune the perf. The optimal factor will
       # depend on the kernel's occupancy, which determines how many blocks can
       # simultaneously run on the SM. TODO: This factor can be tuned further.
-      dim_x = int((sm_count * 6 * 256) / m.dof_tri_row.size)
+      dim_x = ceil((sm_count * 6 * 256) / m.dof_tri_row.size)
       dim_y = dim_x
     else:
       # fall back for CPU


### PR DESCRIPTION
I'm running into the following errors:

nblocks_perblock = int((d.njmax + dim_x - 1) / dim_x)
                           ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
ZeroDivisionError: division by zero
