### PR TITLE
Optimization: value-gate memory reads in qderiv_actuator_passive

### DIFF
--- a/mujoco_warp/_src/derivative.py
+++ b/mujoco_warp/_src/derivative.py
@@ -78,14 +78,13 @@ def _qderiv_actuator_passive(
       if bias == 0.0 and gain == 0.0:
         continue
 
+      vel = bias
       if actuator_dyntype[actid] != DynType.NONE:
-        vel = bias
         if gain != 0.0:
           act_first = actuator_actadr[actid]
           act_last = act_first + actuator_actnum[actid] - 1
           vel += gain * act_in[worldid, act_last]
       else:
-        vel = bias
         if gain != 0.0:
           vel += gain * ctrl_in[worldid, actid]
 


### PR DESCRIPTION
That kernel is turning out to be problematic with implicit integration. This is a stop-gap but it needs more work for actuators that will lead to non-zero qderiv.

numbers for humanoid with implicit integration:

this change: 

```
Summary for 8192 parallel rollouts

Total JIT time: 0.31 s
Total simulation time: 2.54 s
Total steps per second: 3,227,567
Total realtime factor: 16,137.83 x
Total time per step: 309.83 ns
Total converged worlds: 8192 / 8192
```

main:

```
Summary for 8192 parallel rollouts

Total JIT time: 0.31 s
Total simulation time: 2.57 s
Total steps per second: 3,181,960
Total realtime factor: 15,909.80 x
Total time per step: 314.27 ns
Total converged worlds: 8192 / 8192
```