### PR TITLE
`_fluid_force`: zero force for body with negligible mass

### DIFF
--- a/mujoco_warp/_src/passive.py
+++ b/mujoco_warp/_src/passive.py
@@ -296,6 +296,12 @@ def _fluid_force(
     fluid_applied_out[worldid, bodyid] = zero_force
     return
 
+  # skip bodies with negligible mass
+  mass = body_mass[worldid % body_mass.shape[0], bodyid]
+  if mass < MJ_MINVAL:
+    fluid_applied_out[worldid, bodyid] = zero_force
+    return
+
   wind = opt_wind[worldid % opt_wind.shape[0]]
   density = opt_density[worldid % opt_density.shape[0]]
   viscosity = opt_viscosity[worldid % opt_viscosity.shape[0]]


### PR DESCRIPTION
apply zero force to a body that has (very) small mass. this prevents division with a (very) small number than can lead to nans. 

mujoco reference https://github.com/google-deepmind/mujoco/blob/fa044fe0e53d728a0a242bcb5d2a5c7c2c4f4551/src/engine/engine_passive.c#L517

resolves #930