### PR TITLE
remove mesh-plane from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following features are implemented:
 | Actuator Dynamics  | All except `USER`                                                                                       |
 | Actuator Gain      | All except `USER`                                                                                       |
 | Actuator Bias      | All except `USER`                                                                                       |
-| Geom               | All (`MESH`&harr;`SDF` collisions are not yet implemented)                                             |
+| Geom               | All (`MESH`&harr;`SDF` collisions are not yet implemented)                                              |
 | Constraint         | All                                                                                                     |
 | Equality           | All except `FLEX`, `DISTANCE`                                                                           |
 | Integrator         | All except `IMPLICIT`                                                                                   |


### PR DESCRIPTION
These are supported. See 

https://github.com/google-deepmind/mujoco_warp/blob/main/mujoco_warp/_src/collision_primitive.py#L2412