### PR TITLE
Optimization: Revert qfrc_actuator to previously _qfrc_actuator_sparse

### DIFF
--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -44,7 +44,6 @@ class BlockDim:
   euler_dense: int = 32
   actuator_velocity: int = 32
   tendon_velocity: int = 32
-  qfrc_actuator: int = 32
   # ray
   ray: int = 64
   # sensor


### PR DESCRIPTION
This is what I get in our humanoid benchmark:

Main branch:
> step: 606.00
>   forward: 603.14
>     fwd_actuation: 21.22

This branch:
> step: 597.78
>   forward: 594.88
>     fwd_actuation: 1.96

Command:
```
python mujoco_warp/testspeed.py --function=step benchmark/humanoid/humanoid.xml --nworld=8192 --nstep=1000 --njmax=52 --nconmax=200000 -o opt.is_sparse=True -o opt.ls_parallel=True  -o opt.solver=newton -o opt.cone=pyramidal 
```

On Newton, Nsight system gives me this

Main branch:
Time | Total Time | Instances | Avg | Med | Min | Max | StdDev | Name
------- | -------------- | ------------ | ----- | ------ | ----- | ----- | --------- | ----------
6.0% | 1.324 s	| 8059 | 164.283 μs | 161.569 μs | 159.681 μs | 633.987 μs | 26.308 μs | _qfrc_actuator

This branch:
Time | Total Time | Instances | Avg | Med | Min | Max | StdDev | Name
------- | -------------- | ------------ | ----- | ------ | ----- | ----- | --------- | ----------
0.5% | 109.741 ms | 7979 | 13.753 μs | 13.216 μs	| 11.328 μs | 371.394 μs	| 8.882 μs | _qfrc_actuator

Command:
```
python newton/examples/example_mujoco.py --num-frames=2000 --headless --num-envs=8192
```