### PR TITLE
timestep as wp.array

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -15,8 +15,6 @@
 
 """Public API for MJWarp."""
 
-from mujoco_warp._src.types import Constraint as Constraint
-
 from ._src.collision_driver import collision as collision
 from ._src.collision_driver import nxn_broadphase as nxn_broadphase
 from ._src.collision_driver import sap_broadphase as sap_broadphase

--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -15,6 +15,8 @@
 
 """Public API for MJWarp."""
 
+from mujoco_warp._src.types import Constraint as Constraint
+
 from ._src.collision_driver import collision as collision
 from ._src.collision_driver import nxn_broadphase as nxn_broadphase
 from ._src.collision_driver import sap_broadphase as sap_broadphase

--- a/mujoco_warp/_src/inverse.py
+++ b/mujoco_warp/_src/inverse.py
@@ -31,7 +31,7 @@ from .types import Model
 @wp.kernel
 def _qfrc_eulerdamp(
   # Model:
-  opt_timestep: float,
+  opt_timestep: wp.array(dtype=float),
   dof_damping: wp.array2d(dtype=float),
   # Data in:
   qacc_in: wp.array2d(dtype=float),
@@ -39,7 +39,8 @@ def _qfrc_eulerdamp(
   qfrc_out: wp.array2d(dtype=float),
 ):
   worldid, dofid = wp.tid()
-  qfrc_out[worldid, dofid] += opt_timestep * dof_damping[worldid, dofid] * qacc_in[worldid, dofid]
+  timestep = opt_timestep[worldid]
+  qfrc_out[worldid, dofid] += timestep * dof_damping[worldid, dofid] * qacc_in[worldid, dofid]
 
 
 @wp.kernel

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -296,11 +296,11 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
 
     nxn_pairid[pairid] = i
 
-  def create_nmodel_batched_array(mjm_array, dtype):
+  def create_nmodel_batched_array(mjm_array, dtype, expand_dim=True):
     array = wp.array(mjm_array, dtype=dtype)
     array.strides = (0,) + array.strides
-    if type(mjm_array) in wp.types.vector_types:
-      return array  # array of vector type already has a leading dim
+    if not expand_dim:
+      return array
     array.ndim += 1
     array.shape = (1,) + array.shape
     return array
@@ -350,12 +350,12 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     nlsp=nlsp,
     npair=mjm.npair,
     opt=types.Option(
-      timestep=mjm.opt.timestep,
+      timestep=create_nmodel_batched_array(np.array(mjm.opt.timestep), dtype=float, expand_dim=False),
       tolerance=mjm.opt.tolerance,
       ls_tolerance=mjm.opt.ls_tolerance,
-      gravity=create_nmodel_batched_array(wp.vec3(mjm.opt.gravity), dtype=wp.vec3),
-      magnetic=create_nmodel_batched_array(wp.vec3(mjm.opt.magnetic), dtype=wp.vec3),
-      wind=create_nmodel_batched_array(wp.vec3(mjm.opt.wind), dtype=wp.vec3),
+      gravity=create_nmodel_batched_array(mjm.opt.gravity, dtype=wp.vec3, expand_dim=False),
+      magnetic=create_nmodel_batched_array(mjm.opt.magnetic, dtype=wp.vec3, expand_dim=False),
+      wind=create_nmodel_batched_array(mjm.opt.wind, dtype=wp.vec3, expand_dim=False),
       has_fluid=mjm.opt.wind.any() or mjm.opt.density or mjm.opt.viscosity,
       density=mjm.opt.density,
       viscosity=mjm.opt.viscosity,

--- a/mujoco_warp/_src/passive.py
+++ b/mujoco_warp/_src/passive.py
@@ -354,7 +354,7 @@ def _qfrc_passive(
 @wp.kernel
 def _flex_elasticity(
   # Model:
-  opt_timestep: float,
+  opt_timestep: wp.array(dtype=float),
   body_dofadr: wp.array(dtype=int),
   flex_dim: wp.array(dtype=int),
   flex_vertadr: wp.array(dtype=int),
@@ -374,6 +374,7 @@ def _flex_elasticity(
   qfrc_spring_out: wp.array2d(dtype=float),
 ):
   worldid, elemid = wp.tid()
+  timestep = opt_timestep[worldid]
   f = 0  # TODO(quaglino): this should become a function of t
 
   dim = flex_dim[f]
@@ -384,7 +385,7 @@ def _flex_elasticity(
     wp.mat(0, 1, 1, 2, 2, 0, 2, 3, 0, 3, 1, 3, shape=(6, 2), dtype=int),
     wp.mat(1, 2, 2, 0, 0, 1, 0, 0, 0, 0, 0, 0, shape=(6, 2), dtype=int),
   )
-  kD = flex_damping[f] / opt_timestep
+  kD = flex_damping[f] / timestep
 
   gradient = wp.mat(0.0, shape=(6, 6))
   for e in range(nedge):
@@ -402,7 +403,7 @@ def _flex_elasticity(
     vel = flexedge_velocity_in[worldid, flex_edgeadr[f] + idx]
     deformed = flexedge_length_in[worldid, flex_edgeadr[f] + idx]
     reference = flexedge_length0[flex_edgeadr[f] + idx]
-    previous = deformed - vel * opt_timestep
+    previous = deformed - vel * timestep
     elongation[e] = deformed * deformed - reference * reference + (deformed * deformed - previous * previous) * kD
 
   metric = wp.mat(0.0, shape=(6, 6))

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -531,7 +531,7 @@ class Option:
     graph_conditional: flag to use cuda graph conditional, should be False when JAX is used
   """
 
-  timestep: float
+  timestep: wp.array(dtype=float)
   impratio: float
   tolerance: float
   ls_tolerance: float


### PR DESCRIPTION
this is for the MJX integration, unfortunately the MJX API is very opinionated about the types of certain "public" fields, and timestep is one of them