### PR TITLE
Add early CUDA availability check to mjwarp-viewer

### DIFF
--- a/mujoco_warp/viewer.py
+++ b/mujoco_warp/viewer.py
@@ -135,6 +135,16 @@ def _main(argv: Sequence[str]) -> None:
   else:
     wp.config.quiet = flags.FLAGS["verbosity"].value < 1
     wp.init()
+    # ---- CUDA guard ----
+    if not wp.is_cuda_available():
+      raise RuntimeError(
+          "\n mjwarp-viewer requires an NVIDIA CUDA device.\n"
+          "No CUDA GPU was detected.\n\n"
+          "Possible fixes:\n"
+          "  • Install NVIDIA drivers + CUDA\n"
+          "  • Run on a GPU machine\n"
+          "  • Use standard MuJoCo viewer instead\n"
+      )
     if _CLEAR_WARP_CACHE.value:
       wp.clear_kernel_cache()
       wp.clear_lto_cache()


### PR DESCRIPTION
mjwarp-viewer currently prints "CPU-only mode" and later crashes with
`RuntimeError: Must be a CUDA device`.

This PR adds an early CUDA availability check after wp.init(), so the viewer
fails fast with a clear, actionable error message on machines without NVIDIA GPUs.

This improves UX for CPU-only users and avoids a deep Warp stacktrace.
