### PR TITLE
updates for benchmarks

### DIFF
--- a/benchmark/aloha_sdf/scene.xml
+++ b/benchmark/aloha_sdf/scene.xml
@@ -3,7 +3,7 @@
             texturedir="../../mujoco_warp/test_data/collision_sdf/asset" 
             meshdir="../aloha_pot"/>
   <option impratio="10" cone="elliptic" sdf_iterations="10" sdf_initpoints="20">
-    <flag multiccd="enable"/>
+    <!-- <flag multiccd="enable"/> --> TODO(team): enable multiccd
   </option>
   <visual>
     <global azimuth="90" elevation="-20" offwidth="848" offheight="480"/>

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -19,11 +19,13 @@ from mujoco_warp._src import benchmark
 class AlohaCloth(benchmark.BenchmarkSuite):
   """Aloha robot with a towel on the workbench."""
 
+  # TODO(team): update batch_size and nstep after sparsity lands
   path = "aloha_cloth/scene.xml"
   params = benchmark.BenchmarkSuite.params + ("step.euler",)
-  batch_size = 256
+  batch_size = 32
   nconmax = 920
-  njmax = 3606
+  njmax = 6200
+  nstep = 100
 
 
 class AlohaPot(benchmark.BenchmarkSuite):
@@ -80,11 +82,13 @@ class ApptronikApolloTerrain(benchmark.BenchmarkSuite):
 class Cloth(benchmark.BenchmarkSuite):
   """Draping of a cloth over the MuJoCo humanoid."""
 
+  # TODO(team): update batch_size and nstep after sparsity lands
   path = "cloth/scene.xml"
   params = benchmark.BenchmarkSuite.params + ("step.euler",)
-  batch_size = 256
+  batch_size = 32
   nconmax = 200
-  njmax = 600
+  njmax = 3000
+  nstep = 100
 
 
 class FrankaEmikaPanda(benchmark.BenchmarkSuite):
@@ -122,6 +126,7 @@ class ThreeHumanoids(benchmark.BenchmarkSuite):
 
 
 # attach a setup_cache to each test for one-time setup of benchmarks
+AlohaCloth.setup_cache = lambda s: benchmark.BenchmarkSuite.setup_cache(s)
 AlohaPot.setup_cache = lambda s: benchmark.BenchmarkSuite.setup_cache(s)
 AlohaSdf.setup_cache = lambda s: benchmark.BenchmarkSuite.setup_cache(s)
 ApptronikApolloFlat.setup_cache = lambda s: benchmark.BenchmarkSuite.setup_cache(s)


### PR DESCRIPTION
```
asv run benchmark^! --quick
```

