### PR TITLE
update actuator tiles

### DIFF
--- a/mujoco_warp/_src/derivative.py
+++ b/mujoco_warp/_src/derivative.py
@@ -64,6 +64,7 @@ def _actuator_bias_gain_vel(
   act_vel_integration_out[worldid, actid] = bias_vel + gain_vel * ctrl
 
 
+# TODO(team): generalize for actuators
 @cache_kernel
 def _tile_qderiv_actuator_passive(
   tile_nu: TileSet,

--- a/mujoco_warp/_src/derivative.py
+++ b/mujoco_warp/_src/derivative.py
@@ -64,7 +64,6 @@ def _actuator_bias_gain_vel(
   act_vel_integration_out[worldid, actid] = bias_vel + gain_vel * ctrl
 
 
-# TODO(team): generalize for actuators
 @cache_kernel
 def _tile_qderiv_actuator_passive(
   tile_nu: TileSet,

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -649,11 +649,7 @@ def fwd_velocity(m: Model, d: Data):
   if m.opt.is_sparse:
     _actuator_velocity_sparse(m, d)
   else:
-    for tile_nu, tile_nv in zip(m.actuator_moment_tiles_nu, m.actuator_moment_tiles_nv):
-      # TODO(team): avoid creating invalid tiles
-      if tile_nu.size == 0 or tile_nv.size == 0:
-        continue
-
+    for tile_nu, tile_nv in zip(m.actuator_velocity_tiles_nu, m.actuator_velocity_tiles_nv):
       wp.launch_tiled(
         _tile_actuator_velocity_dense(tile_nu, tile_nv),
         dim=(d.nworld, tile_nu.adr.size, tile_nv.adr.size),
@@ -999,10 +995,7 @@ def fwd_actuation(m: Model, d: Data):
     )
 
   else:
-    for tile_nu, tile_nv in zip(m.actuator_moment_tiles_nu, m.actuator_moment_tiles_nv):
-      if tile_nu.size == 0 or tile_nv.size == 0:
-        continue
-
+    for tile_nu, tile_nv in zip(m.qfrc_actuator_tiles_nu, m.qfrc_actuator_tiles_nv):
       wp.launch_tiled(
         _tile_qfrc_actuator(tile_nu, tile_nv),
         dim=(d.nworld, tile_nu.adr.size, tile_nv.adr.size),

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -768,40 +768,61 @@ def _tendon_actuator_force_clamp(
         actuator_force_out[worldid, actid] *= actfrcrange[1] / ten_actfrc
 
 
-@wp.kernel
-def _qfrc_actuator(
-  # Model:
-  nu: int,
-  ngravcomp: int,
-  jnt_actfrclimited: wp.array(dtype=bool),
-  jnt_actfrcrange: wp.array2d(dtype=wp.vec2),
-  jnt_actgravcomp: wp.array(dtype=int),
-  dof_jntid: wp.array(dtype=int),
-  # Data in:
-  actuator_moment_in: wp.array3d(dtype=float),
-  qfrc_gravcomp_in: wp.array2d(dtype=float),
-  actuator_force_in: wp.array2d(dtype=float),
-  # Data out:
-  qfrc_actuator_out: wp.array2d(dtype=float),
-):
-  worldid, dofid = wp.tid()
+def _qfrc_actuator(m: Model, d: Data):
+  NU = m.nu
 
-  qfrc = float(0.0)
-  for uid in range(nu):
-    # TODO consider using Tile API or transpose moment for better access pattern
-    qfrc += actuator_moment_in[worldid, uid, dofid] * actuator_force_in[worldid, uid]
+  @wp.kernel
+  def qfrc_actuator(
+    # Model:
+    ngravcomp: int,
+    jnt_actfrclimited: wp.array(dtype=bool),
+    jnt_actfrcrange: wp.array2d(dtype=wp.vec2),
+    jnt_actgravcomp: wp.array(dtype=int),
+    dof_jntid: wp.array(dtype=int),
+    # Data in:
+    actuator_moment_in: wp.array3d(dtype=float),
+    qfrc_gravcomp_in: wp.array2d(dtype=float),
+    actuator_force_in: wp.array2d(dtype=float),
+    # Data out:
+    qfrc_actuator_out: wp.array2d(dtype=float),
+  ):
+    worldid, dofid = wp.tid()
 
-  jntid = dof_jntid[dofid]
+    actuator_moment_tile = wp.tile_load(actuator_moment_in[worldid], shape=(NU, 1), offset=(0, dofid))
+    actuator_moment_tile = wp.tile_squeeze(actuator_moment_tile, axis=(1,))
+    actuator_force_tile = wp.tile_load(actuator_force_in[worldid], shape=NU)
+    actuator_moment_force_tile = wp.tile_map(wp.mul, actuator_moment_tile, actuator_force_tile)
+    qfrc_tile = wp.tile_reduce(wp.add, actuator_moment_force_tile)
+    qfrc = qfrc_tile[0]
 
-  # actuator-level gravity compensation, skip if added as passive force
-  if ngravcomp and jnt_actgravcomp[jntid]:
-    qfrc += qfrc_gravcomp_in[worldid, dofid]
+    jntid = dof_jntid[dofid]
 
-  if jnt_actfrclimited[jntid]:
-    frcrange = jnt_actfrcrange[worldid, jntid]
-    qfrc = wp.clamp(qfrc, frcrange[0], frcrange[1])
+    # actuator-level gravity compensation, skip if added as passive force
+    if ngravcomp and jnt_actgravcomp[jntid]:
+      qfrc += qfrc_gravcomp_in[worldid, dofid]
 
-  qfrc_actuator_out[worldid, dofid] = qfrc
+    if jnt_actfrclimited[jntid]:
+      frcrange = jnt_actfrcrange[worldid, jntid]
+      qfrc = wp.clamp(qfrc, frcrange[0], frcrange[1])
+
+    qfrc_actuator_out[worldid, dofid] = qfrc
+
+  wp.launch_tiled(
+    qfrc_actuator,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      m.ngravcomp,
+      m.jnt_actfrclimited,
+      m.jnt_actfrcrange,
+      m.jnt_actgravcomp,
+      m.dof_jntid,
+      d.actuator_moment,
+      d.qfrc_gravcomp,
+      d.actuator_force,
+    ],
+    outputs=[d.qfrc_actuator],
+    block_dim=m.block_dim.qfrc_actuator,
+  )
 
 
 @event_scope
@@ -867,23 +888,7 @@ def fwd_actuation(m: Model, d: Data):
       outputs=[d.actuator_force],
     )
 
-  wp.launch(
-    _qfrc_actuator,
-    dim=(d.nworld, m.nv),
-    inputs=[
-      m.nu,
-      m.ngravcomp,
-      m.jnt_actfrclimited,
-      m.jnt_actfrcrange,
-      m.jnt_actgravcomp,
-      m.dof_jntid,
-      d.actuator_moment,
-      d.qfrc_gravcomp,
-      d.actuator_force,
-    ],
-    outputs=[d.qfrc_actuator],
-  )
-
+  _qfrc_actuator(m, d)
   # TODO actuator-level gravity compensation, skip if added as passive force
 
 

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -889,7 +889,6 @@ def fwd_actuation(m: Model, d: Data):
     )
 
   _qfrc_actuator(m, d)
-  # TODO actuator-level gravity compensation, skip if added as passive force
 
 
 @wp.kernel

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -557,7 +557,7 @@ def _actuator_velocity_sparse(m: Model, d: Data):
     qvel_tile = wp.tile_load(qvel_in[worldid], shape=NV)
     moment_qvel_tile = wp.tile_map(wp.mul, moment_tile, qvel_tile)
     actuator_velocity_tile = wp.tile_reduce(wp.add, moment_qvel_tile)
-    wp.tile_store(actuator_velocity_out[worldid], actuator_velocity_tile)
+    actuator_velocity_out[worldid, actid] = actuator_velocity_tile[0]
 
   wp.launch_tiled(
     actuator_velocity_sparse,
@@ -626,7 +626,7 @@ def _tendon_velocity(m: Model, d: Data):
     qvel_tile = wp.tile_load(qvel_in[worldid], shape=NV)
     ten_J_qvel_tile = wp.tile_map(wp.mul, ten_J_tile, qvel_tile)
     ten_velocity_tile = wp.tile_reduce(wp.add, ten_J_qvel_tile)
-    wp.tile_store(ten_velocity_out[worldid], ten_velocity_tile)
+    ten_velocity_out[worldid, tenid] = ten_velocity_tile[0]
 
   wp.launch_tiled(
     tendon_velocity,

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -540,7 +540,7 @@ def fwd_position(m: Model, d: Data):
   smooth.transmission(m, d)
 
 
-# TODO(team): sparse version
+# TODO(team): sparse actuator_moment version
 def _actuator_velocity(m: Model, d: Data):
   NV = m.nv
 

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -42,7 +42,7 @@ def _assert_eq(a, b, name):
 
 class ForwardTest(parameterized.TestCase):
   def test_fwd_velocity(self):
-    _, mjd, m, d = test_util.fixture("humanoid/humanoid.xml", kick=True)
+    _, mjd, m, d = test_util.fixture("pendula.xml", kick=True)
 
     for arr in (d.actuator_velocity, d.qfrc_bias):
       arr.zero_()

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -41,7 +41,7 @@ def _assert_eq(a, b, name):
 
 
 class ForwardTest(parameterized.TestCase):
-  # TODO(team): test sparse when actuator_moment and ten_J have sparse representations
+  # TODO(team): test sparse when actuator_moment and/or ten_J have sparse representation
   @parameterized.product(xml=["humanoid/humanoid.xml", "pendula.xml"])
   def test_fwd_velocity(self, xml):
     _, mjd, m, d = test_util.fixture(xml, kick=True)

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -41,9 +41,10 @@ def _assert_eq(a, b, name):
 
 
 class ForwardTest(parameterized.TestCase):
-  @parameterized.product(xml=["humanoid/humanoid.xml", "pendula.xml"], sparse=[True, False])
-  def test_fwd_velocity(self, xml, sparse):
-    _, mjd, m, d = test_util.fixture(xml, kick=True, sparse=sparse)
+  # TODO(team): test sparse when actuator_moment and ten_J have sparse representations
+  @parameterized.product(xml=["humanoid/humanoid.xml", "pendula.xml"])
+  def test_fwd_velocity(self, xml):
+    _, mjd, m, d = test_util.fixture(xml, kick=True)
 
     for arr in (d.actuator_velocity, d.qfrc_bias):
       arr.zero_()

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -41,8 +41,9 @@ def _assert_eq(a, b, name):
 
 
 class ForwardTest(parameterized.TestCase):
-  def test_fwd_velocity(self):
-    _, mjd, m, d = test_util.fixture("pendula.xml", kick=True)
+  @parameterized.product(xml=["humanoid/humanoid.xml", "pendula.xml"], sparse=[True, False])
+  def test_fwd_velocity(self, xml, sparse):
+    _, mjd, m, d = test_util.fixture(xml, kick=True, sparse=sparse)
 
     for arr in (d.actuator_velocity, d.qfrc_bias):
       arr.zero_()

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -231,16 +231,16 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
 
   actuator_moment_tiles_nv, actuator_moment_tiles_nu = tuple(), tuple()
 
-  # TODO(team): tile support
-  if (mjm.actuator_trntype == mujoco.mjtTrn.mjTRN_BODY).any():
-    actuator_moment_tiles_nv += (types.TileSet(adr=wp.zeros(1, dtype=int), size=mjm.nv),)
-    actuator_moment_tiles_nu += (types.TileSet(adr=wp.zeros(1, dtype=int), size=mjm.nu),)
-  else:
-    for (nv, nu), adr in sorted(tiles.items()):
-      adr_nv = wp.array([nv for nv, _ in adr], dtype=int)
-      adr_nu = wp.array([nu for _, nu in adr], dtype=int)
-      actuator_moment_tiles_nv += (types.TileSet(adr=adr_nv, size=nv),)
-      actuator_moment_tiles_nu += (types.TileSet(adr=adr_nu, size=nu),)
+  for (nv, nu), adr in sorted(tiles.items()):
+    adr_nv = wp.array([nv for nv, _ in adr], dtype=int)
+    adr_nu = wp.array([nu for _, nu in adr], dtype=int)
+    actuator_moment_tiles_nv += (types.TileSet(adr=adr_nv, size=nv),)
+    actuator_moment_tiles_nu += (types.TileSet(adr=adr_nu, size=nu),)
+
+  actuator_velocity_tiles_nu = tuple((types.TileSet(adr=wp.array(np.array(np.arange(mjm.nu)), dtype=int), size=1),))
+  actuator_velocity_tiles_nv = tuple((types.TileSet(adr=wp.zeros(mjm.nu, dtype=int), size=mjm.nv),))
+  qfrc_actuator_tiles_nu = tuple((types.TileSet(adr=wp.zeros(mjm.nv, dtype=int), size=mjm.nu),))
+  qfrc_actuator_tiles_nv = tuple((types.TileSet(adr=wp.array(np.array(np.arange(mjm.nv)), dtype=int), size=1),))
 
   # fixed tendon
   tendon_jnt_adr = []
@@ -591,6 +591,10 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     eq_ten_adr=wp.array(np.nonzero(mjm.eq_type == types.EqType.TENDON.value)[0], dtype=int),
     actuator_moment_tiles_nv=actuator_moment_tiles_nv,
     actuator_moment_tiles_nu=actuator_moment_tiles_nu,
+    actuator_velocity_tiles_nu=actuator_velocity_tiles_nu,
+    actuator_velocity_tiles_nv=actuator_velocity_tiles_nv,
+    qfrc_actuator_tiles_nu=qfrc_actuator_tiles_nu,
+    qfrc_actuator_tiles_nv=qfrc_actuator_tiles_nv,
     actuator_trntype=wp.array(mjm.actuator_trntype, dtype=int),
     actuator_dyntype=wp.array(mjm.actuator_dyntype, dtype=int),
     actuator_gaintype=wp.array(mjm.actuator_gaintype, dtype=int),

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -237,8 +237,6 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     actuator_moment_tiles_nv += (types.TileSet(adr=adr_nv, size=nv),)
     actuator_moment_tiles_nu += (types.TileSet(adr=adr_nu, size=nu),)
 
-  actuator_velocity_tiles_nu = tuple((types.TileSet(adr=wp.array(np.array(np.arange(mjm.nu)), dtype=int), size=1),))
-  actuator_velocity_tiles_nv = tuple((types.TileSet(adr=wp.zeros(mjm.nu, dtype=int), size=mjm.nv),))
   qfrc_actuator_tiles_nu = tuple((types.TileSet(adr=wp.zeros(mjm.nv, dtype=int), size=mjm.nu),))
   qfrc_actuator_tiles_nv = tuple((types.TileSet(adr=wp.array(np.array(np.arange(mjm.nv)), dtype=int), size=1),))
 
@@ -591,8 +589,6 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     eq_ten_adr=wp.array(np.nonzero(mjm.eq_type == types.EqType.TENDON.value)[0], dtype=int),
     actuator_moment_tiles_nv=actuator_moment_tiles_nv,
     actuator_moment_tiles_nu=actuator_moment_tiles_nu,
-    actuator_velocity_tiles_nu=actuator_velocity_tiles_nu,
-    actuator_velocity_tiles_nv=actuator_velocity_tiles_nv,
     qfrc_actuator_tiles_nu=qfrc_actuator_tiles_nu,
     qfrc_actuator_tiles_nv=qfrc_actuator_tiles_nv,
     actuator_trntype=wp.array(mjm.actuator_trntype, dtype=int),

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -237,9 +237,6 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     actuator_moment_tiles_nv += (types.TileSet(adr=adr_nv, size=nv),)
     actuator_moment_tiles_nu += (types.TileSet(adr=adr_nu, size=nu),)
 
-  qfrc_actuator_tiles_nu = tuple((types.TileSet(adr=wp.zeros(mjm.nv, dtype=int), size=mjm.nu),))
-  qfrc_actuator_tiles_nv = tuple((types.TileSet(adr=wp.array(np.array(np.arange(mjm.nv)), dtype=int), size=1),))
-
   # fixed tendon
   tendon_jnt_adr = []
   wrap_jnt_adr = []
@@ -589,8 +586,6 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     eq_ten_adr=wp.array(np.nonzero(mjm.eq_type == types.EqType.TENDON.value)[0], dtype=int),
     actuator_moment_tiles_nv=actuator_moment_tiles_nv,
     actuator_moment_tiles_nu=actuator_moment_tiles_nu,
-    qfrc_actuator_tiles_nu=qfrc_actuator_tiles_nu,
-    qfrc_actuator_tiles_nv=qfrc_actuator_tiles_nv,
     actuator_trntype=wp.array(mjm.actuator_trntype, dtype=int),
     actuator_dyntype=wp.array(mjm.actuator_dyntype, dtype=int),
     actuator_gaintype=wp.array(mjm.actuator_gaintype, dtype=int),

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -885,6 +885,10 @@ class Model:
     eq_ten_adr: eq_* addresses of type `TENDON`              (<=neq,)
     actuator_moment_tiles_nv: tiling configuration
     actuator_moment_tiles_nu: tiling configuration
+    actuator_velocity_tiles_nu: tiling configuration
+    actuator_velocity_tiles_nv: tiling configuration
+    qfrc_actuator_tiles_nu: tiling configuration
+    qfrc_actuator_tiles_nv: tiling configuration
     actuator_affine_bias_gain: affine bias/gain present
     actuator_trntype: transmission type (mjtTrn)             (nu,)
     actuator_dyntype: dynamics type (mjtDyn)                 (nu,)
@@ -1177,6 +1181,10 @@ class Model:
   eq_ten_adr: wp.array(dtype=int)
   actuator_moment_tiles_nv: tuple[TileSet, ...]
   actuator_moment_tiles_nu: tuple[TileSet, ...]
+  actuator_velocity_tiles_nu: tuple[TileSet, ...]  # warp only
+  actuator_velocity_tiles_nv: tuple[TileSet, ...]  # warp only
+  qfrc_actuator_tiles_nu: tuple[TileSet, ...]  # warp only
+  qfrc_actuator_tiles_nv: tuple[TileSet, ...]  # warp only
   actuator_affine_bias_gain: bool  # warp only
   actuator_trntype: wp.array(dtype=int)
   actuator_dyntype: wp.array(dtype=int)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -885,8 +885,6 @@ class Model:
     eq_ten_adr: eq_* addresses of type `TENDON`              (<=neq,)
     actuator_moment_tiles_nv: tiling configuration
     actuator_moment_tiles_nu: tiling configuration
-    qfrc_actuator_tiles_nu: tiling configuration
-    qfrc_actuator_tiles_nv: tiling configuration
     actuator_affine_bias_gain: affine bias/gain present
     actuator_trntype: transmission type (mjtTrn)             (nu,)
     actuator_dyntype: dynamics type (mjtDyn)                 (nu,)
@@ -1179,8 +1177,6 @@ class Model:
   eq_ten_adr: wp.array(dtype=int)
   actuator_moment_tiles_nv: tuple[TileSet, ...]
   actuator_moment_tiles_nu: tuple[TileSet, ...]
-  qfrc_actuator_tiles_nu: tuple[TileSet, ...]  # warp only
-  qfrc_actuator_tiles_nv: tuple[TileSet, ...]  # warp only
   actuator_affine_bias_gain: bool  # warp only
   actuator_trntype: wp.array(dtype=int)
   actuator_dyntype: wp.array(dtype=int)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -44,7 +44,6 @@ class BlockDim:
   # forward
   euler_dense: int = 32
   actuator_velocity: int = 32
-  actuator_velocity_dense: int = 32
   tendon_velocity: int = 32
   qfrc_actuator: int = 32
   # ray

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -43,7 +43,7 @@ class BlockDim:
   qderiv_actuator_passive_no_actuation: int = 256
   # forward
   euler_dense: int = 32
-  actuator_velocity_sparse: int = 32
+  actuator_velocity: int = 32
   actuator_velocity_dense: int = 32
   tendon_velocity: int = 32
   qfrc_actuator: int = 32
@@ -885,8 +885,6 @@ class Model:
     eq_ten_adr: eq_* addresses of type `TENDON`              (<=neq,)
     actuator_moment_tiles_nv: tiling configuration
     actuator_moment_tiles_nu: tiling configuration
-    actuator_velocity_tiles_nu: tiling configuration
-    actuator_velocity_tiles_nv: tiling configuration
     qfrc_actuator_tiles_nu: tiling configuration
     qfrc_actuator_tiles_nv: tiling configuration
     actuator_affine_bias_gain: affine bias/gain present
@@ -1181,8 +1179,6 @@ class Model:
   eq_ten_adr: wp.array(dtype=int)
   actuator_moment_tiles_nv: tuple[TileSet, ...]
   actuator_moment_tiles_nu: tuple[TileSet, ...]
-  actuator_velocity_tiles_nu: tuple[TileSet, ...]  # warp only
-  actuator_velocity_tiles_nv: tuple[TileSet, ...]  # warp only
   qfrc_actuator_tiles_nu: tuple[TileSet, ...]  # warp only
   qfrc_actuator_tiles_nv: tuple[TileSet, ...]  # warp only
   actuator_affine_bias_gain: bool  # warp only

--- a/mujoco_warp/test_data/actuation/actuation.xml
+++ b/mujoco_warp/test_data/actuation/actuation.xml
@@ -27,11 +27,14 @@
     </body>
   </worldbody>
   <actuator>
-    <motor joint="hinge0"/>
+    <motor joint="hinge4"/>
     <motor joint="hinge1"/>
     <motor joint="hinge2"/>
-    <motor joint="hinge3"/>
-    <motor joint="hinge4"/>
     <motor joint="hinge5"/>
+    <motor joint="hinge3"/>
+    <motor joint="hinge0"/>
   </actuator>
+  <keyframe>
+    <key ctrl="1 2 3 4 5 6"/>
+  </keyframe>
 </mujoco>


### PR DESCRIPTION
update actuator tiles to generalize for actuators (eg, actuator order, actuators that effect multiple dof trees)

a todo has been added to derivative.py to update `_tile_qderiv_actuator_passive` to generalize for actuators

fixes #424 