### PR TITLE
Fix illegal if else in _flex_elasticity

### DIFF
--- a/mujoco_warp/_src/passive.py
+++ b/mujoco_warp/_src/passive.py
@@ -379,11 +379,10 @@ def _flex_elasticity(
   dim = flex_dim[f]
   nvert = dim + 1
   nedge = nvert * (nvert - 1) / 2
-  edges = (
-    wp.mat(0, 1, 1, 2, 2, 0, 2, 3, 0, 3, 1, 3, shape=(6, 2), dtype=int)
-    if dim == 3
-    else wp.mat(1, 2, 2, 0, 0, 1, 0, 0, 0, 0, 0, 0, shape=(6, 2), dtype=int)
-  )
+  edges = wp.where(
+      dim == 3,
+      wp.mat(0, 1, 1, 2, 2, 0, 2, 3, 0, 3, 1, 3, shape=(6, 2), dtype=int),
+      wp.mat(1, 2, 2, 0, 0, 1, 0, 0, 0, 0, 0, 0, shape=(6, 2), dtype=int))
   kD = flex_damping[f] / opt_timestep
 
   gradient = wp.mat(0.0, shape=(6, 6))


### PR DESCRIPTION
We had error internally due to the illegal use of if else in the _flex_elasticity kernel.

This is changed to use wp.where instead.