### PR TITLE
Update qacc_warmstart in advance only.

### DIFF
--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -312,6 +312,9 @@ def _advance(m: Model, d: Data, qacc: wp.array, qvel: Optional[wp.array] = None)
     ],
   )
 
+  if not m.opt.disableflags & DisableBit.WARMSTART.value:
+    wp.copy(d.qacc_warmstart, d.qacc)
+
 
 @wp.kernel
 def _euler_damp_qfrc_sparse(
@@ -1026,9 +1029,6 @@ def step(m: Model, d: Data):
   else:
     raise NotImplementedError(f"integrator {m.opt.integrator} not implemented.")
 
-  if not m.opt.disableflags & DisableBit.WARMSTART.value:
-    wp.copy(d.qacc_warmstart, d.qacc)
-
 
 @event_scope
 def step1(m: Model, d: Data):
@@ -1069,6 +1069,3 @@ def step2(m: Model, d: Data):
   else:
     # note: RK4 defaults to Euler
     euler(m, d)
-
-  if not m.opt.disableflags & DisableBit.WARMSTART.value:
-    wp.copy(d.qacc_warmstart, d.qacc)

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -1026,6 +1026,9 @@ def step(m: Model, d: Data):
   else:
     raise NotImplementedError(f"integrator {m.opt.integrator} not implemented.")
 
+  if not m.opt.disableflags & DisableBit.WARMSTART.value:
+    wp.copy(d.qacc_warmstart, d.qacc)
+
 
 @event_scope
 def step1(m: Model, d: Data):
@@ -1066,3 +1069,6 @@ def step2(m: Model, d: Data):
   else:
     # note: RK4 defaults to Euler
     euler(m, d)
+
+  if not m.opt.disableflags & DisableBit.WARMSTART.value:
+    wp.copy(d.qacc_warmstart, d.qacc)

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -312,8 +312,7 @@ def _advance(m: Model, d: Data, qacc: wp.array, qvel: Optional[wp.array] = None)
     ],
   )
 
-  if not m.opt.disableflags & DisableBit.WARMSTART.value:
-    wp.copy(d.qacc_warmstart, d.qacc)
+  wp.copy(d.qacc_warmstart, d.qacc)
 
 
 @wp.kernel

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -421,6 +421,7 @@ class ForwardTest(parameterized.TestCase):
       "qfrc_actuator",
       "qfrc_smooth",
       "qacc",
+      "qacc_warmstart",
       "qvel",
       "qpos",
       "efc_force",

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2009,16 +2009,11 @@ def create_context(m: types.Model, d: types.Data, grad: bool = True):
     _update_gradient(m, d)
 
 
-def _copy_acc(m: types.Model, d: types.Data):
-  wp.copy(d.qacc, d.qacc_smooth)
-  wp.copy(d.qacc_warmstart, d.qacc_smooth)
-  d.solver_niter.fill_(0)
-
-
 @event_scope
 def solve(m: types.Model, d: types.Data):
   if d.njmax == 0:
-    _copy_acc(m, d)
+    wp.copy(d.qacc, d.qacc_smooth)
+    d.solver_niter.fill_(0)
   else:
     _solve(m, d)
 
@@ -2062,5 +2057,3 @@ def _solve(m: types.Model, d: types.Data):
     # It should be removed when JAX becomes compatible.
     for _ in range(m.opt.iterations):
       _solver_iteration(m, d)
-
-  wp.copy(d.qacc_warmstart, d.qacc)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -254,9 +254,7 @@ class SolverTest(parameterized.TestCase):
         ls_parallel=ls_parallel,
       )
 
-      qacc_warmstart = mjd.qacc_warmstart.copy()
       mujoco.mj_forward(mjm, mjd)
-      mjd.qacc_warmstart = qacc_warmstart
 
       d.qacc.zero_()
       d.qfrc_constraint.zero_()


### PR DESCRIPTION
Update warmstart at the same time as all other state variables. This change makes mj_forward idempotent.