### PR TITLE
A few asv improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ benchmark/mujoco_menagerie/
 benchmark/kitchen/combined_assets/
 kitchen_robot.xml
 
+## airspeed velocity working directories
+asv/
+
 # Language-specific files
 # =======================
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -7,6 +7,8 @@
     "python -m build --wheel -o {build_cache_dir}"
   ],
   "install_command": [
+    "in-dir={env_dir} python -m pip install mujoco --pre --upgrade -f https://py.mujoco.org/",
+    "in-dir={env_dir} python -m pip install warp-lang --pre --upgrade -f https://pypi.nvidia.com/warp-lang/",
     "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
   ],
   "branches": ["main"],

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -57,4 +57,11 @@ You can also benchmark your own branch:
 asv run $MYBRANCH
 ```
 
+In order to measure accurate JIT times, the benchmarks disable the Warp kernel cache.  If you would like to re-enable the kernel
+cache, e.g. for quick local debugging, set the `ASV_CACHE_KERNELS` environment variable:
+
+```
+ASV_CACHE_KERNELS=true asv run
+```
+
 See the [airspeed velocity documentation](https://asv.readthedocs.io/en/latest/index.html) for more information.

--- a/mujoco_warp/_src/test_util.py
+++ b/mujoco_warp/_src/test_util.py
@@ -218,21 +218,18 @@ def benchmark(
     list: Number of constraints.
     list: Number of solver iterations.
   """
-  jit_beg = time.perf_counter()
-
-  fn(m, d)
-
-  jit_end = time.perf_counter()
-  jit_duration = jit_end - jit_beg
-  wp.synchronize()
 
   trace = {}
   ncon, nefc, solver_niter = [], [], []
 
   with warp_util.EventTracer(enabled=event_trace) as tracer:
     # capture the whole function as a CUDA graph
+    jit_beg = time.perf_counter()
     with wp.ScopedCapture() as capture:
       fn(m, d)
+    jit_end = time.perf_counter()
+    jit_duration = jit_end - jit_beg
+
     graph = capture.graph
 
     time_vec = np.zeros(nstep)
@@ -322,17 +319,20 @@ class BenchmarkSuite:
     mujoco.mj_forward(mjm, mjd)
 
     wp.init()
+    if os.environ.get("ASV_CACHE_KERNELS", "false").lower() == "false":
+      wp.clear_kernel_cache()
 
     free_before = wp.get_device().free_memory
     m = io.put_model(mjm)
     d = io.put_data(mjm, mjd, self.batch_size, self.nconmax, self.njmax)
+    free_after = wp.get_device().free_memory
 
     jit_duration, _, trace, _, _, solver_niter = benchmark(forward.step, m, d, 1000, True, False, True)
     metrics = {
       "jit_duration": jit_duration,
       "solver_niter_mean": np.mean(solver_niter),
       "solver_niter_p95": np.quantile(solver_niter, 0.95),
-      "device_memory_allocated": free_before - wp.get_device().free_memory,
+      "device_memory_allocated": free_before - free_after,
     }
 
     def tree_flatten(d, parent_k=""):


### PR DESCRIPTION
* Add `asv` geberated directory to `.gitignore`
* Make sure `asv` installs nightly mujoco and warp
* Remove the extra function call in `benchmark`, seems unnecessary now
* Default to always clearing kernel cache so `jit_duration` metric is accurate
* Document how to disable clearing the cache using `ASV_CACHE_KERNELS`