### PR TITLE
Add minimum versions for MuJoCo, Warp dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "etils[epath]",
     "mujoco>=3.3.6.dev802089588",
     "numpy",
-    "warp-lang>=1.8.1",
+    "warp-lang>=1.9.0.dev20250825",
 ]
 
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ requires-python = ">=3.9"
 dependencies = [
     "absl-py",
     "etils[epath]",
-    "mujoco",
+    "mujoco>=3.3.6.dev802089588",
     "numpy",
-    "warp-lang",
+    "warp-lang>=1.8.1",
 ]
 
 [[tool.uv.index]]


### PR DESCRIPTION
We can also think about committing uv.lock which would hard-lock the dependencies and we could guard a bit better against API breakage from dependencies.