### PR TITLE
Remove iterations and ls_iterations from benchmark XMLs

### DIFF
--- a/benchmark/apptronik_apollo/apptronik_apollo.xml
+++ b/benchmark/apptronik_apollo/apptronik_apollo.xml
@@ -1,7 +1,7 @@
 <mujoco model="apptronik_apollo">
     <compiler angle="radian" eulerseq="zyx"/>
 
-    <option timestep="0.005" iterations="10" ls_iterations="20" integrator="Euler">
+    <option timestep="0.005" integrator="Euler">
         <flag eulerdamp="disable" />
     </option>
 

--- a/benchmark/humanoid/humanoid.xml
+++ b/benchmark/humanoid/humanoid.xml
@@ -14,7 +14,7 @@
 -->
 
 <mujoco model="Humanoid">
-  <option timestep="0.005" iterations="10" ls_iterations="20">
+  <option timestep="0.005">
     <flag eulerdamp="disable"/>
   </option>
 


### PR DESCRIPTION
`iterations` and `ls_iterations` not needed after recent improvements, now only has minor perf implication.

* Humanoid step ns before: 501.38
* Humanoid step ns after: 508.07

* Apollo terrain step ns before: 1283.85
* Apollo terrain step ns after: 1314.14