### PR TITLE
Change the license field in pyproject.toml to SPDX string.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "MuJoCo Warp (MJWarp)"
 readme = {file = "README.md", content-type = "text/markdown"}
-license = {text = "Apache License 2.0"}
+license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",


### PR DESCRIPTION
According to the deprecation warning, support for the old way of declaring the license will be removed from setuptools on 2026-Feb-18.