### PR TITLE
Fix override for enums in viewer and testspeed

### DIFF
--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -117,7 +117,7 @@ def _override(model: mjw.Model):
 
     if key in enum_fields:
       try:
-        val = str(enum_fields[key][val.upper()])
+        val = int(enum_fields[key][val.upper()])
       except KeyError:
         raise app.UsageError(f"Unrecognized enum value: {val}")
 
@@ -128,11 +128,6 @@ def _override(model: mjw.Model):
       if i < len(attrs) - 1:
         obj = getattr(obj, attr)
       else:
-        try:
-          val = type(getattr(obj, attr))(ast.literal_eval(val))
-        except (SyntaxError, ValueError):
-          raise app.UsageError(f"Unrecognized value for field: {key}")
-
         setattr(obj, attr, val)
 
 

--- a/mujoco_warp/viewer.py
+++ b/mujoco_warp/viewer.py
@@ -100,7 +100,7 @@ def _override(model: Union[mjw.Model, mujoco.MjModel]):
 
     if key in enum_fields:
       try:
-        val = str(enum_fields[key][val.upper()])
+        val = int(enum_fields[key][val.upper()])
       except KeyError:
         raise app.UsageError(f"Unrecognized enum value: {val}")
 
@@ -111,11 +111,6 @@ def _override(model: Union[mjw.Model, mujoco.MjModel]):
       if i < len(attrs) - 1:
         obj = getattr(obj, attr)
       else:
-        try:
-          val = type(getattr(obj, attr))(ast.literal_eval(val))
-        except (SyntaxError, ValueError):
-          raise app.UsageError(f"Unrecognized value for field: {key}")
-
         setattr(obj, attr, val)
 
 


### PR DESCRIPTION
In the current version, it is not possible to override some properties like cone, solver, etc...
This solves the issue.

The problem is that `literal_eval` does not work with our custom enum.
