### PR TITLE
Optimization: Merging kernels in camlight

### DIFF
--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -513,7 +513,7 @@ def com_pos(m: Model, d: Data):
 
 
 @wp.kernel
-def _cam_fn(
+def _cam_local_to_global(
   # Model:
   cam_mode: wp.array(dtype=int),
   cam_bodyid: wp.array(dtype=int),
@@ -580,7 +580,7 @@ def _cam_fn(
 
 
 @wp.kernel
-def _light_fn(
+def _light_local_to_global(
   # Model:
   light_mode: wp.array(dtype=int),
   light_bodyid: wp.array(dtype=int),
@@ -647,7 +647,7 @@ def camlight(m: Model, d: Data):
   including special handling for tracking and target modes.
   """
   wp.launch(
-    _cam_fn,
+    _cam_local_to_global,
     dim=(d.nworld, m.ncam),
     inputs=[
       m.cam_mode,
@@ -665,7 +665,7 @@ def camlight(m: Model, d: Data):
     outputs=[d.cam_xpos, d.cam_xmat],
   )
   wp.launch(
-    _light_fn,
+    _light_local_to_global,
     dim=(d.nworld, m.nlight),
     inputs=[
       m.light_mode,

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -513,38 +513,19 @@ def com_pos(m: Model, d: Data):
 
 
 @wp.kernel
-def _cam_local_to_global(
-  # Model:
-  cam_bodyid: wp.array(dtype=int),
-  cam_pos: wp.array2d(dtype=wp.vec3),
-  cam_quat: wp.array2d(dtype=wp.quat),
-  # Data in:
-  xpos_in: wp.array2d(dtype=wp.vec3),
-  xquat_in: wp.array2d(dtype=wp.quat),
-  # Data out:
-  cam_xpos_out: wp.array2d(dtype=wp.vec3),
-  cam_xmat_out: wp.array2d(dtype=wp.mat33),
-):
-  """Fixed cameras."""
-  worldid, camid = wp.tid()
-  bodyid = cam_bodyid[camid]
-  xpos = xpos_in[worldid, bodyid]
-  xquat = xquat_in[worldid, bodyid]
-  cam_xpos_out[worldid, camid] = xpos + math.rot_vec_quat(cam_pos[worldid, camid], xquat)
-  cam_xmat_out[worldid, camid] = math.quat_to_mat(math.mul_quat(xquat, cam_quat[worldid, camid]))
-
-
-@wp.kernel
 def _cam_fn(
   # Model:
   cam_mode: wp.array(dtype=int),
   cam_bodyid: wp.array(dtype=int),
   cam_targetbodyid: wp.array(dtype=int),
+  cam_pos: wp.array2d(dtype=wp.vec3),
+  cam_quat: wp.array2d(dtype=wp.quat),
   cam_poscom0: wp.array2d(dtype=wp.vec3),
   cam_pos0: wp.array2d(dtype=wp.vec3),
   cam_mat0: wp.array2d(dtype=wp.mat33),
   # Data in:
   xpos_in: wp.array2d(dtype=wp.vec3),
+  xquat_in: wp.array2d(dtype=wp.quat),
   subtree_com_in: wp.array2d(dtype=wp.vec3),
   # Data out:
   cam_xpos_out: wp.array2d(dtype=wp.vec3),
@@ -556,7 +537,11 @@ def _cam_fn(
   )
   invalid_target = is_target_cam and (cam_targetbodyid[camid] < 0)
   if invalid_target:
-    return
+    bodyid = cam_bodyid[camid]
+    xpos = xpos_in[worldid, bodyid]
+    xquat = xquat_in[worldid, bodyid]
+    cam_xpos_out[worldid, camid] = xpos + math.rot_vec_quat(cam_pos[worldid, camid], xquat)
+    cam_xmat_out[worldid, camid] = math.quat_to_mat(math.mul_quat(xquat, cam_quat[worldid, camid]))
   elif cam_mode[camid] == wp.static(CamLightType.TRACK.value):
     cam_xmat_out[worldid, camid] = cam_mat0[worldid, camid]
     body_xpos = xpos_in[worldid, cam_bodyid[camid]]
@@ -567,6 +552,10 @@ def _cam_fn(
   elif cam_mode[camid] == wp.static(CamLightType.TARGETBODY.value) or cam_mode[camid] == wp.static(
     CamLightType.TARGETBODYCOM.value
   ):
+    bodyid = cam_bodyid[camid]
+    xpos = xpos_in[worldid, bodyid]
+    xquat = xquat_in[worldid, bodyid]
+    cam_xpos_out[worldid, camid] = xpos + math.rot_vec_quat(cam_pos[worldid, camid], xquat)
     pos = xpos_in[worldid, cam_targetbodyid[camid]]
     if cam_mode[camid] == wp.static(CamLightType.TARGETBODYCOM.value):
       pos = subtree_com_in[worldid, cam_targetbodyid[camid]]
@@ -582,28 +571,12 @@ def _cam_fn(
       mat_1[2], mat_2[2], mat_3[2]
     )
     # fmt: on
-
-
-@wp.kernel
-def _light_local_to_global(
-  # Model:
-  light_bodyid: wp.array(dtype=int),
-  light_pos: wp.array2d(dtype=wp.vec3),
-  light_dir: wp.array2d(dtype=wp.vec3),
-  # Data in:
-  xpos_in: wp.array2d(dtype=wp.vec3),
-  xquat_in: wp.array2d(dtype=wp.quat),
-  # Data out:
-  light_xpos_out: wp.array2d(dtype=wp.vec3),
-  light_xdir_out: wp.array2d(dtype=wp.vec3),
-):
-  """Fixed lights."""
-  worldid, lightid = wp.tid()
-  bodyid = light_bodyid[lightid]
-  xpos = xpos_in[worldid, bodyid]
-  xquat = xquat_in[worldid, bodyid]
-  light_xpos_out[worldid, lightid] = xpos + math.rot_vec_quat(light_pos[worldid, lightid], xquat)
-  light_xdir_out[worldid, lightid] = math.rot_vec_quat(light_dir[worldid, lightid], xquat)
+  else:
+    bodyid = cam_bodyid[camid]
+    xpos = xpos_in[worldid, bodyid]
+    xquat = xquat_in[worldid, bodyid]
+    cam_xpos_out[worldid, camid] = xpos + math.rot_vec_quat(cam_pos[worldid, camid], xquat)
+    cam_xmat_out[worldid, camid] = math.quat_to_mat(math.mul_quat(xquat, cam_quat[worldid, camid]))
 
 
 @wp.kernel
@@ -612,12 +585,14 @@ def _light_fn(
   light_mode: wp.array(dtype=int),
   light_bodyid: wp.array(dtype=int),
   light_targetbodyid: wp.array(dtype=int),
+  light_pos: wp.array2d(dtype=wp.vec3),
+  light_dir: wp.array2d(dtype=wp.vec3),
   light_poscom0: wp.array2d(dtype=wp.vec3),
   light_pos0: wp.array2d(dtype=wp.vec3),
   light_dir0: wp.array2d(dtype=wp.vec3),
   # Data in:
   xpos_in: wp.array2d(dtype=wp.vec3),
-  light_xpos_in: wp.array2d(dtype=wp.vec3),
+  xquat_in: wp.array2d(dtype=wp.quat),
   subtree_com_in: wp.array2d(dtype=wp.vec3),
   # Data out:
   light_xpos_out: wp.array2d(dtype=wp.vec3),
@@ -629,6 +604,11 @@ def _light_fn(
   )
   invalid_target = is_target_light and (light_targetbodyid[lightid] < 0)
   if invalid_target:
+    bodyid = light_bodyid[lightid]
+    xpos = xpos_in[worldid, bodyid]
+    xquat = xquat_in[worldid, bodyid]
+    light_xpos_out[worldid, lightid] = xpos + math.rot_vec_quat(light_pos[worldid, lightid], xquat)
+    light_xdir_out[worldid, lightid] = math.rot_vec_quat(light_dir[worldid, lightid], xquat)
     return
   elif light_mode[lightid] == wp.static(CamLightType.TRACK.value):
     light_xdir_out[worldid, lightid] = light_dir0[worldid, lightid]
@@ -640,10 +620,21 @@ def _light_fn(
   elif light_mode[lightid] == wp.static(CamLightType.TARGETBODY.value) or light_mode[lightid] == wp.static(
     CamLightType.TARGETBODYCOM.value
   ):
+    bodyid = light_bodyid[lightid]
+    xpos = xpos_in[worldid, bodyid]
+    xquat = xquat_in[worldid, bodyid]
+    light_xpos_out[worldid, lightid] = xpos + math.rot_vec_quat(light_pos[worldid, lightid], xquat)
     pos = xpos_in[worldid, light_targetbodyid[lightid]]
     if light_mode[lightid] == wp.static(CamLightType.TARGETBODYCOM.value):
       pos = subtree_com_in[worldid, light_targetbodyid[lightid]]
-    light_xdir_out[worldid, lightid] = pos - light_xpos_in[worldid, lightid]
+    light_xdir_out[worldid, lightid] = pos - light_xpos_out[worldid, lightid]
+  else:
+    bodyid = light_bodyid[lightid]
+    xpos = xpos_in[worldid, bodyid]
+    xquat = xquat_in[worldid, bodyid]
+    light_xpos_out[worldid, lightid] = xpos + math.rot_vec_quat(light_pos[worldid, lightid], xquat)
+    light_xdir_out[worldid, lightid] = math.rot_vec_quat(light_dir[worldid, lightid], xquat)
+
   light_xdir_out[worldid, lightid] = wp.normalize(light_xdir_out[worldid, lightid])
 
 
@@ -656,22 +647,22 @@ def camlight(m: Model, d: Data):
   including special handling for tracking and target modes.
   """
   wp.launch(
-    _cam_local_to_global,
-    dim=(d.nworld, m.ncam),
-    inputs=[m.cam_bodyid, m.cam_pos, m.cam_quat, d.xpos, d.xquat],
-    outputs=[d.cam_xpos, d.cam_xmat],
-  )
-  wp.launch(
     _cam_fn,
     dim=(d.nworld, m.ncam),
-    inputs=[m.cam_mode, m.cam_bodyid, m.cam_targetbodyid, m.cam_poscom0, m.cam_pos0, m.cam_mat0, d.xpos, d.subtree_com],
+    inputs=[
+      m.cam_mode,
+      m.cam_bodyid,
+      m.cam_targetbodyid,
+      m.cam_pos,
+      m.cam_quat,
+      m.cam_poscom0,
+      m.cam_pos0,
+      m.cam_mat0,
+      d.xpos,
+      d.xquat,
+      d.subtree_com,
+    ],
     outputs=[d.cam_xpos, d.cam_xmat],
-  )
-  wp.launch(
-    _light_local_to_global,
-    dim=(d.nworld, m.nlight),
-    inputs=[m.light_bodyid, m.light_pos, m.light_dir, d.xpos, d.xquat],
-    outputs=[d.light_xpos, d.light_xdir],
   )
   wp.launch(
     _light_fn,
@@ -680,11 +671,13 @@ def camlight(m: Model, d: Data):
       m.light_mode,
       m.light_bodyid,
       m.light_targetbodyid,
+      m.light_pos,
+      m.light_dir,
       m.light_poscom0,
       m.light_pos0,
       m.light_dir0,
       d.xpos,
-      d.light_xpos,
+      d.xquat,
       d.subtree_com,
     ],
     outputs=[d.light_xpos, d.light_xdir],


### PR DESCRIPTION
- `_cam_local_to_global` and `_cam_fn` are merged
- `_light_local_to_global` and  `_light_fn` are merged

Running the following benchmark:
```
python mujoco_warp/testspeed.py --function=step benchmark/humanoid/humanoid.xml --nworld=8192 --nstep=1000 --njmax=52 --nconmax=200000 -o opt.is_sparse=True -o opt.ls_parallel=True --event_trace=True -o opt.solver=newton -o opt.cone=pyramidal
```

This is what I get for trunk:

> step: 625.70
>   forward: 622.81
>     fwd_position: 104.25
>       camlight: 2.33

And this branch:
> step: 626.44
>   forward: 623.56
>     fwd_position: 103.94
>       camlight: 1.80

So a 30% speedup for the `camlight` function.
I saw similar speedup for other benchmarks.