### PR TITLE
Fix compiler warnings for long->int conversion

### DIFF
--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -34,6 +34,13 @@ MIN_DIST = 1e-10
 FACE_TOL = 0.99999872
 EDGE_TOL = 0.00159999931
 
+# Bit flags for face status in EPA polytope.
+# Defined at module scope to avoid Warp's intermediate type issues with literals.
+# See: https://github.com/NVIDIA/warp/issues/485
+_FACE_DELETED_BIT = wp.constant(wp.uint32(0x80000000))
+_FACE_INVALID_BIT = wp.constant(wp.uint32(0x40000000))
+_FACE_INVALID_OR_DELETED_MASK = wp.constant(wp.uint32(0xC0000000))
+
 
 @wp.struct
 class GJKResult:
@@ -1178,25 +1185,25 @@ def _get_face_verts(face: int) -> wp.vec3i:
 @wp.func
 def _delete_face(face: int) -> int:
   """Return the face with the deleted bit enabled."""
-  return face | 0x80000000
+  return int(wp.uint32(face) | _FACE_DELETED_BIT)
 
 
 @wp.func
 def _is_face_deleted(face: int) -> bool:
   """Return true if face is deleted."""
-  return bool(face & 0x80000000)
+  return bool(wp.uint32(face) & _FACE_DELETED_BIT)
 
 
 @wp.func
 def _invalidate_face(face: int) -> int:
   """Return the face with the invalid bit enabled."""
-  return face | 0x40000000
+  return int(wp.uint32(face) | _FACE_INVALID_BIT)
 
 
 @wp.func
 def _is_invalid_face(face: int) -> bool:
   """Return true if face is invalid or deleted."""
-  return bool(face & 0xC0000000)
+  return bool(wp.uint32(face) & _FACE_INVALID_OR_DELETED_MASK)
 
 
 @wp.func


### PR DESCRIPTION
There are a few warnings abut GJK constants being silently converted from long to int.

We had a similar issue in Newton, so just following that pattern which is blessed by warp experts: https://github.com/newton-physics/newton/commit/95a15928017ef9e73245701a0cd549334dd9c5de