### PR TITLE
ci.yml: pytest update `-n 4` -> `-n 2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           uv pip install --system -e .[dev]
       - name: Test with pytest
         run: |
-          pytest -n 4
+          pytest -n 2
 
   kernel_analyzer:
     name: Kernel analyzer


### PR DESCRIPTION
attempt to fix recurring `Error: The operation was canceled` issue.