### PR TITLE
Delete unused box-mesh test from collision_driver_test

### DIFF
--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -437,23 +437,6 @@ class CollisionTest(parameterized.TestCase):
         """,
   }
 
-  # Temporarily disabled
-  #  "box_mesh": """
-  #      <mujoco>
-  #        <asset>
-  #          <mesh name="boxmesh" scale="0.1 0.1 0.1"
-  #                vertex="-1 -1 -1 1 -1 -1 1 1 -1 1 1 1
-  #                         1 -1 1 -1 1 -1 -1 1 1 -1 -1 1"/>
-  #        </asset>
-  #        <worldbody>
-  #          <geom pos="0 0 -0.1" type="box" size="0.5 0.5 0.1"/>
-  #          <body pos="0 0 .099">
-  #            <joint type="free"/>
-  #            <geom type="mesh" mesh="boxmesh"/>
-  #          </body>
-  #        </worldbody>
-  #      </mujoco>
-  #    """,
   @classmethod
   def setUpClass(cls):
     register_sdf_plugins(mjwarp._src.collision_sdf)


### PR DESCRIPTION
Tests are now [here](https://github.com/google-deepmind/mujoco_warp/blob/main/mujoco_warp/_src/collision_gjk_test.py)