### PR TITLE
improve njmax/nconmax reporting in testspeed

### DIFF
--- a/mujoco_warp/_src/test_util.py
+++ b/mujoco_warp/_src/test_util.py
@@ -258,8 +258,8 @@ def benchmark(
       else:
         trace = tracer.trace()
       if measure_alloc:
-        ncon.append(d.ncon.numpy()[0])
-        nefc.append(np.sum(d.nefc.numpy()))
+        ncon.append(np.max([d.ncon.numpy()[0], d.ncollision.numpy()[0]]))
+        nefc.append(np.max(d.nefc.numpy()))
       if measure_solver_niter:
         solver_niter.append(d.solver_niter.numpy())
 


### PR DESCRIPTION
Right now the output does not really help us tune njmax and nconmax. So I propose these 2 changes:

1. remember the max between ncollision and ncon, because both of these are allocated with nconmax
2. take the max over all worlds for njmax, having an aggregate value does not make any sense for tuning.