### PR TITLE
Initial implementation of airspeed velocity benchmarks.

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,23 @@
+
+{
+  "version": 1,
+  "project": "mujoco-warp",
+  "project_url": "https://github.com/google-deepmind/mujoco_warp",
+  "repo": ".",
+  "build_command": [
+    "python -m build --wheel -o {build_cache_dir}"
+  ],
+  "install_command": [
+    "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
+  ],
+  "branches": ["main"],
+  "dvcs": "git",
+  "environment_type": "virtualenv",
+  "show_commit_url": "https://github.com/google-deepmind/mujoco_warp/commit/",
+  "benchmark_dir": "benchmark",
+  "env_dir": "asv/env",
+  "results_dir": "asv/results",
+  "html_dir": "asv/html",
+  "build_cache_size": 20,
+  "default_benchmark_timeout": 120
+}

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,56 @@
+# MuJoCo Warp Benchmark Suite
+
+MJWarp uses [airspeed velocity](https://github.com/airspeed-velocity/asv) for benchmarks.
+
+Make sure you install MJWarp in develop so you can run the `asv` command:
+
+```
+pip install -e .[dev,cuda]
+```
+
+Run benchmarks like so at the top level of the `mujoco_warp` checkout:
+
+```
+asv run
+```
+
+You should see output that looks like this:
+
+```
+Couldn't load asv.plugins._mamba_helpers because
+No module named 'libmambapy'
+· Creating environments
+· Discovering benchmarks
+·· Uninstalling from virtualenv-py3.12
+·· Installing c6b97641 <asv> into virtualenv-py3.12.
+· Running 7 total benchmarks (1 commits * 1 environments * 7 benchmarks)
+[ 0.00%] · For mujoco-warp commit c6b97641 <asv>:
+[ 0.00%] ·· Benchmarking virtualenv-py3.12
+[14.29%] ··· benchmark.AlohaPot.time_function
+[14.29%] ··· ================== ============
+                  function
+             ------------------ ------------
+                 collision        365±10ns
+                fwd_position      443±10ns
+                fwd_velocity     31.2±0.2ns
+               fwd_actuation     13.3±0.2ns
+              fwd_acceleration   8.58±0.2ns
+                   solve         612±200ns
+                    step          1.90±1μs
+             ================== ============
+...
+```
+
+Benchmarks are slow to run - if you would like to quickly verify benchmarks are working, you can run with `-q`:
+
+```
+asv run -q
+```
+
+You can also benchmark your own branch:
+
+```
+asv run $MYBRANCH
+```
+
+See the [airspeed velocity documentation](https://asv.readthedocs.io/en/latest/index.html) for more information.

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 The Newton Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,0 +1,63 @@
+import mujoco_warp
+
+
+class AlohaPot(mujoco_warp.BenchmarkSuite):
+  """Aloha robot with a pasta pot on the workbench."""
+
+  path = "aloha_pot/scene.xml"
+  batch_size = 8192
+  nconmax = 200_000
+  njmax = 200_000
+
+class ApptronikApolloFlat(mujoco_warp.BenchmarkSuite):
+  """Apptronik Apollo locomoting on an infinite plain."""
+
+  path = "apptronik_apollo/scene_flat.xml"
+  batch_size = 8192
+  nconmax = 200_000
+  njmax = 500_000
+
+class ApptronikApolloHfield(mujoco_warp.BenchmarkSuite):
+  """Apptronik Apollo locomoting on a pyramidal hfield."""
+
+  path = "apptronik_apollo/scene_hfield.xml"
+  batch_size = 1024
+  nconmax = 700_000
+  njmax = 50_000
+
+class ApptronikApolloTerrain(mujoco_warp.BenchmarkSuite):
+  """Apptronik Apollo locomoting on Isaac-style pyramids made of thousands of boxes."""
+
+  path = "apptronik_apollo/scene_terrain.xml"
+  batch_size = 8192
+  nconmax = 400_000
+  njmax = 600_000
+
+class FrankaEmikaPanda(mujoco_warp.BenchmarkSuite):
+  """Franka Emika Panda on an infinite plain."""
+
+  path = "franka_emika_panda/scene.xml"
+  batch_size = 32768
+  nconmax = 10_000
+  njmax = 150_000
+
+class Humanoid(mujoco_warp.BenchmarkSuite):
+  """MuJoCo humanoid on an infinite plain."""
+
+  path = "humanoid/humanoid.xml"
+  batch_size = 8192
+  nconmax = 200_000
+  njmax = 500_000
+
+
+class ThreeHumanoids(mujoco_warp.BenchmarkSuite):
+  """Three MuJoCo humanoids on an infinite plain.
+
+  Ideally, simulation time scales linearly with number of humanoids.
+  """
+
+  repeat = 100
+  path = "humanoid/n_humanoid.xml"
+  batch_size = 1024
+  nconmax = 50_000
+  njmax = 150_000

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,3 +1,18 @@
+# Copyright 2025 The Newton Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import mujoco_warp
 
 
@@ -11,7 +26,7 @@ class AlohaPot(mujoco_warp.BenchmarkSuite):
 
 
 class ApptronikApolloFlat(mujoco_warp.BenchmarkSuite):
-  """Apptronik Apollo locomoting on an infinite plain."""
+  """Apptronik Apollo locomoting on an infinite plane."""
 
   path = "apptronik_apollo/scene_flat.xml"
   batch_size = 8192
@@ -38,7 +53,7 @@ class ApptronikApolloTerrain(mujoco_warp.BenchmarkSuite):
 
 
 class FrankaEmikaPanda(mujoco_warp.BenchmarkSuite):
-  """Franka Emika Panda on an infinite plain."""
+  """Franka Emika Panda on an infinite plane."""
 
   path = "franka_emika_panda/scene.xml"
   batch_size = 32768
@@ -47,7 +62,7 @@ class FrankaEmikaPanda(mujoco_warp.BenchmarkSuite):
 
 
 class Humanoid(mujoco_warp.BenchmarkSuite):
-  """MuJoCo humanoid on an infinite plain."""
+  """MuJoCo humanoid on an infinite plane."""
 
   path = "humanoid/humanoid.xml"
   batch_size = 8192
@@ -56,7 +71,7 @@ class Humanoid(mujoco_warp.BenchmarkSuite):
 
 
 class ThreeHumanoids(mujoco_warp.BenchmarkSuite):
-  """Three MuJoCo humanoids on an infinite plain.
+  """Three MuJoCo humanoids on an infinite plane.
 
   Ideally, simulation time scales linearly with number of humanoids.
   """

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -9,6 +9,7 @@ class AlohaPot(mujoco_warp.BenchmarkSuite):
   nconmax = 200_000
   njmax = 200_000
 
+
 class ApptronikApolloFlat(mujoco_warp.BenchmarkSuite):
   """Apptronik Apollo locomoting on an infinite plain."""
 
@@ -16,6 +17,7 @@ class ApptronikApolloFlat(mujoco_warp.BenchmarkSuite):
   batch_size = 8192
   nconmax = 200_000
   njmax = 500_000
+
 
 class ApptronikApolloHfield(mujoco_warp.BenchmarkSuite):
   """Apptronik Apollo locomoting on a pyramidal hfield."""
@@ -25,6 +27,7 @@ class ApptronikApolloHfield(mujoco_warp.BenchmarkSuite):
   nconmax = 700_000
   njmax = 50_000
 
+
 class ApptronikApolloTerrain(mujoco_warp.BenchmarkSuite):
   """Apptronik Apollo locomoting on Isaac-style pyramids made of thousands of boxes."""
 
@@ -33,6 +36,7 @@ class ApptronikApolloTerrain(mujoco_warp.BenchmarkSuite):
   nconmax = 400_000
   njmax = 600_000
 
+
 class FrankaEmikaPanda(mujoco_warp.BenchmarkSuite):
   """Franka Emika Panda on an infinite plain."""
 
@@ -40,6 +44,7 @@ class FrankaEmikaPanda(mujoco_warp.BenchmarkSuite):
   batch_size = 32768
   nconmax = 10_000
   njmax = 150_000
+
 
 class Humanoid(mujoco_warp.BenchmarkSuite):
   """MuJoCo humanoid on an infinite plain."""

--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -64,6 +64,7 @@ from ._src.solver import solve as solve
 from ._src.support import contact_force as contact_force
 from ._src.support import mul_m as mul_m
 from ._src.support import xfrc_accumulate as xfrc_accumulate
+from ._src.test_util import BenchmarkSuite as BenchmarkSuite
 from ._src.test_util import benchmark as benchmark
 from ._src.types import ConeType as ConeType
 from ._src.types import Constraint as Constraint

--- a/mujoco_warp/_src/test_util.py
+++ b/mujoco_warp/_src/test_util.py
@@ -26,9 +26,9 @@ import warp as wp
 from etils import epath
 
 from . import collision_driver
-from . import solver
 from . import forward
 from . import io
+from . import solver
 from . import warp_util
 from .types import ConeType
 from .types import Data
@@ -297,7 +297,7 @@ class BenchmarkSuite:
     if self._mjm.nkey > 0:
       mujoco.mj_resetDataKeyframe(self._mjm, self._mjd, 0)
 
-    # TODO(team): investigate why mj_forward fixes bug in franka_emika_panda reporting extra contacts
+    # TODO(team): investigate why mj_forward fixes bug in franka reporting extra contacts
     mujoco.mj_forward(self._mjm, self._mjd)
 
     self.timer = lambda: time.perf_counter() / self.batch_size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "asv",
     "pre-commit",
     "pytest",
     "pytest-xdist",


### PR DESCRIPTION
Introduces an initial benchmark suite that any user can run on their local machine using `asv` - the commandline tool for [airspeed velocity](https://github.com/airspeed-velocity/asv).

With this PR, we can run benchmarks on most of the major MJWarp API calls that comprise step:

* `collision`
* `fwd_position`
* `fwd_velocity`
* `fwd_actuation`
* `fwd_acceleration`
* `solve`
* `step`

We can do so for branches, for commit ranges... lots of flexibility on how we use this.

This PR is half the solution for #95 - later we will figure out how to automatically run these benchmarks and publish them somewhere public.

Also, we aren't benchmarking the kitchen scene yet.  We'll look into that in the future.