### PR TITLE
per-world reset

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1774,6 +1774,7 @@ def _reset_nworld(
   eq_active0: wp.array(dtype=bool),
   # Data in:
   nworld_in: int,
+  # In:
   reset_in: wp.array(dtype=bool),
   # Data out:
   solver_niter_out: wp.array(dtype=int),
@@ -1863,7 +1864,7 @@ def _reset_mocap(
   body_mocapid: wp.array(dtype=int),
   body_pos: wp.array2d(dtype=wp.vec3),
   body_quat: wp.array2d(dtype=wp.quat),
-  # Data in:
+  # In:
   reset_in: wp.array(dtype=bool),
   # Data out:
   mocap_pos_out: wp.array2d(dtype=wp.vec3),
@@ -1925,8 +1926,8 @@ def _reset_contact_all(
 def _reset_contact(
   # Data in:
   ncon_in: wp.array(dtype=int),
-  reset_in: wp.array(dtype=bool),
   # In:
+  reset_in: wp.array(dtype=bool),
   nefcaddress: int,
   # Data out:
   contact_dist_out: wp.array(dtype=float),

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1653,6 +1653,9 @@ def get_data_into(
   result.sensordata[:] = d.sensordata.numpy()
 
 
+# TODO(thowell): shared @wp.func for _reset kernel?
+
+
 @wp.kernel
 def _reset_xfrc_applied_all(xfrc_applied_out: wp.array2d(dtype=wp.spatial_vector)):
   worldid, bodyid, elemid = wp.tid()

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1824,7 +1824,7 @@ def _reset_contact(
   contact_worldid_out[conid] = 0
 
 
-def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array(dtype=int)] = None):
+def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array(dtype=bool)] = None):
   """Clear data, set defaults."""
   if reset is None:
     reset = d.reset

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1824,7 +1824,7 @@ def _reset_contact(
   contact_worldid_out[conid] = 0
 
 
-def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array(dtype=bool)] = None):
+def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
   """Clear data, set defaults."""
   if reset is None:
     reset = d.reset

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1119,8 +1119,6 @@ def make_data(mjm: mujoco.MjModel, nworld: int = 1, nconmax: int = -1, njmax: in
     inverse_mul_m_skip=wp.zeros((nworld,), dtype=bool),
     # actuator
     actuator_trntype_body_ncon=wp.zeros((nworld, np.sum(mjm.actuator_trntype == mujoco.mjtTrn.mjTRN_BODY)), dtype=int),
-    # reset
-    reset=wp.array(np.ones(nworld), dtype=bool),
   )
 
 
@@ -1495,8 +1493,6 @@ def put_data(
     inverse_mul_m_skip=wp.zeros((nworld,), dtype=bool),
     # actuator
     actuator_trntype_body_ncon=wp.zeros((nworld, np.sum(mjm.actuator_trntype == mujoco.mjtTrn.mjTRN_BODY)), dtype=int),
-    # reset
-    reset=wp.array(np.ones(nworld), dtype=bool),
   )
 
 
@@ -1658,6 +1654,12 @@ def get_data_into(
 
 
 @wp.kernel
+def _reset_xfrc_applied_all(xfrc_applied_out: wp.array2d(dtype=wp.spatial_vector)):
+  worldid, bodyid, elemid = wp.tid()
+  xfrc_applied_out[worldid, bodyid][elemid] = 0.0
+
+
+@wp.kernel
 def _reset_xfrc_applied(reset_in: wp.array(dtype=bool), xfrc_applied_out: wp.array2d(dtype=wp.spatial_vector)):
   worldid, bodyid, elemid = wp.tid()
 
@@ -1668,6 +1670,12 @@ def _reset_xfrc_applied(reset_in: wp.array(dtype=bool), xfrc_applied_out: wp.arr
 
 
 @wp.kernel
+def _reset_qM_all(qM_out: wp.array3d(dtype=float)):
+  worldid, elemid1, elemid2 = wp.tid()
+  qM_out[worldid, elemid1, elemid2] = 0.0
+
+
+@wp.kernel
 def _reset_qM(reset_in: wp.array(dtype=bool), qM_out: wp.array3d(dtype=float)):
   worldid, elemid1, elemid2 = wp.tid()
 
@@ -1675,6 +1683,79 @@ def _reset_qM(reset_in: wp.array(dtype=bool), qM_out: wp.array3d(dtype=float)):
     return
 
   qM_out[worldid, elemid1, elemid2] = 0.0
+
+
+@wp.kernel
+def _reset_nworld_all(
+  # Model:
+  nq: int,
+  nv: int,
+  nu: int,
+  na: int,
+  neq: int,
+  nsensordata: int,
+  qpos0: wp.array2d(dtype=float),
+  eq_active0: wp.array(dtype=bool),
+  # Data in:
+  nworld_in: int,
+  # Data out:
+  solver_niter_out: wp.array(dtype=int),
+  ncon_out: wp.array(dtype=int),
+  ne_out: wp.array(dtype=int),
+  ne_connect_out: wp.array(dtype=int),
+  ne_weld_out: wp.array(dtype=int),
+  ne_jnt_out: wp.array(dtype=int),
+  ne_ten_out: wp.array(dtype=int),
+  nf_out: wp.array(dtype=int),
+  nl_out: wp.array(dtype=int),
+  nefc_out: wp.array(dtype=int),
+  nsolving_out: wp.array(dtype=int),
+  time_out: wp.array(dtype=float),
+  energy_out: wp.array(dtype=wp.vec2),
+  qpos_out: wp.array2d(dtype=float),
+  qvel_out: wp.array2d(dtype=float),
+  act_out: wp.array2d(dtype=float),
+  qacc_warmstart_out: wp.array2d(dtype=float),
+  ctrl_out: wp.array2d(dtype=float),
+  qfrc_applied_out: wp.array2d(dtype=float),
+  eq_active_out: wp.array2d(dtype=bool),
+  qacc_out: wp.array2d(dtype=float),
+  act_dot_out: wp.array2d(dtype=float),
+  sensordata_out: wp.array2d(dtype=float),
+):
+  worldid = wp.tid()
+
+  solver_niter_out[worldid] = 0
+  if worldid == 0:
+    ncon_out[0] = 0
+  ne_out[worldid] = 0
+  ne_connect_out[worldid] = 0
+  ne_weld_out[worldid] = 0
+  ne_jnt_out[worldid] = 0
+  ne_ten_out[worldid] = 0
+  nf_out[worldid] = 0
+  nl_out[worldid] = 0
+  nefc_out[worldid] = 0
+  if worldid == 0:
+    nsolving_out[0] = nworld_in
+  time_out[worldid] = 0.0
+  energy_out[worldid] = wp.vec2(0.0, 0.0)
+  for i in range(nq):
+    qpos_out[worldid, i] = qpos0[worldid, i]
+    if i < nv:
+      qvel_out[worldid, i] = 0.0
+      qacc_warmstart_out[worldid, i] = 0.0
+      qfrc_applied_out[worldid, i] = 0.0
+      qacc_out[worldid, i] = 0.0
+  for i in range(nu):
+    ctrl_out[worldid, i] = 0.0
+    if i < na:
+      act_out[worldid, i] = 0.0
+      act_dot_out[worldid, i] = 0.0
+  for i in range(neq):
+    eq_active_out[worldid, i] = eq_active0[i]
+  for i in range(nsensordata):
+    sensordata_out[worldid, i] = 0.0
 
 
 @wp.kernel
@@ -1755,6 +1836,25 @@ def _reset_nworld(
 
 
 @wp.kernel
+def _reset_mocap_all(
+  # Model:
+  body_mocapid: wp.array(dtype=int),
+  body_pos: wp.array2d(dtype=wp.vec3),
+  body_quat: wp.array2d(dtype=wp.quat),
+  # Data out:
+  mocap_pos_out: wp.array2d(dtype=wp.vec3),
+  mocap_quat_out: wp.array2d(dtype=wp.quat),
+):
+  worldid, bodyid = wp.tid()
+
+  mocapid = body_mocapid[bodyid]
+
+  if mocapid >= 0:
+    mocap_pos_out[worldid, mocapid] = body_pos[worldid, bodyid]
+    mocap_quat_out[worldid, mocapid] = body_quat[worldid, bodyid]
+
+
+@wp.kernel
 def _reset_mocap(
   # Model:
   body_mocapid: wp.array(dtype=int),
@@ -1776,6 +1876,46 @@ def _reset_mocap(
   if mocapid >= 0:
     mocap_pos_out[worldid, mocapid] = body_pos[worldid, bodyid]
     mocap_quat_out[worldid, mocapid] = body_quat[worldid, bodyid]
+
+
+@wp.kernel
+def _reset_contact_all(
+  # Data in:
+  ncon_in: wp.array(dtype=int),
+  # In:
+  nefcaddress: int,
+  # Data out:
+  contact_dist_out: wp.array(dtype=float),
+  contact_pos_out: wp.array(dtype=wp.vec3),
+  contact_frame_out: wp.array(dtype=wp.mat33),
+  contact_includemargin_out: wp.array(dtype=float),
+  contact_friction_out: wp.array(dtype=types.vec5),
+  contact_solref_out: wp.array(dtype=wp.vec2),
+  contact_solreffriction_out: wp.array(dtype=wp.vec2),
+  contact_solimp_out: wp.array(dtype=types.vec5),
+  contact_dim_out: wp.array(dtype=int),
+  contact_geom_out: wp.array(dtype=wp.vec2i),
+  contact_efc_address_out: wp.array2d(dtype=int),
+  contact_worldid_out: wp.array(dtype=int),
+):
+  conid = wp.tid()
+
+  if conid >= ncon_in[0]:
+    return
+
+  contact_dist_out[conid] = 0.0
+  contact_pos_out[conid] = wp.vec3(0.0, 0.0, 0.0)
+  contact_frame_out[conid] = wp.mat33(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+  contact_includemargin_out[conid] = 0.0
+  contact_friction_out[conid] = types.vec5(0.0, 0.0, 0.0, 0.0, 0.0)
+  contact_solref_out[conid] = wp.vec2(0.0, 0.0)
+  contact_solreffriction_out[conid] = wp.vec2(0.0, 0.0)
+  contact_solimp_out[conid] = types.vec5(0.0, 0.0, 0.0, 0.0, 0.0)
+  contact_dim_out[conid] = 0
+  contact_geom_out[conid] = wp.vec2i(0, 0)
+  for i in range(nefcaddress):
+    contact_efc_address_out[conid, i] = 0
+  contact_worldid_out[conid] = 0
 
 
 @wp.kernel
@@ -1826,77 +1966,132 @@ def _reset_contact(
 
 def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
   """Clear data, set defaults."""
-  if reset is None:
-    reset = d.reset
-
-  wp.launch(_reset_xfrc_applied, dim=(d.nworld, m.nbody, 6), inputs=[reset], outputs=[d.xfrc_applied])
-
   if m.opt.is_sparse:
     qM_dim = (1, m.nM)
   else:
     qM_dim = (m.nv, m.nv)
 
-  wp.launch(_reset_qM, dim=(d.nworld, qM_dim[0], qM_dim[1]), inputs=[reset], outputs=[d.qM])
+  if reset is not None:
+    wp.launch(_reset_xfrc_applied, dim=(d.nworld, m.nbody, 6), inputs=[reset], outputs=[d.xfrc_applied])
+    wp.launch(_reset_qM, dim=(d.nworld, qM_dim[0], qM_dim[1]), inputs=[reset], outputs=[d.qM])
 
-  # set mocap_pos/quat = body_pos/quat for mocap bodies
-  wp.launch(
-    _reset_mocap,
-    dim=(d.nworld, m.nbody),
-    inputs=[m.body_mocapid, m.body_pos, m.body_quat, reset],
-    outputs=[d.mocap_pos, d.mocap_quat],
-  )
+    # set mocap_pos/quat = body_pos/quat for mocap bodies
+    wp.launch(
+      _reset_mocap,
+      dim=(d.nworld, m.nbody),
+      inputs=[m.body_mocapid, m.body_pos, m.body_quat, reset],
+      outputs=[d.mocap_pos, d.mocap_quat],
+    )
 
-  # clear contacts
-  wp.launch(
-    _reset_contact,
-    dim=d.nconmax,
-    inputs=[d.ncon, reset, d.contact.efc_address.shape[1]],
-    outputs=[
-      d.contact.dist,
-      d.contact.pos,
-      d.contact.frame,
-      d.contact.includemargin,
-      d.contact.friction,
-      d.contact.solref,
-      d.contact.solreffriction,
-      d.contact.solimp,
-      d.contact.dim,
-      d.contact.geom,
-      d.contact.efc_address,
-      d.contact.worldid,
-    ],
-  )
+    # clear contacts
+    wp.launch(
+      _reset_contact,
+      dim=d.nconmax,
+      inputs=[d.ncon, reset, d.contact.efc_address.shape[1]],
+      outputs=[
+        d.contact.dist,
+        d.contact.pos,
+        d.contact.frame,
+        d.contact.includemargin,
+        d.contact.friction,
+        d.contact.solref,
+        d.contact.solreffriction,
+        d.contact.solimp,
+        d.contact.dim,
+        d.contact.geom,
+        d.contact.efc_address,
+        d.contact.worldid,
+      ],
+    )
 
-  wp.launch(
-    _reset_nworld,
-    dim=d.nworld,
-    inputs=[m.nq, m.nv, m.nu, m.na, m.neq, m.nsensordata, m.qpos0, m.eq_active0, d.nworld, reset],
-    outputs=[
-      d.solver_niter,
-      d.ncon,
-      d.ne,
-      d.ne_connect,
-      d.ne_weld,
-      d.ne_jnt,
-      d.ne_ten,
-      d.nf,
-      d.nl,
-      d.nefc,
-      d.nsolving,
-      d.time,
-      d.energy,
-      d.qpos,
-      d.qvel,
-      d.act,
-      d.qacc_warmstart,
-      d.ctrl,
-      d.qfrc_applied,
-      d.eq_active,
-      d.qacc,
-      d.act_dot,
-      d.sensordata,
-    ],
-  )
+    wp.launch(
+      _reset_nworld,
+      dim=d.nworld,
+      inputs=[m.nq, m.nv, m.nu, m.na, m.neq, m.nsensordata, m.qpos0, m.eq_active0, d.nworld, reset],
+      outputs=[
+        d.solver_niter,
+        d.ncon,
+        d.ne,
+        d.ne_connect,
+        d.ne_weld,
+        d.ne_jnt,
+        d.ne_ten,
+        d.nf,
+        d.nl,
+        d.nefc,
+        d.nsolving,
+        d.time,
+        d.energy,
+        d.qpos,
+        d.qvel,
+        d.act,
+        d.qacc_warmstart,
+        d.ctrl,
+        d.qfrc_applied,
+        d.eq_active,
+        d.qacc,
+        d.act_dot,
+        d.sensordata,
+      ],
+    )
+  else:
+    wp.launch(_reset_xfrc_applied_all, dim=(d.nworld, m.nbody, 6), outputs=[d.xfrc_applied])
+    wp.launch(_reset_qM_all, dim=(d.nworld, qM_dim[0], qM_dim[1]), outputs=[d.qM])
+    wp.launch(
+      _reset_mocap_all,
+      dim=(d.nworld, m.nbody),
+      inputs=[m.body_mocapid, m.body_pos, m.body_quat],
+      outputs=[d.mocap_pos, d.mocap_quat],
+    )
+    wp.launch(
+      _reset_contact_all,
+      dim=d.nconmax,
+      inputs=[d.ncon, d.contact.efc_address.shape[1]],
+      outputs=[
+        d.contact.dist,
+        d.contact.pos,
+        d.contact.frame,
+        d.contact.includemargin,
+        d.contact.friction,
+        d.contact.solref,
+        d.contact.solreffriction,
+        d.contact.solimp,
+        d.contact.dim,
+        d.contact.geom,
+        d.contact.efc_address,
+        d.contact.worldid,
+      ],
+    )
+    wp.launch(
+      _reset_nworld_all,
+      dim=d.nworld,
+      inputs=[m.nq, m.nv, m.nu, m.na, m.neq, m.nsensordata, m.qpos0, m.eq_active0, d.nworld],
+      outputs=[
+        d.solver_niter,
+        d.ncon,
+        d.ne,
+        d.ne_connect,
+        d.ne_weld,
+        d.ne_jnt,
+        d.ne_ten,
+        d.nf,
+        d.nl,
+        d.nefc,
+        d.nsolving,
+        d.time,
+        d.energy,
+        d.qpos,
+        d.qvel,
+        d.act,
+        d.qacc_warmstart,
+        d.ctrl,
+        d.qfrc_applied,
+        d.eq_active,
+        d.qacc,
+        d.act_dot,
+        d.sensordata,
+      ],
+    )
 
 
 def override_model(model: Union[types.Model, mujoco.MjModel], overrides: Union[dict[str, Any], Sequence[str]]):

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -216,6 +216,35 @@ class IOTest(parameterized.TestCase):
     for arr in d.contact.__dataclass_fields__:
       _assert_eq(getattr(d.contact, arr).numpy(), 0.0, arr)
 
+  def test_reset_data_world(self):
+    """Tests per-world reset."""
+    _MJCF = """
+    <mujoco>
+      <worldbody>
+        <body>
+          <geom type="sphere" size="1"/>
+          <joint type="slide"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+    mjm = mujoco.MjModel.from_xml_string(_MJCF)
+    m = mjwarp.put_model(mjm)
+    d = mjwarp.make_data(mjm, nworld=2)
+
+    # set to nonzero values
+    d.qvel = wp.array(np.array([[1.0], [2.0]]), dtype=float)
+
+    # don't reset second world
+    d.reset = wp.array(np.array([True, False]), dtype=bool)
+
+    mjwarp.reset_data(m, d)
+
+    qvel = d.qvel.numpy()
+
+    _assert_eq(qvel[0], 0.0, "qvel[0]")
+    _assert_eq(qvel[1], 2.0, "qvel[1]")
+
   def test_sdf(self):
     """Tests that an SDF can be loaded."""
     mjm, mjd, m, d = test_data.fixture("collision_sdf/cow.xml")

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -232,18 +232,34 @@ class IOTest(parameterized.TestCase):
     m = mjwarp.put_model(mjm)
     d = mjwarp.make_data(mjm, nworld=2)
 
-    # set to nonzero values
-    d.qvel = wp.array(np.array([[1.0], [2.0]]), dtype=float)
+    # nonzero values
+    qvel = wp.array(np.array([[1.0], [2.0]]), dtype=float)
 
-    # don't reset second world
-    d.reset = wp.array(np.array([True, False]), dtype=bool)
+    wp.copy(d.qvel, qvel)
 
+    # reset both worlds
     mjwarp.reset_data(m, d)
 
-    qvel = d.qvel.numpy()
+    _assert_eq(d.qvel.numpy()[0], 0.0, "qvel[0]")
+    _assert_eq(d.qvel.numpy()[1], 0.0, "qvel[1]")
 
-    _assert_eq(qvel[0], 0.0, "qvel[0]")
-    _assert_eq(qvel[1], 2.0, "qvel[1]")
+    wp.copy(d.qvel, qvel)
+
+    # don't reset second world
+    reset10 = wp.array(np.array([True, False]), dtype=bool)
+    mjwarp.reset_data(m, d, reset=reset10)
+
+    _assert_eq(d.qvel.numpy()[0], 0.0, "qvel[0]")
+    _assert_eq(d.qvel.numpy()[1], 2.0, "qvel[1]")
+
+    wp.copy(d.qvel, qvel)
+
+    # don't reset both worlds
+    reset00 = wp.array(np.array([False, False], dtype=bool))
+    mjwarp.reset_data(m, d, reset=reset00)
+
+    _assert_eq(d.qvel.numpy()[0], 1.0, "qvel[0]")
+    _assert_eq(d.qvel.numpy()[1], 2.0, "qvel[1]")
 
   def test_sdf(self):
     """Tests that an SDF can be loaded."""

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1543,7 +1543,6 @@ class Data:
     ray_geomid: id of geom that intersects with ray             (nworld, 1)
     energy_vel_mul_m_skip: skip mul_m computation               (nworld,)
     actuator_trntype_body_ncon: number of active contacts       (nworld, <=nu)
-    reset: flag for resetting world in reset_data               (nworld,)
   """
 
   nworld: int  # warp only
@@ -1721,6 +1720,3 @@ class Data:
 
   # actuator
   actuator_trntype_body_ncon: wp.array2d(dtype=int)
-
-  # reset
-  reset: wp.array(dtype=bool)  # warp only

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1543,6 +1543,7 @@ class Data:
     ray_geomid: id of geom that intersects with ray             (nworld, 1)
     energy_vel_mul_m_skip: skip mul_m computation               (nworld,)
     actuator_trntype_body_ncon: number of active contacts       (nworld, <=nu)
+    reset: flag for resetting world in reset_data               (nworld,)
   """
 
   nworld: int  # warp only
@@ -1720,3 +1721,6 @@ class Data:
 
   # actuator
   actuator_trntype_body_ncon: wp.array2d(dtype=int)
+
+  # reset
+  reset: wp.array(dtype=bool)  # warp only


### PR DESCRIPTION
adds `reset` field to `Data`. the values in this array determine if the corresponding world is reset when `reset_data` is called. by default values are set to `True`.