### PR TITLE
Optimization: Minor shuffling in update_gradient_JTDAJ_dense_tiled

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1521,8 +1521,7 @@ def update_gradient_JTDAJ_dense_tiled(nv_padded: int, tile_size: int, njmax: int
       # AD: leaving bounds-check disabled here because I'm not entirely sure that
       # everything always hits the fast path. The padding takes care of any
       #  potential OOB accesses.
-      J_ki = wp.tile_load(efc_J_in[worldid], shape=(TILE_SIZE_K, nv_padded), offset=(k, 0), bounds_check=False)
-      J_kj = J_ki
+      J_kj = wp.tile_load(efc_J_in[worldid], shape=(TILE_SIZE_K, nv_padded), offset=(k, 0), bounds_check=False)
 
       # state check
       D_k = wp.tile_load(efc_D_in[worldid], shape=TILE_SIZE_K, offset=k, bounds_check=False)
@@ -1537,7 +1536,7 @@ def update_gradient_JTDAJ_dense_tiled(nv_padded: int, tile_size: int, njmax: int
       active_tile = wp.tile_map(active_check, tid_tile, threshold_tile)
       D_k = wp.tile_map(wp.mul, active_tile, D_k)
 
-      J_ki = wp.tile_map(wp.mul, wp.tile_transpose(J_ki), wp.tile_broadcast(D_k, shape=(nv_padded, TILE_SIZE_K)))
+      J_ki = wp.tile_map(wp.mul, wp.tile_transpose(J_kj), wp.tile_broadcast(D_k, shape=(nv_padded, TILE_SIZE_K)))
 
       sum_val += wp.tile_matmul(J_ki, J_kj)
 


### PR DESCRIPTION
Minor perf improvement:

On the humanoid:
Before:
<img width="1399" height="24" alt="main_humanoid" src="https://github.com/user-attachments/assets/bf8fcfc6-640f-4435-b1ea-0fa1d438fcdf" />

After:
<img width="1406" height="21" alt="optimized_humanoid" src="https://github.com/user-attachments/assets/6f921aaa-5a74-4072-b3cc-43734dcd1556" />

On the apollo:
Before:
<img width="1387" height="26" alt="main_apollo" src="https://github.com/user-attachments/assets/30664179-77a4-4343-b1bd-737993f810b5" />

After:
<img width="1419" height="24" alt="optimized_apollo" src="https://github.com/user-attachments/assets/90c06c77-57ca-4685-90cd-e693f7ecb78d" />


