### PR TITLE
add fixed tendons to aloha pot scene

### DIFF
--- a/benchmark/aloha_pot/scene.xml
+++ b/benchmark/aloha_pot/scene.xml
@@ -536,6 +536,16 @@
       </body>
     </body>
   </worldbody>
+  <tendon>
+    <fixed name="left\fixed">
+      <joint joint="left\left_finger" coef=".5"/>
+      <joint joint="left\right_finger" coef=".5"/>
+    </fixed>
+    <fixed name="right\fixed">
+      <joint joint="right\left_finger" coef=".5"/>
+      <joint joint="right\right_finger" coef=".5"/>
+    </fixed>
+  </tendon>
   <contact>
     <exclude name="//unnamed_contact_0" body1="left\base_link" body2="left\shoulder_link"/>
     <exclude name="//unnamed_contact_1" body1="right\base_link" body2="right\shoulder_link"/>
@@ -551,14 +561,14 @@
     <position name="left\forearm_roll" class="forearm_roll" joint="left\forearm_roll"/>
     <position name="left\wrist_angle" class="wrist_angle" joint="left\wrist_angle"/>
     <position name="left\wrist_rotate" class="wrist_rotate" joint="left\wrist_rotate"/>
-    <position name="left\gripper" class="finger" joint="left\left_finger"/>
+    <position name="left\gripper" class="finger" tendon="left\fixed"/>
     <position name="right\waist" class="waist" joint="right\waist"/>
     <position name="right\shoulder" class="shoulder" joint="right\shoulder"/>
     <position name="right\elbow" class="elbow" joint="right\elbow"/>
     <position name="right\forearm_roll" class="forearm_roll" joint="right\forearm_roll"/>
     <position name="right\wrist_angle" class="wrist_angle" joint="right\wrist_angle"/>
     <position name="right\wrist_rotate" class="wrist_rotate" joint="right\wrist_rotate"/>
-    <position name="right\gripper" class="finger" joint="right\left_finger"/>
+    <position name="right\gripper" class="finger" tendon="right\fixed"/>
   </actuator>
   <keyframe>
     <key

--- a/mujoco_warp/test_data/aloha_pot/scene.xml
+++ b/mujoco_warp/test_data/aloha_pot/scene.xml
@@ -536,6 +536,16 @@
       </body>
     </body>
   </worldbody>
+  <tendon>
+    <fixed name="left\fixed">
+      <joint joint="left\left_finger" coef=".5"/>
+      <joint joint="left\right_finger" coef=".5"/>
+    </fixed>
+    <fixed name="right\fixed">
+      <joint joint="right\left_finger" coef=".5"/>
+      <joint joint="right\right_finger" coef=".5"/>
+    </fixed>
+  </tendon>
   <contact>
     <exclude name="//unnamed_contact_0" body1="left\base_link" body2="left\shoulder_link"/>
     <exclude name="//unnamed_contact_1" body1="right\base_link" body2="right\shoulder_link"/>
@@ -551,14 +561,14 @@
     <position name="left\forearm_roll" class="forearm_roll" joint="left\forearm_roll"/>
     <position name="left\wrist_angle" class="wrist_angle" joint="left\wrist_angle"/>
     <position name="left\wrist_rotate" class="wrist_rotate" joint="left\wrist_rotate"/>
-    <position name="left\gripper" class="finger" joint="left\left_finger"/>
+    <position name="left\gripper" class="finger" tendon="left\fixed"/>
     <position name="right\waist" class="waist" joint="right\waist"/>
     <position name="right\shoulder" class="shoulder" joint="right\shoulder"/>
     <position name="right\elbow" class="elbow" joint="right\elbow"/>
     <position name="right\forearm_roll" class="forearm_roll" joint="right\forearm_roll"/>
     <position name="right\wrist_angle" class="wrist_angle" joint="right\wrist_angle"/>
     <position name="right\wrist_rotate" class="wrist_rotate" joint="right\wrist_rotate"/>
-    <position name="right\gripper" class="finger" joint="right\left_finger"/>
+    <position name="right\gripper" class="finger" tendon="right\fixed"/>
   </actuator>
   <keyframe>
     <key


### PR DESCRIPTION
based on a recommendation from @yuvaltassa, this pr adds fixed tendons to the aloha pot scene.

```
mjwarp-testspeed mujoco_warp/benchmark/aloha_pot/scene.xml --nconmax=200000 --njmax=128 --replay=lift_pot --measure_solver
```

main
```
Rolling out 1000 steps at dt = 0.002...

Summary for 8192 parallel rollouts

Total JIT time: 0.62 s
Total simulation time: 5.65 s
Total steps per second: 1,450,332
Total realtime factor: 2,900.66 x
Total time per step: 689.50 ns
Total converged worlds: 8192 / 8192

solver niter:

mean     std       min  max
---------------------------
2.83956  0.944506    1    9
 2.8739  0.983181    1   10
3.97102   1.69136    1   14
5.48658   1.68678    1   15
 5.7203   1.78359    1   15
5.56193   2.06369    1   16
4.49976   2.10049    1   15
4.59003   1.96566    1   14
4.44851   1.57807    1   15
3.52524   1.35555    1   12
```

this pr
```
Summary for 8192 parallel rollouts

Total JIT time: 0.61 s
Total simulation time: 5.68 s
Total steps per second: 1,441,120
Total realtime factor: 2,882.24 x
Total time per step: 693.90 ns
Total converged worlds: 8192 / 8192

solver niter:

mean     std       min  max
---------------------------
2.83318  0.939307    1    9
2.87934  0.985099    1   10
 3.9531   1.68004    1   15
5.51009   1.71513    1   15
5.75248   1.81376    1   15
5.64862   2.09079    1   15
4.54646   2.12754    1   15
4.61883   1.97576    1   15
4.47117   1.56202    1   13
  3.556   1.36036    1   11
```