```
Creating environments
· Discovering benchmarks
· Running 10 total benchmarks (1 commits * 1 environments * 10 benchmarks)
[ 0.00%] · For mujoco-warp commit 750dfadd <benchmark>:
[ 0.00%] ·· Benchmarking virtualenv-py3.13
[10.00%] ··· Setting up benchmark:127                                                                                                                                                                         ok
[10.00%] ··· benchmark.AlohaCloth.track_metric                                                                                                                                                                ok
[10.00%] ··· =============================================== ====================
                                 function                                        
             ----------------------------------------------- --------------------
                               jit_duration                   41.84777528204722  
                            solver_niter_mean                     3.8203125      
                             solver_niter_p95                        9.0         
                         device_memory_allocated                  3189768192     
                                   step                       315360.5614900589  
                               step.forward                   315195.2702999115  
                        step.forward.fwd_position             68332.70782232285  
                   step.forward.fwd_position.kinematics       206.26299921423197 
                    step.forward.fwd_position.com_pos         103.90900063794106 
                    step.forward.fwd_position.camlight        28.39500058325939  
                      step.forward.fwd_position.crb           93.49600068526343  
                step.forward.fwd_position.tendon_armature     3.967999989981763  
                   step.forward.fwd_position.collision         468.512000516057  
                step.forward.fwd_position.make_constraint     51499.57710504532  
                  step.forward.fwd_position.transmission       22.9210001998581  
                         step.forward.sensor_pos              3.8079999903857242 
                        step.forward.fwd_velocity              609.536009375006  
                    step.forward.fwd_velocity.com_vel         115.35000253934413 
                    step.forward.fwd_velocity.passive         188.5860018664971  
                      step.forward.fwd_velocity.rne           188.2170025492087  
                  step.forward.fwd_velocity.tendon_bias       4.3199999890930485 
                         step.forward.sensor_vel               4.15999998949701  
                        step.forward.fwd_actuation            32.66999960760586  
                      step.forward.fwd_acceleration           553.8759916089475  
              step.forward.fwd_acceleration.xfrc_accumulate   414.1589901410043  
                         step.forward.sensor_acc              4.511999988608295  
                            step.forward.solve                245610.59272289276 
                                step.euler                    150.65600431989878 
             =============================================== ====================

[20.00%] ··· Setting up benchmark:128                                                                                                                                                                         ok
[20.00%] ··· benchmark.AlohaPot.track_metric                                                                                                                                                                  ok
[20.00%] ··· =============================================== =====================
                                 function                                         
             ----------------------------------------------- ---------------------
                               jit_duration                    53.87157169403508  
                            solver_niter_mean                  2.4958387451171875 
                             solver_niter_p95                         5.0         
                         device_memory_allocated                   471859200      
                                   step                        527.4088908336125  
                               step.forward                    520.6608165462967  
                        step.forward.fwd_position              238.92150004394352 
                   step.forward.fwd_position.kinematics        35.213359027693514 
                    step.forward.fwd_position.com_pos           8.97287529642199  
                    step.forward.fwd_position.camlight         1.922874972478894  
                      step.forward.fwd_position.crb            10.427874892229738 
                step.forward.fwd_position.tendon_armature      0.1708749995685821 
                   step.forward.fwd_position.collision         164.73525046603754 
                step.forward.fwd_position.make_constraint      14.19975004682783  
                  step.forward.fwd_position.transmission       1.350617199818771  
                         step.forward.sensor_pos              0.18099999954301893 
                        step.forward.fwd_velocity              30.984093724327977 
                    step.forward.fwd_velocity.com_vel           8.95625028442737  
                    step.forward.fwd_velocity.passive          1.1643750174243905 
                      step.forward.fwd_velocity.rne            12.42324965824082  
                  step.forward.fwd_velocity.tendon_bias       0.17449999955942985 
                         step.forward.sensor_vel              0.17624999955501153 
                        step.forward.fwd_actuation             1.4611250386451502 
                      step.forward.fwd_acceleration            7.571624859338044  
              step.forward.fwd_acceleration.xfrc_accumulate    2.038343757931216  
                         step.forward.sensor_acc              0.17449999955942985 
                            step.forward.solve                 239.36637475708267 
                                step.euler                     6.2209998332036776 
             =============================================== =====================

[30.00%] ··· Setting up benchmark:129                                                                                                                                                                         ok
[30.00%] ··· benchmark.AlohaSdf.track_metric                                                                                                                                                                  ok
[30.00%] ··· =============================================== =====================
                                 function                                         
             ----------------------------------------------- ---------------------
                               jit_duration                    59.835619390010834 
                            solver_niter_mean                  3.502753173828125  
                             solver_niter_p95                         5.0         
                         device_memory_allocated                   572522496      
                                   step                        2185.112777282484  
                               step.forward                    2178.7517295451835 
                        step.forward.fwd_position              1457.5403509661555 
                   step.forward.fwd_position.kinematics        23.91382445784984  
                    step.forward.fwd_position.com_pos          7.044875110295834  
                    step.forward.fwd_position.camlight         1.9119999655003994 
                      step.forward.fwd_position.crb             9.47562487635878  
                step.forward.fwd_position.tendon_armature      0.178249999549962  
                   step.forward.fwd_position.collision         1378.3395013888367 
                step.forward.fwd_position.make_constraint       33.4501250026733  
                  step.forward.fwd_position.transmission       1.2896249983214148 
                         step.forward.sensor_pos              0.17499999955816747 
                        step.forward.fwd_velocity              29.626547078805743 
                    step.forward.fwd_velocity.com_vel          8.751750234296196  
                    step.forward.fwd_velocity.passive          1.1708750135994705 
                      step.forward.fwd_velocity.rne            11.139875133267196 
                  step.forward.fwd_velocity.tendon_bias       0.17474999955879866 
                         step.forward.sensor_vel              0.17224999956511056 
                        step.forward.fwd_actuation             1.523125039284423  
                      step.forward.fwd_acceleration            6.511249930554186  
              step.forward.fwd_acceleration.xfrc_accumulate    1.584824220117298  
                         step.forward.sensor_acc              0.17862499954901523 
                            step.forward.solve                 681.1913749224914  
                                step.euler                     5.823250147841463  
             =============================================== =====================

[40.00%] ··· Setting up benchmark:130                                                                                                                                                                         ok
[40.00%] ··· benchmark.ApptronikApolloFlat.track_metric                                                                                                                                                       ok
[40.00%] ··· =============================================== =====================
                                 function                                         
             ----------------------------------------------- ---------------------
                               jit_duration                    46.12106825102819  
                            solver_niter_mean                  2.9755540771484377 
                             solver_niter_p95                         5.0         
                         device_memory_allocated                   371195904      
                                   step                        514.4799649715424  
                               step.forward                    512.1298204467166  
                        step.forward.fwd_position              102.75849595927866 
                   step.forward.fwd_position.kinematics        35.59221850082395  
                    step.forward.fwd_position.com_pos          9.532374787340814  
                    step.forward.fwd_position.camlight         1.7460000160554046 
                      step.forward.fwd_position.crb            16.698624660421046 
                step.forward.fwd_position.tendon_armature     0.17462499955911426 
                   step.forward.fwd_position.collision         7.136374933907064  
                step.forward.fwd_position.make_constraint      27.666749907439225 
                  step.forward.fwd_position.transmission       2.2957031175110387 
                         step.forward.sensor_pos               2.0321484438454718 
                        step.forward.fwd_velocity              40.450632379361195 
                    step.forward.fwd_velocity.com_vel          11.296500179014402 
                    step.forward.fwd_velocity.passive          1.1892500034491604 
                      step.forward.fwd_velocity.rne            17.06087494494568  
                  step.forward.fwd_velocity.tendon_bias       0.17362499956163902 
                         step.forward.sensor_vel               0.9026250087913468 
                        step.forward.fwd_actuation             1.776000008817391  
                      step.forward.fwd_acceleration            14.759500336367637 
              step.forward.fwd_acceleration.xfrc_accumulate    2.915746162443611  
                         step.forward.sensor_acc               24.79537471481308  
                            step.forward.solve                 322.55524990614504 
                                step.euler                     1.8308749807829372 
             =============================================== =====================

[50.00%] ··· Setting up benchmark:131                                                                                                                                                                         ok
[50.00%] ··· benchmark.ApptronikApolloHfield.track_metric                                                                                                                                                     ok
[50.00%] ··· =============================================== ====================
                                 function                                        
             ----------------------------------------------- --------------------
                               jit_duration                   75.40779126802227  
                            solver_niter_mean                 5.390408081054687  
                             solver_niter_p95                        8.0         
                         device_memory_allocated                  471859200      
                                   step                       912.3725123354234  
                               step.forward                   909.9872688530013  
                        step.forward.fwd_position             361.3068091508467  
                   step.forward.fwd_position.kinematics       35.146952759532724 
                    step.forward.fwd_position.com_pos         9.519874814031937  
                    step.forward.fwd_position.camlight        1.7555000147240207 
                      step.forward.fwd_position.crb           16.68924965451879  
                step.forward.fwd_position.tendon_armature     0.1758749995559583 
                   step.forward.fwd_position.collision        266.32650032115635 
                step.forward.fwd_position.make_constraint     27.179374894330977 
                  step.forward.fwd_position.transmission      2.6014999914423242 
                         step.forward.sensor_pos              2.023050780962876  
                        step.forward.fwd_velocity             40.77824988416978  
                    step.forward.fwd_velocity.com_vel         11.618750274465128 
                    step.forward.fwd_velocity.passive         1.1801250083181003 
                      step.forward.fwd_velocity.rne           17.113249850808643 
                  step.forward.fwd_velocity.tendon_bias       0.1734999995619546 
                         step.forward.sensor_vel              0.9161250072224902 
                        step.forward.fwd_actuation            1.780000006760929  
                      step.forward.fwd_acceleration           14.757750341232168 
              step.forward.fwd_acceleration.xfrc_accumulate   2.8542695815758634 
                         step.forward.sensor_acc              24.785374698694795 
                            step.forward.solve                461.63037451333366 
                                step.euler                    1.8573749701999986 
             =============================================== ====================

[60.00%] ··· Setting up benchmark:132                                                                                                                                                                         ok
[60.00%] ··· benchmark.ApptronikApolloTerrain.track_metric                                                                                                                                                    ok
[60.00%] ··· =============================================== =====================
                                 function                                         
             ----------------------------------------------- ---------------------
                               jit_duration                    30.046620265988167 
                            solver_niter_mean                  2.973789794921875  
                             solver_niter_p95                         5.0         
                         device_memory_allocated                   2753560576     
                                   step                        1409.319162950851  
                               step.forward                    1406.7667578347027 
                        step.forward.fwd_position              905.2552263019606  
                   step.forward.fwd_position.kinematics         59.4060313742375  
                    step.forward.fwd_position.com_pos          10.709249987485236 
                    step.forward.fwd_position.camlight         1.9406249753046723 
                      step.forward.fwd_position.crb            18.734125262199086 
                step.forward.fwd_position.tendon_armature     0.17862499954901523 
                   step.forward.fwd_position.collision         772.5008750567213  
                step.forward.fwd_position.make_constraint      37.307750035324716 
                  step.forward.fwd_position.transmission       2.4574140020376944 
                         step.forward.sensor_pos                2.13245315990207  
                        step.forward.fwd_velocity              45.20298848365201  
                    step.forward.fwd_velocity.com_vel          12.913374824165658 
                    step.forward.fwd_velocity.passive          1.299124985052913  
                      step.forward.fwd_velocity.rne            18.876875003115856 
                  step.forward.fwd_velocity.tendon_bias       0.18112499954270334 
                         step.forward.sensor_vel               1.0025000017321872 
                        step.forward.fwd_actuation             1.9783749876296497 
                      step.forward.fwd_acceleration            16.09387466669432  
              step.forward.fwd_acceleration.xfrc_accumulate    3.201132761205372  
                         step.forward.sensor_acc               26.82237493536377  
                            step.forward.solve                 406.0497496393509  
                                step.euler                     2.0084999978280393 
             =============================================== =====================

[70.00%] ··· Setting up benchmark:133                                                                                                                                                                         ok
[70.00%] ··· benchmark.Cloth.track_metric                                                                                                                                                                     ok
[70.00%] ··· =============================================== ====================
                                 function                                        
             ----------------------------------------------- --------------------
                               jit_duration                   15.063644757959992 
                            solver_niter_mean                      14.2275       
                             solver_niter_p95                        37.0        
                         device_memory_allocated                  2048917504     
                                   step                       262367.77633428574 
                               step.forward                   262222.7200269699  
                        step.forward.fwd_position             51076.78884267807  
                   step.forward.fwd_position.kinematics       139.6470005856827  
                    step.forward.fwd_position.com_pos         92.86400157725438  
                    step.forward.fwd_position.camlight        30.11200022592675  
                      step.forward.fwd_position.crb           77.34400185290724  
                step.forward.fwd_position.tendon_armature     4.511999988608295  
                   step.forward.fwd_position.collision        254.68799308873713 
                step.forward.fwd_position.make_constraint     34442.975878715515 
                  step.forward.fwd_position.transmission      4.3199999890930485 
                         step.forward.sensor_pos              4.287999989173841  
                        step.forward.fwd_velocity             452.0960017107427  
                    step.forward.fwd_velocity.com_vel         79.51999944634736  
                    step.forward.fwd_velocity.passive         195.16799715347588 
                      step.forward.fwd_velocity.rne           150.7200034102425  
                  step.forward.fwd_velocity.tendon_bias       4.543999988527503  
                         step.forward.sensor_vel              4.287999989173841  
                        step.forward.fwd_actuation             9.9200003023725   
                      step.forward.fwd_acceleration           547.2000129520893  
              step.forward.fwd_acceleration.xfrc_accumulate   425.79198628664017 
                         step.forward.sensor_acc              4.351999989012256  
                            step.forward.solve                210079.93692159653 
                                step.euler                    131.6799980122596  
             =============================================== ====================

[80.00%] ··· Setting up benchmark:134                                                                                                                                                                         ok
[80.00%] ··· benchmark.FrankaEmikaPanda.track_metric                                                                                                                                                          ok
[80.00%] ··· =============================================== ======================
                                 function                                          
             ----------------------------------------------- ----------------------
                               jit_duration                    62.380208485992625  
                            solver_niter_mean                  1.106642852783203   
                             solver_niter_p95                         2.0          
                         device_memory_allocated                   337641472       
                                   step                        60.923325283511076  
                               step.forward                     56.8775604115217   
                        step.forward.fwd_position              23.351010831902386  
                   step.forward.fwd_position.kinematics        12.81446388020413   
                    step.forward.fwd_position.com_pos          3.360687500844506   
                    step.forward.fwd_position.camlight         0.3205312466434407  
                      step.forward.fwd_position.crb            4.136374924655684   
                step.forward.fwd_position.tendon_armature     0.044156249888516186 
                   step.forward.fwd_position.collision         0.9044375161693097  
                step.forward.fwd_position.make_constraint      0.9268437511877892  
                  step.forward.fwd_position.transmission       0.3632812585863121  
                         step.forward.sensor_pos              0.04324999989080425  
                        step.forward.fwd_velocity              13.005220672312134  
                    step.forward.fwd_velocity.com_vel          3.6342188236631046  
                    step.forward.fwd_velocity.passive         0.32124999506777385  
                      step.forward.fwd_velocity.rne            4.720812602954538   
                  step.forward.fwd_velocity.tendon_bias       0.04384374988930517  
                         step.forward.sensor_vel              0.04309374989119874  
                        step.forward.fwd_actuation            0.45618749601317177  
                      step.forward.fwd_acceleration            2.335875084554573   
              step.forward.fwd_acceleration.xfrc_accumulate    0.511331057168718   
                         step.forward.sensor_acc               0.0444687498877272  
                            step.forward.solve                 17.13959363041795   
                              step.implicit                    3.913125064173073   
             =============================================== ======================

[90.00%] ··· Setting up benchmark:135                                                                                                                                                                         ok
[90.00%] ··· benchmark.Humanoid.track_metric                                                                                                                                                                  ok
[90.00%] ··· =============================================== =====================
                                 function                                         
             ----------------------------------------------- ---------------------
                               jit_duration                    23.453355169971474 
                            solver_niter_mean                  1.4483133544921876 
                             solver_niter_p95                         3.0         
                         device_memory_allocated                   304087040      
                                   step                        362.3418007919099  
                               step.forward                    359.81541422370356 
                        step.forward.fwd_position              90.30605477892095  
                   step.forward.fwd_position.kinematics        16.724433338822564 
                    step.forward.fwd_position.com_pos          5.935250128004554  
                    step.forward.fwd_position.camlight         1.808874991183984  
                      step.forward.fwd_position.crb            13.265249943287927 
                step.forward.fwd_position.tendon_armature     0.17687499955343355 
                   step.forward.fwd_position.collision          9.36774975298249  
                step.forward.fwd_position.make_constraint      38.81387479759724  
                  step.forward.fwd_position.transmission       2.291953150916015  
                         step.forward.sensor_pos               0.1733749995622702 
                        step.forward.fwd_velocity              29.79537484679895  
                    step.forward.fwd_velocity.com_vel          7.788374908159312  
                    step.forward.fwd_velocity.passive          1.2372499791126756 
                      step.forward.fwd_velocity.rne            8.854625269123062  
                  step.forward.fwd_velocity.tendon_bias       0.17137499956731972 
                         step.forward.sensor_vel              0.17949999954680607 
                        step.forward.fwd_actuation             1.9999999949504854 
                      step.forward.fwd_acceleration            13.579625049715105 
              step.forward.fwd_acceleration.xfrc_accumulate    1.566835948096923  
                         step.forward.sensor_acc              0.17449999955942985 
                            step.forward.solve                 221.72425007011043 
                                step.euler                     1.9992499946965836 
             =============================================== =====================

[100.00%] ··· Setting up benchmark:136                                                                                                                                                                         ok
[100.00%] ··· benchmark.ThreeHumanoids.track_metric                                                                                                                                                            ok
[100.00%] ··· =============================================== ====================
                                  function                                        
              ----------------------------------------------- --------------------
                                jit_duration                   26.470991178997792 
                             solver_niter_mean                  2.5987021484375   
                              solver_niter_p95                        4.0         
                          device_memory_allocated                  203423744      
                                    step                       4764.920191140845  
                                step.forward                   4596.033161273226  
                         step.forward.fwd_position             511.86034342390485 
                    step.forward.fwd_position.kinematics       74.27519022894558  
                     step.forward.fwd_position.com_pos         28.35500038236205  
                     step.forward.fwd_position.camlight        11.461000240160502 
                       step.forward.fwd_position.crb           36.84700117082684  
                 step.forward.fwd_position.tendon_armature     1.4139999964299932 
                    step.forward.fwd_position.collision        48.79999965487514  
                 step.forward.fwd_position.make_constraint     287.09299965703394 
                   step.forward.fwd_position.transmission      8.283187567485584  
                          step.forward.sensor_pos              1.3889999964931121 
                         step.forward.fwd_velocity             146.2170015729498  
                     step.forward.fwd_velocity.com_vel         42.424999810464215 
                     step.forward.fwd_velocity.passive         8.742000223719515  
                       step.forward.fwd_velocity.rne           48.798999734572135 
                   step.forward.fwd_velocity.tendon_bias       1.4039999964552408 
                          step.forward.sensor_vel              1.4149999964274684 
                         step.forward.fwd_actuation            13.773000084256637 
                       step.forward.fwd_acceleration           168.6680010461714  
               step.forward.fwd_acceleration.xfrc_accumulate   13.729406323363946 
                          step.forward.sensor_acc              1.4109999964375675 
                             step.forward.solve                3736.2899967702106 
                                 step.euler                    164.72499950032216 
              =============================================== ====================
```

resolves #987