### PR TITLE
add nconmax and njmax flags to viewer

### DIFF
--- a/mujoco_warp/viewer.py
+++ b/mujoco_warp/viewer.py
@@ -129,14 +129,6 @@ def _main(argv: Sequence[str]) -> None:
           wp.capture_launch(graph)
           wp.synchronize()
 
-        # check number of contacts and number of constraints
-        ncon = d.ncon.numpy()[0]
-        nefc = d.nefc.numpy()[0]
-        if ncon >= d.nconmax:
-          print(f"ncon={ncon} > nconmax={d.nconmax}")
-        if nefc >= d.njmax:
-          print(f"nefc={nefc} > njmax={d.njmax}")
-
         mjwarp.get_data_into(mjd, mjm, d)
 
       viewer.sync()

--- a/mujoco_warp/viewer.py
+++ b/mujoco_warp/viewer.py
@@ -38,6 +38,8 @@ _VIEWER_GLOBAL_STATE = {
   "running": True,
   "step_once": False,
 }
+_NCONMAX = flags.DEFINE_integer("nconmax", None, "Maximum number of contacts.")
+_NJMAX = flags.DEFINE_integer("njmax", None, "Maximum number of constraints.")
 
 
 def key_callback(key: int) -> None:
@@ -87,7 +89,7 @@ def _main(argv: Sequence[str]) -> None:
     mjm_hash = pickle.dumps(mjm)
     m = mjwarp.put_model(mjm)
     m.opt.ls_parallel = _LS_PARALLEL.value
-    d = mjwarp.put_data(mjm, mjd)
+    d = mjwarp.put_data(mjm, mjd, nconmax=_NCONMAX.value, njmax=_NJMAX.value)
 
     if _CLEAR_KERNEL_CACHE.value:
       wp.clear_kernel_cache()
@@ -126,6 +128,14 @@ def _main(argv: Sequence[str]) -> None:
           _VIEWER_GLOBAL_STATE["step_once"] = False
           wp.capture_launch(graph)
           wp.synchronize()
+
+        # check number of contacts and number of constraints
+        ncon = d.ncon.numpy()[0]
+        nefc = d.nefc.numpy()[0]
+        if ncon >= d.nconmax:
+          print(f"ncon={ncon} > nconmax={d.nconmax}")
+        if nefc >= d.njmax:
+          print(f"nefc={nefc} > njmax={d.njmax}")
 
         mjwarp.get_data_into(mjd, mjm, d)
 


### PR DESCRIPTION
add optional flags to set `nconmax` and `njmax` with the viewer

fixes #251
```
python mujoco_warp/viewer.py --mjcf=benchmark/aloha_pot/scene.xml --engine=mjwarp --nconmax=1000 --njmax=4000
```