### PR TITLE
Fix missing raise keyword in check_toolkit_driver()

### DIFF
--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -221,4 +221,4 @@ def check_toolkit_driver():
   wp.init()
   if wp.get_device().is_cuda:
     if not wp.is_conditional_graph_supported():
-      RuntimeError("Minimum supported CUDA version: 12.4.")
+      raise RuntimeError("Minimum supported CUDA version: 12.4.")


### PR DESCRIPTION
### Description

The `RuntimeError` in `check_toolkit_driver()` was being constructed but not raised, causing CUDA version checks to silently pass even when the toolkit is unsupported.

### Changes

- Added missing `raise` keyword before `RuntimeError` in `warp_util.py`

### Before
```python
RuntimeError("Minimum supported CUDA version: 12.4.")
```

### After
```python
raise RuntimeError("Minimum supported CUDA version: 12.4.")
```

Closes #1072 

