### PR TITLE
Add initial multicontact for meshes and boxes

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -494,4 +494,3 @@ def convex_narrowphase(m: Model, d: Data):
           d.contact.worldid,
         ],
       )
-

--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -321,7 +321,8 @@ def ccd_kernel_builder(
           x1 += hfield_prism_vertex(geom1.hfprism, i)
         x1 = x1 / 6.0
 
-      dist, x1, x2 = ccd(
+      dist, count, witness1, witness2 = ccd(
+        False,
         1e-6,
         0.0,
         gjk_iterations,
@@ -344,13 +345,13 @@ def ccd_kernel_builder(
         epa_map_in[tid],
         epa_horizon_in[tid],
       )
-      count = 0
-      if dist < 0.0:
-        count = 1
+      if dist >= 0.0:
+        count = 0
+        return
 
-      points[0] = 0.5 * (x1 + x2)
-      normal = x1 - x2
-
+    for i in range(count):
+      points[i] = 0.5 * (witness1[i] + witness2[i])
+    normal = witness1[0] - witness2[0]
     frame = make_frame(normal)
     for i in range(count):
       # limit maximum number of contacts with height field
@@ -493,3 +494,4 @@ def convex_narrowphase(m: Model, d: Data):
           d.contact.worldid,
         ],
       )
+

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -2160,4 +2160,3 @@ def ccd(
   witness1[0] = x1
   witness2[0] = x2
   return dist, 1, witness1, witness2
-

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -1351,7 +1351,7 @@ def aligned_face_edge(edge: polyverts, nedge: int, face: polyverts, nface: int):
   return 0, res
 
 
-# find up to n <= 2 common integers of two  arrays, return n
+# find up to n <= 2 common integers of two arrays, return n
 @wp.func
 def intersect1(a1: wp.array(dtype=int), a2: wp.array(dtype=int), start1: int, start2: int, len1: int, len2: int):
   count = int(0)

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -27,7 +27,22 @@ FLOAT_MIN = -1e30
 FLOAT_MAX = 1e30
 MJ_MINVAL2 = MJ_MINVAL * MJ_MINVAL
 
+# TODO(kbayes): write out formulas to derive these constants
+FACE_TOL = 0.99999872
+EDGE_TOL = 0.00159999931
+
+MAX_POLYVERT = 15
+polyverts = wp.types.matrix(shape=(MAX_POLYVERT, 3), dtype=float)
+polyclip = wp.types.matrix(shape=(2 * MAX_POLYVERT, 3), dtype=float)
+polyvec = wp.types.vector(MAX_POLYVERT, dtype=float)
+polyindices = wp.types.vector(MAX_POLYVERT, dtype=int)
+
+
 mat43 = wp.types.matrix(shape=(4, 3), dtype=float)
+mat63 = wp.types.matrix(shape=(6, 3), dtype=float)
+
+MULTI_CONTACT_COUNT = 4
+mat3c = wp.types.matrix(shape=(MULTI_CONTACT_COUNT, 3), dtype=float)
 
 
 @wp.struct
@@ -1278,8 +1293,700 @@ def _epa(tolerance2: float, epa_iterations: int, pt: Polytope, geom1: Geom, geom
   # return from valid face
   if idx > -1:
     x1, x2 = _epa_witness(pt, idx)
-    return -wp.sqrt(pt.face_norm2[idx]), x1, x2
-  return 0.0, wp.vec3(), wp.vec3()
+    return -wp.sqrt(pt.face_norm2[idx]), x1, x2, idx
+  return 0.0, wp.vec3(), wp.vec3(), -1
+
+
+# return number (1, 2 or 3) of dimensions of a simplex; reorder vertices if necessary
+@wp.func
+def feature_dim(face: wp.vec3i, vert_index: wp.array(dtype=int), vert: wp.array(dtype=wp.vec3)):
+  v1i = vert_index[face[0]]
+  v2i = vert_index[face[1]]
+  v3i = vert_index[face[2]]
+
+  feature_index = wp.vec3i(v1i, v2i, v3i)
+  feature_vert = wp.mat33()
+  feature_vert[0] = vert[face[0]]
+  feature_vert[1] = vert[face[1]]
+  feature_vert[2] = vert[face[2]]
+
+  if v1i != v2i:
+    if v3i == v1i or v3i == v2i:
+      return 2, feature_index, feature_vert
+    else:
+      return 3, feature_index, feature_vert
+
+  feature_index[1] = v3i
+  feature_vert[1] = vert[face[2]]
+
+  if v1i != v3i:
+    return 2, feature_index, feature_vert
+  return 1, feature_index, feature_vert
+
+
+# find two normals that are facing each other within a tolerance, return 1 if found
+@wp.func
+def aligned_faces(vert1: polyverts, len1: int, vert2: polyverts, len2: int):
+  res = wp.vec2i()
+  for i in range(len1):
+    for j in range(len2):
+      if wp.dot(vert1[i], vert2[j]) < -FACE_TOL:
+        res[0] = i
+        res[1] = j
+        return 1, res
+  return 0, res
+
+
+# find two normals that are perpendicular to each other within a tolerance
+# return 1 if found
+@wp.func
+def aligned_face_edge(edge: polyverts, nedge: int, face: polyverts, nface: int):
+  res = wp.vec2i()
+  for i in range(nface):
+    for j in range(nedge):
+      if wp.abs(wp.dot(edge[j], face[i])) < EDGE_TOL:
+        res[0] = j
+        res[1] = i
+        return 1, res
+  return 0, res
+
+
+# find up to n <= 2 common integers of two  arrays, return n
+@wp.func
+def intersect1(a1: wp.array(dtype=int), a2: wp.array(dtype=int), start1: int, start2: int, len1: int, len2: int):
+  count = int(0)
+  res = wp.vec2i()
+  for i in range(start1, start1 + len1):
+    for j in range(start2, start2 + len2):
+      if a1[i] == a2[j]:
+        res[count] = a1[i]
+        count += 1
+        if count == 2:
+          return 2, res
+  return count, res
+
+
+@wp.func
+def intersect2(a1: wp.vec2i, a2: wp.array(dtype=int), start2: int, len1: int, len2: int):
+  count = int(0)
+  res = wp.vec2i()
+  for i in range(len1):
+    for j in range(start2, start2 + len2):
+      if a1[i] == a2[j]:
+        res[count] = a1[i]
+        count += 1
+        if count == 2:
+          return 2, res
+  return count, res
+
+
+# compute possible polygon normals of a mesh given up to 3 vertices
+@wp.func
+def mesh_normals(
+  # In:
+  feature_dim: int,
+  feature_index: wp.vec3i,
+  mat: wp.mat33,
+  vertadr: int,
+  polyadr: int,
+  polynormal: wp.array(dtype=wp.vec3),
+  polymapadr: wp.array(dtype=int),
+  polymapnum: wp.array(dtype=int),
+  polymap: wp.array(dtype=int),
+):
+  normals = polyverts()
+  indices = polyindices()
+
+  v1 = feature_index[0]
+  v2 = feature_index[1]
+  v3 = feature_index[2]
+  if feature_dim == 3:
+    v1_adr = polymapadr[vertadr + v1]
+    v1_num = polymapnum[vertadr + v1]
+
+    v2_adr = polymapadr[vertadr + v2]
+    v2_num = polymapnum[vertadr + v2]
+
+    v3_adr = polymapadr[vertadr + v3]
+    v3_num = polymapnum[vertadr + v3]
+
+    faceset = wp.vec2i()
+    n, edgeset = intersect1(polymap, polymap, v1_adr, v2_adr, v1_num, v2_num)
+    if n == 0:
+      return 0, normals, indices
+    n, faceset = intersect2(edgeset, polymap, v3_adr, n, v3_num)
+    if n == 0:
+      return 0, normals, indices
+
+    # three vertices defined an unique face
+    normals[0] = mat @ polynormal[polyadr + faceset[0]]
+    indices[0] = faceset[0]
+    return 1, normals, indices
+
+  if feature_dim == 2:
+    v1_adr = polymapadr[vertadr + v1]
+    v1_num = polymapnum[vertadr + v1]
+
+    v2_adr = polymapadr[vertadr + v2]
+    v2_num = polymapnum[vertadr + v2]
+
+    # up to two faces if vertices defined an edge
+    n, edgeset = intersect1(polymap, polymap, v1_adr, v2_adr, v1_num, v2_num)
+    if n == 0:
+      return 0, normals, indices
+    for i in range(n):
+      normals[i] = mat @ polynormal[polyadr + edgeset[i]]
+      indices[i] = edgeset[i]
+    return n, normals, indices
+
+  if feature_dim == 1:
+    v1_adr = polymapadr[vertadr + v1]
+    v1_num = polymapnum[vertadr + v1]
+    if v1_num > MAX_POLYVERT:
+      v1_num = MAX_POLYVERT
+    for i in range(v1_num):
+      index = polymap[v1_adr + i]
+      normals[i] = mat @ polynormal[polyadr + index]
+      indices[i] = index
+    return v1_num, normals, indices
+  return 0, normals, indices
+
+
+# compute normal directional vectors along possible edges given by up to two vertices
+@wp.func
+def mesh_edge_normals(
+  # In:
+  dim: int,
+  mat: wp.mat33,
+  pos: wp.vec3,
+  vertadr: int,
+  polyadr: int,
+  vert: wp.array(dtype=wp.vec3),
+  polyvertadr: wp.array(dtype=int),
+  polyvertnum: wp.array(dtype=int),
+  polyvert: wp.array(dtype=int),
+  polymapadr: wp.array(dtype=int),
+  polymapnum: wp.array(dtype=int),
+  polymap: wp.array(dtype=int),
+  v1: wp.vec3,
+  v2: wp.vec3,
+  v1i: int,
+):
+  normals = polyverts()
+  endverts = polyverts()
+
+  # only one edge
+  if dim == 2:
+    endverts[0] = v2
+    normals[0] = wp.normalize(v2 - v1)
+    return 1, normals, endverts
+
+  if dim == 1:
+    v1_adr = polymapadr[vertadr + v1i]
+    v1_num = polymapnum[vertadr + v1i]
+    if v1_num > MAX_POLYVERT:
+      v1_num = MAX_POLYVERT
+
+    # loop through all faces with vertex v1
+    for i in range(v1_num):
+      idx = polymap[v1_adr + i]
+      adr = polyvertadr[polyadr + idx]
+      nvert = polyvertnum[polyadr + idx]
+      # find previous vertex in polygon to form edge
+      for j in range(nvert):
+        if polyvert[adr + j] == v1i:
+          k = wp.where(j == 0, nvert - 1, j - 1)
+          endverts[i] = mat @ vert[vertadr + polyvert[adr + k]] + pos
+          normals[i] = wp.normalize(endverts[i] - v1)
+    return v1_num, normals, endverts
+  return 0, normals, endverts
+
+
+# try recovering box normal from collision normal
+@wp.func
+def box_normals2(mat: wp.mat33, n: wp.vec3):
+  normals = polyverts()
+  indices = polyindices()
+
+  # list of box face normals
+  face_normals = mat63(1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -1.0)
+
+  # get local coordinates of the normal
+
+  local_n = wp.normalize(
+    wp.vec3(
+      mat[0][0] * n[0] + mat[1][0] * n[1] + mat[2][0] * n[2],
+      mat[0][1] * n[0] + mat[1][1] * n[1] + mat[2][1] * n[2],
+      mat[0][2] * n[0] + mat[1][2] * n[1] + mat[2][2] * n[2],
+    )
+  )
+
+  # determine if there is a side close to the normal
+  for i in range(6):
+    if wp.dot(local_n, face_normals[i]) > FACE_TOL:
+      normals[0] = mat @ face_normals[i]
+      indices[0] = i
+      return 1, normals, indices
+
+  return 0, normals, indices
+
+
+# compute possible face normals of a box given up to 3 vertices
+@wp.func
+def box_normals(feature_dim: int, feature_index: wp.vec3i, mat: wp.mat33, dir: wp.vec3):
+  normals = polyverts()
+  indices = polyindices()
+
+  v1 = feature_index[0]
+  v2 = feature_index[1]
+  v3 = feature_index[2]
+
+  if feature_dim == 3:
+    c = 0
+    x = int((v1 & 1) and (v2 & 1) and (v3 & 1)) - int(not (v1 & 1) and not (v2 & 1) and not (v3 & 1))
+    y = int((v1 & 2) and (v2 & 2) and (v3 & 2)) - int(not (v1 & 2) and not (v2 & 2) and not (v3 & 2))
+    z = int((v1 & 4) and (v2 & 4) and (v3 & 4)) - int(not (v1 & 4) and not (v2 & 4) and not (v3 & 4))
+    normals[0] = mat @ wp.vec3(float(x), float(y), float(z))
+    sgn = x + y + z
+    if x:
+      indices[c] = 0
+      c += 1
+    if y:
+      indices[c] = 2
+      c += 1
+    if z:
+      indices[c] = 4
+      c += 1
+    if sgn == -1.0:
+      indices[0] = indices[0] + 1
+    if c == 1:
+      return 1, normals, indices
+    return box_normals2(mat, dir)
+  if feature_dim == 2:
+    c = 0
+    x = int((v1 & 1) and (v2 & 1)) - int(not (v1 & 1) and not (v2 & 1))
+    y = int((v1 & 2) and (v2 & 2)) - int(not (v1 & 2) and not (v2 & 2))
+    z = int((v1 & 4) and (v2 & 4)) - int(not (v1 & 4) and not (v2 & 4))
+    if x:
+      normals[c] = mat @ wp.vec3(float(x), 0.0, 0.0)
+      indices[c] = int(x <= 0)
+      c += 1
+    if y:
+      normals[c] = mat @ wp.vec3(0.0, float(y), 0.0)
+      indices[c] = int(y <= 0) + 2
+      c += 1
+    if z:
+      normals[c] = mat @ wp.vec3(0.0, 0.0, float(z))
+      indices[c] = int(z <= 0) + 4
+      c += 1
+    if c == 2:
+      return 2, normals, indices
+    return box_normals2(mat, dir)
+
+  if feature_dim == 1:
+    x = wp.where(v1 & 1, -1, 1)
+    y = wp.where(v1 & 2, -1, 1)
+    z = wp.where(v1 & 4, -1, 1)
+    normals[0] = mat @ wp.vec3(float(x), 0.0, 0.0)
+    normals[1] = mat @ wp.vec3(0.0, float(y), 0.0)
+    normals[2] = mat @ wp.vec3(0.0, 0.0, float(z))
+    indices[0] = int(x <= 0) + 0
+    indices[1] = int(y <= 0) + 2
+    indices[2] = int(z <= 0) + 4
+    return 3, normals, indices
+  return 0, normals, indices
+
+
+# compute possible edge normals for box for edge collisions
+@wp.func
+def box_edge_normals(dim: int, mat: wp.mat33, pos: wp.vec3, size: wp.vec3, v1: wp.vec3, v2: wp.vec3, v1i: int):
+  normals = polyverts()
+  endverts = polyverts()
+
+  if dim == 2:
+    endverts[0] = v2
+    normals[0] = wp.normalize(v2 - v1)
+    return 1, endverts, normals
+
+  # return 3 adjacent vertices
+  if dim == 1:
+    x = size[0]
+    y = size[1]
+    z = size[2]
+    if v1i & 1:
+      x = -size[0]
+    if v1i & 2:
+      y = -size[1]
+    if v1i & 4:
+      z = -size[2]
+
+    endverts[0] = mat @ wp.vec3(-x, y, z) + pos
+    normals[0] = wp.normalize(endverts[0] - v1)
+
+    endverts[1] = mat @ wp.vec3(x, -y, z) + pos
+    normals[1] = wp.normalize(endverts[1] - v1)
+
+    endverts[2] = mat @ wp.vec3(x, y, -z) + pos
+    normals[2] = wp.normalize(endverts[2] - v1)
+    return 3, normals, endverts
+  return 0, normals, endverts
+
+
+# recover face of a box from its index
+@wp.func
+def box_face(mat: wp.mat33, pos: wp.vec3, size: wp.vec3, idx: int):
+  res = polyverts()
+
+  # compute global coordinates of the box face and face normal
+  if idx == 0:  # right
+    res[0] = mat @ wp.vec(size[0], size[1], size[2]) + pos
+    res[1] = mat @ wp.vec(size[0], size[1], -size[2]) + pos
+    res[2] = mat @ wp.vec(size[0], -size[1], -size[2]) + pos
+    res[3] = mat @ wp.vec(size[0], -size[1], size[2]) + pos
+    return 4, res
+  if idx == 1:  # left
+    res[0] = mat @ wp.vec(-size[0], size[1], -size[2]) + pos
+    res[1] = mat @ wp.vec(-size[0], size[1], size[2]) + pos
+    res[2] = mat @ wp.vec(-size[0], -size[1], size[2]) + pos
+    res[3] = mat @ wp.vec(-size[0], -size[1], -size[2]) + pos
+    return 4, res
+  if idx == 2:  # top
+    res[0] = mat @ wp.vec(-size[0], size[1], -size[2]) + pos
+    res[1] = mat @ wp.vec(size[0], size[1], -size[2]) + pos
+    res[2] = mat @ wp.vec(size[0], size[1], size[2]) + pos
+    res[3] = mat @ wp.vec(-size[0], size[1], size[2]) + pos
+    return 4, res
+  if idx == 3:  # bottom
+    res[0] = mat @ wp.vec(-size[0], -size[1], size[2]) + pos
+    res[1] = mat @ wp.vec(size[0], -size[1], size[2]) + pos
+    res[2] = mat @ wp.vec(size[0], -size[1], -size[2]) + pos
+    res[3] = mat @ wp.vec(-size[0], -size[1], -size[2]) + pos
+    return 4, res
+  if idx == 4:  # front
+    res[0] = mat @ wp.vec(-size[0], size[1], size[2]) + pos
+    res[1] = mat @ wp.vec(size[0], size[1], size[2]) + pos
+    res[2] = mat @ wp.vec(size[0], -size[1], size[2]) + pos
+    res[3] = mat @ wp.vec(-size[0], -size[1], size[2]) + pos
+    return 4, res
+  if idx == 5:  # back
+    res[0] = mat @ wp.vec(size[0], size[1], -size[2]) + pos
+    res[1] = mat @ wp.vec(-size[0], size[1], -size[2]) + pos
+    res[2] = mat @ wp.vec(-size[0], -size[1], -size[2]) + pos
+    res[3] = mat @ wp.vec(size[0], -size[1], -size[2]) + pos
+    return 4, res
+  return 0, res
+
+
+# recover mesh polygon from its index, return number of edges
+@wp.func
+def mesh_face(
+  # In:
+  mat: wp.mat33,
+  pos: wp.vec3,
+  vertadr: int,
+  polyadr: int,
+  vert: wp.array(dtype=wp.vec3),
+  polyvertadr: wp.array(dtype=int),
+  polyvertnum: wp.array(dtype=int),
+  polyvert: wp.array(dtype=int),
+  idx: int,
+):
+  res = polyverts()
+
+  adr = polyvertadr[polyadr + idx]
+  j = int(0)
+  nvert = polyvertnum[polyadr + idx]
+  if nvert > MAX_POLYVERT:
+    nvert = MAX_POLYVERT
+  for i in range(nvert - 1, -1, -1):
+    v = vert[vertadr + polyvert[adr + i]]
+    res[j] = mat @ v + pos
+    j += 1
+  return nvert, res
+
+
+@wp.func
+def plane_normal(v1: wp.vec3, v2: wp.vec3, n: wp.vec3):
+  v3 = v1 + n
+  res = wp.cross(v2 - v1, v3 - v1)
+  return wp.dot(res, v1), res
+
+
+@wp.func
+def halfspace(a: wp.vec3, n: wp.vec3, p: wp.vec3):
+  return wp.dot(p - a, n) > -MJ_MINVAL
+
+
+@wp.func
+def plane_intersect(pn: wp.vec3, pd: float, a: wp.vec3, b: wp.vec3):
+  res = wp.vec3()
+  ab = b - a
+  temp = wp.dot(pn, ab)
+  if temp == 0.0:
+    return FLOAT_MAX, res  # parallel; no intersection
+  t = (pd - wp.dot(pn, a)) / temp
+  if t >= 0.0 and t <= 1.0:
+    res[0] = a[0] + t * ab[0]
+    res[1] = a[1] + t * ab[1]
+    res[2] = a[2] + t * ab[2]
+  return t, res
+
+
+# clip a polygon against another polygon
+@wp.func
+def polygon_clip(face1: polyverts, nface1: int, face2: polyverts, nface2: int, n: wp.vec3, dir: wp.vec3):
+  witness1 = mat3c()
+  witness2 = mat3c()
+
+  # clipping face needs to be at least a triangle
+  if nface1 < 3:
+    return 0, witness1, witness2
+
+  # compute plane normal and distance to plane for each vertex
+  pn = polyverts()
+  pd = polyvec()
+  for i in range(nface1):
+    pdi, pni = plane_normal(face1[i], face1[i + 1], n)
+    pd[i] = pdi
+    pn[i] = pni
+  pdi, pni = plane_normal(face1[nface1 - 1], face1[0], n)
+  pd[nface1 - 1] = pdi
+  pn[nface1 - 1] = pni
+
+  # reserve 2 * max_sides as max sides for a clipped polygon
+  polygon1 = polyclip()
+  polygon2 = polyclip()
+  npolygon = nface2
+  nclipped = int(0)
+
+  polygon = polygon1
+  clipped = polygon2
+
+  for i in range(nface2):
+    polygon[i] = face2[i]
+
+  # clip the polygon by one edge e at a time
+  for e in range(nface1):
+    for i in range(npolygon):
+      # get edge PQ of the polygon
+      P = polygon[i]
+      if i < npolygon - 1:
+        Q = polygon[i + 1]
+      else:
+        Q = polygon[0]
+
+      # determine if P and Q are in the halfspace of the clipping edge
+      inside1 = halfspace(face1[e], pn[e], P)
+      inside2 = halfspace(face1[e], pn[e], Q)
+
+      # PQ entirely outside the clipping edge, skip
+      if not inside1 and not inside2:
+        continue
+
+      # edge PQ is inside the clipping edge, add Q
+      if inside1 and inside2:
+        clipped[nclipped] = Q
+        nclipped += 1
+        continue
+
+      # add new vertex to clipped polygon where PQ intersects the clipping edge
+      t, res = plane_intersect(pn[e], pd[e], P, Q)
+      if t < 0.0 or t > 1.0:
+        clipped[nclipped] = res
+        nclipped += 1
+
+      # add Q as PQ is now back inside the clipping edge
+      if inside2:
+        clipped[nclipped] = Q
+        nclipped += 1
+
+    # swap clipped and polygon
+    tmp = polygon
+    polygon = clipped
+    clipped = tmp
+    npolygon = nclipped
+    nclipped = 0
+
+  if npolygon < 1:
+    return 0, witness1, witness2
+
+  # no pruning needed
+  for i in range(npolygon):
+    witness2[i] = polygon[i]
+    witness1[i] = witness2[i] + dir
+  return npolygon, witness2, witness1
+
+
+# recover multiple contacts from EPA polytope
+@wp.func
+def multicontact(
+  pt: Polytope, face: wp.vec3i, x1: wp.vec3, x2: wp.vec3, geom1: Geom, geom2: Geom, geomtype1: int, geomtype2: int
+):
+  witness1 = mat3c()
+  witness2 = mat3c()
+  witness1[0] = x1
+  witness2[0] = x2
+
+  face1 = polyverts()
+  face2 = polyverts()
+  endverts = polyverts()
+
+  if geomtype1 == int(GeomType.MESH.value):
+    vert = geom1.vert
+    polynormal = geom1.mesh_polynormal
+    polyvertadr = geom1.mesh_polyvertadr
+    polyvertnum = geom1.mesh_polyvertnum
+    polyvert = geom1.mesh_polyvert
+    polymapadr = geom1.mesh_polymapadr
+    polymapnum = geom1.mesh_polymapnum
+    polymap = geom1.mesh_polymap
+  elif geomtype2 == int(GeomType.MESH.value):
+    vert = geom2.vert
+    polynormal = geom2.mesh_polynormal
+    polyvertadr = geom2.mesh_polyvertadr
+    polyvertnum = geom2.mesh_polyvertnum
+    polyvert = geom2.mesh_polyvert
+    polymapadr = geom2.mesh_polymapadr
+    polymapnum = geom2.mesh_polymapnum
+    polymap = geom2.mesh_polymap
+
+  # get dimensions of features of geoms 1 and 2
+  nface1, feature_index1, feature_vertex1 = feature_dim(face, pt.vert_index1, pt.vert1)
+  nface2, feature_index2, feature_vertex2 = feature_dim(face, pt.vert_index2, pt.vert2)
+
+  dir = x2 - x1
+  dir_neg = -dir
+
+  # get all possible face normals for each geom
+  if geomtype1 == int(GeomType.BOX.value):
+    nnorms1, n1, idx1 = box_normals(nface1, feature_index1, geom1.rot, dir_neg)
+  elif geomtype1 == int(GeomType.MESH.value):
+    nnorms1, n1, idx1 = mesh_normals(
+      nface1, feature_index1, geom1.rot, geom1.vertadr, geom1.mesh_polyadr, polynormal, polymapadr, polymapnum, polymap
+    )
+  if geomtype2 == int(GeomType.BOX.value):
+    nnorms2, n2, idx2 = box_normals(nface2, feature_index2, geom2.rot, dir)
+  elif geomtype2 == int(GeomType.MESH.value):
+    nnorms2, n2, idx2 = mesh_normals(
+      nface2, feature_index2, geom2.rot, geom2.vertadr, geom2.mesh_polyadr, polynormal, polymapadr, polymapnum, polymap
+    )
+
+  # determine if any two face normals match
+  edgecon1 = 0
+  edgecon2 = 0
+  nres, res = aligned_faces(n1, nnorms1, n2, nnorms2)
+  if not nres:
+    # check if edge-face collision
+    if nface1 < 3 and nface1 <= nface2:
+      nnorms1 = 0
+      if geomtype1 == int(GeomType.BOX.value):
+        nnorms1, n1, endverts = box_edge_normals(
+          nface1, geom1.rot, geom1.pos, geom1.size, feature_vertex1[0], feature_vertex1[1], feature_index1[0]
+        )
+      elif geomtype1 == int(GeomType.MESH.value):
+        nnorms1, n1, endverts = mesh_edge_normals(
+          nface1,
+          geom1.rot,
+          geom1.pos,
+          geom1.vertadr,
+          geom1.mesh_polyadr,
+          geom1.vert,
+          polyvertadr,
+          polyvertnum,
+          polyvert,
+          polymapadr,
+          polymapnum,
+          polymap,
+          feature_vertex1[0],
+          feature_vertex1[1],
+          feature_index1[0],
+        )
+      nres, res = aligned_face_edge(n1, nnorms1, n2, nnorms2)
+      if not nres:
+        return 1, witness1, witness2
+      edgecon1 = 1
+
+    # check if face-edge collision
+    elif nface2 < 3:
+      nnorms2 = 0
+      if geomtype2 == int(GeomType.BOX.value):
+        nnorms2, n2, endverts = box_edge_normals(
+          nface2, geom2.rot, geom2.pos, geom2.size, feature_vertex2[0], feature_vertex2[1], feature_index2[0]
+        )
+      elif geomtype2 == int(GeomType.MESH.value):
+        nnorms2, n2, endverts = mesh_edge_normals(
+          nface2,
+          geom2.rot,
+          geom2.pos,
+          geom2.vertadr,
+          geom2.mesh_polyadr,
+          geom2.vert,
+          polyvertadr,
+          polyvertnum,
+          polyvert,
+          polymapadr,
+          polymapnum,
+          polymap,
+          feature_vertex2[0],
+          feature_vertex2[1],
+          feature_index2[0],
+        )
+      nres, res = aligned_face_edge(n2, nnorms2, n1, nnorms1)
+      if not nres:
+        return 1, witness1, witness2
+      edgecon2 = 1
+    else:
+      # no multi-contact
+      return 1, witness1, witness2
+
+  i = res[0]
+  j = res[1]
+
+  # recover geom1 matching edge or face
+  if edgecon1:
+    face1[0] = pt.vert1[face[0]]
+    face1[1] = endverts[i]
+    nface1 = 2
+  else:
+    ind = wp.where(edgecon2, idx1[j], idx1[i])
+    if geomtype1 == int(GeomType.BOX.value):
+      nface1, face1 = box_face(geom1.rot, geom1.pos, geom1.size, ind)
+    elif geomtype1 == int(GeomType.MESH.value):
+      nface1, face1 = mesh_face(
+        geom1.rot, geom1.pos, geom1.vertadr, geom1.mesh_polyadr, vert, polyvertadr, polyvertnum, polyvert, ind
+      )
+
+  # recover geom2 matching edge or face
+  if edgecon2:
+    face2[0] = pt.vert2[face[0]]
+    face2[1] = endverts[i]
+    nface2 = 2
+  else:
+    if geomtype2 == int(GeomType.BOX.value):
+      nface2, face2 = box_face(geom2.rot, geom2.pos, geom2.size, idx2[j])
+    elif geomtype2 == int(GeomType.MESH.value):
+      nface2, face2 = mesh_face(
+        geom2.rot, geom2.pos, geom2.vertadr, geom2.mesh_polyadr, vert, polyvertadr, polyvertnum, polyvert, idx2[j]
+      )
+
+  # TODO(kbayes): this approximates the contact direction, by scaling the face normal by the
+  # single contact direction's magnitude. This is effective, but polygonClip should compute
+  # this for each contact point.
+  approx_dir = wp.vec3()
+
+  # face1 is an edge; clip face1 against face2
+  if edgecon1:
+    approx_dir = wp.norm_l2(dir) * n2[j]
+    return polygon_clip(face2, nface2, face1, nface1, n2[j], approx_dir)
+
+  # face2 is an edge; clip face2 against face1
+  if edgecon2:
+    approx_dir = -wp.norm_l2(dir) * n1[j]
+    return polygon_clip(face1, nface1, face2, nface2, n1[j], approx_dir)
+
+  # face-face collision
+  approx_dir = wp.norm_l2(dir) * n2[j]
+  return polygon_clip(face1, nface1, face2, nface2, n1[i], approx_dir)
 
 
 @wp.func
@@ -1297,6 +2004,7 @@ def inflate(dist: float, x1: wp.vec3, x2: wp.vec3, margin1: float, margin2: floa
 @wp.func
 def ccd(
   # In:
+  multiccd: bool,
   tolerance: float,
   cutoff: float,
   gjk_iterations: int,
@@ -1319,6 +2027,8 @@ def ccd(
   face_map: wp.array(dtype=int),
   horizon: wp.array(dtype=int),
 ):
+  witness1 = mat3c()
+  witness2 = mat3c()
   """General convex collision detection via GJK/EPA."""
   margin1 = 0.0
   margin2 = 0.0
@@ -1337,8 +2047,13 @@ def ccd(
     # shallow penetration, inflate contact
     if result.dist > tolerance:
       if result.dist == FLOAT_MAX:
-        return result.dist, result.x1, result.x2
-      return inflate(result.dist, result.x1, result.x2, margin1, margin2)
+        witness1[0] = result.x1
+        witness2[0] = result.x2
+        return result.dist, 1, witness1, witness2
+      dist, x1, x2 = inflate(result.dist, result.x1, result.x2, margin1, margin2)
+      witness1[0] = x1
+      witness2[0] = x2
+      return dist, 1, witness1, witness2
 
     # deep penetration, reset initial conditions and rerun GJK + EPA
     cutoff -= margin1 + margin2
@@ -1347,7 +2062,9 @@ def ccd(
 
   # no penetration depth to recover
   if result.dist > tolerance or result.dim < 2:
-    return result.dist, result.x1, result.x2
+    witness1[0] = result.x1
+    witness2[0] = result.x2
+    return result.dist, 1, witness1, witness2
 
   pt = Polytope()
   pt.nface = 0
@@ -1427,6 +2144,20 @@ def ccd(
 
   # origin on boundary (objects are not considered penetrating)
   if pt.status:
-    return result.dist, result.x1, result.x2
+    witness1[0] = result.x1
+    witness2[0] = result.x2
+    return result.dist, 1, witness1, witness2
 
-  return _epa(tolerance * tolerance, epa_iterations, pt, geom1, geom2, geomtype1, geomtype2)
+  dist, x1, x2, idx = _epa(tolerance * tolerance, epa_iterations, pt, geom1, geom2, geomtype1, geomtype2)
+  if (
+    multiccd
+    and (geomtype1 == int(GeomType.BOX.value) or geomtype1 == int(GeomType.MESH.value))
+    and (geomtype2 == int(GeomType.BOX.value) or geomtype2 == int(GeomType.MESH.value))
+  ):
+    num, w1, w2 = multicontact(pt, pt.face[idx], x1, x2, geom1, geom2, geomtype1, geomtype2)
+    if num > 0:
+      return dist, num, w1, w2
+  witness1[0] = x1
+  witness2[0] = x2
+  return dist, 1, witness1, witness2
+

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -1418,7 +1418,7 @@ def mesh_normals(
     if n == 0:
       return 0, normals, indices
 
-    # three vertices defined an unique face
+    # three vertices on mesh define a unique face
     normals[0] = mat @ polynormal[polyadr + faceset[0]]
     indices[0] = faceset[0]
     return 1, normals, indices
@@ -1430,7 +1430,7 @@ def mesh_normals(
     v2_adr = polymapadr[vertadr + v2]
     v2_num = polymapnum[vertadr + v2]
 
-    # up to two faces if vertices defined an edge
+    # up to two faces as two vertices define an edge
     n, edgeset = intersect1(polymap, polymap, v1_adr, v2_adr, v1_num, v2_num)
     if n == 0:
       return 0, normals, indices

--- a/mujoco_warp/_src/collision_gjk_test.py
+++ b/mujoco_warp/_src/collision_gjk_test.py
@@ -96,9 +96,11 @@ def _geom_dist(m: Model, d: Data, gid1: int, gid2: int, iterations: int):
 
     (
       dist,
+      count,
       x1,
       x2,
     ) = ccd(
+      False,
       1e-6,
       1.0e30,
       iterations,
@@ -123,8 +125,8 @@ def _geom_dist(m: Model, d: Data, gid1: int, gid2: int, iterations: int):
     )
 
     dist_out[0] = dist
-    pos_out[0] = x1
-    pos_out[1] = x2
+    pos_out[0] = x1[0]
+    pos_out[1] = x2[0]
 
   vert = wp.array(shape=(iterations,), dtype=wp.vec3)
   vert1 = wp.array(shape=(iterations,), dtype=wp.vec3)


### PR DESCRIPTION
This is the initial port of multiccd. Currently default to off.

Follow up PRs need to address the following before we can default to on:

* Polish up code, fix any remaining bugs
* Better support for larger meshes (memory layout changes)
* Contact pruning
* Port of test suite

Mesh-mesh demo:
<img width="1140" height="901" alt="warp_multiccd" src="https://github.com/user-attachments/assets/6309af9e-b6d4-4592-aaa1-45abfacadccf" />
