### PR TITLE
convex collision pair

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -965,10 +965,10 @@ _collision_kernels = {}
 
 def gjk_narrowphase(m: Model, d: Data):
   if len(_collision_kernels) == 0:
-    for i in range(m.convex_collision_pair.size):
+    for i in range(m.convex_collision_pair.shape[0]):
       convex_collision_pair = m.convex_collision_pair[i]
-      t1 = convex_collision_pair[0]
-      t2 = convex_collision_pair[1]
+      t1 = int(convex_collision_pair[0])
+      t2 = int(convex_collision_pair[1])
       _collision_kernels[(t1, t2)] = _gjk_epa_pipeline(
         t1,
         t2,

--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -965,9 +965,10 @@ _collision_kernels = {}
 
 def gjk_narrowphase(m: Model, d: Data):
   if len(_collision_kernels) == 0:
-    for types in _CONVEX_COLLISION_FUNC:
-      t1 = types[0]
-      t2 = types[1]
+    for i in range(m.convex_collision_pair.size):
+      convex_collision_pair = m.convex_collision_pair[i]
+      t1 = convex_collision_pair[0]
+      t2 = convex_collision_pair[1]
       _collision_kernels[(t1, t2)] = _gjk_epa_pipeline(
         t1,
         t2,

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -21,6 +21,7 @@ import warp as wp
 
 from . import math
 from . import types
+from .collision_convex import _CONVEX_COLLISION_FUNC
 
 
 def _hfield_geom_pair(mjm: mujoco.MjModel) -> Tuple[int, np.array]:
@@ -295,6 +296,9 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
       pairid = np.int32(math.upper_tri_index(mjm.ngeom, int(pair_geom1), int(pair_geom2)))
 
     nxn_pairid[pairid] = i
+
+  convex_collision_pair = _CONVEX_COLLISION_FUNC & set(zip(mjm.geom_type[geom1], mjm.geom_type[geom2]))
+  convex_collision_pair = np.array([collision_pair for collision_pair in convex_collision_pair])
 
   def create_nmodel_batched_array(mjm_array, dtype, expand_dim=True):
     array = wp.array(mjm_array, dtype=dtype)
@@ -702,6 +706,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     mat_rgba=create_nmodel_batched_array(mjm.mat_rgba, dtype=wp.vec4),
     geompair2hfgeompair=wp.array(_hfield_geom_pair(mjm)[1], dtype=int),
     block_dim=types.BlockDim(),
+    convex_collision_pair=wp.array(convex_collision_pair, dtype=wp.vec2i),
   )
 
   return m

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -706,7 +706,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     mat_rgba=create_nmodel_batched_array(mjm.mat_rgba, dtype=wp.vec4),
     geompair2hfgeompair=wp.array(_hfield_geom_pair(mjm)[1], dtype=int),
     block_dim=types.BlockDim(),
-    convex_collision_pair=wp.array(convex_collision_pair, dtype=wp.vec2i),
+    convex_collision_pair=convex_collision_pair,
   )
 
   return m

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -16,6 +16,7 @@ import dataclasses
 import enum
 
 import mujoco
+import numpy as np
 import warp as wp
 
 MJ_MINVAL = mujoco.mjMINVAL
@@ -1262,7 +1263,7 @@ class Model:
   mat_rgba: wp.array2d(dtype=wp.vec4)
   geompair2hfgeompair: wp.array(dtype=int)  # warp only
   block_dim: BlockDim  # warp only
-  convex_collision_pair: wp.array(dtype=wp.vec2i)  # warp only
+  convex_collision_pair: np.array  # warp only
 
 
 @dataclasses.dataclass

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -979,6 +979,8 @@ class Model:
     geompair2hfgeompair: geom pair to geom pair with         (ngeom * (ngeom - 1) // 2,)
                          height field mapping
     block_dim: BlockDim
+    convex_collision_pair: geom type id pairs for convex
+                           collision functions
   """
 
   nq: int
@@ -1260,6 +1262,7 @@ class Model:
   mat_rgba: wp.array2d(dtype=wp.vec4)
   geompair2hfgeompair: wp.array(dtype=int)  # warp only
   block_dim: BlockDim  # warp only
+  convex_collision_pair: wp.array(dtype=wp.vec2i)  # warp only
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
only create and launch kernels for convex collision pairs that are included in `Model`

```
mjwarp-testspeed --function=step --mjcf=test_data/humanoid/humanoid.xml --batch_size=8192 --nconmax=450000 --njmax=450000
```
this pr:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.31 s
 Total simulation time: 30.10 s
 Total steps per second: 272,121
 Total realtime factor: 1,360.61 x
 Total time per step: 3674.83 ns
```

main:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.98 s
 Total simulation time: 31.85 s
 Total steps per second: 257,208
 Total realtime factor: 1,286.04 x
 Total time per step: 3887.90 ns
```
