### PR TITLE
README.md: include Windows setup instructions for Mujoco Warp

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,17 @@ source env/bin/activate
 pip install --upgrade pip
 pip install uv
 ```
+<details><summary>Windows (native Python only, not MSYS2 or WSL)</summary>
 
+```powershell
+git clone https://github.com/google-deepmind/mujoco_warp.git
+cd mujoco_warp
+python -m venv env
+.\env\Scripts\Activate.ps1  # For MSYS2 Python: env\bin\activate
+pip install --upgrade pip
+pip install uv
+```
+</details>
 
 Then install MJWarp in editable mode for local development:
 


### PR DESCRIPTION
Mujoco Warp is amazing — thank you all for this repo!  
I’m currently using my Windows device with an RTX card to train policies and run execution with Mujoco Warp.  
Since some commands differ on Windows, I thought adding Win-specific instructions might help during the dev period.  

### Description  
Added Windows (native Python) installation instructions to `README.md` for setting up Mujoco Warp. 
-  Main differ: env activate part,  for keeping the clean style, collapse for the additional commands 

### Motivation  
Provide clear setup steps for Windows users (non-WSL/MSYS2).  

### Test  
No code changes.  

### Contribution  
- Followed the [Contribution Guide](https://github.com/google-deepmind/mujoco_warp/blob/main/CONTRIBUTING.md)  
- Agreement signed with my GitHub ID: **wayne-xyz**  

