### PR TITLE
GitHub CI: separate release and dev tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.12"]
-        warp-version: ["nightly", "release"]
+        dep-version: ["release", "dev"]
 
-    continue-on-error: ${{ matrix.warp-version == 'release' }}
+    continue-on-error: ${{ matrix.dep-version == 'release' }}
 
     steps:
       - uses: actions/checkout@v3
@@ -64,16 +64,19 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install pip and uv
         run: |
           python -m pip install --upgrade pip
           pip install uv
-          uv pip install --system -e .[dev,cpu]
-      - name: Uninstall nightly warp-lang and install release warp-lang
-        if: matrix.warp-version == 'release'
+      - name: Install release
+        if: matrix.dep-version == 'release'
         run: |
-          pip uninstall -y warp-lang
-          pip install warp-lang
+          pip install pytest pytest-xdist
+          uv pip install --system -e .
+      - name: Install dev
+        if: matrix.dep-version == 'dev'
+        run: |
+          uv pip install --system -e .[dev]
       - name: Test with pytest
         run: |
           pytest


### PR DESCRIPTION
update to ci.yml to test release and dev versions of warp-lang and mujoco