### PR TITLE
Incorrect indexing of hfield data when checking for collisions with height field

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -458,9 +458,9 @@ def ccd_kernel_builder(
     # see MuJoCo mjc_ConvexHField
     if wp.static(is_hfield):
       # height field subgrid
-      nrow = hfield_nrow[g1]
-      ncol = hfield_ncol[g1]
-      size = hfield_size[g1]
+      nrow = hfield_nrow[geom1_dataid]
+      ncol = hfield_ncol[geom1_dataid]
+      size = hfield_size[geom1_dataid]
 
       # subgrid
       x_scale = 0.5 * float(ncol - 1) / size[0]


### PR DESCRIPTION
Geom id was being used to index hfield data instead of the geom data id for hfield. This could have been overlooked because usually the first geom is the terrain geom which is indexed as 0 and there is usually only one height field. As soon as you add more than 1 height field or more terrain geoms, you start to see inconsistent behavior during collision with height maps, specifically sinking.

Partially related to #736 . This does not relate to the slow compilation issue, which hasn't been the case in my experience at HEAD 