### PR TITLE
Expose RenderContext.

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -98,6 +98,7 @@ from mujoco_warp._src.types import GeomType as GeomType
 from mujoco_warp._src.types import IntegratorType as IntegratorType
 from mujoco_warp._src.types import JointType as JointType
 from mujoco_warp._src.types import Option as Option
+from mujoco_warp._src.types import RenderContext as RenderContext
 from mujoco_warp._src.types import SolverType as SolverType
 from mujoco_warp._src.types import State as State
 from mujoco_warp._src.types import Statistic as Statistic


### PR DESCRIPTION
create_render_context is part of the public API and returns RenderContext. Downstream users need to be able to declare the returned type. `mjwarp._src.types.RenderContext` is quite ugly.