### PR TITLE
order step, Model, and Data first in __init__.py

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -15,6 +15,12 @@
 
 """Public API for MJWarp."""
 
+# isort: off
+from ._src.forward import step as step
+from ._src.types import Model as Model
+from ._src.types import Data as Data
+# isort: on
+
 from ._src import collision_sdf as collision_sdf
 from ._src.collision_driver import collision as collision
 from ._src.collision_driver import nxn_broadphase as nxn_broadphase
@@ -30,7 +36,6 @@ from ._src.forward import fwd_position as fwd_position
 from ._src.forward import fwd_velocity as fwd_velocity
 from ._src.forward import implicit as implicit
 from ._src.forward import rungekutta4 as rungekutta4
-from ._src.forward import step as step
 from ._src.inverse import inverse as inverse
 from ._src.io import get_data_into as get_data_into
 from ._src.io import make_data as make_data
@@ -63,12 +68,10 @@ from ._src.test_util import benchmark as benchmark
 from ._src.types import ConeType as ConeType
 from ._src.types import Constraint as Constraint
 from ._src.types import Contact as Contact
-from ._src.types import Data as Data
 from ._src.types import DisableBit as DisableBit
 from ._src.types import DynType as DynType
 from ._src.types import EnableBit as EnableBit
 from ._src.types import JointType as JointType
-from ._src.types import Model as Model
 from ._src.types import Option as Option
 from ._src.types import Statistic as Statistic
 from ._src.types import TrnType as TrnType


### PR DESCRIPTION
order `step`, `Model`, and `Data` first for documentation