### PR TITLE
contact sensor: check contact type

### DIFF
--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -2266,6 +2266,7 @@ def _contact_match(
   contact_geom_in: wp.array(dtype=wp.vec2i),
   contact_efc_address_in: wp.array2d(dtype=int),
   contact_worldid_in: wp.array(dtype=int),
+  contact_type_in: wp.array(dtype=int),
   efc_force_in: wp.array2d(dtype=float),
   njmax_in: int,
   nacon_in: wp.array(dtype=int),
@@ -2279,6 +2280,9 @@ def _contact_match(
   sensorid = sensor_contact_adr[contactsensorid]
 
   if contactid >= nacon_in[0]:
+    return
+
+  if not contact_type_in[contactid] & ContactType.CONSTRAINT:
     return
 
   # sensor information
@@ -2517,6 +2521,7 @@ def sensor_acc(m: Model, d: Data):
         d.contact.geom,
         d.contact.efc_address,
         d.contact.worldid,
+        d.contact.type,
         d.efc.force,
         d.njmax,
         d.nacon,


### PR DESCRIPTION
update `_contact_match` to check contact type. if a contact is only for collision sensors it should not be included in contact matching for the contact sensor.