### PR TITLE
per-world contact

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -178,17 +178,16 @@ def ccd_kernel_builder(
     # Data out:
     ncon_out: wp.array(dtype=int),
     ncon_hfield_out: wp.array2d(dtype=int),
-    contact_dist_out: wp.array(dtype=float),
-    contact_pos_out: wp.array(dtype=wp.vec3),
-    contact_frame_out: wp.array(dtype=wp.mat33),
-    contact_includemargin_out: wp.array(dtype=float),
-    contact_friction_out: wp.array(dtype=vec5),
-    contact_solref_out: wp.array(dtype=wp.vec2),
-    contact_solreffriction_out: wp.array(dtype=wp.vec2),
-    contact_solimp_out: wp.array(dtype=vec5),
-    contact_dim_out: wp.array(dtype=int),
-    contact_geom_out: wp.array(dtype=wp.vec2i),
-    contact_worldid_out: wp.array(dtype=int),
+    contact_dist_out: wp.array2d(dtype=float),
+    contact_pos_out: wp.array2d(dtype=wp.vec3),
+    contact_frame_out: wp.array2d(dtype=wp.mat33),
+    contact_includemargin_out: wp.array2d(dtype=float),
+    contact_friction_out: wp.array2d(dtype=vec5),
+    contact_solref_out: wp.array2d(dtype=wp.vec2),
+    contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+    contact_solimp_out: wp.array2d(dtype=vec5),
+    contact_dim_out: wp.array2d(dtype=int),
+    contact_geom_out: wp.array2d(dtype=wp.vec2i),
   ):
     tid = wp.tid()
     if tid >= ncollision_in[0]:
@@ -382,7 +381,6 @@ def ccd_kernel_builder(
         contact_solimp_out,
         contact_dim_out,
         contact_geom_out,
-        contact_worldid_out,
       )
 
   return ccd_kernel
@@ -416,7 +414,7 @@ def convex_narrowphase(m: Model, d: Data):
           False,
           0.1,
         ),
-        dim=d.nconmax,
+        dim=d.nworld * d.nconmax,
         inputs=[
           m.ngeom,
           m.geom_type,
@@ -490,6 +488,5 @@ def convex_narrowphase(m: Model, d: Data):
           d.contact.solimp,
           d.contact.dim,
           d.contact.geom,
-          d.contact.worldid,
         ],
       )

--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -490,9 +490,9 @@ class CollisionTest(parameterized.TestCase):
       actual_pos = mjd.contact.pos[i]
       actual_frame = mjd.contact.frame[i][0:3]
       result = False
-      test_dist = d.contact.dist.numpy()[i]
-      test_pos = d.contact.pos.numpy()[i, :]
-      test_frame = d.contact.frame.numpy()[i].flatten()[0:3]
+      test_dist = d.contact.dist.numpy()[0, i]
+      test_pos = d.contact.pos.numpy()[0, i, :]
+      test_frame = d.contact.frame.numpy()[0, i].flatten()[0:3]
       check_dist = np.allclose(actual_dist, test_dist, rtol=5e-2, atol=1.0e-1)
       check_frame = np.allclose(actual_frame, test_frame, rtol=5e-2, atol=1.0e-1)
       check_pos = np.allclose(actual_pos, test_pos, rtol=5e-2, atol=1.0e-1)
@@ -520,9 +520,9 @@ class CollisionTest(parameterized.TestCase):
       actual_frame = mjd.contact.frame[i]
       result = False
       for j in range(d.ncon.numpy()[0]):
-        test_dist = d.contact.dist.numpy()[j]
-        test_pos = d.contact.pos.numpy()[j, :]
-        test_frame = d.contact.frame.numpy()[j].flatten()
+        test_dist = d.contact.dist.numpy()[0, j]
+        test_pos = d.contact.pos.numpy()[0, j, :]
+        test_frame = d.contact.frame.numpy()[0, j].flatten()
         check_dist = np.allclose(actual_dist, test_dist, rtol=5e-2, atol=1.0e-2)
         check_pos = np.allclose(actual_pos, test_pos, rtol=5e-2, atol=1.0e-2)
         check_frame = np.allclose(actual_frame, test_frame, rtol=5e-2, atol=1.0e-2)
@@ -645,12 +645,12 @@ class CollisionTest(parameterized.TestCase):
     mjwarp.collision(m, d)
 
     self.assertEqual(d.ncon.numpy()[0], 1)
