### PR TITLE
Avoid running SDF collision detection without SDFs in model

### DIFF
--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -496,4 +496,6 @@ def collision(m: Model, d: Data):
   # TODO(team) switch between collision functions and GJK/EPA here
   convex_narrowphase(m, d)
   primitive_narrowphase(m, d)
-  sdf_narrowphase(m, d)
+
+  if m.has_sdf_geom:
+    sdf_narrowphase(m, d)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -752,6 +752,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     geompair2hfgeompair=wp.array(_hfield_geom_pair(mjm)[1], dtype=int),
     block_dim=types.BlockDim(),
     geom_type_pair=geom_type_pair,
+    has_sdf_geom=bool(np.any(mjm.geom_type == mujoco.mjtGeom.mjGEOM_SDF)),
   )
 
   return m

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -989,6 +989,7 @@ class Model:
                          height field mapping
     block_dim: BlockDim
     geom_type_pair: geom type id pairs for collisions
+    has_sdf_geom: whether the model contains SDF geoms
   """
 
   nq: int
@@ -1275,6 +1276,7 @@ class Model:
   geompair2hfgeompair: wp.array(dtype=int)  # warp only
   block_dim: BlockDim  # warp only
   geom_type_pair: tuple[int, ...]  # warp only
+  has_sdf_geom: bool  # warp only
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Adds some static computation to avoid another launch with nconmax size.