### PR TITLE
static multiccd

### DIFF
--- a/mujoco_warp/_src/collision_gjk_test.py
+++ b/mujoco_warp/_src/collision_gjk_test.py
@@ -184,8 +184,7 @@ def _geom_dist(
       ncon,
       x1,
       x2,
-    ) = ccd(
-      multiccd,
+    ) = wp.static(ccd(multiccd))(
       tolerance[0],
       1.0e30,
       iterations,


### PR DESCRIPTION
```
mjwarp-testspeed benchmark/aloha_pot/scene.xml --nconmax=24 --njmax=128
```

this pr:
```
Summary for 8192 parallel rollouts

Total JIT time: 0.81 s
Total simulation time: 4.14 s
Total steps per second: 1,980,035
Total realtime factor: 3,960.07 x
Total time per step: 505.04 ns
Total converged worlds: 8192 / 8192
```

main:
```
Summary for 8192 parallel rollouts

Total JIT time: 0.76 s
Total simulation time: 4.33 s
Total steps per second: 1,892,002
Total realtime factor: 3,784.00 x
Total time per step: 528.54 ns
Total converged worlds: 8192 / 8192
```