### PR TITLE
Change the license field in pyproject.toml to SPDX string.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,11 @@ authors = [
 ]
 description = "MuJoCo Warp (MJWarp)"
 readme = {file = "README.md", content-type = "text/markdown"}
-license = {text = "Apache License 2.0"}
+license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
According to the deprecation warning, support for the old way of declaring the license will be removed from setuptools on 2026-Feb-18.