### PR TITLE
update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "etils[epath]",
     "mujoco>=3.3.7",
     "numpy",
-    "warp-lang>=1.9.0",
+    "warp-lang>=1.9.1",
 ]
 
 [[tool.uv.index]]
@@ -57,7 +57,7 @@ dev = [
     "pygls>=1.0.0,<2.0.0",
     "lsprotocol>=2023.0.1,<2024.0.0",
     "mujoco>=3.3.7.dev0",
-    "warp-lang>=1.9.0.dev0",
+    "warp-lang>=1.9.1.dev0",
 ]
 # TODO(team): cpu and cuda JAX optional dependencies are temporary, remove after we land MJX:Warp
 cpu = [


### PR DESCRIPTION
prior this this pr, a release build of warp was being installed instead of the nightly build. with this pr, the nightly build of warp will be installed with [dev].

note: 1) the nightly mujoco build was and is always installed 2) a dev dependency for mujoco is added to install the nightly build (this is a no op, but matches how warp release/nightly builds are installed)