### PR TITLE
Benchmark improvments, and better cache clearing.

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -37,12 +37,12 @@ To run specific benchmarks, use the `-f` or `--filter` option with a regex patte
 ./run.sh -f cloth
 ```
 
-### Clearing the Kernel Cache
+### Clearing the Warp Cache
 
-By default, benchmarks use Warp's kernel cache for faster execution. To measure accurate JIT compilation times, you can disable the cache:
+By default, benchmarks use Warp's caches for faster execution. To measure accurate JIT compilation times, you can disable the cache:
 
 ```bash
-./run.sh --clear_kernel_cache=true
+./run.sh --clear_warp_cache=true
 ```
 
 ## Output Format
@@ -50,7 +50,7 @@ By default, benchmarks use Warp's kernel cache for faster execution. To measure 
 The benchmark script uses `mjwarp-testspeed` with the `--format=short` option, which outputs metrics in a columnar format:
 
 ```
-2026-01-12 18:57:20] mjwarp-testspeed /home/<username>/mujoco_warp/benchmarks/humanoid/humanoid.xml --nworld=8192 --nconmax=24 --njmax=64 --clear_kernel_cache=false --format=short --event_trace=true --memory=true --measure_solver=true --measure_alloc=true
+2026-01-12 18:57:20] mjwarp-testspeed /home/<username>/mujoco_warp/benchmarks/humanoid/humanoid.xml --nworld=8192 --nconmax=24 --njmax=64 --clear_warp_cache=false --format=short --event_trace=true --memory=true --measure_solver=true --measure_alloc=true
 [2026-01-12 18:57:26] humanoid:jit_duration                                              0.3430611090734601
 [2026-01-12 18:57:26] humanoid:run_time                                                  3.0016206190921366
 [2026-01-12 18:57:26] humanoid:steps_per_second                                          2729192.3395961127

