### PR TITLE
height field: fix margin

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -363,8 +363,7 @@ def ccd_hfield_kernel_builder(
     min_pos = wp.vec3(MJ_MAXVAL, MJ_MAXVAL, MJ_MAXVAL)
     min_id = int(-1)
 
-    # TODO(team): height field margin?
-    geom1.margin = margin
+    # geom1 margin added to z-axis of hfield prism top points below
     geom2.margin = margin
 
     # EPA memory


### PR DESCRIPTION
the current implementation for height field geoms adds `margin` to the top 3 prism vertices in the local z direction **and** sets `geom1.margin = margin`. as a result, the support function computation is incorrect when `margin > 0` since the returned support point includes an additional (incorrect in this case) `0.5 * margin * dir` term.

this pr fixes the issue by setting `geom1.margin = 0` and tests the height field support function.

thanks @kevinzakka for pointing out this issue! 