### PR TITLE
Fixes for ray.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,3 +36,5 @@ def pytest_configure(config):
     wp.config.verify_cuda = True
   if config.getoption("--lineinfo"):
     wp.config.lineinfo = True
+  wp.config.mode = "debug"
+  wp.config.print_launches = True

--- a/conftest.py
+++ b/conftest.py
@@ -36,5 +36,3 @@ def pytest_configure(config):
     wp.config.verify_cuda = True
   if config.getoption("--lineinfo"):
     wp.config.lineinfo = True
-  wp.config.mode = "debug"
-  wp.config.print_launches = True

--- a/mujoco_warp/_src/ray.py
+++ b/mujoco_warp/_src/ray.py
@@ -586,7 +586,11 @@ def _ray_mesh(
 
   # get mesh face and vertex data
   face_start = mesh_faceadr[data_id]
-  face_end = wp.where(data_id + 1 < mesh_faceadr.shape[0], mesh_faceadr[data_id + 1], nmeshface)
+
+  if data_id + 1 < mesh_faceadr.shape[0]:
+    face_end = mesh_faceadr[data_id + 1]
+  else:
+    face_end = nmeshface
 
   # iterate through all faces
   for i in range(face_start, face_end):

--- a/mujoco_warp/_src/ray_test.py
+++ b/mujoco_warp/_src/ray_test.py
@@ -295,7 +295,7 @@ class RayTest(absltest.TestCase):
     mjm, mjd, m, d = test_util.fixture("ray.xml")
 
     # nothing hit with transparent geoms
-    m.geom_rgba = wp.array2d([[wp.vec4(0.0, 0.0, 0.0, 0.0)]], dtype=wp.vec4)
+    m.geom_rgba = wp.array2d([[wp.vec4(0.0, 0.0, 0.0, 0.0)] * 8], dtype=wp.vec4) # this needs to be ngeom?
     mujoco.mj_forward(mjm, mjd)
 
     pnt = wp.array([wp.vec3(2.0, 1.0, 3.0)], dtype=wp.vec3).reshape((1, 1))

--- a/mujoco_warp/_src/ray_test.py
+++ b/mujoco_warp/_src/ray_test.py
@@ -295,7 +295,7 @@ class RayTest(absltest.TestCase):
     mjm, mjd, m, d = test_util.fixture("ray.xml")
 
     # nothing hit with transparent geoms
-    m.geom_rgba = wp.array2d([[wp.vec4(0.0, 0.0, 0.0, 0.0)] * 8], dtype=wp.vec4) # this needs to be ngeom?
+    m.geom_rgba = wp.array2d([[wp.vec4(0.0, 0.0, 0.0, 0.0)] * 8], dtype=wp.vec4)
     mujoco.mj_forward(mjm, mjd)
 
     pnt = wp.array([wp.vec3(2.0, 1.0, 3.0)], dtype=wp.vec3).reshape((1, 1))


### PR DESCRIPTION
* wp.where doesn't short-circuit, so one out-of-bounds access there.

* ray expects mat_rgba to be of size ngeom, but the test only sets 1 element.