### PR TITLE
Optimization of solve_beta for the CG solver

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -980,8 +980,6 @@ def make_data(mjm: mujoco.MjModel, nworld: int = 1, nconmax: int = -1, njmax: in
       prev_grad=wp.zeros((nworld, mjm.nv), dtype=float),
       prev_Mgrad=wp.zeros((nworld, mjm.nv), dtype=float),
       beta=wp.zeros((nworld,), dtype=float),
-      beta_num=wp.zeros((nworld,), dtype=float),
-      beta_den=wp.zeros((nworld,), dtype=float),
       done=wp.zeros((nworld,), dtype=bool),
       # linesearch
       ls_done=wp.zeros((nworld,), dtype=bool),
@@ -1361,8 +1359,6 @@ def put_data(
       prev_grad=wp.empty(shape=(nworld, mjm.nv), dtype=float),
       prev_Mgrad=wp.empty(shape=(nworld, mjm.nv), dtype=float),
       beta=wp.empty(shape=(nworld,), dtype=float),
-      beta_num=wp.empty(shape=(nworld,), dtype=float),
-      beta_den=wp.empty(shape=(nworld,), dtype=float),
       done=wp.empty(shape=(nworld,), dtype=bool),
       ls_done=wp.zeros(shape=(nworld,), dtype=bool),
       p0=wp.empty(shape=(nworld,), dtype=wp.vec3),

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -629,8 +629,6 @@ class Constraint:
     prev_grad: previous grad                          (nworld, nv)
     prev_Mgrad: previous Mgrad                        (nworld, nv)
     beta: polak-ribiere beta                          (nworld,)
-    beta_num: numerator of beta                       (nworld,)
-    beta_den: denominator of beta                     (nworld,)
     done: solver done                                 (nworld,)
     ls_done: linesearch done                          (nworld,)
     p0: initial point                                 (nworld, 3)
@@ -685,8 +683,6 @@ class Constraint:
   prev_grad: wp.array2d(dtype=float)
   prev_Mgrad: wp.array2d(dtype=float)
   beta: wp.array(dtype=float)
-  beta_num: wp.array(dtype=float)
-  beta_den: wp.array(dtype=float)
   done: wp.array(dtype=bool)
   # linesearch
   ls_done: wp.array(dtype=bool)


### PR DESCRIPTION
Combined the three kernels for `solve_beta` and removed the corresponding properties.

Perf improvements is difficult to measure, but on Nsight system, I can see on the main branch that the three kernels took around 2% of the total time (10us per solver iteration), after the change it's only 0.7% (4us per solver iteration).

Command used:
`python mujoco_warp/testspeed.py --function=step --mjcf=benchmark/apptronik_apollo/scene_flat.xml --batch_size=8192 --nconmax=150000 --njmax=53 --is_sparse=True --ls_parallel=False --solver=cg`

I saw similar results for the humanoid.