### PR TITLE
Fix issues with wp.array return type hint and Typing.Tuple

### DIFF
--- a/mujoco_warp/_src/ray.py
+++ b/mujoco_warp/_src/ray.py
@@ -829,7 +829,7 @@ def ray(
   geomgroup: vec6 = None,
   flg_static: bool = True,
   bodyexclude: int = -1,
-) -> Tuple[wp.array2d(dtype=float), wp.array2d(dtype=int)]:
+) -> tuple[wp.array2d(dtype=float), wp.array2d(dtype=int)]:
   """Returns the distance at which rays intersect with primitive geoms.
 
   Args:


### PR DESCRIPTION
moving to tuple now. We have a weird mix in the codebase so at some point we should decide on what versions to use.

Fixes this: https://github.com/newton-physics/newton/issues/244 issue reported in newton.