### PR TITLE
Second attempt of airspeed velocity benchmarks.

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "project": "mujoco-warp",
+  "project_url": "https://github.com/google-deepmind/mujoco_warp",
+  "repo": ".",
+  "build_command": [
+    "python -m build --wheel -o {build_cache_dir}"
+  ],
+  "install_command": [
+    "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
+  ],
+  "branches": ["main"],
+  "dvcs": "git",
+  "environment_type": "virtualenv",
+  "show_commit_url": "https://github.com/google-deepmind/mujoco_warp/commit/",
+  "benchmark_dir": "benchmark",
+  "env_dir": "asv/env",
+  "results_dir": "asv/results",
+  "html_dir": "asv/html",
+  "build_cache_size": 20,
+  "default_benchmark_timeout": 120
+}

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -8,7 +8,7 @@ Make sure you install MJWarp in develop so you can run the `asv` command:
 pip install -e .[dev,cuda]
 ```
 
-Run benchmarks like so at the top level of the `mujoco_warp` checkout:
+To execute benchmarks, from the `mujoco_warp` directory run:
 
 ```
 asv run

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,60 @@
+# MuJoCo Warp Benchmark Suite
+
+MJWarp uses [airspeed velocity](https://github.com/airspeed-velocity/asv) for benchmarks.
+
+Make sure you install MJWarp in develop so you can run the `asv` command:
+
+```
+pip install -e .[dev,cuda]
+```
+
+Run benchmarks like so at the top level of the `mujoco_warp` checkout:
+
+```
+asv run
+```
+
+You should see output that looks like this:
+
+```
+Couldn't load asv.plugins._mamba_helpers because
+No module named 'libmambapy'
+· Creating environments
+· Discovering benchmarks
+· Running 6 total benchmarks (1 commits * 1 environments * 6 benchmarks)
+[ 0.00%] · For mujoco-warp commit 603429ca <asv-2>:
+[ 0.00%] ·· Benchmarking virtualenv-py3.12
+[16.67%] ··· Setting up benchmark:85                                                                                                                                   ok
+[16.67%] ··· benchmark.ApptronikApolloFlat.track_metric                                                                                                                ok
+[16.67%] ··· =============================================== =====================
+                                 function                                         
+             ----------------------------------------------- ---------------------
+                               jit_duration                   0.21160659193992615 
+                            solver_niter_mean                  3.263658447265625  
+                             solver_niter_p95                         5.0         
+                         device_memory_allocated                   887095296      
+                                   step                        758.2121635787189  
+                               step.forward                    753.6720001371577  
+                        step.forward.fwd_position              106.35671483032638 
+                   step.forward.fwd_position.kinematics        38.16051127068931  
+                    step.forward.fwd_position.com_pos          11.754250321246218 
+                    step.forward.fwd_position.camlight         2.2997500059318554 
+                      step.forward.fwd_position.crb             18.2445002192253  
+                step.forward.fwd_position.tendon_armature     0.17412499956037664 
+                   step.forward.fwd_position.collision          6.07399994669322  
+...
+```
+
+Benchmarks are slow to run - if you would like to filter a single benchmark, use `-b`:
+
+```
+asv run -b ApptronikApolloFlat
+```
+
+You can also benchmark your own branch:
+
+```
+asv run $MYBRANCH
+```
+
+See the [airspeed velocity documentation](https://asv.readthedocs.io/en/latest/index.html) for more information.

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 The Newton Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -71,7 +71,7 @@ class Humanoid(mujoco_warp.BenchmarkSuite):
   path = "humanoid/humanoid.xml"
   params = mujoco_warp.BenchmarkSuite.params + ("step.euler",)
   batch_size = 8192
-  nconmax = 150_000
+  nconmax = 200_000
   njmax = 64
 
 
@@ -79,9 +79,9 @@ class ThreeHumanoids(mujoco_warp.BenchmarkSuite):
   """Three MuJoCo humanoids on an infinite plane.
   Ideally, simulation time scales linearly with number of humanoids.
   """
-
   path = "humanoid/n_humanoid.xml"
   params = mujoco_warp.BenchmarkSuite.params + ("step.euler",)
+  # TODO: use batch_size=8192 once performance is fixed
   batch_size = 1024
   nconmax = 100_000
   njmax = 192

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,0 +1,96 @@
+# Copyright 2025 The Newton Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import mujoco_warp
+
+# TODO(team): uncomment once elliptic cone is fixed
+# class AlohaPot(mujoco_warp.BenchmarkSuite):
+#   """Aloha robot with a pasta pot on the workbench."""
+
+#   path = "aloha_pot/scene.xml"
+#   batch_size = 8192
+#   nconmax = 200_000
+#   njmax = 128
+
+
+class ApptronikApolloFlat(mujoco_warp.BenchmarkSuite):
+  """Apptronik Apollo locomoting on an infinite plane."""
+
+  path = "apptronik_apollo/scene_flat.xml"
+  params = mujoco_warp.BenchmarkSuite.params + ("step.euler",)
+  batch_size = 8192
+  nconmax = 100_000
+  njmax = 64
+
+
+class ApptronikApolloHfield(mujoco_warp.BenchmarkSuite):
+  """Apptronik Apollo locomoting on a pyramidal hfield."""
+
+  path = "apptronik_apollo/scene_hfield.xml"
+  params = mujoco_warp.BenchmarkSuite.params + ("step.euler",)
+  batch_size = 1024
+  nconmax = 700_000
+  njmax = 128
+
+
+class ApptronikApolloTerrain(mujoco_warp.BenchmarkSuite):
+  """Apptronik Apollo locomoting on Isaac-style pyramids made of thousands of boxes."""
+
+  path = "apptronik_apollo/scene_terrain.xml"
+  params = mujoco_warp.BenchmarkSuite.params + ("step.euler",)
+  batch_size = 8192
+  nconmax = 400_000
+  njmax = 96
+
+
+class FrankaEmikaPanda(mujoco_warp.BenchmarkSuite):
+  """Franka Emika Panda on an infinite plane."""
+
+  path = "franka_emika_panda/scene.xml"
+  params = mujoco_warp.BenchmarkSuite.params + ("step.implicit",)
+  batch_size = 32768
+  nconmax = 10_000
+  njmax = 5
+
+
+class Humanoid(mujoco_warp.BenchmarkSuite):
+  """MuJoCo humanoid on an infinite plane."""
+
+  path = "humanoid/humanoid.xml"
+  params = mujoco_warp.BenchmarkSuite.params + ("step.euler",)
+  batch_size = 8192
+  nconmax = 150_000
+  njmax = 64
+
+
+class ThreeHumanoids(mujoco_warp.BenchmarkSuite):
+  """Three MuJoCo humanoids on an infinite plane.
+  Ideally, simulation time scales linearly with number of humanoids.
+  """
+
+  path = "humanoid/n_humanoid.xml"
+  params = mujoco_warp.BenchmarkSuite.params + ("step.euler",)
+  batch_size = 1024
+  nconmax = 100_000
+  njmax = 192
+
+
+# attach a setup_cache to each test for one-time setup of benchmarks
+ApptronikApolloFlat.setup_cache = lambda s: mujoco_warp.BenchmarkSuite.setup_cache(s)
+ApptronikApolloHfield.setup_cache = lambda s: mujoco_warp.BenchmarkSuite.setup_cache(s)
+ApptronikApolloTerrain.setup_cache = lambda s: mujoco_warp.BenchmarkSuite.setup_cache(s)
+FrankaEmikaPanda.setup_cache = lambda s: mujoco_warp.BenchmarkSuite.setup_cache(s)
+Humanoid.setup_cache = lambda s: mujoco_warp.BenchmarkSuite.setup_cache(s)
+ThreeHumanoids.setup_cache = lambda s: mujoco_warp.BenchmarkSuite.setup_cache(s)

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -79,6 +79,7 @@ class ThreeHumanoids(mujoco_warp.BenchmarkSuite):
   """Three MuJoCo humanoids on an infinite plane.
   Ideally, simulation time scales linearly with number of humanoids.
   """
+
   path = "humanoid/n_humanoid.xml"
   params = mujoco_warp.BenchmarkSuite.params + ("step.euler",)
   # TODO: use batch_size=8192 once performance is fixed

--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -64,6 +64,7 @@ from ._src.solver import solve as solve
 from ._src.support import contact_force as contact_force
 from ._src.support import mul_m as mul_m
 from ._src.support import xfrc_accumulate as xfrc_accumulate
+from ._src.test_util import BenchmarkSuite as BenchmarkSuite
 from ._src.test_util import benchmark as benchmark
 from ._src.types import BroadphaseType as BroadphaseType
 from ._src.types import ConeType as ConeType

--- a/mujoco_warp/_src/test_util.py
+++ b/mujoco_warp/_src/test_util.py
@@ -335,11 +335,11 @@ class BenchmarkSuite:
       "device_memory_allocated": free_before - wp.get_device().free_memory,
     }
 
-    def tree_flatten(d, parent_k=''):
+    def tree_flatten(d, parent_k=""):
       ret = {}
       steps = self.batch_size * 1000
       for k, v in d.items():
-        k = parent_k + '.' + k if parent_k else k
+        k = parent_k + "." + k if parent_k else k
         ret = ret | {k: 1e6 * v[0][0] / steps} | tree_flatten(v[1], k)
       return ret
 

--- a/mujoco_warp/_src/test_util.py
+++ b/mujoco_warp/_src/test_util.py
@@ -15,6 +15,8 @@
 
 """Utilities for testing."""
 
+import importlib
+import os
 import time
 from typing import Callable, Optional, Tuple
 
@@ -23,6 +25,7 @@ import numpy as np
 import warp as wp
 from etils import epath
 
+from . import forward
 from . import io
 from . import warp_util
 from .types import ConeType
@@ -242,26 +245,107 @@ def benchmark(
             m.actuator_ctrllimited, m.actuator_ctrlrange, i, 0.01
           ],
           outputs=[d.ctrl])  # fmt: skip
