### PR TITLE
Don't run collision detection if there are no potential pairs.

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -356,8 +356,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   )
 
   # Disable collisions if there are no potentially colliding pairs
-  valid_mask = nxn_pairid > -2
-  if not valid_mask.any():
+  if np.sum(geom_type_pair_count) == 0:
     mjm.opt.disableflags |= types.DisableBit.CONTACT.value
 
   def create_nmodel_batched_array(mjm_array, dtype, expand_dim=True):


### PR DESCRIPTION
This is as simple as it gets.

We could also do that by prefiltering the nxn_geom_pairs and then checking the shape - I went down that avenue but it wasn't trivial to combine it with the way filtering is done in the SAP broadphase that also relies on the pairid array. So leaving this for the future. @thowell I think you wanted to do this as well at some point, right?