### PR TITLE
box-box: avoid illegal memory access

### DIFF
--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -2281,9 +2281,9 @@ def box_box(
           if k != i and (int(cross_axis[k] > 0) ^ int(box_dist < 0)):
             cle1 += 1 << k
           if k != j:
-            if (int(rot21[i, 3 - k - j] > 0) ^ int(box_dist < 0) ^ int((k - j + 3) % 3 == 1)):
+            if int(rot21[i, 3 - k - j] > 0) ^ int(box_dist < 0) ^ int((k - j + 3) % 3 == 1):
               cle2 += 1 << k
-            
+
         axis_code = 12 + i * 3 + j
         clnorm = cross_axis
         inv = box_dist < 0


### PR DESCRIPTION
warp does not short-circuit if statements, so a combined statement will always evaluate all the conditions. This means that the second part can access invalid memory there.