### PR TITLE
Optimization: linesearch_prepare_gauss

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -738,20 +738,6 @@ def linesearch_jv_fused(nv: int, dofs_per_thread: int):
   return kernel
 
 
-@wp.kernel
-def linesearch_zero_quad_gauss(
-  # Data in:
-  efc_done_in: wp.array(dtype=bool),
-  # Data out:
-  efc_quad_gauss_out: wp.array(dtype=wp.vec3),
-):
-  """Zero quad_gauss array before atomic adds."""
-  worldid = wp.tid()
-  if efc_done_in[worldid]:
-    return
-  efc_quad_gauss_out[worldid] = wp.vec3(0.0, 0.0, 0.0)
-
-
 @cache_kernel
 def linesearch_prepare_gauss(nv: int, dofs_per_thread: int):
   @nested_kernel(module="unique", enable_backward=False)


### PR DESCRIPTION
Similar optimization as for solve_init_jaref.

The optimization is too minor to show up clearly on the benchmark result but it is clear on nsight:
With optimization
<img width="1399" height="18" alt="Screenshot from 2026-01-06 14-36-27" src="https://github.com/user-attachments/assets/11974bee-002e-40d2-a535-f56d79617c8e" />

Without optimization
<img width="1348" height="22" alt="Screenshot from 2026-01-06 14-38-43" src="https://github.com/user-attachments/assets/adc64c27-dae5-4d34-be2a-de06dae4e216" />


Results obtained running the following command:
```
python mujoco_warp/testspeed.py --function=step benchmark/humanoid/n_humanoid.xml --nworld=8192 --nstep=1000 --njmax=190 --nconmax=70 -o opt.ls_parallel=True
```