### PR TITLE
check friction in `io.put_model`

### DIFF
--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -882,26 +882,27 @@ class CollisionTest(parameterized.TestCase):
     np.testing.assert_equal(d.nacon.numpy()[0], 4)
 
   def test_min_friction(self):
-    _, _, _, d = test_data.fixture(
-      xml="""
-    <mujoco>
-      <worldbody>
-        <body>
-          <geom type="sphere" size=".1" friction="0 0 0"/>
-          <joint type="slide"/>
-        </body>
-        <body>
-          <geom type="sphere" size=".1" friction="0 0 0"/>
-          <joint type="slide"/>
-        </body>
-      </worldbody>
-      <keyframe>
-        <key qpos="0 .1"/>
-      </keyframe>
-    </mujoco>
-    """,
-      keyframe=0,
-    )
+    with self.assertWarns(UserWarning):
+      _, _, _, d = test_data.fixture(
+        xml="""
+      <mujoco>
+        <worldbody>
+          <body>
+            <geom type="sphere" size=".1" friction="0 0 0"/>
+            <joint type="slide"/>
+          </body>
+          <body>
+            <geom type="sphere" size=".1" friction="0 0 0"/>
+            <joint type="slide"/>
+          </body>
+        </worldbody>
+        <keyframe>
+          <key qpos="0 .1"/>
+        </keyframe>
+      </mujoco>
+      """,
+        keyframe=0,
+      )
 
     self.assertEqual(d.nacon.numpy()[0], 1)
     np.testing.assert_allclose(d.contact.friction.numpy()[0], types.MJ_MINMU)

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -582,6 +582,43 @@ class IOTest(parameterized.TestCase):
 
     self.assertEqual(m.opt.contact_sensor_maxmatch, 5)
 
+  @parameterized.parameters(
+    '<worldbody><geom type="sphere" size=".1" condim="3" friction="0 0.1 0.1"/></worldbody>',
+    '<worldbody><geom type="sphere" size=".1" condim="4" friction="1 0 0.1"/></worldbody>',
+    '<worldbody><geom type="sphere" size=".1" condim="6" friction="1 1 0"/></worldbody>',
+    """
+      <worldbody>
+        <geom name="g1" type="sphere" size=".1"/>
+        <geom name="g2" type="sphere" size=".1" pos="0.5 0 0"/>
+      </worldbody>
+      <contact>
+        <pair geom1="g1" geom2="g2" condim="3" friction="0 1 1 1 1"/>
+      </contact>
+    """,
+    """
+      <worldbody>
+        <geom name="g1" type="sphere" size=".1"/>
+        <geom name="g2" type="sphere" size=".1" pos="0.5 0 0"/>
+      </worldbody>
+      <contact>
+        <pair geom1="g1" geom2="g2" condim="4" friction="1 0 0 1 1"/>
+      </contact>
+    """,
+    """
+      <worldbody>
+        <geom name="g1" type="sphere" size=".1"/>
+        <geom name="g2" type="sphere" size=".1" pos="0.5 0 0"/>
+      </worldbody>
+      <contact>
+        <pair geom1="g1" geom2="g2" condim="6" friction="1 1 1 0 0"/>
+      </contact>
+    """,
+  )
+  def test_small_friction_warning(self, xml):
+    """Tests that a warning is raised for small friction values."""
+    with self.assertWarns(UserWarning):
+      mjwarp.put_model(mujoco.MjModel.from_xml_string(f"<mujoco>{xml}</mujoco>"))
+
   @parameterized.product(active=["true", "false"], make_data=[True, False])
   def test_eq_active(self, active, make_data):
     mjm, mjd, m, d = test_data.fixture(


### PR DESCRIPTION
instead of silently overriding, provide a warning if small friction values are provided