### PR TITLE
Split CCD kernel generator into hfield/non-hfield generators

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -702,7 +702,6 @@ def ccd_hfield_kernel_builder(
   return ccd_hfield_kernel
 
 
-
 @cache_kernel
 def ccd_kernel_builder(
   geomtype1: int,


### PR DESCRIPTION
This works around issues that have been reported with cuda 12.4 that boil down to CUDA issues with graphs and large sets of kernel arguments. Splitting the 2 allows us to save some arguments, working around the issue.

This depends on the fact that heightfield-convex collisions don't do multiccd. I don't know whether that is never happening, or just does not exist yet.