### PR TITLE
Fix sphere GJK support function returning center instead of surface point.

### DIFF
--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -92,7 +92,7 @@ def support(geom: Geom, geomtype: int, dir: wp.vec3) -> SupportPoint:
   sp.cached_index = -1
   sp.vertex_index = -1
   if geomtype == GeomType.SPHERE:
-    sp.point = geom.pos + (0.5 * geom.margin) * geom.size[0] * dir
+    sp.point = geom.pos + (geom.size[0] + 0.5 * geom.margin) * dir
     return sp
 
   local_dir = wp.transpose(geom.rot) @ dir


### PR DESCRIPTION
The sphere support was `pos + (0.5 * margin) * size[0] * dir`, which returns the sphere center when margin=0. Fixed to `pos + size[0] * dir` with margin handled at function end like other geom types.

**Before**

<img width="2532" height="1203" alt="Screenshot From 2026-01-14 13-24-16" src="https://github.com/user-attachments/assets/409ea169-6ba3-4e71-bf7e-8b70491b943f" />

**After**

<img width="2532" height="1203" alt="Screenshot From 2026-01-14 13-36-29" src="https://github.com/user-attachments/assets/7c762408-dac3-43ac-a0b5-dc9cf6a18e14" />
