### PR TITLE
Remove epa_pr

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -236,7 +236,6 @@ def ccd_hfield_kernel_builder(
     epa_vert_index1_in: wp.array2d(dtype=int),
     epa_vert_index2_in: wp.array2d(dtype=int),
     epa_face_in: wp.array2d(dtype=int),
-    epa_pr_in: wp.array2d(dtype=wp.vec3),
     epa_norm2_in: wp.array2d(dtype=float),
     epa_horizon_in: wp.array2d(dtype=int),
     # Data out:
@@ -380,7 +379,6 @@ def ccd_hfield_kernel_builder(
     epa_vert_index1 = epa_vert_index1_in[tid]
     epa_vert_index2 = epa_vert_index2_in[tid]
     epa_face = epa_face_in[tid]
-    epa_pr = epa_pr_in[tid]
     epa_norm2 = epa_norm2_in[tid]
     epa_horizon = epa_horizon_in[tid]
 
@@ -461,7 +459,6 @@ def ccd_hfield_kernel_builder(
             epa_vert_index1,
             epa_vert_index2,
             epa_face,
-            epa_pr,
             epa_norm2,
             epa_horizon,
           )
@@ -720,7 +717,6 @@ def ccd_kernel_builder(
     epa_vert_index1_in: wp.array2d(dtype=int),
     epa_vert_index2_in: wp.array2d(dtype=int),
     epa_face_in: wp.array2d(dtype=int),
-    epa_pr_in: wp.array2d(dtype=wp.vec3),
     epa_norm2_in: wp.array2d(dtype=float),
     epa_horizon_in: wp.array2d(dtype=int),
     multiccd_polygon_in: wp.array2d(dtype=wp.vec3),
@@ -792,7 +788,6 @@ def ccd_kernel_builder(
       epa_vert_index1_in[tid],
       epa_vert_index2_in[tid],
       epa_face_in[tid],
-      epa_pr_in[tid],
       epa_norm2_in[tid],
       epa_horizon_in[tid],
     )
@@ -933,7 +928,6 @@ def ccd_kernel_builder(
     epa_vert_index1_in: wp.array2d(dtype=int),
     epa_vert_index2_in: wp.array2d(dtype=int),
     epa_face_in: wp.array2d(dtype=int),
-    epa_pr_in: wp.array2d(dtype=wp.vec3),
     epa_norm2_in: wp.array2d(dtype=float),
     epa_horizon_in: wp.array2d(dtype=int),
     multiccd_polygon_in: wp.array2d(dtype=wp.vec3),
@@ -1031,7 +1025,6 @@ def ccd_kernel_builder(
       epa_vert_index1_in,
       epa_vert_index2_in,
       epa_face_in,
-      epa_pr_in,
       epa_norm2_in,
       epa_horizon_in,
       multiccd_polygon_in,
@@ -1150,8 +1143,6 @@ def convex_narrowphase(m: Model, d: Data):
   epa_vert_index2 = wp.empty(shape=(d.naconmax, 5 + epa_iterations), dtype=int)
   # epa_face: faces of polytope represented by three indices
   epa_face = wp.empty(shape=(d.naconmax, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=int)
-  # epa_pr: projection of origin on polytope faces
-  epa_pr = wp.empty(shape=(d.naconmax, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=wp.vec3)
   # epa_norm2: epa_pr * epa_pr
   epa_norm2 = wp.empty(shape=(d.naconmax, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=float)
   # epa_horizon: index pair (i j) of edges on horizon
@@ -1235,7 +1226,6 @@ def convex_narrowphase(m: Model, d: Data):
           epa_vert_index1,
           epa_vert_index2,
           epa_face,
-          epa_pr,
           epa_norm2,
           epa_horizon,
         ],
@@ -1320,7 +1310,6 @@ def convex_narrowphase(m: Model, d: Data):
           epa_vert_index1,
           epa_vert_index2,
           epa_face,
-          epa_pr,
           epa_norm2,
           epa_horizon,
           multiccd_polygon,

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -933,7 +933,6 @@ def _epa_witness(
 def _polytope2(
   # In:
   pt: Polytope,
-  dist: float,
   simplex: mat43,
   simplex1: mat43,
   simplex2: mat43,
@@ -1116,16 +1115,11 @@ def _polytope3(
 def _polytope4(
   # In:
   pt: Polytope,
-  dist: float,
   simplex: mat43,
   simplex1: mat43,
   simplex2: mat43,
   simplex_index1: wp.vec4i,
   simplex_index2: wp.vec4i,
-  geom1: Geom,
-  geom2: Geom,
-  geomtype1: int,
-  geomtype2: int,
 ) -> Tuple[Polytope, GJKResult]:
   """Create polytope for EPA given a 3-simplex from GJK."""
   pt.vert1[0] = simplex1[0]
@@ -2306,7 +2300,6 @@ def ccd(
   if result.dim == 2:
     pt, new_result = _polytope2(
       pt,
-      result.dist,
       result.simplex,
       result.simplex1,
       result.simplex2,
@@ -2327,16 +2320,11 @@ def ccd(
   elif result.dim == 4:
     pt, new_result = _polytope4(
       pt,
-      result.dist,
       result.simplex,
       result.simplex1,
       result.simplex2,
       result.simplex_index1,
       result.simplex_index2,
-      geom1,
-      geom2,
-      geomtype1,
-      geomtype2,
     )
     if pt.status == -1:
       result.simplex = new_result.simplex

--- a/mujoco_warp/_src/collision_gjk_test.py
+++ b/mujoco_warp/_src/collision_gjk_test.py
@@ -50,7 +50,6 @@ def _geom_dist(
   epa_vert_index1 = wp.empty(5 + m.opt.ccd_iterations, dtype=int)
   epa_vert_index2 = wp.empty(5 + m.opt.ccd_iterations, dtype=int)
   epa_face = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=int)
-  epa_pr = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=wp.vec3)
   epa_norm2 = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=float)
   epa_horizon = wp.empty(2 * MJ_MAX_EPAHORIZON, dtype=int)
   multiccd_polygon = wp.empty(2 * nmaxpolygon, dtype=wp.vec3)
@@ -96,7 +95,6 @@ def _geom_dist(
     vert_index1: wp.array(dtype=int),
     vert_index2: wp.array(dtype=int),
     face: wp.array(dtype=int),
-    face_pr: wp.array(dtype=wp.vec3),
     face_norm2: wp.array(dtype=float),
     horizon: wp.array(dtype=int),
     polygon: wp.array(dtype=wp.vec3),
@@ -199,7 +197,6 @@ def _geom_dist(
       vert_index1,
       vert_index2,
       face,
-      face_pr,
       face_norm2,
       horizon,
     )
@@ -268,7 +265,6 @@ def _geom_dist(
       epa_vert_index1,
       epa_vert_index2,
       epa_face,
-      epa_pr,
       epa_norm2,
       epa_horizon,
       multiccd_polygon,


### PR DESCRIPTION
DO NOT MERGE (needs further benchmarking)

mjwarp-testspeed benchmark/aloha_pot/scene.xml --nconmax=24 --njmax=128 --event_trace --memory

Before:

```
Summary for 8192 parallel rollouts

Total JIT time: 0.89 s
Total simulation time: 4.23 s
Total steps per second: 1,938,721
Total realtime factor: 3,877.44 x
Total time per step: 515.80 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 513.39
  forward: 506.49
    fwd_position: 238.21
      kinematics: 34.60
      com_pos: 8.99
      camlight: 1.86
      flex: 0.18
      crb: 10.23
      tendon_armature: 0.19
      collision: 162.63
        nxn_broadphase: 84.31
        convex_narrowphase: 75.09
        primitive_narrowphase: 2.24
      make_constraint: 16.21
      transmission: 1.36
    sensor_pos: 0.18
    fwd_velocity: 30.68
      com_vel: 8.88
      passive: 1.14
      rne: 12.29
      tendon_bias: 0.19
    sensor_vel: 0.19
    fwd_actuation: 1.46
    fwd_acceleration: 7.54
      xfrc_accumulate: 2.00
    solve: 226.10
      mul_m: 2.56
    sensor_acc: 0.18
  euler: 6.30

Model memory 5.38 MB (0.36% of used memory):
 (no field >= 1% of used memory)
Data memory 427.43 MB (28.46% of used memory):
 geom_xpos: 19.12 MB (1.27%)
 geom_xmat: 57.38 MB (3.82%)
 qM: 18.00 MB (1.20%)
 qLD: 16.53 MB (1.10%)
 efc.J: 96.00 MB (6.39%)
Other memory: 1069.19 MB (71.18% of used memory)
Total memory: 1502.00 MB (3.10% of total device memory)

```

After:

```
Summary for 8192 parallel rollouts

Total JIT time: 0.90 s
Total simulation time: 4.22 s
Total steps per second: 1,939,639
Total realtime factor: 3,879.28 x
Total time per step: 515.56 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 513.36
  forward: 506.49
    fwd_position: 239.93
      kinematics: 34.67
      com_pos: 8.99
      camlight: 1.86
      flex: 0.18
      crb: 10.22
      tendon_armature: 0.19
      collision: 164.55
        nxn_broadphase: 84.36
        convex_narrowphase: 76.99
        primitive_narrowphase: 2.24
      make_constraint: 16.02
      transmission: 1.34
    sensor_pos: 0.18
    fwd_velocity: 30.62
      com_vel: 8.87
      passive: 1.13
      rne: 12.28
      tendon_bias: 0.18
    sensor_vel: 0.18
    fwd_actuation: 1.45
    fwd_acceleration: 7.52
      xfrc_accumulate: 2.00
    solve: 224.49
      mul_m: 2.53
    sensor_acc: 0.18
  euler: 6.27

Model memory 5.38 MB (0.50% of used memory):
 (no field >= 1% of used memory)
Data memory 427.43 MB (39.36% of used memory):
 geom_xpos: 19.12 MB (1.76%)
 geom_xmat: 57.38 MB (5.28%)
 qM: 18.00 MB (1.66%)
 qLD: 16.53 MB (1.52%)
 efc.J: 96.00 MB (8.84%)
 efc.quad: 12.00 MB (1.10%)
Other memory: 653.19 MB (60.15% of used memory)
Total memory: 1086.00 MB (2.24% of total device memory)

```