### PR TITLE
Fix testspeed and viewer cone flag bug.

### DIFF
--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -48,7 +48,7 @@ _ITERATIONS = flags.DEFINE_integer("iterations", None, "Override model solver it
 _LS_ITERATIONS = flags.DEFINE_integer("ls_iterations", None, "Override model linesearch iterations")
 _LS_PARALLEL = flags.DEFINE_bool("ls_parallel", False, "solve with parallel linesearch")
 _IS_SPARSE = flags.DEFINE_bool("is_sparse", None, "Override model sparse config")
-_CONE = flags.DEFINE_enum_class("cone", mjwarp.ConeType.PYRAMIDAL, mjwarp.ConeType, "Friction cone type")
+_CONE = flags.DEFINE_enum_class("cone", None, mjwarp.ConeType, "Friction cone type")
 _NCONMAX = flags.DEFINE_integer(
   "nconmax",
   None,
@@ -120,7 +120,8 @@ def _main(argv: Sequence[str]):
   else:
     mjm = _load_model(path.as_posix())
 
-  mjm.opt.cone = _CONE.value
+  if _CONE.value is not None:
+    mjm.opt.cone = _CONE.value
 
   if _IS_SPARSE.value == True:
     mjm.opt.jacobian = mujoco.mjtJacobian.mjJAC_SPARSE

--- a/mujoco_warp/viewer.py
+++ b/mujoco_warp/viewer.py
@@ -39,7 +39,7 @@ class EngineOptions(enum.IntEnum):
 _MODEL_PATH = flags.DEFINE_string("mjcf", None, "Path to a MuJoCo MJCF file.", required=True)
 _CLEAR_KERNEL_CACHE = flags.DEFINE_bool("clear_kernel_cache", False, "Clear kernel cache (to calculate full JIT time)")
 _ENGINE = flags.DEFINE_enum_class("engine", EngineOptions.MJWARP, EngineOptions, "Simulation engine")
-_CONE = flags.DEFINE_enum_class("cone", mjwarp.ConeType.PYRAMIDAL, mjwarp.ConeType, "Friction cone type")
+_CONE = flags.DEFINE_enum_class("cone", None, mjwarp.ConeType, "Friction cone type")
 _LS_PARALLEL = flags.DEFINE_bool("ls_parallel", False, "Engine solver with parallel linesearch")
 _VIEWER_GLOBAL_STATE = {
   "running": True,
@@ -90,7 +90,10 @@ def _main(argv: Sequence[str]) -> None:
     mjm = mujoco.MjModel.from_binary_path(_MODEL_PATH.value)
   else:
     mjm = _load_model()
+
+  if _CONE.value is not None:
     mjm.opt.cone = _CONE.value
+
   mjd = mujoco.MjData(mjm)
   if _KEYFRAME.value is not None:
     mujoco.mj_resetDataKeyframe(mjm, mjd, _KEYFRAME.value)


### PR DESCRIPTION
Testspeed and viewer were overriding cone type by default.

`aloha_pot` scene uses elliptic cone, and this override has been causing confusion in perf testing and debugging.