### PR TITLE
Render Cleanup 3

### DIFF
--- a/mujoco_warp/_src/bvh.py
+++ b/mujoco_warp/_src/bvh.py
@@ -15,8 +15,8 @@
 
 from typing import Tuple
 
-import numpy as np
 import mujoco
+import numpy as np
 import warp as wp
 
 from .render_context import RenderContext

--- a/mujoco_warp/_src/bvh_test.py
+++ b/mujoco_warp/_src/bvh_test.py
@@ -175,7 +175,7 @@ class BvhTest(absltest.TestCase):
     group_root = rc.group_root.numpy()
     self.assertEqual(rc.group_root.shape[0], 16, "group_root")
     self.assertEqual(len(set(group_root)), 16, "group_root")
-  
+
   def test_build_mesh_bvh(self):
     """Tests that build_mesh_bvh creates a valid BVH."""
     mjm, mjd, m, d = test_data.fixture("ray.xml")

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -106,7 +106,8 @@ def compute_ray(
   intrinsic: wp.vec4,
   img_w: int,
   img_h: int,
-  px: int, py: int,
+  px: int,
+  py: int,
   znear: float,
 ) -> wp.vec3:
   """Compute ray direction for a pixel with per-world camera parameters.
@@ -703,7 +704,6 @@ def render_megakernel(m: Model, d: Data, rc: RenderContext):
 
     # Map active camera index to MuJoCo camera ID
     mujoco_cam_id = cam_id_map[cam_idx]
-
 
     if wp.static(rc.ray is None):
       img_w = cam_res[cam_idx][0]

--- a/mujoco_warp/_src/render_context.py
+++ b/mujoco_warp/_src/render_context.py
@@ -39,7 +39,6 @@ def _camera_frustum_bounds(
   znear: float,
 ) -> tuple[float, float, float, float, bool]:
   """Replicate MuJoCo's frustum computation to derive near-plane bounds."""
-
   if cam_projection == ProjectionType.ORTHOGRAPHIC:
     half_height = cam_fovy * 0.5
     aspect = img_w / img_h
@@ -765,12 +764,8 @@ def _make_faces_3d_shells(
 
 
 def _make_flex_mesh(
-  mjm: mujoco.MjModel,
-  m: Model,
-  d: Data,
-  constructor: str = "sah",
-  leaf_size: int = 2
-  ) -> tuple[wp.Mesh, wp.array, wp.array, wp.array, wp.array, wp.array, int]:
+  mjm: mujoco.MjModel, m: Model, d: Data, constructor: str = "sah", leaf_size: int = 2
+) -> tuple[wp.Mesh, wp.array, wp.array, wp.array, wp.array, wp.array, int]:
   """Create a Warp Mesh for flex meshes.
 
   We create a single Warp Mesh (single BVH) for all flex objects across all worlds
@@ -867,13 +862,7 @@ def _make_flex_mesh(
         outputs=[face_point, face_index, group],
       )
 
-  flex_mesh = wp.Mesh(
-    points=face_point,
-    indices=face_index,
-    groups=group,
-    bvh_constructor=constructor,
-    bvh_leaf_size=leaf_size
-  )
+  flex_mesh = wp.Mesh(points=face_point, indices=face_index, groups=group, bvh_constructor=constructor, bvh_leaf_size=leaf_size)
 
   group_root = wp.zeros(d.nworld, dtype=int)
   wp.launch(

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -121,6 +121,7 @@ class ProjectionType(enum.IntEnum):
     PERSPECTIVE: perspective projection
     ORTHOGRAPHIC: orthographic projection
   """
+
   PERSPECTIVE = mujoco.mjtProjection.mjPROJ_PERSPECTIVE
   ORTHOGRAPHIC = mujoco.mjtProjection.mjPROJ_ORTHOGRAPHIC
 


### PR DESCRIPTION
More cleanup to the render branch:

- Domain randomization for cam_fovy or cam_intrinsics
- Renaming of the global bvh to scene bvh for clarity with other build_xxx_bvh methods
- Move mesh bvh to bvh.py (Flex will be moved later as additional testing and improvements are needed)
- Improve performance of Mesh BVH by increasing leaf_size (2 seems optimal for now)
- Add new enum ProjectionType to match C MuJoCo enum type