### PR TITLE
collision_gjk: remove norm2 array and compute inline

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -214,7 +214,6 @@ def ccd_kernel_builder(
     epa_vert_index2_in: wp.array2d(dtype=int),
     epa_face_in: wp.array2d(dtype=wp.vec3i),
     epa_pr_in: wp.array2d(dtype=wp.vec3),
-    epa_norm2_in: wp.array2d(dtype=float),
     epa_index_in: wp.array2d(dtype=int),
     epa_map_in: wp.array2d(dtype=int),
     epa_horizon_in: wp.array2d(dtype=int),
@@ -289,7 +288,6 @@ def ccd_kernel_builder(
       epa_vert_index2_in[tid],
       epa_face_in[tid],
       epa_pr_in[tid],
-      epa_norm2_in[tid],
       epa_index_in[tid],
       epa_map_in[tid],
       epa_horizon_in[tid],
@@ -440,7 +438,6 @@ def ccd_kernel_builder(
     epa_vert_index2_in: wp.array2d(dtype=int),
     epa_face_in: wp.array2d(dtype=wp.vec3i),
     epa_pr_in: wp.array2d(dtype=wp.vec3),
-    epa_norm2_in: wp.array2d(dtype=float),
     epa_index_in: wp.array2d(dtype=int),
     epa_map_in: wp.array2d(dtype=int),
     epa_horizon_in: wp.array2d(dtype=int),
@@ -588,7 +585,6 @@ def ccd_kernel_builder(
       epa_vert_index2 = epa_vert_index2_in[tid]
       epa_face = epa_face_in[tid]
       epa_pr = epa_pr_in[tid]
-      epa_norm2 = epa_norm2_in[tid]
       epa_index = epa_index_in[tid]
       epa_map = epa_map_in[tid]
       epa_horizon = epa_horizon_in[tid]
@@ -661,7 +657,6 @@ def ccd_kernel_builder(
               epa_vert_index2,
               epa_face,
               epa_pr,
-              epa_norm2,
               epa_index,
               epa_map,
               epa_horizon,
@@ -903,7 +898,6 @@ def ccd_kernel_builder(
         epa_vert_index2_in,
         epa_face_in,
         epa_pr_in,
-        epa_norm2_in,
         epa_index_in,
         epa_map_in,
         epa_horizon_in,
@@ -998,8 +992,6 @@ def convex_narrowphase(m: Model, d: Data):
   epa_face = wp.empty(shape=(d.naconmax, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=wp.vec3i)
   # epa_pr: projection of origin on polytope faces
   epa_pr = wp.empty(shape=(d.naconmax, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=wp.vec3)
-  # epa_norm2: epa_pr * epa_pr
-  epa_norm2 = wp.empty(shape=(d.naconmax, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=float)
   # epa_index: index of face in polytope map
   epa_index = wp.empty(shape=(d.naconmax, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=int)
   # epa_map: status of faces in polytope
@@ -1091,7 +1083,6 @@ def convex_narrowphase(m: Model, d: Data):
           epa_vert_index2,
           epa_face,
           epa_pr,
-          epa_norm2,
           epa_index,
           epa_map,
           epa_horizon,

--- a/mujoco_warp/_src/collision_gjk_test.py
+++ b/mujoco_warp/_src/collision_gjk_test.py
@@ -52,7 +52,6 @@ def _geom_dist(
   epa_vert_index2 = wp.empty(5 + m.opt.ccd_iterations, dtype=int)
   epa_face = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=wp.vec3i)
   epa_pr = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=wp.vec3)
-  epa_norm2 = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=float)
   epa_index = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=int)
   epa_map = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=int)
   epa_horizon = wp.empty(2 * MJ_MAX_EPAHORIZON, dtype=int)
@@ -101,7 +100,6 @@ def _geom_dist(
     vert_index2: wp.array(dtype=int),
     face: wp.array(dtype=wp.vec3i),
     face_pr: wp.array(dtype=wp.vec3),
-    face_norm2: wp.array(dtype=float),
     face_index: wp.array(dtype=int),
     face_map: wp.array(dtype=int),
     horizon: wp.array(dtype=int),
@@ -207,7 +205,6 @@ def _geom_dist(
       vert_index2,
       face,
       face_pr,
-      face_norm2,
       face_index,
       face_map,
       horizon,
@@ -279,7 +276,6 @@ def _geom_dist(
       epa_vert_index2,
       epa_face,
       epa_pr,
-      epa_norm2,
       epa_index,
       epa_map,
       epa_horizon,


### PR DESCRIPTION
improve EPA memory utilization by computing a dot product of 3-vectors inline instead of storing the result

**aloha_pot**

```
mjwarp-testspeed benchmark/aloha_pot/scene.xml --nconmax=24 --njmax=128
```

this pr
```
Summary for 8192 parallel rollouts

Total JIT time: 0.69 s
Total simulation time: 4.17 s
Total steps per second: 1,962,558
Total realtime factor: 3,925.12 x
Total time per step: 509.54 ns
Total converged worlds: 8192 / 8192
```

main (24e07def301f3c073d8bc0f948831c5611737ff0)
```
Summary for 8192 parallel rollouts

Total JIT time: 0.66 s
Total simulation time: 4.18 s
Total steps per second: 1,959,876
Total realtime factor: 3,919.75 x
Total time per step: 510.24 ns
Total converged worlds: 8192 / 8192
```

throughput remains about the same