### PR TITLE
Follow-up: compile time fixes

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -113,7 +113,7 @@ def ccd_kernel_builder(
   depth_extension: float,
 ):
   # runs convex collision on a set of geom pairs to recover contact info
-  @nested_kernel(module="unique")
+  @nested_kernel(module="unique", enable_backward=False)
   def ccd_kernel(
     # Model:
     ngeom: int,

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -419,7 +419,7 @@ def _sap_range(
 
 @cache_kernel
 def _sap_broadphase(broadphase_filter):
-  @nested_kernel(module="unique")
+  @nested_kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
     ngeom: int,
@@ -625,7 +625,7 @@ def sap_broadphase(m: Model, d: Data):
 
 @cache_kernel
 def _nxn_broadphase(broadphase_filter):
-  @nested_kernel(module="unique")
+  @nested_kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
     geom_type: wp.array(dtype=int),

--- a/mujoco_warp/_src/collision_gjk_test.py
+++ b/mujoco_warp/_src/collision_gjk_test.py
@@ -30,7 +30,7 @@ MAX_ITERATIONS = 20
 
 
 def _geom_dist(m: Model, d: Data, gid1: int, gid2: int, iterations: int, multiccd=False):
-  @nested_kernel
+  @nested_kernel(module="unique", enable_backward=False)
   def _gjk_kernel(
     # Model:
     geom_type: wp.array(dtype=int),

--- a/mujoco_warp/_src/collision_hfield.py
+++ b/mujoco_warp/_src/collision_hfield.py
@@ -24,6 +24,7 @@ from .types import Model
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.func
 def _hfield_subgrid(
   # In:

--- a/mujoco_warp/_src/collision_hfield.py
+++ b/mujoco_warp/_src/collision_hfield.py
@@ -22,6 +22,7 @@ from .types import Data
 from .types import GeomType
 from .types import Model
 
+wp.set_module_options({"enable_backward": False})
 
 @wp.func
 def _hfield_subgrid(

--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -1457,7 +1457,7 @@ def _primitive_narrowphase_builder(m: Model):
       _primitive_collisions_types.append(types)
       _primitive_collisions_func.append(func)
 
-  @nested_kernel(module="unique")
+  @nested_kernel(module="unique", enable_backward=False)
   def _primitive_narrowphase(
     # Model:
     geom_type: wp.array(dtype=int),

--- a/mujoco_warp/_src/collision_sdf.py
+++ b/mujoco_warp/_src/collision_sdf.py
@@ -32,6 +32,7 @@ from .types import vec8i
 from .util_misc import halton
 from .warp_util import event_scope
 
+wp.set_module_options({"enable_backward": False})
 
 @wp.struct
 class OptimizationParams:

--- a/mujoco_warp/_src/collision_sdf.py
+++ b/mujoco_warp/_src/collision_sdf.py
@@ -34,6 +34,7 @@ from .warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.struct
 class OptimizationParams:
   rel_mat: wp.mat33

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -357,7 +357,7 @@ def _euler_sparse(m: Model, d: Data):
 
 @cache_kernel
 def _tile_euler_dense(tile: TileSet):
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def euler_dense(
     # Model:
     dof_damping: wp.array2d(dtype=float),
@@ -557,7 +557,7 @@ def fwd_position(m: Model, d: Data, factorize: bool = True):
 def _actuator_velocity(m: Model, d: Data):
   NV = m.nv
 
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def actuator_velocity(
     # Data in:
     qvel_in: wp.array2d(dtype=float),
@@ -589,7 +589,7 @@ def _actuator_velocity(m: Model, d: Data):
 def _tendon_velocity(m: Model, d: Data):
   NV = m.nv
 
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def tendon_velocity(
     # Data in:
     qvel_in: wp.array2d(dtype=float),

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -357,7 +357,7 @@ def _euler_sparse(m: Model, d: Data):
 
 @cache_kernel
 def _tile_euler_dense(tile: TileSet):
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def euler_dense(
     # Model:
     dof_damping: wp.array2d(dtype=float),
@@ -557,7 +557,7 @@ def fwd_position(m: Model, d: Data, factorize: bool = True):
 def _actuator_velocity(m: Model, d: Data):
   NV = m.nv
 
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def actuator_velocity(
     # Data in:
     qvel_in: wp.array2d(dtype=float),
@@ -589,7 +589,7 @@ def _actuator_velocity(m: Model, d: Data):
 def _tendon_velocity(m: Model, d: Data):
   NV = m.nv
 
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def tendon_velocity(
     # Data in:
     qvel_in: wp.array2d(dtype=float),

--- a/mujoco_warp/_src/inverse.py
+++ b/mujoco_warp/_src/inverse.py
@@ -27,6 +27,7 @@ from .types import EnableBit
 from .types import IntegratorType
 from .types import Model
 
+wp.set_module_options({"enable_backward": False})
 
 @wp.kernel
 def _qfrc_eulerdamp(

--- a/mujoco_warp/_src/inverse.py
+++ b/mujoco_warp/_src/inverse.py
@@ -29,6 +29,7 @@ from .types import Model
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.kernel
 def _qfrc_eulerdamp(
   # Model:

--- a/mujoco_warp/_src/passive.py
+++ b/mujoco_warp/_src/passive.py
@@ -24,6 +24,7 @@ from .types import JointType
 from .types import Model
 from .warp_util import event_scope
 
+wp.set_module_options({"enable_backward": False})
 
 @wp.kernel
 def _spring_damper_dof_passive(

--- a/mujoco_warp/_src/passive.py
+++ b/mujoco_warp/_src/passive.py
@@ -26,6 +26,7 @@ from .warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.kernel
 def _spring_damper_dof_passive(
   # Model:

--- a/mujoco_warp/_src/ray.py
+++ b/mujoco_warp/_src/ray.py
@@ -26,6 +26,7 @@ from .types import vec6
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.func
 def _ray_map(pos: wp.vec3, mat: wp.mat33, pnt: wp.vec3, vec: wp.vec3) -> Tuple[wp.vec3, wp.vec3]:
   """Maps ray to local geom frame coordinates.

--- a/mujoco_warp/_src/ray.py
+++ b/mujoco_warp/_src/ray.py
@@ -24,6 +24,7 @@ from .types import GeomType
 from .types import Model
 from .types import vec6
 
+wp.set_module_options({"enable_backward": False})
 
 @wp.func
 def _ray_map(pos: wp.vec3, mat: wp.mat33, pnt: wp.vec3, vec: wp.vec3) -> Tuple[wp.vec3, wp.vec3]:

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -44,6 +44,7 @@ from .warp_util import cache_kernel
 from .warp_util import event_scope
 from .warp_util import kernel as nested_kernel
 
+wp.set_module_options({"enable_backward": False})
 
 @wp.func
 def _write_scalar(
@@ -2534,7 +2535,7 @@ def energy_pos(m: Model, d: Data):
 
 @cache_kernel
 def _energy_vel_kinetic(nv: int):
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def energy_vel_kinetic(
     # Data in:
     qvel_in: wp.array2d(dtype=float),

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -46,6 +46,7 @@ from .warp_util import kernel as nested_kernel
 
 wp.set_module_options({"enable_backward": False})
 
+
 @wp.func
 def _write_scalar(
   # Model:
@@ -2535,7 +2536,7 @@ def energy_pos(m: Model, d: Data):
 
 @cache_kernel
 def _energy_vel_kinetic(nv: int):
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def energy_vel_kinetic(
     # Data in:
     qvel_in: wp.array2d(dtype=float),

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -921,7 +921,7 @@ def _factor_i_sparse(m: Model, d: Data, M: wp.array3d(dtype=float), L: wp.array3
 def _tile_cholesky_factorize(tile: TileSet):
   """Returns a kernel for dense Cholesky factorization of a tile."""
 
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def cholesky_factorize(
     # Data In:
     qM_in: wp.array3d(dtype=float),
@@ -2362,7 +2362,7 @@ def _solve_LD_sparse(
 def _tile_cholesky_solve(tile: TileSet):
   """Returns a kernel for dense Cholesky backsubstitution of a tile."""
 
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def cholesky_solve(
     # In:
     L: wp.array3d(dtype=float),
@@ -2441,7 +2441,7 @@ def solve_m(m: Model, d: Data, x: wp.array2d(dtype=float), y: wp.array2d(dtype=f
 def _tile_cholesky_factorize_solve(tile: TileSet):
   """Returns a kernel for dense Cholesky factorization and backsubstitution of a tile."""
 
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def cholesky_factorize_solve(
     # In:
     M: wp.array3d(dtype=float),

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -921,7 +921,7 @@ def _factor_i_sparse(m: Model, d: Data, M: wp.array3d(dtype=float), L: wp.array3
 def _tile_cholesky_factorize(tile: TileSet):
   """Returns a kernel for dense Cholesky factorization of a tile."""
 
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def cholesky_factorize(
     # Data In:
     qM_in: wp.array3d(dtype=float),
@@ -2362,7 +2362,7 @@ def _solve_LD_sparse(
 def _tile_cholesky_solve(tile: TileSet):
   """Returns a kernel for dense Cholesky backsubstitution of a tile."""
 
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def cholesky_solve(
     # In:
     L: wp.array3d(dtype=float),
@@ -2441,7 +2441,7 @@ def solve_m(m: Model, d: Data, x: wp.array2d(dtype=float), y: wp.array2d(dtype=f
 def _tile_cholesky_factorize_solve(tile: TileSet):
   """Returns a kernel for dense Cholesky factorization and backsubstitution of a tile."""
 
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def cholesky_factorize_solve(
     # In:
     M: wp.array3d(dtype=float),

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -702,7 +702,7 @@ def linesearch_zero_jv(
 
 @cache_kernel
 def linesearch_jv_fused(nv: int, dofs_per_thread: int):
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def kernel(
     # Data in:
     nefc_in: wp.array(dtype=int),
@@ -1211,7 +1211,7 @@ def update_constraint_init_qfrc_constraint(
 
 @cache_kernel
 def update_constraint_gauss_cost(nv: int, dofs_per_thread: int):
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def kernel(
     # Data in:
     qacc_in: wp.array2d(dtype=float),
@@ -1603,7 +1603,7 @@ def update_gradient_JTCJ(
 
 @cache_kernel
 def update_gradient_cholesky(tile_size: int):
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def kernel(
     # Data in:
     efc_grad_in: wp.array2d(dtype=float),
@@ -1629,7 +1629,7 @@ def update_gradient_cholesky(tile_size: int):
 
 @cache_kernel
 def update_gradient_cholesky_blocked(tile_size: int):
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def kernel(
     # Data in:
     efc_grad_in: wp.array3d(dtype=float),

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -702,7 +702,7 @@ def linesearch_zero_jv(
 
 @cache_kernel
 def linesearch_jv_fused(nv: int, dofs_per_thread: int):
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def kernel(
     # Data in:
     nefc_in: wp.array(dtype=int),
@@ -1211,7 +1211,7 @@ def update_constraint_init_qfrc_constraint(
 
 @cache_kernel
 def update_constraint_gauss_cost(nv: int, dofs_per_thread: int):
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def kernel(
     # Data in:
     qacc_in: wp.array2d(dtype=float),
@@ -1603,7 +1603,7 @@ def update_gradient_JTCJ(
 
 @cache_kernel
 def update_gradient_cholesky(tile_size: int):
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def kernel(
     # Data in:
     efc_grad_in: wp.array2d(dtype=float),
@@ -1629,7 +1629,7 @@ def update_gradient_cholesky(tile_size: int):
 
 @cache_kernel
 def update_gradient_cholesky_blocked(tile_size: int):
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def kernel(
     # Data in:
     efc_grad_in: wp.array3d(dtype=float),

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -86,7 +86,7 @@ def mul_m_sparse_ij(
 def mul_m_dense(tile: TileSet):
   """Returns a matmul kernel for some tile size"""
 
-  @nested_kernel(enable_backward=False)
+  @nested_kernel(module="unique", enable_backward=False)
   def kernel(
     # Data In:
     qM_in: wp.array3d(dtype=float),

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -86,7 +86,7 @@ def mul_m_sparse_ij(
 def mul_m_dense(tile: TileSet):
   """Returns a matmul kernel for some tile size"""
 
-  @nested_kernel
+  @nested_kernel(enable_backward=False)
   def kernel(
     # Data In:
     qM_in: wp.array3d(dtype=float),


### PR DESCRIPTION
Looks like we had a big regressions on the time to run unittests because the per-module backward pass disable did not disable it for the module=unique kernels.

This fixes the issue, but is rather verbose. I'll look into providing a cleaner solution with the warp team.