### PR TITLE
Optimization: switching tree traversal per branch

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -259,18 +259,18 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   branches = [ancestor_chain(l) for l in np.where(children_count[1:] == 0)[0] + 1]
   m.nbranch = len(branches)
 
-  branch_bodies_flat = []
-  branch_start = []
+  body_branches = []
+  body_branch_start = []
   offset = 0
 
   for branch in branches:
-    branch_start.append(offset)
-    branch_bodies_flat.extend(branch)
+    body_branches.extend(branch)
+    body_branch_start.append(offset)
     offset += len(branch)
-  branch_start.append(offset)
+  body_branch_start.append(offset)
 
-  m.branch_bodies = np.array(branch_bodies_flat, dtype=int)
-  m.branch_start = np.array(branch_start, dtype=int)
+  m.body_branches = np.array(body_branches, dtype=int)
+  m.body_branch_start = np.array(body_branch_start, dtype=int)
 
   m.mocap_bodyid = np.arange(mjm.nbody)[mjm.body_mocapid >= 0]
   m.mocap_bodyid = m.mocap_bodyid[mjm.body_mocapid[mjm.body_mocapid >= 0].argsort()]

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -54,8 +54,8 @@ def _kinematics_branch(
   jnt_qposadr: wp.array(dtype=int),
   jnt_pos: wp.array2d(dtype=wp.vec3),
   jnt_axis: wp.array2d(dtype=wp.vec3),
-  branch_bodies: wp.array(dtype=int),
-  branch_start: wp.array(dtype=int),
+  body_branches: wp.array(dtype=int),
+  body_branch_start: wp.array(dtype=int),
   # Data in:
   qpos_in: wp.array2d(dtype=float),
   mocap_pos_in: wp.array2d(dtype=wp.vec3),
@@ -68,13 +68,13 @@ def _kinematics_branch(
 ):
   worldid, branchid = wp.tid()
 
-  start = branch_start[branchid]
-  end = branch_start[branchid + 1]
+  start = body_branch_start[branchid]
+  end = body_branch_start[branchid + 1]
 
   qpos = qpos_in[worldid]
 
   for i in range(start, end):
-    bodyid = branch_bodies[i]
+    bodyid = body_branches[i]
     pid = body_parentid[bodyid]
     jntadr = body_jntadr[bodyid]
     jntnum = body_jntnum[bodyid]
@@ -313,8 +313,8 @@ def kinematics(m: Model, d: Data):
       m.jnt_qposadr,
       m.jnt_pos,
       m.jnt_axis,
-      m.branch_bodies,
-      m.branch_start,
+      m.body_branches,
+      m.body_branch_start,
       d.qpos,
       d.mocap_pos,
       d.mocap_quat,
@@ -1022,8 +1022,8 @@ def _cacc_branch(
   body_parentid: wp.array(dtype=int),
   body_dofnum: wp.array(dtype=int),
   body_dofadr: wp.array(dtype=int),
-  branch_bodies: wp.array(dtype=int),
-  branch_start: wp.array(dtype=int),
+  body_branches: wp.array(dtype=int),
+  body_branch_start: wp.array(dtype=int),
   # Data in:
   qvel_in: wp.array2d(dtype=float),
   qacc_in: wp.array2d(dtype=float),
@@ -1036,14 +1036,14 @@ def _cacc_branch(
 ):
   worldid, branchid = wp.tid()
 
-  start = branch_start[branchid]
-  end = branch_start[branchid + 1]
+  start = body_branch_start[branchid]
+  end = body_branch_start[branchid + 1]
 
-  bodyid = branch_bodies[start]
+  bodyid = body_branches[start]
   pid = body_parentid[bodyid]
   local_cacc = cacc_out[worldid, pid]
   for i in range(start, end):
-    bodyid = branch_bodies[i]
+    bodyid = body_branches[i]
     dofnum = body_dofnum[bodyid]
     dofadr = body_dofadr[bodyid]
     for j in range(dofnum):
@@ -1061,8 +1061,8 @@ def _rne_cacc_forward(m: Model, d: Data, flg_acc: bool = False):
       m.body_parentid,
       m.body_dofnum,
       m.body_dofadr,
-      m.branch_bodies,
-      m.branch_start,
+      m.body_branches,
+      m.body_branch_start,
       d.qvel,
       d.qacc,
       d.cdof,
@@ -1716,8 +1716,8 @@ def _comvel_branch(
   body_jntadr: wp.array(dtype=int),
   body_dofadr: wp.array(dtype=int),
   jnt_type: wp.array(dtype=int),
-  branch_bodies: wp.array(dtype=int),
-  branch_start: wp.array(dtype=int),
+  body_branches: wp.array(dtype=int),
+  body_branch_start: wp.array(dtype=int),
   # Data in:
   qvel_in: wp.array2d(dtype=float),
   cdof_in: wp.array2d(dtype=wp.spatial_vector),
@@ -1727,14 +1727,14 @@ def _comvel_branch(
 ):
   worldid, branchid = wp.tid()
 
-  start = branch_start[branchid]
-  end = branch_start[branchid + 1]
+  start = body_branch_start[branchid]
+  end = body_branch_start[branchid + 1]
 
   qvel = qvel_in[worldid]
   cdof = cdof_in[worldid]
 
   for i in range(start, end):
-    bodyid = branch_bodies[i]
+    bodyid = body_branches[i]
     pid = body_parentid[bodyid]
     cvel = cvel_out[worldid, pid]
     dofid = body_dofadr[bodyid]
@@ -1799,8 +1799,8 @@ def com_vel(m: Model, d: Data):
       m.body_jntadr,
       m.body_dofadr,
       m.jnt_type,
-      m.branch_bodies,
-      m.branch_start,
+      m.body_branches,
+      m.body_branch_start,
       d.qvel,
       d.cdof,
     ],

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1023,8 +1023,8 @@ class Model:
     has_sdf_geom: whether the model contains SDF geoms
     block_dim: block dim options
     body_tree: list of body ids by tree level
-    branch_bodies: flattened body ids for all branches
-    branch_start: start index in branch_bodies for each branch   (nbranch + 1,)
+    body_branches: flattened body ids for all branches
+    body_branch_start: start index in body_branches for each branch   (nbranch + 1,)
     mocap_bodyid: id of body for mocap                       (nmocap,)
     body_fluid_ellipsoid: does body use ellipsoid fluid      (nbody,)
     jnt_limited_slide_hinge_adr: limited/slide/hinge jntadr
@@ -1372,8 +1372,8 @@ class Model:
   has_sdf_geom: bool
   block_dim: BlockDim
   body_tree: tuple[wp.array(dtype=int), ...]
-  branch_bodies: wp.array(dtype=int)
-  branch_start: wp.array(dtype=int)
+  body_branches: wp.array(dtype=int)
+  body_branch_start: wp.array(dtype=int)
   mocap_bodyid: array("nmocap", int)
   body_fluid_ellipsoid: array("nbody", bool)
   jnt_limited_slide_hinge_adr: wp.array(dtype=int)


### PR DESCRIPTION
~~This PR changes the way we do tree traversal depending on tree topology.
In case where the kinematic tree is deep and narrow, the tree traversal is switched to a per branch traversal.~~

This PR changes the way we do tree traversal from a level approach to a per branch traversal.

Perf improvement on my RTX4080 (average of 5 runs):

| Environment               | Step time (main) | Step time (this PR) | Δ %     |
| ----------------------------- | --------------------- | ------------------------- | --------- |
AlohaPot                       |  691.5                 |   681                      |  1.5      |
ApptronikApolloFlat      |  674.6                 |   632                      |  6.3      |
ApptronikApolloHfield   |  3057.5               |  3032                     |  0.8      |
ApptronikApolloTerrain  |  1940.6              |  1889.4                   |  2.6     |
FrankaEmikaPanda      |  82.0                   |  72.1                      |  12.0   |
Humanoid                     |  474.7                 |  462.7                    |  2.5      |
ThreeHumanoids          |  5951.5               |  5883.7                  |  1.1      |