### PR TITLE
update testspeed ctrlnoise

### DIFF
--- a/mujoco_warp/_src/benchmark.py
+++ b/mujoco_warp/_src/benchmark.py
@@ -45,28 +45,49 @@ def _sum(stack1, stack2):
 @wp.kernel
 def ctrl_noise(
   # Model:
+  opt_timestep: wp.array(dtype=float),
   actuator_ctrllimited: wp.array(dtype=bool),
   actuator_ctrlrange: wp.array2d(dtype=wp.vec2),
+  # Data in:
+  ctrl_in: wp.array2d(dtype=float),
   # In:
   ctrl_center: wp.array1d(dtype=float),
   step: int,
-  ctrlnoise: float,
+  ctrlnoisestd: float,
+  ctrlnoiserate: float,
   # Data out:
   ctrl_out: wp.array2d(dtype=float),
 ):
   worldid, actid = wp.tid()
 
-  center = 0.0
-  radius = 1.0
+  # convert rate and scale to discrete time (Ornstein-Uhlenbeck)
+  rate = wp.exp(-opt_timestep[0] / ctrlnoiserate)
+  scale = ctrlnoisestd * wp.sqrt(1.0 - rate * rate)
+
+  midpoint = 0.0
+  halfrange = 1.0
   ctrlrange = actuator_ctrlrange[0, actid]
+  is_limited = actuator_ctrllimited[actid]
+  if is_limited:
+    midpoint = 0.5 * (ctrlrange[1] + ctrlrange[0])
+    halfrange = 0.5 * (ctrlrange[1] - ctrlrange[0])
   if ctrl_center.shape[0] > 0:
-    center = ctrl_center[actid]
-  elif actuator_ctrllimited[actid]:
-    center = (ctrlrange[1] + ctrlrange[0]) / 2.0
-    radius = (ctrlrange[1] - ctrlrange[0]) / 2.0
-  radius *= ctrlnoise
-  noise = 2.0 * halton((step + 1) * (worldid + 1), actid + 2) - 1.0
-  ctrl_out[worldid, actid] = center + radius * noise
+    midpoint = ctrl_center[actid]
+
+  # exponential convergence to midpoint at ctrlnoiserate
+  if step > 0:
+    ctrl = rate * ctrl_in[worldid, actid] + (1.0 - rate) * midpoint
+  else:
+    ctrl = midpoint
+
+  # add noise
+  ctrl += scale * halfrange * (2.0 * halton((step + 1) * (worldid + 1), actid + 2) - 1.0)
+
+  # clip to range if limited
+  if is_limited:
+    ctrl = wp.clamp(ctrl, ctrlrange[0], ctrlrange[1])
+
+  ctrl_out[worldid, actid] = ctrl
 
 
 def benchmark(
@@ -126,7 +147,7 @@ def benchmark(
         wp.launch(
           ctrl_noise,
           dim=(d.nworld, m.nu),
-          inputs=[m.actuator_ctrllimited, m.actuator_ctrlrange, center, i, 0.01],
+          inputs=[m.opt.timestep, m.actuator_ctrllimited, m.actuator_ctrlrange, d.ctrl, center, i, 0.01, 0.1],
           outputs=[d.ctrl],
         )
         wp.synchronize()

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -127,6 +127,9 @@ def _main(argv: Sequence[str]):
     mujoco.mj_resetDataKeyframe(mjm, mjd, keys[0])
   elif mjm.nkey > 0 and _KEYFRAME.value > -1:
     mujoco.mj_resetDataKeyframe(mjm, mjd, _KEYFRAME.value)
+    if ctrls is None:
+      ctrls = [mjd.ctrl.copy() for _ in range(_NSTEP.value)]
+
   # populate some constraints
   mujoco.mj_forward(mjm, mjd)
 


### PR DESCRIPTION
- update `benchmark.ctrl_noise` to more closely match the [mujoco implementation](https://github.com/google-deepmind/mujoco/blob/9e5c5b110dc8bf578034f0843a82c4e6ab2711f6/sample/testspeed.cc#L63)
- testspeed: if not replay mode and a keyframe is provided, set `ctrls` to a trajectory of keyframe `ctrl`s (`benchmark.ctrl_noise` will utilize the keyframe `ctrl` as `midpoint`)