### PR TITLE
Fix issue where when a geom penetrates a height field and sinks, it stays sunk and there is no force exerted to bring it out

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -246,18 +246,18 @@ def ccd_kernel_builder(
         # Hfield "up" (world)
         up = geom1.rot[:, 2]
         if wp.dot(top_n, up) < 0.0:
-            top_n = -top_n
+          top_n = -top_n
 
         # Start from the CCD/GJK normal but replace it if it's not in the up half-space
         n = wp.normalize(normal)
         if wp.dot(n, up) < 1.0e-6:
-            n = top_n
+          n = top_n
 
         # (Optional but helpful) Re-project contact points onto the top face along n,
         # so pos/normal are coherent for the solver:
         for i in range(ncontact):
-            d = wp.dot((points[i] - v0), top_n)
-            points[i] = points[i] - d * top_n
+          d = wp.dot((points[i] - v0), top_n)
+          points[i] = points[i] - d * top_n
 
         normal = n
       frame = make_frame(normal)


### PR DESCRIPTION
1. Mujoco has code to handle the flipping of the normal direction in the above specified case: [link](https://github.com/google-deepmind/mujoco/blob/main/src/engine/engine_collision_convex.c#L1346)
2. MJX Jax backend also has this implemented: [link](https://github.com/google-deepmind/mujoco/blob/main/mjx/mujoco/mjx/_src/collision_convex.py#L1036)

Here is the [test.xml](https://github.com/user-attachments/files/23306347/test.xml) used to reproduce this issue.
You can run this with `mjwarp-viewer test.xml`

Before:

https://github.com/user-attachments/assets/34d7c76b-8fd5-42f4-b565-c9182831262c

After:

https://github.com/user-attachments/assets/ca4e67a4-73d7-4f7f-a97b-037c76fd798e