--- a/benchmarks/backfill.sh
+++ b/benchmarks/backfill.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+
+# Copyright 2026 The Newton Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Backfill script for generating historical benchmark data.
+#
+# Unlike nightly.sh, this script:
+# - Uses testspeed.py and config.txt from HEAD (not each commit's version)
+# - Uses a local python environment instead of uv run
+# - Does NOT update last_commit.txt or push to git
+# - Targets a range of commits by number (HEAD~start to HEAD~end)
+#
+# Usage:
+#   ./backfill.sh [--mock] [--start=N] [--end=N]
+#
+# Options:
+#   --mock      Run benchmarks with nworld=1 and nstep=10 for fast testing
+#   --start=N   Start from HEAD~N (default: 100, the oldest commit)
+#   --end=N     End at HEAD~N (default: 1, most recent)
+#
+# Examples:
+#   ./backfill.sh                    # Process HEAD~100 to HEAD~1
+#   ./backfill.sh --start=50         # Process HEAD~50 to HEAD~1
+#   ./backfill.sh --start=100 --end=90  # Process only HEAD~100 to HEAD~90
+
+set -euo pipefail
+
+# Script location (HEAD checkout with current testspeed.py and config.txt)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HEAD_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Configuration - clone from local dir to avoid SSH key issues and for speed
+WORK_DIR="/tmp/mujoco_warp-backfill-$$"
+RESULTS_DIR_PATH="$HEAD_DIR/../mujoco_warp_gh_pages/nightly"
+CONFIG="$SCRIPT_DIR/config.txt"
+
+# Default options
+START=100
+END=1
+MOCK_MODE=false
+
+# Parse arguments
+for arg in "$@"; do
+    case $arg in
+        --mock)
+            MOCK_MODE=true
+            shift
+            ;;
+        --start=*)
+            START="${arg#*=}"
+            shift
+            ;;
+        --end=*)
+            END="${arg#*=}"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $arg"
+            echo "Usage: $0 [--mock] [--start=N] [--end=N]"
+            exit 1
+            ;;
+    esac
+done
+
+log() {
+    ( [ -n "${1:-}" ] && echo "$@" || cat ) | while read -r l; do
+        printf "[%(%Y-%m-%d %H:%M:%S)T] %s\n" -1 "$l"
+    done
+}
+
+error() {
+    log "ERROR: $*" >&2
+    exit 1
+}
+
+cleanup() {
+    if [[ -d "$WORK_DIR" ]]; then
+        log "Cleaning up work directory..."
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# Verify environment
+if [[ ! -f "$CONFIG" ]]; then
+    error "Config file not found at $CONFIG"
+fi
+if [[ ! -d "$RESULTS_DIR_PATH" ]]; then
+    error "Results directory not found at $RESULTS_DIR_PATH"
+fi
+
+log "Backfill configuration:"
+log "  RANGE: HEAD~$START to HEAD~$END"
+log "  MOCK_MODE: $MOCK_MODE"
+log "  HEAD_DIR: $HEAD_DIR"
+log "  RESULTS_DIR: $RESULTS_DIR_PATH"
+
+# Clone from local directory (faster than GitHub, no SSH key needed)
+log "Cloning mujoco_warp to work directory..."
+git clone "$HEAD_DIR" "$WORK_DIR"
+
+# Get list of commits in range (oldest first)
+cd "$HEAD_DIR"
+COMMITS=$(git rev-list --reverse "HEAD~${START}..HEAD~${END}")
+TOTAL_COMMITS=$(echo "$COMMITS" | wc -l)
+log "Found $TOTAL_COMMITS commits to process"
+
+CURRENT=0
+for commit in $COMMITS; do
+    CURRENT=$((CURRENT + 1))
+    log "[$CURRENT/$TOTAL_COMMITS] Processing commit $commit"
+    
+    # Checkout the commit in work directory (force to handle uv.lock changes)
+    cd "$WORK_DIR"
+    git checkout --force "$commit" 2>&1 | log
+    
+    # Copy HEAD's testspeed.py into the work directory (overwrite historical version)
+    cp "$HEAD_DIR/mujoco_warp/testspeed.py" "$WORK_DIR/mujoco_warp/testspeed.py"
+    
+    # Get commit timestamp
+    COMMIT_TIMESTAMP=$(TZ=UTC git log -1 --format=%cd --date=format-local:'%Y-%m-%dT%H:%M:%S+00:00' "$commit")
+    
+    # Run benchmarks using HEAD's config.txt
+    while read -r NAME MJCF NWORLD NCONMAX NJMAX NSTEP REPLAY; do
+        # Skip comments and empty lines
+        [[ "$NAME" =~ ^#.*$ || -z "$NAME" ]] && continue
+        
+        log "Running benchmark: $NAME"
+        
+        # In mock mode, use small nworld and nstep for speed
+        if [[ "$MOCK_MODE" == "true" ]]; then
+            NWORLD=1
+            NSTEP=10
+        fi
+        
+        # Build command arguments for mjwarp-testspeed
+        CMD=(
+            "mjwarp-testspeed"
+            "$SCRIPT_DIR/$MJCF"
+            "--nworld=$NWORLD"
+            "--nconmax=$NCONMAX"
+            "--njmax=$NJMAX"
+            "--clear_warp_cache=true"
+            "--format=json"
+            "--event_trace=true"
+            "--memory=true"
+            "--measure_solver=true"
+            "--measure_alloc=true"
+        )
+        [[ "$NSTEP" != "-" ]] && CMD+=( "--nstep=$NSTEP" )
+        [[ "$REPLAY" != "-" ]] && CMD+=( "--replay=$REPLAY" )
+        
+        # Run benchmark using uv run from WORK_DIR (historical commit + HEAD's testspeed.py)
+        # Send uv's stderr to /dev/null (or log), capture only stdout (JSON)
+        cd "$WORK_DIR"
+        log "Command: UV_NO_CONFIG=1 uv run --prerelease=allow --upgrade ${CMD[*]}"
+        if ! BENCHMARK_JSON=$(UV_NO_CONFIG=1 uv run --prerelease=allow --upgrade "${CMD[@]}" 2>/dev/null); then
+            log "WARNING: Benchmark $NAME failed for commit $commit, retrying with verbose output..."
+            UV_NO_CONFIG=1 uv run --prerelease=allow --upgrade "${CMD[@]}" 2>&1 | log
+            continue
+        fi
+
+        echo "$BENCHMARK_JSON"
+        
+        # Convert multi-line JSON to single line and add commit metadata
+        # Use tail -n 1 to ignore any log spam before the JSON output
+        RESULT=$(echo "$BENCHMARK_JSON" | tail -n 1 | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+data['commit'] = '$commit'
+data['timestamp'] = '$COMMIT_TIMESTAMP'
+print(json.dumps(data))
+")
+        
+        # Append to benchmark-specific JSONL file
+        BENCHMARK_FILE="$RESULTS_DIR_PATH/${NAME}.jsonl"
+        printf "%s\n" "$RESULT" >> "$BENCHMARK_FILE"
+        log "Benchmark $NAME completed"
+    done < "$CONFIG"
+    
+    log "Finished processing commit $commit"
+done
+
+log "Backfill complete!"
+log "Results written to: $RESULTS_DIR_PATH"
+log ""
+log "Next steps:"
+log "  1. Review the JSONL files for correctness"
+log "  2. If satisfied, commit and push the results manually:"
+log "     cd $RESULTS_DIR_PATH/.."
+log "     git add nightly/*.jsonl"
+log "     git commit -m 'Backfill benchmarks for HEAD~$START to HEAD~$END'"
+log "     git push origin gh-pages"

--- a/benchmarks/nightly.sh
+++ b/benchmarks/nightly.sh
@@ -122,7 +122,7 @@ for commit in $COMMITS; do
         [[ "$NAME" =~ ^#.*$ || -z "$NAME" ]] && continue
         
         log "Running benchmark: $NAME"
-        
+
         # Build command arguments for mjwarp-testspeed
         CMD=(
             "mjwarp-testspeed"
@@ -130,7 +130,7 @@ for commit in $COMMITS; do
             "--nworld=$NWORLD"
             "--nconmax=$NCONMAX"
             "--njmax=$NJMAX"
-            "--clear_kernel_cache=false"
+            "--clear_warp_cache=true"
             "--format=json"
             "--event_trace=true"
             "--memory=true"
@@ -143,10 +143,12 @@ for commit in $COMMITS; do
         # Run benchmark using uv run (handles venv and dependencies automatically)
         # --prerelease=allow: accept dev/nightly builds
         # --upgrade: always get the latest versions
+        log "Command: UV_NO_CONFIG=1 uv run --prerelease=allow --upgrade ${CMD[*]}"
         BENCHMARK_JSON=$(UV_NO_CONFIG=1 uv run --prerelease=allow --upgrade "${CMD[@]}")
-        
+
         # Convert multi-line JSON to single line and add commit metadata
-        RESULT=$(echo "$BENCHMARK_JSON" | python3 -c "
+        # Use tail -n 1 to ignore any log spam before the JSON output
+        RESULT=$(echo "$BENCHMARK_JSON" | tail -n 1 | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
 data['commit'] = '$commit'

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -37,7 +37,7 @@ usage() {
 }
 
 FILTER=""
-CLEAR_KERNEL_CACHE="false"
+CLEAR_WARP_CACHE="false"
 
 while [[ $# -gt 0 ]]; do
   # if the argument contains '=', split it into key and value
@@ -45,7 +45,7 @@ while [[ $# -gt 0 ]]; do
     set -- "${1%%=*}" "${1#*=}" "${@:2}"
   fi
   case $1 in
-    --clear_kernel_cache) CLEAR_KERNEL_CACHE="$2"; shift 2 ;;
+    --clear_warp_cache) CLEAR_WARP_CACHE="$2"; shift 2 ;;
     -f|--filter) FILTER="$2"; shift 2 ;;
     -h|--help) usage ;;
     *) error "Unknown option: $1" ;;
@@ -63,6 +63,11 @@ if ! command -v mjwarp-testspeed &> /dev/null; then
   error "mjwarp-testspeed not found. Please install MuJoCo Warp (or activate its environment)."
 fi
 
+# Clear CUDA driver-level cache if requested (ensures cold JIT timing)
+if [[ "$CLEAR_WARP_CACHE" == "true" ]]; then
+  log "Warp cache clearing will be handled by testspeed.py"
+fi
+
 while read -r NAME MJCF NWORLD NCONMAX NJMAX NSTEP REPLAY; do
     # Skip comments and empty lines
     [[ "$NAME" =~ ^#.*$ || -z "$NAME" ]] && continue
@@ -76,7 +81,7 @@ while read -r NAME MJCF NWORLD NCONMAX NJMAX NSTEP REPLAY; do
       "--nworld=$NWORLD"
       "--nconmax=$NCONMAX"
       "--njmax=$NJMAX"
-      "--clear_kernel_cache=$CLEAR_KERNEL_CACHE"
+      "--clear_warp_cache=$CLEAR_WARP_CACHE"
       "--format=short"
       "--event_trace=true"
       "--memory=true"

--- a/mujoco_warp/viewer.py
+++ b/mujoco_warp/viewer.py
@@ -24,6 +24,7 @@ Example:
 import copy
 import enum
 import logging
+import shutil
 import sys
 import time
 from typing import Sequence
@@ -51,7 +52,7 @@ class EngineOptions(enum.IntEnum):
   C = 1
 
 
-_CLEAR_KERNEL_CACHE = flags.DEFINE_bool("clear_kernel_cache", False, "Clear kernel cache (to calculate full JIT time)")
+_CLEAR_WARP_CACHE = flags.DEFINE_bool("clear_warp_cache", False, "Clear warp caches (kernel, LTO, CUDA compute)")
 _ENGINE = flags.DEFINE_enum_class("engine", EngineOptions.WARP, EngineOptions, "Simulation engine")
 _NCONMAX = flags.DEFINE_integer("nconmax", None, "Maximum number of contacts.")
 _NJMAX = flags.DEFINE_integer("njmax", None, "Maximum number of constraints per world.")
@@ -134,8 +135,14 @@ def _main(argv: Sequence[str]) -> None:
   else:
     wp.config.quiet = flags.FLAGS["verbosity"].value < 1
     wp.init()
-    if _CLEAR_KERNEL_CACHE.value:
+    if _CLEAR_WARP_CACHE.value:
       wp.clear_kernel_cache()
+      wp.clear_lto_cache()
+      # Clear CUDA compute cache for truly cold start JIT
+      compute_cache = epath.Path("~/.nv/ComputeCache").expanduser()
+      if compute_cache.exists():
+        shutil.rmtree(compute_cache)
+        compute_cache.mkdir()
 
     with wp.ScopedDevice(_DEVICE.value):
       m = mjw.put_model(mjm)


### PR DESCRIPTION
Updates the flag in `mjwarp-testspeed` and `mjwarp-viewer` to clear all Warp-relevant caches to better measure cold start JIT time.

Also introduces a `backfill.sh` used to populate old benchmark data.
Also fixes a small bug in the nightly script where warning spam from `mjwarp-testspeed` would break the script behavior.