### PR TITLE
`testspeed`: update "human" format

### DIFF
--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -60,6 +60,7 @@ _DEVICE = flags.DEFINE_string("device", None, "override the default Warp device"
 _REPLAY = flags.DEFINE_string("replay", None, "keyframe sequence to replay, keyframe name must prefix match")
 _MEMORY = flags.DEFINE_bool("memory", False, "print memory report")
 _FORMAT = flags.DEFINE_enum("format", "human", ["human", "short", "json"], "output format for results")
+_INFO = flags.DEFINE_bool("info", False, "print Model and Data info")
 
 
 def _load_model(path: epath.Path) -> mujoco.MjModel:
@@ -252,7 +253,7 @@ def _main(argv: Sequence[str]):
 
   path = epath.Path(argv[1])
   if _FORMAT.value == "human":
-    print(f"Loading model from: {path}...")
+    print(f"Loading model from: {path}...\n")
   mjm = _load_model(path)
   mjd = mujoco.MjData(mjm)
   ctrls = None
@@ -278,16 +279,167 @@ def _main(argv: Sequence[str]):
     override_model(m, _OVERRIDE.value)
     d = mjw.put_data(mjm, mjd, nworld=_NWORLD.value, nconmax=_NCONMAX.value, njmax=_NJMAX.value)
     if _FORMAT.value == "human":
+      # Model sizes
+      if _INFO.value:
+        size_fields = [
+          "nq",
+          "nv",
+          "nu",
+          "na",
+          "nbody",
+          "noct",
+          "njnt",
+          "nM",
+          "nC",
+          "ngeom",
+          "nsite",
+          "ncam",
+          "nlight",
+          "nflex",
+          "nflexvert",
+          "nflexedge",
+          "nflexelem",
+          "nflexelemdata",
+          "nflexelemedge",
+          "nmesh",
+          "nmeshvert",
+          "nmeshnormal",
+          "nmeshface",
+          "nmeshgraph",
+          "nmeshpoly",
+          "nmeshpolyvert",
+          "nmeshpolymap",
+          "nhfield",
+          "nhfielddata",
+          "nmat",
+          "npair",
+          "nexclude",
+          "neq",
+          "ntendon",
+          "nwrap",
+          "nsensor",
+          "nmocap",
+          "nplugin",
+          "ngravcomp",
+          "nsensordata",
+        ]
+      else:
+        size_fields = [
+          "nq",
+          "nv",
+          "nu",
+          "nbody",
+          "ngeom",
+        ]
+
+      size_items = [f"{name}: {getattr(m, name)}" for name in size_fields if getattr(m, name) > 0]
+      # Wrap sizes at 10 items per line
+      sizes_lines = []
+      for i in range(0, len(size_items), 5):
+        sizes_lines.append("  " + " ".join(size_items[i : i + 5]))
+      sizes_str = "\n".join(sizes_lines) + "\n"
+
+      # Parse Option.disableflags and Option.enableflags to show individual flag names
+      disable_names = [f.name for f in mjw.DisableBit if m.opt.disableflags & f]
+      enable_names = [f.name for f in mjw.EnableBit if m.opt.enableflags & f]
+      disableflags_str = ", ".join(disable_names) if disable_names else "none"
+      enableflags_str = ", ".join(enable_names) if enable_names else "none"
+
+      # Option fields
+      if _INFO.value:
+        opt_str = (
+          f"Option\n"
+          f"  timestep: {m.opt.timestep.numpy()[0]:g}\n"
+          f"  tolerance: {m.opt.tolerance.numpy()[0]:g} ls_tolerance: {m.opt.ls_tolerance.numpy()[0]:g}\n"
+          f"  ccd_tolerance: {m.opt.ccd_tolerance.numpy()[0]:g}\n"
+          f"  density: {m.opt.density.numpy()[0]:g} viscosity: {m.opt.viscosity.numpy()[0]:g}\n"
+          f"  gravity: {m.opt.gravity.numpy()[0]}\n"
+          f"  wind: {m.opt.wind.numpy()[0]} magnetic: {m.opt.magnetic.numpy()[0]}\n"
+          f"  integrator: {mjw.IntegratorType(m.opt.integrator).name}\n"
+          f"  cone: {mjw.ConeType(m.opt.cone).name}\n"
+          f"  solver: {mjw.SolverType(m.opt.solver).name} iterations: {m.opt.iterations} ls_iterations: {m.opt.ls_iterations}\n"
+          f"  ccd_iterations: {m.opt.ccd_iterations}\n"
+          f"  sdf_initpoints: {m.opt.sdf_initpoints} sdf_iterations: {m.opt.sdf_iterations}\n"
+          f"  disableflags: [{disableflags_str}]\n"
+          f"  enableflags: [{enableflags_str}]\n"
+          f"  impratio: {1.0 / np.square(m.opt.impratio_invsqrt.numpy()[0]):g}\n"
+          f"  is_sparse: {m.opt.is_sparse}\n"
+          f"  ls_parallel: {m.opt.ls_parallel} ls_parallel_min_step: {m.opt.ls_parallel_min_step:g}\n"
+          f"  has_fluid: {m.opt.has_fluid}\n"
+          f"  broadphase: {m.opt.broadphase.name} broadphase_filter: {m.opt.broadphase_filter.name}\n"
+          f"  graph_conditional: {m.opt.graph_conditional}\n"
+          f"  run_collision_detection: {m.opt.run_collision_detection}\n"
+          f"  contact_sensor_maxmatch: {m.opt.contact_sensor_maxmatch}\n"
+        )
+      else:
+        opt_str = (
+          f"Option\n"
+          f"  integrator: {mjw.IntegratorType(m.opt.integrator).name}\n"
+          f"  cone: {mjw.ConeType(m.opt.cone).name}\n"
+          f"  solver: {mjw.SolverType(m.opt.solver).name} iterations: {m.opt.iterations} ls_iterations: {m.opt.ls_iterations}\n"
+          f"  is_sparse: {m.opt.is_sparse}\n"
+          f"  ls_parallel: {m.opt.ls_parallel}\n"
+          f"  broadphase: {m.opt.broadphase.name} broadphase_filter: {m.opt.broadphase_filter.name}\n"
+        )
+
+      if _INFO.value:
+        # Collider types grouped by category
+        from mujoco_warp._src import collision_convex
+        from mujoco_warp._src import collision_primitive
+
+        def trid_to_types(trid):
+          """Convert triangular index back to geom type pair."""
+          n = len(mjw.GeomType)
+          i = 0
+          while (i + 1) * (2 * n - i) // 2 <= trid:
+            i += 1
+          j = trid - i * (2 * n - i - 1) // 2
+          return mjw.GeomType(i), mjw.GeomType(j)
+
+        # Categorize collision pairs
+        primitive_pairs = set(collision_primitive._PRIMITIVE_COLLISIONS.keys())
+        hfield_ccd_pairs = set(collision_convex._HFIELD_COLLISION_PAIRS)
+        ccd_pairs = set(collision_convex._NON_HFIELD_COLLISION_PAIRS)
+
+        primitive_colliders, hfield_ccd_colliders, ccd_colliders = [], [], []
+        for trid, count in enumerate(m.geom_pair_type_count):
+          if count > 0:
+            t1, t2 = trid_to_types(trid)
+            pair = (t1, t2)
+            pair_str = f"{t1.name}-{t2.name}: {count}"
+            if pair in primitive_pairs:
+              primitive_colliders.append(pair_str)
+            elif pair in hfield_ccd_pairs:
+              hfield_ccd_colliders.append(pair_str)
+            elif pair in ccd_pairs:
+              ccd_colliders.append(pair_str)
+
+        collider_lines = []
+        if primitive_colliders:
+          primitives = "  Primitive"
+          for collider in primitive_colliders:
+            primitives += f"\n  {collider}"
+          collider_lines.append(primitives)
+        if hfield_ccd_colliders:
+          hfield = "  HFieldCCD"
+          for collider in hfield_ccd_colliders:
+            hfield += f"\n  {collider}"
+          collider_lines.append(hfield)
+        if ccd_colliders:
+          ccd = "  CCD"
+          for collider in ccd_colliders:
+            ccd += f"\n  {collider}"
+          collider_lines.append(ccd)
+        max_collisions = sum(m.geom_pair_type_count)
+        collider_lines.append(f"  max collisions: {max_collisions}")
+        collider_str = "Colliders\n" + "\n".join(collider_lines) + "\n" if collider_lines else ""
+      else:
+        collider_str = ""
+
       print(
-        f"  nbody: {m.nbody} nv: {m.nv} ngeom: {m.ngeom} nu: {m.nu} is_sparse: {m.opt.is_sparse}"
-        f" graph_conditional: {m.opt.graph_conditional}\n"
-        f"  broadphase: {m.opt.broadphase.name} broadphase_filter: {m.opt.broadphase_filter.name}\n"
-        f"  solver: {mjw.SolverType(m.opt.solver).name} iterations: {m.opt.iterations}"
-        f" linesearch: {'parallel' if m.opt.ls_parallel else 'iterative'} ls_iterations: {m.opt.ls_iterations}\n"
-        f"  cone: {mjw.ConeType(m.opt.cone).name} integrator: {mjw.IntegratorType(m.opt.integrator).name}\n"
-        f"  impratio: {1.0 / np.square(m.opt.impratio_invsqrt.numpy()[0]):g}\n"
+        f"Model\n{sizes_str}{opt_str}{collider_str}"
         f"Data\n  nworld: {d.nworld} naconmax: {d.naconmax} njmax: {d.njmax}\n\n"
-        f"Rolling out {_NSTEP.value} steps at dt = {m.opt.timestep.numpy()[0]:.3f}..."
+        f"Rolling out {_NSTEP.value} steps at dt = {f'{m.opt.timestep.numpy()[0]:g}' if m.opt.timestep.numpy()[0] < 0.001 else f'{m.opt.timestep.numpy()[0]:.3f}'}..."
       )
 
     fn = _FUNCS[_FUNCTION.value]


### PR DESCRIPTION
## Summary
Improves the "human" format output of testspeed with:
- **Model sizes**: Reports all MJWarp and MuJoCo shared sizes that are non-zero
- **Options**: Reports all options, including names of active bits for `disableflags` and `enableflags`
- **Colliders**: Reports collider pair information including category, number of potential collisions per pair type, and maximum number of collisions

## Examples

### humanoid

```bash
mjwarp-testspeed benchmarks/humanoid/humanoid.xml --nworld=8192 --nconmax=24 --njmax=64 --nstep=1
```

```
Loading model from: benchmarks/humanoid/humanoid.xml...
Model
  nq: 28 nv: 27 nu: 21 nbody: 17 njnt: 22 nM: 243 nC: 243 ngeom: 20 ncam: 3 nlight: 2
  nmat: 2

Option
  timestep: 0.005000 tolerance: 1e-06
  ls_tolerance: 0.01 ccd_tolerance: 1e-06
  density: 0 viscosity: 0
  gravity: [ 0.    0.   -9.81] wind: [0. 0. 0.] magnetic: [ 0.  -0.5  0. ]
  integrator: EULER cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  ccd_iterations: 35 sdf_initpoints: 40 sdf_iterations: 10
  disableflags: [EULERDAMP]
  enableflags: [none]
  impratio: 1 is_sparse: False
  ls_parallel: False ls_parallel_min_step: 1e-06 has_fluid: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
  graph_conditional: True run_collision_detection: True
  contact_sensor_maxmatch: 64

Colliders
  Primitive: PLANE-SPHERE: 3, PLANE-CAPSULE: 16, SPHERE-SPHERE: 3, SPHERE-CAPSULE: 39, CAPSULE-CAPSULE: 100
  max collisions: 161
Data
  nworld: 8192 naconmax: 196608 njmax: 64

Rolling out 1 steps at dt = 0.005...

Summary for 8192 parallel rollouts

Total JIT time: 0.52 s
Total simulation time: 0.01 s
Total steps per second: 989,223
Total realtime factor: 4,946.11 x
Total time per step: 1010.89 ns
Total converged worlds: 8192 / 8192
```

### aloha_pot

```bash
Loading model from: benchmarks/aloha_pot/scene.xml...
Model
  nq: 24 nv: 23 nu: 14 nbody: 26 njnt: 18 nM: 98 nC: 98 ngeom: 204 nsite: 17 ncam: 6
  nlight: 3 nmesh: 134 nmeshvert: 32478 nmeshnormal: 32480 nmeshface: 64609 nmeshgraph: 383083 nmeshpoly: 37468 nmeshpolyvert: 125076 nmeshpolymap: 125076 nmat: 3
  nexclude: 2 neq: 2

Option
  timestep: 0.002000 tolerance: 1e-06
  ls_tolerance: 0.01 ccd_tolerance: 1e-06
  density: 0 viscosity: 0
  gravity: [ 0.    0.   -9.81] wind: [0. 0. 0.] magnetic: [ 0.  -0.5  0. ]
  integrator: EULER cone: ELLIPTIC
  solver: NEWTON iterations: 100 ls_iterations: 50
  ccd_iterations: 35 sdf_initpoints: 40 sdf_iterations: 10
  disableflags: [none]
  enableflags: [none]
  impratio: 10 is_sparse: False
  ls_parallel: False ls_parallel_min_step: 1e-06 has_fluid: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
  graph_conditional: True run_collision_detection: True
  contact_sensor_maxmatch: 64

Colliders
  Primitive: PLANE-SPHERE: 12, PLANE-MESH: 131, SPHERE-SPHERE: 54, SPHERE-BOX: 12
  CCD: SPHERE-MESH: 1908, BOX-MESH: 131, MESH-MESH: 6906
  max collisions: 9154
Data
  nworld: 8192 naconmax: 196608 njmax: 128

Rolling out 1 steps at dt = 0.002...

Summary for 8192 parallel rollouts

Total JIT time: 1.03 s
Total simulation time: 0.01 s
Total steps per second: 630,947
Total realtime factor: 1,261.89 x
Total time per step: 1584.92 ns
Total converged worlds: 8192 / 8192
```