+        wp.synchronize()
 
         run_beg = time.perf_counter()
         wp.capture_launch(graph)
         wp.synchronize()
+        run_end = time.perf_counter()
 
-      run_end = time.perf_counter()
       time_vec[i] = run_end - run_beg
       if trace:
         trace = _sum(trace, tracer.trace())
       else:
         trace = tracer.trace()
-      if measure_alloc or measure_solver_niter:
-        wp.synchronize()
       if measure_alloc:
         ncon.append(d.ncon.numpy()[0])
         nefc.append(np.sum(d.nefc.numpy()))
       if measure_solver_niter:
         solver_niter.append(d.solver_niter.numpy())
 
-    wp.synchronize()
     run_duration = np.sum(time_vec)
 
   return jit_duration, run_duration, trace, ncon, nefc, solver_niter
+
+
+class BenchmarkSuite:
+  """Base suite for all model benchmarks."""
+
+  path = ""
+  batch_size = -1
+  nconmax = -1
+  njmax = -1
+  param_names = ("function",)
+  params = (
+    "jit_duration",
+    "solver_niter_mean",
+    "solver_niter_p95",
+    "device_memory_allocated",
+    "step",
+    "step.forward",
+    "step.forward.fwd_position",
+    "step.forward.fwd_position.kinematics",
+    "step.forward.fwd_position.com_pos",
+    "step.forward.fwd_position.camlight",
+    "step.forward.fwd_position.crb",
+    "step.forward.fwd_position.tendon_armature",
+    "step.forward.fwd_position.collision",
+    "step.forward.fwd_position.make_constraint",
+    "step.forward.fwd_position.transmission",
+    "step.forward.sensor_pos",
+    "step.forward.fwd_velocity",
+    "step.forward.fwd_velocity.com_vel",
+    "step.forward.fwd_velocity.passive",
+    "step.forward.fwd_velocity.rne",
+    "step.forward.fwd_velocity.tendon_bias",
+    "step.forward.sensor_vel",
+    "step.forward.fwd_actuation",
+    "step.forward.fwd_acceleration",
+    "step.forward.fwd_acceleration.xfrc_accumulate",
+    "step.forward.sensor_acc",
+    "step.forward.solve",
+  )
+  number = 1
+  rounds = 1
+  sample_time = 0
+  repeat = 1
+
+  def setup_cache(self):
+    module = importlib.import_module(self.__module__)
+    path = os.path.join(os.path.realpath(os.path.dirname(module.__file__)), self.path)
+    mjm = mujoco.MjModel.from_xml_path(path)
+    mjd = mujoco.MjData(mjm)
+    if mjm.nkey > 0:
+      mujoco.mj_resetDataKeyframe(mjm, mjd, 0)
+
+    # TODO(team): mj_forward call shouldn't be necessary, but it is
+    mujoco.mj_forward(mjm, mjd)
+
+    wp.init()
+
+    free_before = wp.get_device().free_memory
+    m = io.put_model(mjm)
+    d = io.put_data(mjm, mjd, self.batch_size, self.nconmax, self.njmax)
+
+    jit_duration, _, trace, _, _, solver_niter = benchmark(forward.step, m, d, 1000, True, False, True)
+    metrics = {
+      "jit_duration": jit_duration,
+      "solver_niter_mean": np.mean(solver_niter),
+      "solver_niter_p95": np.quantile(solver_niter, 0.95),
+      "device_memory_allocated": free_before - wp.get_device().free_memory,
+    }
+
+    def tree_flatten(d, parent_k=''):
+      ret = {}
+      steps = self.batch_size * 1000
+      for k, v in d.items():
+        k = parent_k + '.' + k if parent_k else k
+        ret = ret | {k: 1e6 * v[0][0] / steps} | tree_flatten(v[1], k)
+      return ret
+
+    metrics = metrics | tree_flatten(trace)
+
+    return metrics
+
+  def track_metric(self, metrics, fn):
+    return metrics[fn]

