### PR TITLE
github ci concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     types: [ opened, reopened, synchronize, edited ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   format:
     name: Ruff format


### PR DESCRIPTION
this should enable currently running tests to continue instead of being canceled when more tests are scheduled, for example when a new pr is created or a pr is updated