### PR TITLE
Remove support for Warp < 1.11 in block cholesky.

### DIFF
--- a/mujoco_warp/_src/block_cholesky.py
+++ b/mujoco_warp/_src/block_cholesky.py
@@ -32,9 +32,6 @@ def create_blocked_cholesky_func(block_size: int):
 
     It returns a lower-triangular matrix L such that A = L L^T.
     """
-    # TODO(team): remove conditional after mjwarp relies on >= 1.11
-    bleeding_edge_warp = wp.static(tuple(map(int, wp.__version__.split(".")[:2])) >= (1, 11))
-
     # Process the matrix in blocks along its leading dimension.
     for k in range(0, matrix_size, block_size):
       end = k + block_size
@@ -45,10 +42,7 @@ def create_blocked_cholesky_func(block_size: int):
 
       for j in range(0, k, block_size):
         L_block = wp.tile_load(L, shape=(block_size, block_size), offset=(k, j), storage="shared")
-        if bleeding_edge_warp:
-          wp.tile_matmul(L_block, wp.tile_transpose(L_block), A_kk_tile, alpha=-1.0)
-        else:
-          A_kk_tile -= wp.tile_matmul(L_block, wp.tile_transpose(L_block))
+        wp.tile_matmul(L_block, wp.tile_transpose(L_block), A_kk_tile, alpha=-1.0)
 
       # Compute the Cholesky factorization for the block
       L_kk_tile = wp.tile_cholesky(A_kk_tile)
@@ -61,15 +55,9 @@ def create_blocked_cholesky_func(block_size: int):
         for j in range(0, k, block_size):
           L_tile = wp.tile_load(L, shape=(block_size, block_size), offset=(i, j), storage="shared")
           L_2_tile = wp.tile_load(L, shape=(block_size, block_size), offset=(k, j), storage="shared")
-          if bleeding_edge_warp:
-            wp.tile_matmul(L_tile, wp.tile_transpose(L_2_tile), A_ik_tile, alpha=-1.0)
-          else:
-            A_ik_tile -= wp.tile_matmul(L_tile, wp.tile_transpose(L_2_tile))
+          wp.tile_matmul(L_tile, wp.tile_transpose(L_2_tile), A_ik_tile, alpha=-1.0)
 
-        if bleeding_edge_warp:
-          wp.tile_lower_solve_inplace(L_kk_tile, wp.tile_transpose(A_ik_tile))
-        else:
-          A_ik_tile = wp.tile_transpose(wp.tile_lower_solve(L_kk_tile, wp.tile_transpose(A_ik_tile)))
+        wp.tile_lower_solve_inplace(L_kk_tile, wp.tile_transpose(A_ik_tile))
         wp.tile_store(L, A_ik_tile, offset=(i, k))
 
   return blocked_cholesky_func
@@ -91,8 +79,6 @@ def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int)
     Solves A x = b given the Cholesky factor L (A = L L^T) using blocked forward and backward
     substitution.
     """
-    # TODO(team): remove conditional after mjwarp relies on >= 1.11
-    bleeding_edge_warp = wp.static(tuple(map(int, wp.__version__.split(".")[:2])) >= (1, 11))
     rhs_tile = wp.tile_load(b, shape=(matrix_size_static, 1), offset=(0, 0), storage="shared", bounds_check=False)
 
     # Forward substitution: solve L y = b
@@ -101,17 +87,10 @@ def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int)
       for j in range(0, i, block_size):
         L_block = wp.tile_load(L, shape=(block_size, block_size), offset=(i, j), storage="shared")
         y_block = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(j, 0))
-        if bleeding_edge_warp:
-          wp.tile_matmul(L_block, y_block, rhs_view, alpha=-1.0)
-        else:
-          rhs_view -= wp.tile_matmul(L_block, y_block)
+        wp.tile_matmul(L_block, y_block, rhs_view, alpha=-1.0)
 
       L_tile = wp.tile_load(L, shape=(block_size, block_size), offset=(i, i), storage="shared")
-      if bleeding_edge_warp:
-        wp.tile_lower_solve_inplace(L_tile, rhs_view)
-      else:
-        rhs_tmp = wp.tile_lower_solve(L_tile, rhs_view)
-        wp.tile_assign(rhs_tile, rhs_tmp, offset=(i, 0))
+      wp.tile_lower_solve_inplace(L_tile, rhs_view)
 
     # Backward substitution: solve L^T x = y
     for i in range(matrix_size - block_size, -1, -block_size):
@@ -120,16 +99,10 @@ def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int)
       for j in range(i_end, matrix_size, block_size):
         L_tile = wp.tile_load(L, shape=(block_size, block_size), offset=(j, i), storage="shared")
         x_tile = wp.tile_load(x, shape=(block_size, 1), offset=(j, 0), storage="shared", bounds_check=False)
-        if bleeding_edge_warp:
-          wp.tile_matmul(wp.tile_transpose(L_tile), x_tile, tmp_tile, alpha=-1.0)
-        else:
-          tmp_tile -= wp.tile_matmul(wp.tile_transpose(L_tile), x_tile)
+        wp.tile_matmul(wp.tile_transpose(L_tile), x_tile, tmp_tile, alpha=-1.0)
       L_tile = wp.tile_load(L, shape=(block_size, block_size), offset=(i, i), storage="shared")
 
-      if bleeding_edge_warp:
-        wp.tile_upper_solve_inplace(wp.tile_transpose(L_tile), tmp_tile)
-      else:
-        tmp_tile = wp.tile_upper_solve(wp.tile_transpose(L_tile), tmp_tile)
+      wp.tile_upper_solve_inplace(wp.tile_transpose(L_tile), tmp_tile)
       wp.tile_store(x, tmp_tile, offset=(i, 0), bounds_check=False)
 
   return blocked_cholesky_solve_func


### PR DESCRIPTION
We recently bumped our dep to `"warp-lang>=1.11.0"` so we can remove this old backwards-compatible code.