### PR TITLE
io.put_model check for implicit integrators and fluid model

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -122,6 +122,12 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   if mjm.opt.noslip_iterations > 0:
     raise NotImplementedError(f"noslip solver not implemented.")
 
+  if (mjm.opt.viscosity > 0 or mjm.opt.density > 0) and mjm.opt.integrator in [
+    mujoco.mjtIntegrator.mjINT_IMPLICITFAST,
+    mujoco.mjtIntegrator.mjINT_IMPLICIT,
+  ]:
+    raise NotImplementedError(f"Implicit integrators and fluid model not implemented.")
+
   # TODO(team): remove after _update_gradient for Newton uses tile operations for islands
   nv_max = 60
   if mjm.nv > nv_max and mjm.opt.jacobian == mujoco.mjtJacobian.mjJAC_DENSE:

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -228,6 +228,23 @@ class IOTest(parameterized.TestCase):
     if m.oct_aabb.size > 0:
       self.assertEqual(m.oct_aabb.shape[1], 2)
 
+  def test_implicit_integrator_fluid_model(self):
+    """Tests for implicit integrator with fluid model."""
+    with self.assertRaises(NotImplementedError):
+      test_util.fixture(
+        xml="""
+        <mujoco>
+          <option viscosity="1" density="1" integrator="implicitfast"/>
+          <worldbody>
+            <body>
+              <geom type="sphere" size=".1"/>
+              <freejoint/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+      )
+
 
 if __name__ == "__main__":
   wp.init()


### PR DESCRIPTION
currently missing and implementation of `mjd_inertiaBoxFluid`
https://github.com/google-deepmind/mujoco/blob/4b18009f47559a23e2c90b662769e0118b77c61e/src/engine/engine_derivative.c#L1270 

this pr provides a check in `io.put_model` for an `mjModel` with an implicit integrator and fluid model.