### PR TITLE
Fix crash in aloha_pot benchmark

### DIFF
--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -179,9 +179,13 @@ def _sap_project(
   radius = rbound + geom_margin[worldid, geomid]
   center = wp.dot(direction_in, xpos)
 
-  sap_projection_lower_out[worldid, geomid] = center - radius
-  sap_projection_upper_out[worldid, geomid] = center + radius
   sap_sort_index_out[worldid, geomid] = geomid
+  if not wp.isnan(center):
+    sap_projection_lower_out[worldid, geomid] = center - radius
+    sap_projection_upper_out[worldid, geomid] = center + radius
+  else:
+    sap_projection_lower_out[worldid, geomid] = MJ_MAXVAL
+    sap_projection_upper_out[worldid, geomid] = MJ_MAXVAL
 
 
 @wp.kernel


### PR DESCRIPTION
Issue was described in #458.

In summary, instability of the benchmark was generating NaN values.
It looks like the tile_sort does not handle the NaN values correctly and output sorting indices that are larger than ngeom, which causes out of bound memory issue and a subsequent crash

I am still figuring out what is happening on the tile_sort and whether there are bugs there.
This PR can be view as a quickfix, if I can fix it on the tile_sort, then I would revert this PR.