### PR TITLE
Fix out-of-bounds access in _ray_bvh for multi-world raycasting

### DIFF
--- a/mujoco_warp/_src/ray.py
+++ b/mujoco_warp/_src/ray.py
@@ -1265,7 +1265,7 @@ def rays(
       _ray_bvh,
       dim=(d.nworld, pnt.shape[1]),
       inputs=[
-        m.ngeom,
+        rc.bvh_ngeom,
         m.body_weldid,
         m.geom_type,
         m.geom_bodyid,


### PR DESCRIPTION
The _ray_bvh kernel computes per-world BVH indices as `bounds_nr - (worldid * ngeom)`. When geom group filtering is active, the BVH contains only enabled geoms (bvh_ngeom per world), but `rays()` was passing `m.ngeom` (total geom count). For worldid > 0 this produces negative indices into `enabled_geom_ids`, causing CUDA error 700 (illegal memory access).

Use `rc.bvh_ngeom` instead of `m.ngeom` so the per-world offset matches the actual BVH layout.