### PR TITLE
Optimization: disable bounds_check in mul_m_dense

### DIFF
--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -116,10 +116,10 @@ def mul_m_dense(tile: TileSet, check_skip: bool):
         return
 
     dofid = adr[nodeid]
-    qM_tile = wp.tile_load(qM_in[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid))
-    vec_tile = wp.tile_load(vec[worldid], shape=(TILE_SIZE, 1), offset=(dofid, 0))
+    qM_tile = wp.tile_load(qM_in[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid), bounds_check=False)
+    vec_tile = wp.tile_load(vec[worldid], shape=(TILE_SIZE, 1), offset=(dofid, 0), bounds_check=False)
     res_tile = wp.tile_matmul(qM_tile, vec_tile)
-    wp.tile_store(res[worldid], res_tile, offset=(dofid, 0))
+    wp.tile_store(res[worldid], res_tile, offset=(dofid, 0), bounds_check=False)
 
   return _mul_m_dense
 


### PR DESCRIPTION
This PR:

```
Summary for 8192 parallel rollouts

Total JIT time: 0.32 s
Total simulation time: 2.28 s
Total steps per second: 3,593,219
Total realtime factor: 17,966.09 x
Total time per step: 278.30 ns
Total converged worlds: 8192 / 8192
```

main:

```
Summary for 8192 parallel rollouts

Total JIT time: 0.32 s
Total simulation time: 2.30 s
Total steps per second: 3,569,207
Total realtime factor: 17,846.03 x
Total time per step: 280.17 ns
Total converged worlds: 8192 / 8192
```
