### PR TITLE
make_constraint: traverse dof tree when constructing contact constraints and is sparse

### DIFF
--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -1218,6 +1218,7 @@ def _efc_contact_pyramidal(
   opt_impratio_invsqrt: wp.array(dtype=float),
   body_parentid: wp.array(dtype=int),
   body_rootid: wp.array(dtype=int),
+  body_weldid: wp.array(dtype=int),
   body_dofnum: wp.array(dtype=int),
   body_dofadr: wp.array(dtype=int),
   body_invweight0: wp.array2d(dtype=wp.vec2),
@@ -1308,10 +1309,10 @@ def _efc_contact_pyramidal(
       invweight = invweight * 2.0 * fri0 * fri0 * impratio_invsqrt * impratio_invsqrt
 
     Jqvel = float(0.0)
-    while body1 > 0 and body_dofnum[body1] == 0:
-      body1 = body_parentid[body1]
-    while body2 > 0 and body_dofnum[body2] == 0:
-      body2 = body_parentid[body2]
+
+    # skip fixed bodies
+    body1 = body_weldid[body1]
+    body2 = body_weldid[body2]
 
     da1 = body_dofadr[body1] + body_dofnum[body1] - 1
     da2 = body_dofadr[body2] + body_dofnum[body2] - 1
@@ -1415,6 +1416,7 @@ def _efc_contact_elliptic(
   opt_impratio_invsqrt: wp.array(dtype=float),
   body_parentid: wp.array(dtype=int),
   body_rootid: wp.array(dtype=int),
+  body_weldid: wp.array(dtype=int),
   body_dofnum: wp.array(dtype=int),
   body_dofadr: wp.array(dtype=int),
   body_invweight0: wp.array2d(dtype=wp.vec2),
@@ -1491,10 +1493,10 @@ def _efc_contact_elliptic(
     body2 = geom_bodyid[geom[1]]
 
     Jqvel = float(0.0)
-    while body1 > 0 and body_dofnum[body1] == 0:
-      body1 = body_parentid[body1]
-    while body2 > 0 and body_dofnum[body2] == 0:
-      body2 = body_parentid[body2]
+
+    # skip fixed bodies
+    body1 = body_weldid[body1]
+    body2 = body_weldid[body2]
 
     da1 = body_dofadr[body1] + body_dofnum[body1] - 1
     da2 = body_dofadr[body2] + body_dofnum[body2] - 1
@@ -1990,6 +1992,7 @@ def make_constraint(m: types.Model, d: types.Data):
             m.opt.impratio_invsqrt,
             m.body_parentid,
             m.body_rootid,
+            m.body_weldid,
             m.body_dofnum,
             m.body_dofadr,
             m.body_invweight0,
@@ -2038,6 +2041,7 @@ def make_constraint(m: types.Model, d: types.Data):
             m.opt.impratio_invsqrt,
             m.body_parentid,
             m.body_rootid,
+            m.body_weldid,
             m.body_dofnum,
             m.body_dofadr,
             m.body_invweight0,


### PR DESCRIPTION
this pr is part of the effort to implement sparse Jacobians #88

when `is_sparse==True`, instead of iterating over all dofs to construction contact constraints, traverse dof tree for each contact bodies

mujoco reference: https://github.com/google-deepmind/mujoco/blob/08b4b4144d70c69206f96cf329d5044ae686a1e6/src/engine/engine_core_util.c#L55

---

**humanoid**

performance for dense should be unchanged

```
mjwarp-testspeed ./benchmark/humanoid/humanoid.xml --nconmax=24 --njmax=64 --nworld=8192 --event_trace=True
```
this pr:
```
Summary for 8192 parallel rollouts

Total JIT time: 0.33 s
Total simulation time: 2.96 s
Total steps per second: 2,767,435
Total realtime factor: 13,837.18 x
Total time per step: 361.35 ns
Total converged worlds: 8192 / 8192

step: 359.65
  forward: 357.14
    fwd_position: 89.85
      kinematics: 16.37
      com_pos: 5.85
      camlight: 1.75
      flex: 0.17
      crb: 13.22
      tendon_armature: 0.17
      collision: 9.35
        nxn_broadphase: 3.71
        convex_narrowphase: 0.17
        primitive_narrowphase: 4.57
      make_constraint: 39.00
```

main (bb81495d036b7eb5bcd544a87bf57d07ab410218):
```
Total JIT time: 0.32 s
Total simulation time: 2.96 s
Total steps per second: 2,767,848
Total realtime factor: 13,839.24 x
Total time per step: 361.29 ns
Total converged worlds: 8192 / 8192

step: 359.55
  forward: 357.04
    fwd_position: 89.84
      kinematics: 16.36
      com_pos: 5.85
      camlight: 1.75
      flex: 0.17
      crb: 13.23
      tendon_armature: 0.17
      collision: 9.35
        nxn_broadphase: 3.71
        convex_narrowphase: 0.18
        primitive_narrowphase: 4.57
      make_constraint: 38.99
```

performance for sparse should be improved

```
mjwarp-testspeed ./benchmark/humanoid/humanoid.xml --nconmax=24 --njmax=64 --nworld=8192 --event_trace=True -o "opt.is_sparse=True"
```

this pr:
```
Total JIT time: 0.81 s
Total simulation time: 3.10 s
Total steps per second: 2,641,695
Total realtime factor: 13,208.47 x
Total time per step: 378.54 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 376.86
  forward: 374.33
    fwd_position: 77.87
      kinematics: 16.36
      com_pos: 5.84
      camlight: 1.74
      flex: 0.17
      crb: 9.98
      tendon_armature: 0.17
      collision: 9.34
        nxn_broadphase: 3.71
        convex_narrowphase: 0.17
        primitive_narrowphase: 4.57
      make_constraint: 30.65
```

main (bb81495d036b7eb5bcd544a87bf57d07ab410218):
```
Total JIT time: 0.25 s
Total simulation time: 3.17 s
Total steps per second: 2,586,971
Total realtime factor: 12,934.85 x
Total time per step: 386.55 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 384.86
  forward: 382.33
    fwd_position: 86.29
      kinematics: 16.36
      com_pos: 5.84
      camlight: 1.74
      flex: 0.17
      crb: 9.99
      tendon_armature: 0.17
      collision: 9.34
        nxn_broadphase: 3.71
        convex_narrowphase: 0.17
        primitive_narrowphase: 4.56
      make_constraint: 38.73
```

notes:
- performance should be further improved once `efc.J` is represented in a sparse format and it is not necessary to zero memory on each call to `make_constraint`
- replacing repeated code in `contact_pyramidal` and `contact_elliptic` with a `wp.func` introduced overhead? as a result, to maintain performance for now there is duplicated code in dense and sparse cases.

---

todo
- [ ] improve tree traversal performance with dense