### PR TITLE
Update _render_megakernel decorator

### DIFF
--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -414,8 +414,6 @@ def render(m: Model, d: Data, rc: RenderContext):
   rc.rgb_data.fill_(rc.background_color)
   rc.depth_data.fill_(0.0)
 
-  # TODO: Adding "unique" causes kernel re-compilation issues, need to investigate
-  # and fix it.
   @wp.kernel(module="unique", enable_backward=False)
   def _render_megakernel(
     # Model:


### PR DESCRIPTION
Fix decorator on render kernel.

Downstream Mjlab was not re-compiling this kernel when the domain randomization was being added to the cam_fovy. This fix solves this issue, and also aligns with recent mjwarp PR to remove nested_kernel usage.