### PR TITLE
Replace wp.config.enable_backward calls with module config calls

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -36,7 +36,7 @@ from .warp_util import event_scope
 from .warp_util import kernel as nested_kernel
 
 # TODO(team): improve compile time to enable backward pass
-wp.config.enable_backward = False
+wp.set_module_options({"enable_backward": False})
 
 MULTI_CONTACT_COUNT = 8
 mat3c = wp.types.matrix(shape=(MULTI_CONTACT_COUNT, 3), dtype=float)

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -21,7 +21,7 @@ from .types import MJ_MINVAL
 from .types import GeomType
 
 # TODO(team): improve compile time to enable backward pass
-wp.config.enable_backward = False
+wp.set_module_options({"enable_backward": False})
 
 FLOAT_MIN = -1e30
 FLOAT_MAX = 1e30

--- a/mujoco_warp/_src/collision_gjk_legacy.py
+++ b/mujoco_warp/_src/collision_gjk_legacy.py
@@ -26,7 +26,7 @@ from .types import MJ_MINVAL
 from .types import GeomType
 
 # TODO(team): improve compile time to enable backward pass
-wp.config.enable_backward = False
+wp.set_module_options({"enable_backward": False})
 
 FLOAT_MIN = -1e30
 FLOAT_MAX = 1e30

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -23,7 +23,7 @@ from .types import vec5
 from .types import vec11
 from .warp_util import event_scope
 
-wp.config.enable_backward = False
+wp.set_module_options({"enable_backward": False})
 
 
 @wp.kernel


### PR DESCRIPTION
Changing the global option is bad practice, this switch does this on a per-module basis.