### PR TITLE
Zero collision counts in a kernel

### DIFF
--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -40,10 +40,10 @@ def _zero_collision_arrays(
   # In:
   hfield_geom_pair_in: int,
   # Data out:
-  ncollision_out: wp.array(dtype=int),
   ncon_out: wp.array(dtype=int),
   ncon_hfield_out: wp.array(dtype=int),  # kernel_analyzer: ignore
   collision_hftri_index_out: wp.array(dtype=int),
+  ncollision_out: wp.array(dtype=int),
 ):
   tid = wp.tid()
 

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -32,6 +32,7 @@ from .warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.kernel
 def _zero_collision_arrays(
   # Data in:
@@ -45,7 +46,7 @@ def _zero_collision_arrays(
   collision_hftri_index: wp.array(dtype=int),
 ):
   tid = wp.tid()
-  
+
   if tid == 0:
     # Zero the single collision counter
     ncollision[0] = 0
@@ -53,7 +54,7 @@ def _zero_collision_arrays(
 
   if tid < hfield_geom_pair * nworld:
     ncon_hfield[tid] = 0
-    
+
   # Zero collision pair indices
   collision_hftri_index[tid] = 0
 
@@ -488,7 +489,7 @@ def nxn_broadphase(m: Model, d: Data):
 @event_scope
 def collision(m: Model, d: Data):
   """Collision detection."""
-  
+
   # zero collision-related arrays
   wp.launch(
     _zero_collision_arrays,

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -36,27 +36,27 @@ wp.set_module_options({"enable_backward": False})
 @wp.kernel
 def _zero_collision_arrays(
   # Data in:
-  nworld: int,
+  nworld_in: int,
   # In:
-  hfield_geom_pair: int,
+  hfield_geom_pair_in: int,
   # Data out:
-  ncollision: wp.array(dtype=int),
-  ncon: wp.array(dtype=int),
-  ncon_hfield: wp.array(dtype=int),
-  collision_hftri_index: wp.array(dtype=int),
+  ncollision_out: wp.array(dtype=int),
+  ncon_out: wp.array(dtype=int),
+  ncon_hfield_out: wp.array(dtype=int),  # kernel_analyzer: ignore
+  collision_hftri_index_out: wp.array(dtype=int),
 ):
   tid = wp.tid()
 
   if tid == 0:
     # Zero the single collision counter
-    ncollision[0] = 0
-    ncon[0] = 0
+    ncollision_out[0] = 0
+    ncon_out[0] = 0
 
-  if tid < hfield_geom_pair * nworld:
-    ncon_hfield[tid] = 0
+  if tid < hfield_geom_pair_in * nworld_in:
+    ncon_hfield_out[tid] = 0
 
   # Zero collision pair indices
-  collision_hftri_index[tid] = 0
+  collision_hftri_index_out[tid] = 0
 
 
 @wp.func

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -497,10 +497,10 @@ def collision(m: Model, d: Data):
     inputs=[
       d.nworld,
       d.ncon_hfield.shape[1],
-      d.ncollision,
       d.ncon,
       d.ncon_hfield.reshape(-1),
       d.collision_hftri_index,
+      d.ncollision,
     ],
   )
 

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -32,6 +32,31 @@ from .warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
 
+@wp.kernel
+def _zero_collision_arrays(
+  # Data in:
+  nworld: int,
+  # In:
+  hfield_geom_pair: int,
+  # Data out:
+  ncollision: wp.array(dtype=int),
+  ncon: wp.array(dtype=int),
+  ncon_hfield: wp.array(dtype=int),
+  collision_hftri_index: wp.array(dtype=int),
+):
+  tid = wp.tid()
+  
+  if tid == 0:
+    # Zero the single collision counter
+    ncollision[0] = 0
+    ncon[0] = 0
+
+  if tid < hfield_geom_pair * nworld:
+    ncon_hfield[tid] = 0
+    
+  # Zero collision pair indices
+  collision_hftri_index[tid] = 0
+
 
 @wp.func
 def _sphere_filter(
@@ -463,11 +488,20 @@ def nxn_broadphase(m: Model, d: Data):
 @event_scope
 def collision(m: Model, d: Data):
   """Collision detection."""
-
-  d.ncollision.zero_()
-  d.ncon.zero_()
-  d.ncon_hfield.zero_()
-  d.collision_hftri_index.zero_()
+  
+  # zero collision-related arrays
+  wp.launch(
+    _zero_collision_arrays,
+    dim=d.nconmax,
+    inputs=[
+      d.nworld,
+      d.ncon_hfield.shape[1],
+      d.ncollision,
+      d.ncon,
+      d.ncon_hfield.reshape(-1),
+      d.collision_hftri_index,
+    ],
+  )
 
   if d.nconmax == 0:
     return


### PR DESCRIPTION
calling zero_() here in sequence is ~1us per operation with a bit of idle time in-between, while having all of them in 1 kernel is the price of just 1 operation. 6us -> <1us for each step.

A tiny thing, but we should do this in other places as well.