### PR TITLE
reduce block_dim for linesearch_iterative.

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -485,7 +485,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data):
       d.njmax,
     ],
     outputs=[d.efc.alpha],
-    block_dim=64
+    block_dim=m.block_dim.linesearch_iterative,
   )
 
 

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -61,6 +61,7 @@ class BlockDim:
   update_gradient_cholesky_blocked: int = 32
   update_gradient_JTDAJ_sparse: int = 64
   update_gradient_JTDAJ_dense: int = 96
+  linesearch_iterative: int = 64
   # support
   mul_m_dense: int = 32
 


### PR DESCRIPTION
Low-hanging fruit that actually helps, although we should look at the kernel in general.

humanoid on RTX Pro 6000 Blackwell

This PR

```
Summary for 8192 parallel rollouts

Total JIT time: 0.33 s
Total simulation time: 2.24 s
Total steps per second: 3,663,506
Total realtime factor: 18,317.53 x
Total time per step: 272.96 ns
Total converged worlds: 8192 / 8192
```

main

```
Summary for 8192 parallel rollouts

Total JIT time: 0.35 s
Total simulation time: 2.33 s
Total steps per second: 3,510,668
Total realtime factor: 17,553.34 x
Total time per step: 284.85 ns
Total converged worlds: 8192 / 8192
```

