### PR TITLE
update `quat_to_mat`

### DIFF
--- a/mujoco_warp/_src/math.py
+++ b/mujoco_warp/_src/math.py
@@ -59,9 +59,6 @@ def axis_angle_to_quat(axis: wp.vec3, angle: float) -> wp.quat:
 @wp.func
 def quat_to_mat(quat: wp.quat) -> wp.mat33:
   """Converts a quaternion into 3x3 rotation matrix."""
-  if quat[0] == 1.0 and quat[1] == 0.0 and quat[2] == 0.0 and quat[3] == 0.0:
-    return wp.identity(3, dtype=float)
-
   q00 = quat[0] * quat[0]
   q01 = quat[0] * quat[1]
   q02 = quat[0] * quat[2]


### PR DESCRIPTION
update the implementation to only compute necessary elements of the outer product following the mujoco implementation: https://github.com/google-deepmind/mujoco/blob/main/src/engine/engine_util_spatial.c#L144

not sure how meaningful of a speedup this is

```
mjwarp-testspeed ./benchmark/humanoid/humanoid.xml --nconmax=24 --njmax=64
```

this pr
```
Summary for 8192 parallel rollouts

Total JIT time: 6.36 s
Total simulation time: 2.86 s
Total steps per second: 2,867,615
Total realtime factor: 14,338.08 x
Total time per step: 348.72 ns
Total converged worlds: 8192 / 8192
```

main (b2b726f60d06706e43a6c86036f0c99195a323c7)
```
Summary for 8192 parallel rollouts

Total JIT time: 0.30 s
Total simulation time: 2.86 s
Total steps per second: 2,863,913
Total realtime factor: 14,319.57 x
Total time per step: 349.17 ns
Total converged worlds: 8192 / 8192
```