--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -100,7 +100,7 @@ def event_scope(fn, name: str = ""):
       return fn(*args, **kwargs)
 
     for frame_info in inspect.stack():
-      if frame_info.function in ('capture_while', 'capture_if'):
+      if frame_info.function in ("capture_while", "capture_if"):
         return fn(*args, **kwargs)
 
     # push into next level of stack

--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 import functools
+import inspect
 from typing import Callable, Optional
 
 import warp as wp
@@ -97,6 +98,11 @@ def event_scope(fn, name: str = ""):
     global _STACK
     if _STACK is None:
       return fn(*args, **kwargs)
+
+    for frame_info in inspect.stack():
+      if frame_info.function in ('capture_while', 'capture_if'):
+        return fn(*args, **kwargs)
+
     # push into next level of stack
     saved_stack, _STACK = _STACK, {}
     beg = wp.Event(enable_timing=True)

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -144,10 +144,7 @@ def _main(argv: Sequence[str]):
 
   with wp.ScopedDevice(_DEVICE.value):
     m = mjwarp.put_model(mjm)
-    if _EVENT_TRACE.value:
-      if m.opt.graph_conditional:
-        print("Warning: graph conditional is disabled, feature not supported with event tracing")
-        m.opt.graph_conditional = False  # graph conditional doesn't work with event trace
+
     # integrator
     IntegratorType = mjwarp._src.types.IntegratorType
     integrators = {IntegratorType.EULER: "Euler", IntegratorType.IMPLICITFAST: "implicitfast", IntegratorType.RK4: "RK4"}


### PR DESCRIPTION
I decided I didn't like #522 for two reasons:

1) it's slow
2) it introduces a second way to benchmark when we already have `testspeed`

So I decided to redo it.  This new approach uses the same core code as `testspeed` by fixing the limitation in `testspeed` that `event_trace` param could not work with `graph_conditional` - this PR fixes that, and removes the recent change that forced `graph_conditional=False` when using event tracing.

After fixing this, I'm finding that using Warp events are pretty reliable.  I see only ~0.5% stddev from run to run, and the numbers all make sense to me.  Also, these tests run much faster - the entire benchmark suite runs in <2 mins on my machine, where the previous approach was probably closer to 10 minutes or more.