### PR TITLE
add option for maxconpair

### DIFF
--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -833,10 +833,11 @@ class CollisionTest(parameterized.TestCase):
     """
 
     _, _, m, d = test_util.fixture(xml=_XML, keyframe=0)
+    m.opt.maxconpair = mujoco.mjMAXCONPAIR
 
     mjwarp.collision(m, d)
 
-    np.testing.assert_equal(d.ncon.numpy()[0], types.MJ_MAXCONPAIR)
+    np.testing.assert_equal(d.ncon.numpy()[0], m.opt.maxconpair)
 
   def test_min_friction(self):
     _, _, _, d = test_util.fixture(

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -453,6 +453,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
       sdf_initpoints=mjm.opt.sdf_initpoints,
       sdf_iterations=mjm.opt.sdf_iterations,
       run_collision_detection=True,
+      maxconpair=4,
     ),
     stat=types.Statistic(
       meaninertia=mjm.stat.meaninertia,

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -22,7 +22,6 @@ MJ_MINVAL = mujoco.mjMINVAL
 MJ_MAXVAL = mujoco.mjMAXVAL
 MJ_MINIMP = mujoco.mjMINIMP  # minimum constraint impedance
 MJ_MAXIMP = mujoco.mjMAXIMP  # maximum constraint impedance
-MJ_MAXCONPAIR = mujoco.mjMAXCONPAIR
 MJ_MINMU = mujoco.mjMINMU  # minimum friction
 
 
@@ -550,6 +549,7 @@ class Option:
     run_collision_detection: if False, skips collision detection and allows user-populated
       contacts during the physics step (as opposed to DisableBit.CONTACT which explicitly
       zeros out the contacts at each step)
+    maxconpair: maximum number of contacts per geom pair
   """
 
   timestep: wp.array(dtype=float)
@@ -579,6 +579,7 @@ class Option:
   sdf_initpoints: int
   sdf_iterations: int
   run_collision_detection: bool  # warp only
+  maxconpair: int  # warp only
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
- add field `maxconpair` to `Option` that limits the maximum number of contacts per geom pair
- default is changed from `mujoco.mjMAXCONPAIR` (50) to 4