### PR TITLE
Zero constraint counts in a kernel

### DIFF
--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -34,9 +34,9 @@ def zero_constraint_counts(
   ne_weld_out: wp.array(dtype=int),
   ne_jnt_out: wp.array(dtype=int),
   ne_ten_out: wp.array(dtype=int),
-  nefc_out: wp.array(dtype=int),
   nf_out: wp.array(dtype=int),
   nl_out: wp.array(dtype=int),
+  nefc_out: wp.array(dtype=int),
 ):
   # Zero all constraint counters
   ne_out[0] = 0
@@ -44,9 +44,9 @@ def zero_constraint_counts(
   ne_weld_out[0] = 0
   ne_jnt_out[0] = 0
   ne_ten_out[0] = 0
-  nefc_out[0] = 0
   nf_out[0] = 0
   nl_out[0] = 0
+  nefc_out[0] = 0
 
 
 @wp.func
@@ -1487,9 +1487,9 @@ def make_constraint(m: types.Model, d: types.Data):
       d.ne_weld,
       d.ne_jnt,
       d.ne_ten,
-      d.nefc,
       d.nf,
       d.nl,
+      d.nefc,
     ],
   )
 


### PR DESCRIPTION
Same thing as for collisions, instead of the overhead of a memset op for each, let's do this in 1 kernel that zeros all of them. 6us -> 450ns.

Also avoid some of the overhead of interleaving kernels with memsets.