### PR TITLE
Fix --override Flag Scope in testspeed and viewer

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1306,6 +1306,7 @@ def override_model(model: Union[types.Model, mujoco.MjModel], overrides: Union[d
   }
   mjw_only_fields = {"opt.broadphase", "opt.broadphase_filter", "opt.ls_parallel", "opt.graph_conditional"}
   mj_only_fields = {"opt.jacobian"}
+  readonly_fields = {"opt.is_sparse"}
 
   if not isinstance(overrides, dict):
     overrides_dict = {}
@@ -1322,6 +1323,9 @@ def override_model(model: Union[types.Model, mujoco.MjModel], overrides: Union[d
       continue
     if key in mj_only_fields and isinstance(model, types.Model):
       continue
+
+    if key in readonly_fields and isinstance(model, types.Model):
+      raise ValueError(f"Cannot override {key} on mjw.Model: field affects model initialization and has side effects")
 
     obj, attrs = model, key.split(".")
     for i, attr in enumerate(attrs):


### PR DESCRIPTION
## Problem #876
The `--override` flag allowed overriding `opt.is_sparse` on mjw.Model after initialization. This field affects memory allocation during model creation, causing subtle bugs when changed afterwards.

## Solution
Added validation to prevent overriding fields with side effects. The `opt.is_sparse` field is now read-only on mjw.Model and will throw an exception if override is attempted.

## Changes
- Added `readonly_fields` set to track fields that cannot be overridden
- Added validation check in `override_model()` function
- Raises clear error message when attempting to override restricted fields
