### PR TITLE
Update flex benchmark parameters after quality(2023) (#938)

### DIFF
--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -60,7 +60,7 @@ class IOTest(parameterized.TestCase):
     EXPECTED_SIZES = {
       "pendula.xml": (48, 64),
       "collision_sdf/tactile.xml": (64, 256),
-      "flex/floppy.xml": (256, 512),
+      "flex/floppy.xml": (512, 1024),
       "actuation/tendon_force_limit.xml": (48, 64),
       "actuation/tendon_force_limit.xml": (48, 64),
       "hfield/hfield.xml": (96, 384),


### PR DESCRIPTION
## Summary
Updated flex benchmark expected sizes in `io_test.py` to reflect quality improvements from 2023.

## Details
- **Before:** `"flex/floppy.xml": (256, 512)`
- **After:** Updated values matching current quality(2023) implementation
- Verified against latest MuJoCo flex model expectations

## Testing
- Local CI tests pass ✅
- Benchmark sizes now match production flex models

**Closes #938**
