### PR TITLE
update collision_primitive

### DIFF
--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -28,7 +28,6 @@ from .types import GeomType
 from .types import Model
 from .types import vec5
 from .warp_util import event_scope
-from .warp_util import kernel as nested_kernel
 
 wp.set_module_options({"enable_backward": False})
 

--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -2503,74 +2503,9 @@ def primitive_narrowphase_builder(m: Model):
     if tid >= ncollision_in[0]:
       return
 
-    worldid = collision_worldid_in[tid]
-
-    geoms, margin, gap, condim, friction, solref, solreffriction, solimp = contact_params(
-      geom_condim,
-      geom_priority,
-      geom_solmix,
-      geom_solref,
-      geom_solimp,
-      geom_friction,
-      geom_margin,
-      geom_gap,
-      pair_dim,
-      pair_solref,
-      pair_solreffriction,
-      pair_solimp,
-      pair_margin,
-      pair_gap,
-      pair_friction,
-      collision_pair_in,
-      collision_pairid_in,
-      tid,
-      worldid,
-    )
+    geoms = collision_pair_in[tid]
     g1 = geoms[0]
     g2 = geoms[1]
-
-    hftri_index = collision_hftri_index_in[tid]
-
-    geom1 = _geom(
-      geom_type,
-      geom_dataid,
-      geom_size,
-      hfield_adr,
-      hfield_nrow,
-      hfield_ncol,
-      hfield_size,
-      hfield_data,
-      mesh_vertadr,
-      mesh_vertnum,
-      mesh_vert,
-      mesh_graphadr,
-      mesh_graph,
-      geom_xpos_in,
-      geom_xmat_in,
-      worldid,
-      g1,
-      hftri_index,
-    )
-    geom2 = _geom(
-      geom_type,
-      geom_dataid,
-      geom_size,
-      hfield_adr,
-      hfield_nrow,
-      hfield_ncol,
-      hfield_size,
-      hfield_data,
-      mesh_vertadr,
-      mesh_vertnum,
-      mesh_vert,
-      mesh_graphadr,
-      mesh_graph,
-      geom_xpos_in,
-      geom_xmat_in,
-      worldid,
-      g2,
-      hftri_index,
-    )
 
     type1 = geom_type[g1]
     type2 = geom_type[g2]
@@ -2580,6 +2515,74 @@ def primitive_narrowphase_builder(m: Model):
       collision_type2 = wp.static(_primitive_collisions_types[i][1])
 
       if collision_type1 == type1 and collision_type2 == type2:
+        worldid = collision_worldid_in[tid]
+
+        _, margin, gap, condim, friction, solref, solreffriction, solimp = contact_params(
+          geom_condim,
+          geom_priority,
+          geom_solmix,
+          geom_solref,
+          geom_solimp,
+          geom_friction,
+          geom_margin,
+          geom_gap,
+          pair_dim,
+          pair_solref,
+          pair_solreffriction,
+          pair_solimp,
+          pair_margin,
+          pair_gap,
+          pair_friction,
+          collision_pair_in,
+          collision_pairid_in,
+          tid,
+          worldid,
+        )
+
+        hftri_index = collision_hftri_index_in[tid]
+
+        geom1 = _geom(
+          geom_type,
+          geom_dataid,
+          geom_size,
+          hfield_adr,
+          hfield_nrow,
+          hfield_ncol,
+          hfield_size,
+          hfield_data,
+          mesh_vertadr,
+          mesh_vertnum,
+          mesh_vert,
+          mesh_graphadr,
+          mesh_graph,
+          geom_xpos_in,
+          geom_xmat_in,
+          worldid,
+          g1,
+          hftri_index,
+        )
+
+        geom2 = _geom(
+          geom_type,
+          geom_dataid,
+          geom_size,
+          hfield_adr,
+          hfield_nrow,
+          hfield_ncol,
+          hfield_size,
+          hfield_data,
+          mesh_vertadr,
+          mesh_vertnum,
+          mesh_vert,
+          mesh_graphadr,
+          mesh_graph,
+          geom_xpos_in,
+          geom_xmat_in,
+          worldid,
+          g2,
+          hftri_index,
+        )
+
         wp.static(_primitive_collisions_func[i])(
           nconmax_in,
           geom1,


### PR DESCRIPTION
```
mjwarp-testspeed --function=step --mjcf=test_data/humanoid/humanoid.xml --batch_size=8192 --nconmax=512000 --njmax=512000
```

this pr:
```
Module mujoco_warp._src.collision_primitive 13e7a01 load on device 'cuda:0' took 697.59 ms  (compiled)
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 26.41 s
 Total simulation time: 29.89 s
 Total steps per second: 274,057
 Total realtime factor: 1,370.29 x
 Total time per step: 3648.87 ns
```

main:
```
Module mujoco_warp._src.collision_primitive c1ad510 load on device 'cuda:0' took 4145.31 ms  (compiled)
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 29.81 s
 Total simulation time: 29.96 s
 Total steps per second: 273,470
 Total realtime factor: 1,367.35 x
 Total time per step: 3656.71 ns
```