### PR TITLE
Move narrowphase kernel compilation to separate conftest.py that is included in the package

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,7 @@ import warp as wp
 
 collect_ignore = ["benchmark/mujoco_menagerie"]
 
+
 def pytest_addoption(parser):
   parser.addoption("--cpu", action="store_true", default=False, help="run tests with cpu")
   parser.addoption(

--- a/mujoco_warp/conftest.py
+++ b/mujoco_warp/conftest.py
@@ -17,6 +17,7 @@ import mujoco_warp as mjw
 from mujoco_warp import GeomType
 from mujoco_warp import test_data
 
+
 def pytest_configure(config):
   ## initialize primitive colliders
   # clear cache


### PR DESCRIPTION
running the tests from a clean pip install is broken because conftest.py is not included in the package. This change adds another conftest.py inside the package that sets up the kernel cache for the tests.

I was hoping to find a better way to include the main conftest.py into the package, but I can't do it the same way as test_data because it's a .py file and will not be considered by setuptools. Happy to consider another approach though, I'm not a setuptools expert.