### PR TITLE
Optimization: Adding static to broadphase filter

### DIFF
--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -29,7 +29,9 @@ from .types import Data
 from .types import DisableBit
 from .types import GeomType
 from .types import Model
+from .warp_util import cache_kernel
 from .warp_util import event_scope
+from .warp_util import kernel as nested_kernel
 
 wp.set_module_options({"enable_backward": False})
 
@@ -248,54 +250,56 @@ def _obb_filter(
   return True
 
 
-@wp.func
-def _broadphase_filter(
-  # Model:
-  opt_broadphase_filter: int,
-  geom_aabb: wp.array2d(dtype=wp.vec3),
-  geom_rbound: wp.array2d(dtype=float),
-  geom_margin: wp.array2d(dtype=float),
-  # Data in:
-  geom_xpos_in: wp.array2d(dtype=wp.vec3),
-  geom_xmat_in: wp.array2d(dtype=wp.mat33),
-  # In:
-  geom1: int,
-  geom2: int,
-  worldid: int,
-) -> bool:
-  # 1: plane
-  # 2: sphere
-  # 4: aabb
-  # 8: obb
+def _broadphase_filter(opt_broadphase_filter: int):
+  @wp.func
+  def func(
+    # Model:
+    geom_aabb: wp.array2d(dtype=wp.vec3),
+    geom_rbound: wp.array2d(dtype=float),
+    geom_margin: wp.array2d(dtype=float),
+    # Data in:
+    geom_xpos_in: wp.array2d(dtype=wp.vec3),
+    geom_xmat_in: wp.array2d(dtype=wp.mat33),
+    # In:
+    geom1: int,
+    geom2: int,
+    worldid: int,
+  ) -> bool:
+    # 1: plane
+    # 2: sphere
+    # 4: aabb
+    # 8: obb
 
-  center1 = geom_aabb[geom1, 0]
-  center2 = geom_aabb[geom2, 0]
-  size1 = geom_aabb[geom1, 1]
-  size2 = geom_aabb[geom2, 1]
-  rbound1 = geom_rbound[worldid, geom1]
-  rbound2 = geom_rbound[worldid, geom2]
-  margin1 = geom_margin[worldid, geom1]
-  margin2 = geom_margin[worldid, geom2]
-  xpos1 = geom_xpos_in[worldid, geom1]
-  xpos2 = geom_xpos_in[worldid, geom2]
-  xmat1 = geom_xmat_in[worldid, geom1]
-  xmat2 = geom_xmat_in[worldid, geom2]
+    center1 = geom_aabb[geom1, 0]
+    center2 = geom_aabb[geom2, 0]
+    size1 = geom_aabb[geom1, 1]
+    size2 = geom_aabb[geom2, 1]
+    rbound1 = geom_rbound[worldid, geom1]
+    rbound2 = geom_rbound[worldid, geom2]
+    margin1 = geom_margin[worldid, geom1]
+    margin2 = geom_margin[worldid, geom2]
+    xpos1 = geom_xpos_in[worldid, geom1]
+    xpos2 = geom_xpos_in[worldid, geom2]
+    xmat1 = geom_xmat_in[worldid, geom1]
+    xmat2 = geom_xmat_in[worldid, geom2]
 
-  if rbound1 == 0.0 or rbound2 == 0.0:
-    if opt_broadphase_filter & int(BroadphaseFilter.PLANE.value):
-      return _plane_filter(rbound1, rbound2, margin1, margin2, xpos1, xpos2, xmat1, xmat2)
-  else:
-    if opt_broadphase_filter & int(BroadphaseFilter.SPHERE.value):
-      if not _sphere_filter(rbound1, rbound2, margin1, margin2, xpos1, xpos2):
-        return False
-    if opt_broadphase_filter & int(BroadphaseFilter.AABB.value):
-      if not _aabb_filter(center1, center2, size1, size2, margin1, margin2, xpos1, xpos2, xmat1, xmat2):
-        return False
-    if opt_broadphase_filter & int(BroadphaseFilter.OBB.value):
-      if not _obb_filter(center1, center2, size1, size2, margin1, margin2, xpos1, xpos2, xmat1, xmat2):
-        return False
+    if rbound1 == 0.0 or rbound2 == 0.0:
+      if wp.static(opt_broadphase_filter & int(BroadphaseFilter.PLANE.value)):
+        return _plane_filter(rbound1, rbound2, margin1, margin2, xpos1, xpos2, xmat1, xmat2)
+    else:
+      if wp.static(opt_broadphase_filter & int(BroadphaseFilter.SPHERE.value)):
+        if not _sphere_filter(rbound1, rbound2, margin1, margin2, xpos1, xpos2):
+          return False
+      if wp.static(opt_broadphase_filter & int(BroadphaseFilter.AABB.value)):
+        if not _aabb_filter(center1, center2, size1, size2, margin1, margin2, xpos1, xpos2, xmat1, xmat2):
+          return False
+      if wp.static(opt_broadphase_filter & int(BroadphaseFilter.OBB.value)):
+        if not _obb_filter(center1, center2, size1, size2, margin1, margin2, xpos1, xpos2, xmat1, xmat2):
+          return False
 
-  return True
+    return True
+
+  return func
 
 
 @wp.func
@@ -413,82 +417,81 @@ def _sap_range(
   sap_range_out[worldid, geomid] = limit - geomid
 
 
-@wp.kernel
-def _sap_broadphase(
-  # Model:
-  ngeom: int,
-  opt_broadphase_filter: int,
-  geom_type: wp.array(dtype=int),
-  geom_aabb: wp.array2d(dtype=wp.vec3),
-  geom_rbound: wp.array2d(dtype=float),
-  geom_margin: wp.array2d(dtype=float),
-  nxn_pairid: wp.array(dtype=int),
-  # Data in:
-  nworld_in: int,
-  nconmax_in: int,
-  geom_xpos_in: wp.array2d(dtype=wp.vec3),
-  geom_xmat_in: wp.array2d(dtype=wp.mat33),
-  sap_sort_index_in: wp.array2d(dtype=int),  # kernel_analyzer: ignore
-  sap_cumulative_sum_in: wp.array(dtype=int),  # kernel_analyzer: ignore
-  # In:
-  nsweep_in: int,
-  # Data out:
-  collision_pair_out: wp.array(dtype=wp.vec2i),
-  collision_hftri_index_out: wp.array(dtype=int),
-  collision_pairid_out: wp.array(dtype=int),
-  collision_worldid_out: wp.array(dtype=int),
-  ncollision_out: wp.array(dtype=int),
-):
-  worldgeomid = wp.tid()
+@cache_kernel
+def _sap_broadphase(broadphase_filter):
+  @nested_kernel
+  def kernel(
+    # Model:
+    ngeom: int,
+    geom_type: wp.array(dtype=int),
+    geom_aabb: wp.array2d(dtype=wp.vec3),
+    geom_rbound: wp.array2d(dtype=float),
+    geom_margin: wp.array2d(dtype=float),
+    nxn_pairid: wp.array(dtype=int),
+    # Data in:
+    nworld_in: int,
+    nconmax_in: int,
+    geom_xpos_in: wp.array2d(dtype=wp.vec3),
+    geom_xmat_in: wp.array2d(dtype=wp.mat33),
+    sap_sort_index_in: wp.array2d(dtype=int),  # kernel_analyzer: ignore
+    sap_cumulative_sum_in: wp.array(dtype=int),  # kernel_analyzer: ignore
+    # In:
+    nsweep_in: int,
+    # Data out:
+    collision_pair_out: wp.array(dtype=wp.vec2i),
+    collision_hftri_index_out: wp.array(dtype=int),
+    collision_pairid_out: wp.array(dtype=int),
+    collision_worldid_out: wp.array(dtype=int),
+    ncollision_out: wp.array(dtype=int),
+  ):
+    worldgeomid = wp.tid()
 
-  nworldgeom = nworld_in * ngeom
-  nworkpackages = sap_cumulative_sum_in[nworldgeom - 1]
+    nworldgeom = nworld_in * ngeom
+    nworkpackages = sap_cumulative_sum_in[nworldgeom - 1]
 
-  while worldgeomid < nworkpackages:
-    # binary search to find current and next geom pair indices
-    i = _binary_search(sap_cumulative_sum_in, worldgeomid, 0, nworldgeom)
-    j = i + worldgeomid + 1
+    while worldgeomid < nworkpackages:
+      # binary search to find current and next geom pair indices
+      i = _binary_search(sap_cumulative_sum_in, worldgeomid, 0, nworldgeom)
+      j = i + worldgeomid + 1
 
-    if i > 0:
-      j -= sap_cumulative_sum_in[i - 1]
+      if i > 0:
+        j -= sap_cumulative_sum_in[i - 1]
 
-    worldid = i // ngeom
-    i = i % ngeom
-    j = j % ngeom
+      worldid = i // ngeom
+      i = i % ngeom
+      j = j % ngeom
 
-    # get geom indices and swap if necessary
-    geom1 = sap_sort_index_in[worldid, i]
-    geom2 = sap_sort_index_in[worldid, j]
+      # get geom indices and swap if necessary
+      geom1 = sap_sort_index_in[worldid, i]
+      geom2 = sap_sort_index_in[worldid, j]
 
-    # find linear index of (geom1, geom2) in upper triangular nxn_pairid
-    if geom2 < geom1:
-      idx = upper_tri_index(ngeom, geom2, geom1)
-    else:
-      idx = upper_tri_index(ngeom, geom1, geom2)
+      # find linear index of (geom1, geom2) in upper triangular nxn_pairid
+      if geom2 < geom1:
+        idx = upper_tri_index(ngeom, geom2, geom1)
+      else:
+        idx = upper_tri_index(ngeom, geom1, geom2)
 
-    if nxn_pairid[idx] < -1:
       worldgeomid += nsweep_in
-      continue
+      if nxn_pairid[idx] < -1:
+        continue
 
-    if _broadphase_filter(
-      opt_broadphase_filter, geom_aabb, geom_rbound, geom_margin, geom_xpos_in, geom_xmat_in, geom1, geom2, worldid
-    ):
-      _add_geom_pair(
-        geom_type,
-        nxn_pairid,
-        nconmax_in,
-        geom1,
-        geom2,
-        worldid,
-        idx,
-        collision_pair_out,
-        collision_hftri_index_out,
-        collision_pairid_out,
-        collision_worldid_out,
-        ncollision_out,
-      )
+      if broadphase_filter(geom_aabb, geom_rbound, geom_margin, geom_xpos_in, geom_xmat_in, geom1, geom2, worldid):
+        _add_geom_pair(
+          geom_type,
+          nxn_pairid,
+          nconmax_in,
+          geom1,
+          geom2,
+          worldid,
+          idx,
+          collision_pair_out,
+          collision_hftri_index_out,
+          collision_pairid_out,
+          collision_worldid_out,
+          ncollision_out,
+        )
 
-    worldgeomid += nsweep_in
+  return kernel
 
 
 def _segmented_sort(tile_size: int):
@@ -591,12 +594,12 @@ def sap_broadphase(m: Model, d: Data):
   # estimate number of overlap checks
   # assumes each geom has 5 other geoms (batched over all worlds)
   nsweep = 5 * nworldgeom
+  broadphase_filter = _broadphase_filter(m.opt.broadphase_filter)
   wp.launch(
-    kernel=_sap_broadphase,
+    kernel=_sap_broadphase(broadphase_filter),
     dim=nsweep,
     inputs=[
       m.ngeom,
-      m.opt.broadphase_filter,
       m.geom_type,
       m.geom_aabb,
       m.geom_rbound,
@@ -620,50 +623,51 @@ def sap_broadphase(m: Model, d: Data):
   )
 
 
-@wp.kernel
-def _nxn_broadphase(
-  # Model:
-  opt_broadphase_filter: int,
-  geom_type: wp.array(dtype=int),
-  geom_aabb: wp.array2d(dtype=wp.vec3),
-  geom_rbound: wp.array2d(dtype=float),
-  geom_margin: wp.array2d(dtype=float),
-  nxn_geom_pair: wp.array(dtype=wp.vec2i),
-  nxn_pairid: wp.array(dtype=int),
-  # Data in:
-  nconmax_in: int,
-  geom_xpos_in: wp.array2d(dtype=wp.vec3),
-  geom_xmat_in: wp.array2d(dtype=wp.mat33),
-  # Data out:
-  collision_pair_out: wp.array(dtype=wp.vec2i),
-  collision_hftri_index_out: wp.array(dtype=int),
-  collision_pairid_out: wp.array(dtype=int),
-  collision_worldid_out: wp.array(dtype=int),
-  ncollision_out: wp.array(dtype=int),
-):
-  worldid, elementid = wp.tid()
-
-  geom = nxn_geom_pair[elementid]
-  geom1 = geom[0]
-  geom2 = geom[1]
-
-  if _broadphase_filter(
-    opt_broadphase_filter, geom_aabb, geom_rbound, geom_margin, geom_xpos_in, geom_xmat_in, geom1, geom2, worldid
+@cache_kernel
+def _nxn_broadphase(broadphase_filter):
+  @nested_kernel
+  def kernel(
+    # Model:
+    geom_type: wp.array(dtype=int),
+    geom_aabb: wp.array2d(dtype=wp.vec3),
+    geom_rbound: wp.array2d(dtype=float),
+    geom_margin: wp.array2d(dtype=float),
+    nxn_geom_pair: wp.array(dtype=wp.vec2i),
+    nxn_pairid: wp.array(dtype=int),
+    # Data in:
+    nconmax_in: int,
+    geom_xpos_in: wp.array2d(dtype=wp.vec3),
+    geom_xmat_in: wp.array2d(dtype=wp.mat33),
+    # Data out:
+    collision_pair_out: wp.array(dtype=wp.vec2i),
+    collision_hftri_index_out: wp.array(dtype=int),
+    collision_pairid_out: wp.array(dtype=int),
+    collision_worldid_out: wp.array(dtype=int),
+    ncollision_out: wp.array(dtype=int),
   ):
-    _add_geom_pair(
-      geom_type,
-      nxn_pairid,
-      nconmax_in,
-      geom1,
-      geom2,
-      worldid,
-      elementid,
-      collision_pair_out,
-      collision_hftri_index_out,
-      collision_pairid_out,
-      collision_worldid_out,
-      ncollision_out,
-    )
+    worldid, elementid = wp.tid()
+
+    geom = nxn_geom_pair[elementid]
+    geom1 = geom[0]
+    geom2 = geom[1]
+
+    if broadphase_filter(geom_aabb, geom_rbound, geom_margin, geom_xpos_in, geom_xmat_in, geom1, geom2, worldid):
+      _add_geom_pair(
+        geom_type,
+        nxn_pairid,
+        nconmax_in,
+        geom1,
+        geom2,
+        worldid,
+        elementid,
+        collision_pair_out,
+        collision_hftri_index_out,
+        collision_pairid_out,
+        collision_worldid_out,
+        ncollision_out,
+      )
+
+  return kernel
 
 
 @event_scope
@@ -681,11 +685,11 @@ def nxn_broadphase(m: Model, d: Data):
   `contype`/`conaffinity`, parent-child relationships, and explicit `<exclude>` tags.
   """
 
+  broadphase_filter = _broadphase_filter(m.opt.broadphase_filter)
   wp.launch(
-    _nxn_broadphase,
+    _nxn_broadphase(broadphase_filter),
     dim=(d.nworld, m.nxn_geom_pair_filtered.shape[0]),
     inputs=[
-      m.opt.broadphase_filter,
       m.geom_type,
       m.geom_aabb,
       m.geom_rbound,


### PR DESCRIPTION
Added static to broadphase filter.
This allows the compiler to know which portion of the code will be used and optimize the code generation accordingly.

This change does not produce any measurable change for most of benchmark, except `aloha_pot`:
| This branch | Main | 
| ---------------- | ------- |
|  548.02 x     |  514.95 x |

And If I run only on the `collision` function:
| This branch | Main | 
| ---------------- | ------- |
|  5,012.54 x    |  3,822.85 x |

Command run:
```
python mujoco_warp/testspeed.py --function=step benchmark/aloha_pot/scene.xml --keyframe=0 --nworld=8192 --nstep=1000 --njmax=80 --nconmax=130000 -o opt.is_sparse=True -o opt.ls_parallel=False
```