-    self.assertEqual(d.contact.includemargin.numpy()[0], -1)
-    self.assertEqual(d.contact.dim.numpy()[0], 6)
-    np.testing.assert_allclose(d.contact.friction.numpy()[0], np.array([5, 4, 3, 2, 1]))
-    np.testing.assert_allclose(d.contact.solref.numpy()[0], np.array([-0.25, -0.5]))
-    np.testing.assert_allclose(d.contact.solreffriction.numpy()[0], np.array([2.0, 4.0]))
-    np.testing.assert_allclose(d.contact.solimp.numpy()[0], np.array([0.1, 0.2, 0.3, 0.4, 0.5]))
+    self.assertEqual(d.contact.includemargin.numpy()[0, 0], -1)
+    self.assertEqual(d.contact.dim.numpy()[0, 0], 6)
+    np.testing.assert_allclose(d.contact.friction.numpy()[0, 0], np.array([5, 4, 3, 2, 1]))
+    np.testing.assert_allclose(d.contact.solref.numpy()[0, 0], np.array([-0.25, -0.5]))
+    np.testing.assert_allclose(d.contact.solreffriction.numpy()[0, 0], np.array([2.0, 4.0]))
+    np.testing.assert_allclose(d.contact.solimp.numpy()[0, 0], np.array([0.1, 0.2, 0.3, 0.4, 0.5]))
 
     # 1 pair: override contype and conaffinity
     _, _, m, d = test_util.fixture(
@@ -689,12 +689,12 @@ class CollisionTest(parameterized.TestCase):
     mjwarp.collision(m, d)
 
     self.assertEqual(d.ncon.numpy()[0], 1)
-    self.assertEqual(d.contact.includemargin.numpy()[0], -1)
-    self.assertEqual(d.contact.dim.numpy()[0], 6)
-    np.testing.assert_allclose(d.contact.friction.numpy()[0], np.array([5, 4, 3, 2, 1]))
-    np.testing.assert_allclose(d.contact.solref.numpy()[0], np.array([-0.25, -0.5]))
-    np.testing.assert_allclose(d.contact.solreffriction.numpy()[0], np.array([2.0, 4.0]))
-    np.testing.assert_allclose(d.contact.solimp.numpy()[0], np.array([0.1, 0.2, 0.3, 0.4, 0.5]))
+    self.assertEqual(d.contact.includemargin.numpy()[0, 0], -1)
+    self.assertEqual(d.contact.dim.numpy()[0, 0], 6)
+    np.testing.assert_allclose(d.contact.friction.numpy()[0, 0], np.array([5, 4, 3, 2, 1]))
+    np.testing.assert_allclose(d.contact.solref.numpy()[0, 0], np.array([-0.25, -0.5]))
+    np.testing.assert_allclose(d.contact.solreffriction.numpy()[0, 0], np.array([2.0, 4.0]))
+    np.testing.assert_allclose(d.contact.solimp.numpy()[0, 0], np.array([0.1, 0.2, 0.3, 0.4, 0.5]))
 
     # 1 pair: override exclude
     _, _, m, d = test_util.fixture(
@@ -734,12 +734,12 @@ class CollisionTest(parameterized.TestCase):
     mjwarp.collision(m, d)
 
     self.assertEqual(d.ncon.numpy()[0], 1)
-    self.assertEqual(d.contact.includemargin.numpy()[0], -1)
-    self.assertEqual(d.contact.dim.numpy()[0], 6)
-    np.testing.assert_allclose(d.contact.friction.numpy()[0], np.array([5, 4, 3, 2, 1]))
-    np.testing.assert_allclose(d.contact.solref.numpy()[0], np.array([-0.25, -0.5]))
-    np.testing.assert_allclose(d.contact.solreffriction.numpy()[0], np.array([2.0, 4.0]))
-    np.testing.assert_allclose(d.contact.solimp.numpy()[0], np.array([0.1, 0.2, 0.3, 0.4, 0.5]))
+    self.assertEqual(d.contact.includemargin.numpy()[0, 0], -1)
+    self.assertEqual(d.contact.dim.numpy()[0, 0], 6)
+    np.testing.assert_allclose(d.contact.friction.numpy()[0, 0], np.array([5, 4, 3, 2, 1]))
+    np.testing.assert_allclose(d.contact.solref.numpy()[0, 0], np.array([-0.25, -0.5]))
+    np.testing.assert_allclose(d.contact.solreffriction.numpy()[0, 0], np.array([2.0, 4.0]))
+    np.testing.assert_allclose(d.contact.solimp.numpy()[0, 0], np.array([0.1, 0.2, 0.3, 0.4, 0.5]))
 
     # 1 pair 1 exclude
     _, _, m, d = test_util.fixture(
@@ -783,12 +783,12 @@ class CollisionTest(parameterized.TestCase):
     mjwarp.collision(m, d)
 
     self.assertEqual(d.ncon.numpy()[0], 2)
-    self.assertEqual(d.contact.includemargin.numpy()[1], -1)
-    self.assertEqual(d.contact.dim.numpy()[1], 6)
-    np.testing.assert_allclose(d.contact.friction.numpy()[1], np.array([5, 4, 3, 2, 1]))
-    np.testing.assert_allclose(d.contact.solref.numpy()[1], np.array([-0.25, -0.5]))
-    np.testing.assert_allclose(d.contact.solreffriction.numpy()[1], np.array([2.0, 4.0]))
-    np.testing.assert_allclose(d.contact.solimp.numpy()[1], np.array([0.1, 0.2, 0.3, 0.4, 0.5]))
+    self.assertEqual(d.contact.includemargin.numpy()[0, 1], -1)
+    self.assertEqual(d.contact.dim.numpy()[0, 1], 6)
+    np.testing.assert_allclose(d.contact.friction.numpy()[0, 1], np.array([5, 4, 3, 2, 1]))
+    np.testing.assert_allclose(d.contact.solref.numpy()[0, 1], np.array([-0.25, -0.5]))
+    np.testing.assert_allclose(d.contact.solreffriction.numpy()[0, 1], np.array([2.0, 4.0]))
+    np.testing.assert_allclose(d.contact.solimp.numpy()[0, 1], np.array([0.1, 0.2, 0.3, 0.4, 0.5]))
 
     # TODO(team): test sap_broadphase
 
@@ -861,7 +861,7 @@ class CollisionTest(parameterized.TestCase):
     )
 
     self.assertEqual(d.ncon.numpy()[0], 1)
-    np.testing.assert_allclose(d.contact.friction.numpy()[0], types.MJ_MINMU)
+    np.testing.assert_allclose(d.contact.friction.numpy()[0, 0], types.MJ_MINMU)
 
   # TODO(team): test contact parameter mixing
 

--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -163,34 +163,32 @@ def write_contact(
   worldid_in: int,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   active = (dist_in - margin_in) < 0
   if active:
-    cid = wp.atomic_add(ncon_out, 0, 1)
+    cid = wp.atomic_add(ncon_out, worldid_in, 1)
     if cid < nconmax_in:
-      contact_dist_out[cid] = dist_in
-      contact_pos_out[cid] = pos_in
-      contact_frame_out[cid] = frame_in
-      contact_geom_out[cid] = geoms_in
-      contact_worldid_out[cid] = worldid_in
+      contact_dist_out[worldid_in, cid] = dist_in
+      contact_pos_out[worldid_in, cid] = pos_in
+      contact_frame_out[worldid_in, cid] = frame_in
+      contact_geom_out[worldid_in, cid] = geoms_in
       includemargin = margin_in - gap_in
-      contact_includemargin_out[cid] = includemargin
-      contact_dim_out[cid] = condim_in
-      contact_friction_out[cid] = friction_in
-      contact_solref_out[cid] = solref_in
-      contact_solreffriction_out[cid] = solreffriction_in
-      contact_solimp_out[cid] = solimp_in
+      contact_includemargin_out[worldid_in, cid] = includemargin
+      contact_dim_out[worldid_in, cid] = condim_in
+      contact_friction_out[worldid_in, cid] = friction_in
+      contact_solref_out[worldid_in, cid] = solref_in
+      contact_solreffriction_out[worldid_in, cid] = solreffriction_in
+      contact_solimp_out[worldid_in, cid] = solimp_in
 
 
 @wp.func
@@ -218,17 +216,16 @@ def plane_sphere(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   dist, pos = _plane_sphere(plane.normal, plane.pos, sphere.pos, sphere.size[0])
 
@@ -257,7 +254,6 @@ def plane_sphere(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -281,17 +277,16 @@ def _sphere_sphere(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   dir = pos2 - pos1
   dist = wp.length(dir)
@@ -327,7 +322,6 @@ def _sphere_sphere(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -353,17 +347,16 @@ def _sphere_sphere_ext(
   mat2: wp.mat33,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   dir = pos2 - pos1
   dist = wp.length(dir)
@@ -403,7 +396,6 @@ def _sphere_sphere_ext(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -425,17 +417,16 @@ def sphere_sphere(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   _sphere_sphere(
     nconmax_in,
@@ -463,7 +454,6 @@ def sphere_sphere(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -485,17 +475,16 @@ def sphere_capsule(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   """Calculates one contact between a sphere and a capsule."""
   axis = wp.vec3(cap.rot[0, 2], cap.rot[1, 2], cap.rot[2, 2])
@@ -532,7 +521,6 @@ def sphere_capsule(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -554,17 +542,16 @@ def capsule_capsule(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   axis1 = wp.vec3(cap1.rot[0, 2], cap1.rot[1, 2], cap1.rot[2, 2])
   axis2 = wp.vec3(cap2.rot[0, 2], cap2.rot[1, 2], cap2.rot[2, 2])
@@ -606,7 +593,6 @@ def capsule_capsule(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -628,17 +614,16 @@ def plane_capsule(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   """Calculates two contacts between a capsule and a plane."""
   n = plane.normal
@@ -682,7 +667,6 @@ def plane_capsule(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
   dist2, pos2 = _plane_sphere(n, plane.pos, cap.pos - segment, cap.size[0])
@@ -711,7 +695,6 @@ def plane_capsule(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -733,17 +716,16 @@ def plane_ellipsoid(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   sphere_support = -wp.normalize(wp.cw_mul(wp.transpose(ellipsoid.rot) @ plane.normal, ellipsoid.size))
   pos = ellipsoid.pos + ellipsoid.rot @ wp.cw_mul(sphere_support, ellipsoid.size)
@@ -775,7 +757,6 @@ def plane_ellipsoid(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -797,17 +778,16 @@ def plane_box(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   count = int(0)
   corner = wp.vec3()
@@ -856,7 +836,6 @@ def plane_box(
       contact_solimp_out,
       contact_dim_out,
       contact_geom_out,
-      contact_worldid_out,
     )
     count += 1
     if count >= 4:
@@ -884,17 +863,16 @@ def plane_convex(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   """Calculates contacts between a plane and a convex object."""
 
@@ -1135,7 +1113,6 @@ def plane_convex(
         contact_solimp_out,
         contact_dim_out,
         contact_geom_out,
-        contact_worldid_out,
       )
 
 
@@ -1157,17 +1134,16 @@ def sphere_cylinder(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   axis = wp.vec3(
     cylinder.rot[0, 2],
@@ -1226,7 +1202,6 @@ def sphere_cylinder(
       contact_solimp_out,
       contact_dim_out,
       contact_geom_out,
-      contact_worldid_out,
     )
     return
 
@@ -1269,7 +1244,6 @@ def sphere_cylinder(
       contact_solimp_out,
       contact_dim_out,
       contact_geom_out,
-      contact_worldid_out,
     )
 
     return
@@ -1309,7 +1283,6 @@ def sphere_cylinder(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -1331,17 +1304,16 @@ def plane_cylinder(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   """Calculates contacts between a cylinder and a plane."""
   # Extract plane normal and cylinder axis
@@ -1407,7 +1379,6 @@ def plane_cylinder(
       contact_solimp_out,
       contact_dim_out,
       contact_geom_out,
-      contact_worldid_out,
     )
   else:
     # If nearest point is above margin, no contacts
@@ -1442,7 +1413,6 @@ def plane_cylinder(
       contact_solimp_out,
       contact_dim_out,
       contact_geom_out,
-      contact_worldid_out,
     )
 
   # Try triangle contact points on side closer to plane
@@ -1480,7 +1450,6 @@ def plane_cylinder(
       contact_solimp_out,
       contact_dim_out,
       contact_geom_out,
-      contact_worldid_out,
     )
 
     # Add contact point B - adjust to closest side
@@ -1510,7 +1479,6 @@ def plane_cylinder(
       contact_solimp_out,
       contact_dim_out,
       contact_geom_out,
-      contact_worldid_out,
     )
 
 
@@ -1615,17 +1583,16 @@ def _sphere_box(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   center = wp.transpose(box_rot) @ (sphere_pos - box_pos)
 
@@ -1683,7 +1650,6 @@ def _sphere_box(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -1705,17 +1671,16 @@ def sphere_box(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   _sphere_box(
     nconmax_in,
@@ -1744,7 +1709,6 @@ def sphere_box(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
 
@@ -1766,17 +1730,16 @@ def capsule_box(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   """Calculates contacts between a capsule and a box."""
   # Based on the mjc implementation
@@ -2098,7 +2061,6 @@ def capsule_box(
     contact_solimp_out,
     contact_dim_out,
     contact_geom_out,
-    contact_worldid_out,
   )
 
   if secondpos > -3:  # secondpos was modified
@@ -2131,7 +2093,6 @@ def capsule_box(
       contact_solimp_out,
       contact_dim_out,
       contact_geom_out,
-      contact_worldid_out,
     )
 
 
@@ -2185,17 +2146,16 @@ def box_box(
   geoms: wp.vec2i,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   # Compute transforms between box's frames
 
@@ -2606,7 +2566,7 @@ def box_box(
     normal = wp.where(inv, -1.0, 1.0) * rw @ rnorm
 
   frame = make_frame(normal)
-  coff = wp.atomic_add(ncon_out, 0, n)
+  coff = wp.atomic_add(ncon_out, worldid, n)
 
   for i in range(min(nconmax_in - coff, n)):
     points[i, 2] += hz
@@ -2614,17 +2574,16 @@ def box_box(
 
     cid = coff + i
 
-    contact_dist_out[cid] = depth[i]
-    contact_pos_out[cid] = pos
-    contact_frame_out[cid] = frame
-    contact_geom_out[cid] = geoms
-    contact_worldid_out[cid] = worldid
-    contact_includemargin_out[cid] = margin - gap
-    contact_dim_out[cid] = condim
-    contact_friction_out[cid] = friction
-    contact_solref_out[cid] = solref
-    contact_solreffriction_out[cid] = solreffriction
-    contact_solimp_out[cid] = solimp
+    contact_dist_out[worldid, cid] = depth[i]
+    contact_pos_out[worldid, cid] = pos
+    contact_frame_out[worldid, cid] = frame
+    contact_geom_out[worldid, cid] = geoms
+    contact_includemargin_out[worldid, cid] = margin - gap
+    contact_dim_out[worldid, cid] = condim
+    contact_friction_out[worldid, cid] = friction
+    contact_solref_out[worldid, cid] = solref
+    contact_solreffriction_out[worldid, cid] = solreffriction
+    contact_solimp_out[worldid, cid] = solimp
 
 
 _PRIMITIVE_COLLISIONS = {
@@ -2719,17 +2678,16 @@ def _primitive_narrowphase_builder(m: Model):
     ncollision_in: wp.array(dtype=int),
     # Data out:
     ncon_out: wp.array(dtype=int),
-    contact_dist_out: wp.array(dtype=float),
-    contact_pos_out: wp.array(dtype=wp.vec3),
-    contact_frame_out: wp.array(dtype=wp.mat33),
-    contact_includemargin_out: wp.array(dtype=float),
-    contact_friction_out: wp.array(dtype=vec5),
-    contact_solref_out: wp.array(dtype=wp.vec2),
-    contact_solreffriction_out: wp.array(dtype=wp.vec2),
-    contact_solimp_out: wp.array(dtype=vec5),
-    contact_dim_out: wp.array(dtype=int),
-    contact_geom_out: wp.array(dtype=wp.vec2i),
-    contact_worldid_out: wp.array(dtype=int),
+    contact_dist_out: wp.array2d(dtype=float),
+    contact_pos_out: wp.array2d(dtype=wp.vec3),
+    contact_frame_out: wp.array2d(dtype=wp.mat33),
+    contact_includemargin_out: wp.array2d(dtype=float),
+    contact_friction_out: wp.array2d(dtype=vec5),
+    contact_solref_out: wp.array2d(dtype=wp.vec2),
+    contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+    contact_solimp_out: wp.array2d(dtype=vec5),
+    contact_dim_out: wp.array2d(dtype=int),
+    contact_geom_out: wp.array2d(dtype=wp.vec2i),
   ):
     tid = wp.tid()
 
@@ -2858,7 +2816,6 @@ def _primitive_narrowphase_builder(m: Model):
           contact_solimp_out,
           contact_dim_out,
           contact_geom_out,
-          contact_worldid_out,
         )
 
   return _primitive_narrowphase
@@ -2884,7 +2841,7 @@ def primitive_narrowphase(m: Model, d: Data):
   # for pair types without collisions, as well as updating the launch dimensions.
   wp.launch(
     _primitive_narrowphase_builder(m),
-    dim=d.nconmax,
+    dim=d.nworld * d.nconmax,
     inputs=[
       m.geom_type,
       m.geom_condim,
@@ -2944,6 +2901,5 @@ def primitive_narrowphase(m: Model, d: Data):
       d.contact.solimp,
       d.contact.dim,
       d.contact.geom,
-      d.contact.worldid,
     ],
   )

--- a/mujoco_warp/_src/collision_sdf.py
+++ b/mujoco_warp/_src/collision_sdf.py
@@ -330,17 +330,16 @@ def _sdf_narrowphase(
   sdf_iterations: int,
   # Data out:
   ncon_out: wp.array(dtype=int),
-  contact_dist_out: wp.array(dtype=float),
-  contact_pos_out: wp.array(dtype=wp.vec3),
-  contact_frame_out: wp.array(dtype=wp.mat33),
-  contact_includemargin_out: wp.array(dtype=float),
-  contact_friction_out: wp.array(dtype=vec5),
-  contact_solref_out: wp.array(dtype=wp.vec2),
-  contact_solreffriction_out: wp.array(dtype=wp.vec2),
-  contact_solimp_out: wp.array(dtype=vec5),
-  contact_dim_out: wp.array(dtype=int),
-  contact_geom_out: wp.array(dtype=wp.vec2i),
-  contact_worldid_out: wp.array(dtype=int),
+  contact_dist_out: wp.array2d(dtype=float),
+  contact_pos_out: wp.array2d(dtype=wp.vec3),
+  contact_frame_out: wp.array2d(dtype=wp.mat33),
+  contact_includemargin_out: wp.array2d(dtype=float),
+  contact_friction_out: wp.array2d(dtype=vec5),
+  contact_solref_out: wp.array2d(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array2d(dtype=wp.vec2),
+  contact_solimp_out: wp.array2d(dtype=vec5),
+  contact_dim_out: wp.array2d(dtype=int),
+  contact_geom_out: wp.array2d(dtype=wp.vec2i),
 ):
   tid = wp.tid()
 
@@ -518,7 +517,6 @@ def _sdf_narrowphase(
       contact_solimp_out,
       contact_dim_out,
       contact_geom_out,
-      contact_worldid_out,
     )
 
 
@@ -526,7 +524,7 @@ def _sdf_narrowphase(
 def sdf_narrowphase(m: Model, d: Data):
   wp.launch(
     _sdf_narrowphase,
-    dim=d.nconmax,
+    dim=d.nworld * d.nconmax,
     inputs=[
       m.geom_type,
       m.geom_condim,
@@ -594,6 +592,5 @@ def sdf_narrowphase(m: Model, d: Data):
       d.contact.solimp,
       d.contact.dim,
       d.contact.geom,
-      d.contact.worldid,
     ],
   )

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -207,6 +207,7 @@ def _next_time(
   # Model:
   opt_timestep: wp.array(dtype=float),
   # Data in:
+  nworld_in: int,
   nconmax_in: int,
   njmax_in: int,
   ncon_in: wp.array(dtype=int),
@@ -219,17 +220,18 @@ def _next_time(
   worldid = wp.tid()
   time_out[worldid] = time_in[worldid] + opt_timestep[worldid]
   nefc = nefc_in[worldid]
+  ncon = ncon_in[worldid]
 
   if nefc > njmax_in:
     wp.printf("nefc overflow - please increase njmax to %u\n", nefc)
 
+  if ncon > nconmax_in:
+    wp.printf("ncon overflow - please increase nconmax to %u\n", ncon)
+
   if worldid == 0:
     ncollision = ncollision_in[0]
-    if ncollision > nconmax_in:
-      wp.printf("ncollision overflow - please increase nconmax to %u\n", ncollision)
-
-    if ncon_in[0] > nconmax_in:
-      wp.printf("ncon overflow - please increase nconmax to %u\n", ncon_in[0])
+    if ncollision > nworld_in * nconmax_in:
+      wp.printf("ncollision overflow - please increase nconmax to %u\n", ncollision // nworld_in)
 
 
 def _advance(m: Model, d: Data, qacc: wp.array, qvel: Optional[wp.array] = None):
@@ -300,6 +302,7 @@ def _advance(m: Model, d: Data, qacc: wp.array, qvel: Optional[wp.array] = None)
     dim=(d.nworld,),
     inputs=[
       m.opt.timestep,
+      d.nworld,
       d.nconmax,
       d.njmax,
       d.ncon,

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -174,42 +174,40 @@ def linesearch_iterative_init_p0_elliptic1(
   opt_impratio: wp.array(dtype=float),
   # Data in:
   ncon_in: wp.array(dtype=int),
-  contact_friction_in: wp.array(dtype=types.vec5),
-  contact_dim_in: wp.array(dtype=int),
-  contact_efc_address_in: wp.array2d(dtype=int),
-  contact_worldid_in: wp.array(dtype=int),
+  contact_friction_in: wp.array2d(dtype=types.vec5),
+  contact_dim_in: wp.array2d(dtype=int),
+  contact_efc_address_in: wp.array3d(dtype=int),
   efc_D_in: wp.array2d(dtype=float),
   efc_jv_in: wp.array2d(dtype=float),
   efc_quad_in: wp.array2d(dtype=wp.vec3),
   efc_done_in: wp.array(dtype=bool),
-  efc_u_in: wp.array(dtype=types.vec6),
-  efc_uu_in: wp.array(dtype=float),
-  efc_uv_in: wp.array(dtype=float),
-  efc_vv_in: wp.array(dtype=float),
+  efc_u_in: wp.array2d(dtype=types.vec6),
+  efc_uu_in: wp.array2d(dtype=float),
+  efc_uv_in: wp.array2d(dtype=float),
+  efc_vv_in: wp.array2d(dtype=float),
   # Data out:
   efc_p0_out: wp.array(dtype=wp.vec3),
 ):
-  conid = wp.tid()
+  worldid, conid = wp.tid()
 
-  if conid >= ncon_in[0]:
+  if conid >= ncon_in[worldid]:
     return
 
-  worldid = contact_worldid_in[conid]
   if efc_done_in[worldid]:
     return
 
-  if contact_dim_in[conid] < 2:
+  if contact_dim_in[worldid, conid] < 2:
     return
 
-  efcid = contact_efc_address_in[conid, 0]
+  efcid = contact_efc_address_in[worldid, conid, 0]
 
   pt = _eval_pt_elliptic(
     opt_impratio[worldid],
-    contact_friction_in[conid],
-    efc_u_in[conid][0],
-    efc_uu_in[conid],
-    efc_uv_in[conid],
-    efc_vv_in[conid],
+    contact_friction_in[worldid, conid],
+    efc_u_in[worldid, conid][0],
+    efc_uu_in[worldid, conid],
+    efc_uv_in[worldid, conid],
+    efc_vv_in[worldid, conid],
     efc_jv_in[worldid, efcid],
     efc_D_in[worldid, efcid],
     efc_quad_in[worldid, efcid],
@@ -313,43 +311,41 @@ def linesearch_iterative_init_lo_elliptic1(
   opt_impratio: wp.array(dtype=float),
   # Data in:
   ncon_in: wp.array(dtype=int),
-  contact_friction_in: wp.array(dtype=types.vec5),
-  contact_dim_in: wp.array(dtype=int),
-  contact_efc_address_in: wp.array2d(dtype=int),
-  contact_worldid_in: wp.array(dtype=int),
+  contact_friction_in: wp.array2d(dtype=types.vec5),
+  contact_dim_in: wp.array2d(dtype=int),
+  contact_efc_address_in: wp.array3d(dtype=int),
   efc_D_in: wp.array2d(dtype=float),
   efc_jv_in: wp.array2d(dtype=float),
   efc_quad_in: wp.array2d(dtype=wp.vec3),
   efc_done_in: wp.array(dtype=bool),
   efc_lo_alpha_in: wp.array(dtype=float),
-  efc_u_in: wp.array(dtype=types.vec6),
-  efc_uu_in: wp.array(dtype=float),
-  efc_uv_in: wp.array(dtype=float),
-  efc_vv_in: wp.array(dtype=float),
+  efc_u_in: wp.array2d(dtype=types.vec6),
+  efc_uu_in: wp.array2d(dtype=float),
+  efc_uv_in: wp.array2d(dtype=float),
+  efc_vv_in: wp.array2d(dtype=float),
   # Data out:
   efc_lo_out: wp.array(dtype=wp.vec3),
 ):
-  conid = wp.tid()
+  worldid, conid = wp.tid()
 
-  if conid >= ncon_in[0]:
+  if conid >= ncon_in[worldid]:
     return
 
-  worldid = contact_worldid_in[conid]
   if efc_done_in[worldid]:
     return
 
-  if contact_dim_in[conid] < 2:
+  if contact_dim_in[worldid, conid] < 2:
     return
 
-  efcid = contact_efc_address_in[conid, 0]
+  efcid = contact_efc_address_in[worldid, conid, 0]
   alpha = efc_lo_alpha_in[worldid]
   pt = _eval_pt_elliptic(
     opt_impratio[worldid],
-    contact_friction_in[conid],
-    efc_u_in[conid][0],
-    efc_uu_in[conid],
-    efc_uv_in[conid],
-    efc_vv_in[conid],
+    contact_friction_in[worldid, conid],
+    efc_u_in[worldid, conid][0],
+    efc_uu_in[worldid, conid],
+    efc_uv_in[worldid, conid],
+    efc_vv_in[worldid, conid],
     efc_jv_in[worldid, efcid],
     efc_D_in[worldid, efcid],
     efc_quad_in[worldid, efcid],
@@ -539,10 +535,9 @@ def linesearch_iterative_next_quad_elliptic1(
   opt_impratio: wp.array(dtype=float),
   # Data in:
   ncon_in: wp.array(dtype=int),
-  contact_friction_in: wp.array(dtype=types.vec5),
-  contact_dim_in: wp.array(dtype=int),
-  contact_efc_address_in: wp.array2d(dtype=int),
-  contact_worldid_in: wp.array(dtype=int),
+  contact_friction_in: wp.array2d(dtype=types.vec5),
+  contact_dim_in: wp.array2d(dtype=int),
+  contact_efc_address_in: wp.array3d(dtype=int),
   efc_D_in: wp.array2d(dtype=float),
   efc_jv_in: wp.array2d(dtype=float),
   efc_quad_in: wp.array2d(dtype=wp.vec3),
@@ -550,35 +545,33 @@ def linesearch_iterative_next_quad_elliptic1(
   efc_lo_next_alpha_in: wp.array(dtype=float),
   efc_hi_next_alpha_in: wp.array(dtype=float),
   efc_mid_alpha_in: wp.array(dtype=float),
-  efc_u_in: wp.array(dtype=types.vec6),
-  efc_uu_in: wp.array(dtype=float),
-  efc_uv_in: wp.array(dtype=float),
-  efc_vv_in: wp.array(dtype=float),
+  efc_u_in: wp.array2d(dtype=types.vec6),
+  efc_uu_in: wp.array2d(dtype=float),
+  efc_uv_in: wp.array2d(dtype=float),
+  efc_vv_in: wp.array2d(dtype=float),
   # Data out:
   efc_lo_next_out: wp.array(dtype=wp.vec3),
   efc_hi_next_out: wp.array(dtype=wp.vec3),
   efc_mid_out: wp.array(dtype=wp.vec3),
 ):
-  conid = wp.tid()
+  worldid, conid = wp.tid()
 
-  if conid >= ncon_in[0]:
+  if conid >= ncon_in[worldid]:
     return
-
-  worldid = contact_worldid_in[conid]
 
   if efc_done_in[worldid]:
     return
 
-  if contact_dim_in[conid] < 2:
+  if contact_dim_in[worldid, conid] < 2:
     return
 
-  efcid = contact_efc_address_in[conid, 0]
+  efcid = contact_efc_address_in[worldid, conid, 0]
   impratio = opt_impratio[worldid]
-  friction = contact_friction_in[conid]
-  u = efc_u_in[conid][0]
-  uu = efc_uu_in[conid]
-  uv = efc_uv_in[conid]
-  vv = efc_vv_in[conid]
+  friction = contact_friction_in[worldid, conid]
+  u = efc_u_in[worldid, conid][0]
+  uu = efc_uu_in[worldid, conid]
+  uv = efc_uv_in[worldid, conid]
+  vv = efc_vv_in[worldid, conid]
   jv = efc_jv_in[worldid, efcid]
   d = efc_D_in[worldid, efcid]
   quad = efc_quad_in[worldid, efcid]
@@ -756,10 +749,10 @@ def _linesearch_iterative(m: types.Model, d: types.Data):
       outputs=[d.efc.p0])  # fmt: skip
     wp.launch(
       linesearch_iterative_init_p0_elliptic1,
-      dim=(d.nconmax),
+      dim=(d.nworld, d.nconmax),
       inputs=[
         m.opt.impratio, d.ncon, d.contact.friction, d.contact.dim,
-        d.contact.efc_address, d.contact.worldid, d.efc.D, d.efc.jv, d.efc.quad,
+        d.contact.efc_address, d.efc.D, d.efc.jv, d.efc.quad,
         d.efc.done, d.efc.u, d.efc.uu, d.efc.uv, d.efc.vv
       ],
       outputs=[d.efc.p0])  # fmt: skip
@@ -790,10 +783,10 @@ def _linesearch_iterative(m: types.Model, d: types.Data):
       outputs=[d.efc.lo])  # fmt: skip
     wp.launch(
       linesearch_iterative_init_lo_elliptic1,
-      dim=(d.nconmax),
+      dim=(d.nworld, d.nconmax),
       inputs=[
         m.opt.impratio, d.ncon, d.contact.friction, d.contact.dim,
-        d.contact.efc_address, d.contact.worldid, d.efc.D, d.efc.jv, d.efc.quad,
+        d.contact.efc_address, d.efc.D, d.efc.jv, d.efc.quad,
         d.efc.done, d.efc.lo_alpha, d.efc.u, d.efc.uu, d.efc.uv, d.efc.vv
       ],
       outputs=[d.efc.lo])  # fmt: skip
@@ -840,9 +833,9 @@ def _linesearch_iterative(m: types.Model, d: types.Data):
         outputs=[d.efc.lo_next, d.efc.hi_next, d.efc.mid])  # fmt: skip
       wp.launch(
         linesearch_iterative_next_quad_elliptic1,
-        dim=(d.nconmax),
+        dim=(d.nworld, d.nconmax),
         inputs=[
-          m.opt.impratio, d.ncon, d.contact.friction, d.contact.dim, d.contact.efc_address, d.contact.worldid, d.efc.D,
+          m.opt.impratio, d.ncon, d.contact.friction, d.contact.dim, d.contact.efc_address, d.efc.D,
           d.efc.jv, d.efc.quad, d.efc.done, d.efc.lo_next_alpha, d.efc.hi_next_alpha, d.efc.mid_alpha, d.efc.u, d.efc.uu,
           d.efc.uv, d.efc.vv
         ],
@@ -1093,45 +1086,43 @@ def linesearch_init_quad(
 def linesearch_quad_elliptic(
   # Data in:
   ncon_in: wp.array(dtype=int),
-  contact_friction_in: wp.array(dtype=types.vec5),
-  contact_dim_in: wp.array(dtype=int),
-  contact_efc_address_in: wp.array2d(dtype=int),
-  contact_worldid_in: wp.array(dtype=int),
+  contact_friction_in: wp.array2d(dtype=types.vec5),
+  contact_dim_in: wp.array2d(dtype=int),
+  contact_efc_address_in: wp.array3d(dtype=int),
   efc_jv_in: wp.array2d(dtype=float),
   efc_quad_in: wp.array2d(dtype=wp.vec3),
   efc_done_in: wp.array(dtype=bool),
-  efc_u_in: wp.array(dtype=types.vec6),
+  efc_u_in: wp.array2d(dtype=types.vec6),
   # Data out:
   efc_quad_out: wp.array2d(dtype=wp.vec3),
-  efc_uv_out: wp.array(dtype=float),
-  efc_vv_out: wp.array(dtype=float),
+  efc_uv_out: wp.array2d(dtype=float),
+  efc_vv_out: wp.array2d(dtype=float),
 ):
-  conid, dimid = wp.tid()
+  worldid, conid, dimid = wp.tid()
   dimid += 1
 
-  if conid >= ncon_in[0]:
+  if conid >= ncon_in[worldid]:
     return
 
-  worldid = contact_worldid_in[conid]
   if efc_done_in[worldid]:
     return
 
-  condim = contact_dim_in[conid]
+  condim = contact_dim_in[worldid, conid]
 
   if condim == 1 or (dimid >= condim):
     return
 
-  efcid0 = contact_efc_address_in[conid, 0]
-  efcid = contact_efc_address_in[conid, dimid]
+  efcid0 = contact_efc_address_in[worldid, conid, 0]
+  efcid = contact_efc_address_in[worldid, conid, dimid]
 
   # complete vector quadratic (for bottom zone)
   wp.atomic_add(efc_quad_out, worldid, efcid0, efc_quad_in[worldid, efcid])
 
   # rescale to make primal cone circular
-  u = efc_u_in[conid][dimid]
-  v = efc_jv_in[worldid, efcid] * contact_friction_in[conid][dimid - 1]
-  wp.atomic_add(efc_uv_out, conid, u * v)
-  wp.atomic_add(efc_vv_out, conid, v * v)
+  u = efc_u_in[worldid, conid][dimid]
+  v = efc_jv_in[worldid, efcid] * contact_friction_in[worldid, conid][dimid - 1]
+  wp.atomic_add(efc_uv_out[worldid], conid, u * v)
+  wp.atomic_add(efc_vv_out[worldid], conid, v * v)
 
 
 @wp.kernel
@@ -1241,13 +1232,12 @@ def _linesearch(m: types.Model, d: types.Data):
     d.efc.vv.zero_()
     wp.launch(
       linesearch_quad_elliptic,
-      dim=(d.nconmax, m.condim_max - 1),
+      dim=(d.nworld, d.nconmax, m.condim_max - 1),
       inputs=[
         d.ncon,
         d.contact.friction,
         d.contact.dim,
         d.contact.efc_address,
-        d.contact.worldid,
         d.efc.jv,
         d.efc.quad,
         d.efc.done,
@@ -1415,29 +1405,27 @@ def update_constraint_u_elliptic(
   opt_impratio: wp.array(dtype=float),
   # Data in:
   ncon_in: wp.array(dtype=int),
-  contact_friction_in: wp.array(dtype=types.vec5),
-  contact_dim_in: wp.array(dtype=int),
-  contact_efc_address_in: wp.array2d(dtype=int),
-  contact_worldid_in: wp.array(dtype=int),
+  contact_friction_in: wp.array2d(dtype=types.vec5),
+  contact_dim_in: wp.array2d(dtype=int),
+  contact_efc_address_in: wp.array3d(dtype=int),
   efc_Jaref_in: wp.array2d(dtype=float),
   efc_done_in: wp.array(dtype=bool),
   # Data out:
-  efc_u_out: wp.array(dtype=types.vec6),
-  efc_uu_out: wp.array(dtype=float),
+  efc_u_out: wp.array2d(dtype=types.vec6),
+  efc_uu_out: wp.array2d(dtype=float),
   efc_condim_out: wp.array2d(dtype=int),
 ):
-  conid, dimid = wp.tid()
+  worldid, conid, dimid = wp.tid()
 
-  if conid >= ncon_in[0]:
+  if conid >= ncon_in[worldid]:
     return
 
-  worldid = contact_worldid_in[conid]
   if efc_done_in[worldid]:
     return
 
-  efcid = contact_efc_address_in[conid, dimid]
+  efcid = contact_efc_address_in[worldid, conid, dimid]
 
-  condim = contact_dim_in[conid]
+  condim = contact_dim_in[worldid, conid]
   efc_condim_out[worldid, efcid] = condim
 
   if condim == 1:
@@ -1445,13 +1433,13 @@ def update_constraint_u_elliptic(
 
   if dimid < condim:
     if dimid == 0:
-      fri = contact_friction_in[conid][0] / wp.sqrt(opt_impratio[worldid])
+      fri = contact_friction_in[worldid, conid][0] / wp.sqrt(opt_impratio[worldid])
     else:
-      fri = contact_friction_in[conid][dimid - 1]
+      fri = contact_friction_in[worldid, conid][dimid - 1]
     u = efc_Jaref_in[worldid, efcid] * fri
-    efc_u_out[conid][dimid] = u
+    efc_u_out[worldid, conid][dimid] = u
     if dimid > 0:
-      wp.atomic_add(efc_uu_out, conid, u * u)
+      wp.atomic_add(efc_uu_out[worldid], conid, u * u)
 
 
 @wp.kernel
@@ -1460,32 +1448,30 @@ def update_constraint_active_elliptic_bottom_zone(
   opt_impratio: wp.array(dtype=float),
   # Data in:
   ncon_in: wp.array(dtype=int),
-  contact_friction_in: wp.array(dtype=types.vec5),
-  contact_dim_in: wp.array(dtype=int),
-  contact_efc_address_in: wp.array2d(dtype=int),
-  contact_worldid_in: wp.array(dtype=int),
+  contact_friction_in: wp.array2d(dtype=types.vec5),
+  contact_dim_in: wp.array2d(dtype=int),
+  contact_efc_address_in: wp.array3d(dtype=int),
   efc_done_in: wp.array(dtype=bool),
-  efc_u_in: wp.array(dtype=types.vec6),
-  efc_uu_in: wp.array(dtype=float),
+  efc_u_in: wp.array2d(dtype=types.vec6),
+  efc_uu_in: wp.array2d(dtype=float),
   # Data out:
   efc_active_out: wp.array2d(dtype=bool),
 ):
-  conid, dimid = wp.tid()
+  worldid, conid, dimid = wp.tid()
 
-  if conid >= ncon_in[0]:
+  if conid >= ncon_in[worldid]:
     return
 
-  worldid = contact_worldid_in[conid]
   if efc_done_in[worldid]:
     return
 
-  condim = contact_dim_in[conid]
+  condim = contact_dim_in[worldid, conid]
   if condim == 1:
     return
 
-  mu = contact_friction_in[conid][0] / wp.sqrt(opt_impratio[worldid])
-  n = efc_u_in[conid][0]
-  tt = efc_uu_in[conid]
+  mu = contact_friction_in[worldid, conid][0] / wp.sqrt(opt_impratio[worldid])
+  n = efc_u_in[worldid, conid][0]
+  tt = efc_uu_in[worldid, conid]
   if tt <= 0.0:
     t = 0.0
   else:
@@ -1495,7 +1481,7 @@ def update_constraint_active_elliptic_bottom_zone(
   bottom_zone = ((t <= 0.0) and (n < 0.0)) or ((t > 0.0) and ((mu * n + t) <= 0.0))
 
   # update active
-  efcid = contact_efc_address_in[conid, dimid]
+  efcid = contact_efc_address_in[worldid, conid, dimid]
   efc_active_out[worldid, efcid] = bottom_zone
 
 
@@ -1575,38 +1561,36 @@ def update_constraint_efc_elliptic1(
   opt_impratio: wp.array(dtype=float),
   # Data in:
   ncon_in: wp.array(dtype=int),
-  contact_friction_in: wp.array(dtype=types.vec5),
-  contact_dim_in: wp.array(dtype=int),
-  contact_efc_address_in: wp.array2d(dtype=int),
-  contact_worldid_in: wp.array(dtype=int),
+  contact_friction_in: wp.array2d(dtype=types.vec5),
+  contact_dim_in: wp.array2d(dtype=int),
+  contact_efc_address_in: wp.array3d(dtype=int),
   efc_D_in: wp.array2d(dtype=float),
   efc_done_in: wp.array(dtype=bool),
-  efc_u_in: wp.array(dtype=types.vec6),
-  efc_uu_in: wp.array(dtype=float),
+  efc_u_in: wp.array2d(dtype=types.vec6),
+  efc_uu_in: wp.array2d(dtype=float),
   # Data out:
   efc_force_out: wp.array2d(dtype=float),
   efc_cost_out: wp.array(dtype=float),
 ):
-  conid, dimid = wp.tid()
+  worldid, conid, dimid = wp.tid()
 
-  if conid >= ncon_in[0]:
+  if conid >= ncon_in[worldid]:
     return
 
-  worldid = contact_worldid_in[conid]
   if efc_done_in[worldid]:
     return
 
-  condim = contact_dim_in[conid]
+  condim = contact_dim_in[worldid, conid]
 
   if condim == 1 or dimid >= condim:
     return
 
-  friction = contact_friction_in[conid]
-  efcid = contact_efc_address_in[conid, dimid]
+  friction = contact_friction_in[worldid, conid]
+  efcid = contact_efc_address_in[worldid, conid, dimid]
 
   mu = friction[0] / wp.sqrt(opt_impratio[worldid])
-  n = efc_u_in[conid][0]
-  tt = efc_uu_in[conid]
+  n = efc_u_in[worldid, conid][0]
+  tt = efc_uu_in[worldid, conid]
   if tt <= 0.0:
     t = 0.0
   else:
@@ -1617,7 +1601,7 @@ def update_constraint_efc_elliptic1(
 
   # tangent and friction for middle zone:
   if middle_zone:
-    efcid0 = contact_efc_address_in[conid, 0]
+    efcid0 = contact_efc_address_in[worldid, conid, 0]
     mu2 = mu * mu
     dm = efc_D_in[worldid, efcid0] / wp.max(mu2 * float(1.0 + mu2), types.MJ_MINVAL)
 
@@ -1626,11 +1610,10 @@ def update_constraint_efc_elliptic1(
     force = -dm * nmt * mu
     if dimid > 0:
       force_fri = -force / t
-      force_fri *= efc_u_in[conid][dimid] * friction[dimid - 1]
+      force_fri *= efc_u_in[worldid, conid][dimid] * friction[dimid - 1]
       efc_force_out[worldid, efcid] += force_fri
     else:
       efc_force_out[worldid, efcid] += force
-      worldid = contact_worldid_in[conid]
       wp.atomic_add(efc_cost_out, worldid, 0.5 * dm * nmt * nmt)
 
 
@@ -1737,14 +1720,13 @@ def _update_constraint(m: types.Model, d: types.Data):
     d.efc.condim.fill_(-1)
     wp.launch(
       update_constraint_u_elliptic,
-      dim=(d.nconmax, m.condim_max),
+      dim=(d.nworld, d.nconmax, m.condim_max),
       inputs=[
         m.opt.impratio,
         d.ncon,
         d.contact.friction,
         d.contact.dim,
         d.contact.efc_address,
-        d.contact.worldid,
         d.efc.Jaref,
         d.efc.done,
       ],
@@ -1752,14 +1734,13 @@ def _update_constraint(m: types.Model, d: types.Data):
     )
     wp.launch(
       update_constraint_active_elliptic_bottom_zone,
-      dim=(d.nconmax, m.condim_max),
+      dim=(d.nworld, d.nconmax, m.condim_max),
       inputs=[
         m.opt.impratio,
         d.ncon,
         d.contact.friction,
         d.contact.dim,
         d.contact.efc_address,
-        d.contact.worldid,
         d.efc.done,
         d.efc.u,
         d.efc.uu,
@@ -1785,14 +1766,13 @@ def _update_constraint(m: types.Model, d: types.Data):
     )
     wp.launch(
       update_constraint_efc_elliptic1,
-      dim=(d.nconmax, m.condim_max),
+      dim=(d.nworld, d.nconmax, m.condim_max),
       inputs=[
         m.opt.impratio,
         d.ncon,
         d.contact.friction,
         d.contact.dim,
         d.contact.efc_address,
-        d.contact.worldid,
         d.efc.D,
         d.efc.done,
         d.efc.u,
@@ -1972,22 +1952,21 @@ def update_gradient_JTCJ(
   # Data in:
   nconmax_in: int,
   ncon_in: wp.array(dtype=int),
-  contact_friction_in: wp.array(dtype=types.vec5),
-  contact_dim_in: wp.array(dtype=int),
-  contact_efc_address_in: wp.array2d(dtype=int),
-  contact_worldid_in: wp.array(dtype=int),
+  contact_friction_in: wp.array2d(dtype=types.vec5),
+  contact_dim_in: wp.array2d(dtype=int),
+  contact_efc_address_in: wp.array3d(dtype=int),
   efc_J_in: wp.array3d(dtype=float),
   efc_D_in: wp.array2d(dtype=float),
   efc_done_in: wp.array(dtype=bool),
-  efc_u_in: wp.array(dtype=types.vec6),
-  efc_uu_in: wp.array(dtype=float),
+  efc_u_in: wp.array2d(dtype=types.vec6),
+  efc_uu_in: wp.array2d(dtype=float),
   # In:
   nblocks_perblock: int,
   dim_block: int,
   # Data out:
   efc_h_out: wp.array3d(dtype=float),
 ):
-  conid_start, elementid = wp.tid()
+  worldid, conid_start, elementid = wp.tid()
 
   dof1id = dof_tri_row[elementid]
   dof2id = dof_tri_col[elementid]
@@ -1995,22 +1974,21 @@ def update_gradient_JTCJ(
   for i in range(nblocks_perblock):
     conid = conid_start + i * dim_block
 
-    if conid >= min(ncon_in[0], nconmax_in):
+    if conid >= min(ncon_in[worldid], nconmax_in):
       return
 
-    worldid = contact_worldid_in[conid]
     if efc_done_in[worldid]:
       continue
 
-    condim = contact_dim_in[conid]
+    condim = contact_dim_in[worldid, conid]
 
     if condim == 1:
       continue
 
-    fri = contact_friction_in[conid]
+    fri = contact_friction_in[worldid, conid]
     mu = fri[0] / wp.sqrt(opt_impratio[worldid])
-    n = efc_u_in[conid][0]
-    tt = efc_uu_in[conid]
+    n = efc_u_in[worldid, conid][0]
+    tt = efc_uu_in[worldid, conid]
     if tt <= 0.0:
       t = 0.0
     else:
@@ -2025,13 +2003,13 @@ def update_gradient_JTCJ(
     ttt = wp.max(t * t * t, types.MJ_MINVAL)
 
     mu2 = mu * mu
-    efc0 = contact_efc_address_in[conid, 0]
+    efc0 = contact_efc_address_in[worldid, conid, 0]
     dm = efc_D_in[worldid, efc0] / wp.max(mu2 * (1.0 + mu2), types.MJ_MINVAL)
 
     if dm == 0.0:
       continue
 
-    u = efc_u_in[conid]
+    u = efc_u_in[worldid, conid]
 
     efc_h = float(0.0)
 
@@ -2039,7 +2017,7 @@ def update_gradient_JTCJ(
       if dim1id == 0:
         efcid1 = efc0
       else:
-        efcid1 = contact_efc_address_in[conid, dim1id]
+        efcid1 = contact_efc_address_in[worldid, conid, dim1id]
 
       efc_J11 = efc_J_in[worldid, efcid1, dof1id]
       efc_J12 = efc_J_in[worldid, efcid1, dof2id]
@@ -2050,7 +2028,7 @@ def update_gradient_JTCJ(
         if dim2id == 0:
           efcid2 = efc0
         else:
-          efcid2 = contact_efc_address_in[conid, dim2id]
+          efcid2 = contact_efc_address_in[worldid, conid, dim2id]
 
         efc_J21 = efc_J_in[worldid, efcid2, dof1id]
         efc_J22 = efc_J_in[worldid, efcid2, dof2id]
@@ -2090,7 +2068,6 @@ def update_gradient_JTCJ(
           if dim1id != dim2id:
             efc_h += hcone * efc_J12 * efc_J21
 
-    worldid = contact_worldid_in[conid]
     efc_h_out[worldid, dof1id, dof2id] += efc_h
 
 
@@ -2225,7 +2202,7 @@ def _update_gradient(m: types.Model, d: types.Data):
 
       wp.launch(
         update_gradient_JTCJ,
-        dim=(dim_block, m.dof_tri_row.size),
+        dim=(d.nworld, dim_block, m.dof_tri_row.size),
         inputs=[
           m.opt.impratio,
           m.dof_tri_row,
@@ -2235,7 +2212,6 @@ def _update_gradient(m: types.Model, d: types.Data):
           d.contact.friction,
           d.contact.dim,
           d.contact.efc_address,
-          d.contact.worldid,
           d.efc.J,
           d.efc.D,
           d.efc.done,

--- a/mujoco_warp/_src/support_test.py
+++ b/mujoco_warp/_src/support_test.py
@@ -106,7 +106,7 @@ class SupportTest(parameterized.TestCase):
     mj_force = np.zeros(6, dtype=float)
     mujoco.mj_contactForce(mjm, mjd, 0, mj_force)
 
-    contact_ids = wp.zeros(1, dtype=int)
+    contact_ids = wp.zeros(1, dtype=wp.vec2i)
     force = wp.zeros(1, dtype=wp.spatial_vector)
 
     mjwarp.contact_force(m, d, contact_ids, to_world_frame, force)

--- a/mujoco_warp/_src/test_util.py
+++ b/mujoco_warp/_src/test_util.py
@@ -256,7 +256,7 @@ def benchmark(
       if measure_alloc or measure_solver_niter:
         wp.synchronize()
       if measure_alloc:
-        ncon.append(d.ncon.numpy()[0])
+        ncon.append(np.sum(d.ncon.numpy()))
         nefc.append(np.sum(d.nefc.numpy()))
       if measure_solver_niter:
         solver_niter.append(d.solver_niter.numpy())

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -703,10 +703,10 @@ class Constraint:
   mid_alpha: wp.array(dtype=float)
   cost_candidate: wp.array2d(dtype=float)
   # elliptic cone
-  u: wp.array(dtype=vec6)
-  uu: wp.array(dtype=float)
-  uv: wp.array(dtype=float)
-  vv: wp.array(dtype=float)
+  u: wp.array2d(dtype=vec6)
+  uu: wp.array2d(dtype=float)
+  uv: wp.array2d(dtype=float)
+  vv: wp.array2d(dtype=float)
   condim: wp.array2d(dtype=int)
 
 
@@ -1342,21 +1342,19 @@ class Contact:
     dim: contact space dimensionality: 1, 3, 4 or 6
     geom: geom ids; -1 for flex
     efc_address: address in efc; -1: not included
-    worldid: world id
   """
 
-  dist: wp.array(dtype=float)
-  pos: wp.array(dtype=wp.vec3)
-  frame: wp.array(dtype=wp.mat33)
-  includemargin: wp.array(dtype=float)
-  friction: wp.array(dtype=vec5)
-  solref: wp.array(dtype=wp.vec2)
-  solreffriction: wp.array(dtype=wp.vec2)
-  solimp: wp.array(dtype=vec5)
-  dim: wp.array(dtype=int)
-  geom: wp.array(dtype=wp.vec2i)
-  efc_address: wp.array2d(dtype=int)
-  worldid: wp.array(dtype=int)
+  dist: wp.array2d(dtype=float)
+  pos: wp.array2d(dtype=wp.vec3)
+  frame: wp.array2d(dtype=wp.mat33)
+  includemargin: wp.array2d(dtype=float)
+  friction: wp.array2d(dtype=vec5)
+  solref: wp.array2d(dtype=wp.vec2)
+  solreffriction: wp.array2d(dtype=wp.vec2)
+  solimp: wp.array2d(dtype=vec5)
+  dim: wp.array2d(dtype=int)
+  geom: wp.array2d(dtype=wp.vec2i)
+  efc_address: wp.array3d(dtype=int)
 
 
 @dataclasses.dataclass
@@ -1365,10 +1363,10 @@ class Data:
 
   Attributes:
     nworld: number of worlds
-    nconmax: maximum number of contacts
+    nconmax: maximum number of contacts per world
     njmax: maximum number of constraints per world
     solver_niter: number of solver iterations                   (nworld,)
-    ncon: number of detected contacts
+    ncon: number of detected contacts per world                 (nworld,)
     ncon_hfield: number of contacts per geom pair with hfield   (nworld, nhfieldgeompair)
     ne: number of equality constraints
     ne_connect: number of equality connect constraints

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -52,7 +52,7 @@ _CONE = flags.DEFINE_enum_class("cone", None, mjwarp.ConeType, "Friction cone ty
 _NCONMAX = flags.DEFINE_integer(
   "nconmax",
   None,
-  "Override default maximum number of contacts in a batch physics step.",
+  "Override default maximum number of contacts per world in a batch physics step.",
 )
 _NJMAX = flags.DEFINE_integer(
   "njmax",

--- a/mujoco_warp/viewer.py
+++ b/mujoco_warp/viewer.py
@@ -45,7 +45,7 @@ _VIEWER_GLOBAL_STATE = {
   "running": True,
   "step_once": False,
 }
-_NCONMAX = flags.DEFINE_integer("nconmax", None, "Maximum number of contacts.")
+_NCONMAX = flags.DEFINE_integer("nconmax", None, "Maximum number of contacts per world.")
 _NJMAX = flags.DEFINE_integer("njmax", None, "Maximum number of constraints per world.")
 _BROADPHASE = flags.DEFINE_enum_class("broadphase", None, mjwarp.BroadphaseType, "Broadphase collision routine.")
 _BROADPHASE_FILTER = flags.DEFINE_integer("broadphase_filter", None, "Broadphase collision filter routine.")


### PR DESCRIPTION
inspired by the performance improvements from changing constraints from all-worlds to per-world #361, this pr investigates changing contacts from all-worlds to per-world.

tldr
performance seems to be about the same, but there might be other benefits from changing contacts to per-world.

**humanoid**

main
```
mjwarp-testspeed --function=step --mjcf=test_data/humanoid/humanoid.xml --batch_size=8192 --nconmax=196608 --njmax=64
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.25 s
 Total simulation time: 16.96 s
 Total steps per second: 483,045
 Total realtime factor: 2,415.22 x
 Total time per step: 2070.20 ns
```

this pr
```
mjwarp-testspeed --function=step --mjcf=test_data/humanoid/humanoid.xml --batch_size=8192 --nconmax=24 --njmax=64
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.88 s
 Total simulation time: 16.88 s
 Total steps per second: 485,250
 Total realtime factor: 2,426.25 x
 Total time per step: 2060.79 ns
```

**aloha + pot**

main
```
mjwarp-testspeed --function=step --mjcf=benchmark/aloha_pot/scene.xml --batch_size=8192 --nconmax=131136 --njmax=96 --cone=pyramidal --keyframe=0
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.65 s
 Total simulation time: 33.28 s
 Total steps per second: 246,178
 Total realtime factor: 492.36 x
 Total time per step: 4062.09 ns
```

this pr
```
mjwarp-testspeed --function=step --mjcf=benchmark/aloha_pot/scene.xml --batch_size=8192 --nconmax=16 --njmax=96 --cone=pyramidal --keyframe=0
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.58 s
 Total simulation time: 33.28 s
 Total steps per second: 246,161
 Total realtime factor: 492.32 x
 Total time per step: 4062.38 ns
```

additional benefits from changing contacts to per-world:

- `njmax` and `nconmax` would share per-world semantics
- i think `njmax` and `nconmax` could be moved from `Data` to `Model` and utilize the existing fields in `mjModel`

there might be performance improvements for elliptic friction cones. once open issues for elliptic friction cones are resolved we can revisit potential performance improvements from this pr.