### PR TITLE
update `override_model`

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2085,6 +2085,13 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
         if val.upper() not in ("TRUE", "FALSE"):
           raise ValueError(f"Unrecognized value for field: {key}")
         val = val.upper() == "TRUE"
+      elif typ is wp.array and isinstance(val, str):
+        arr = getattr(obj, attr)
+        floats = [float(p) for p in val.strip("[]").split()]
+        val = wp.array([arr.dtype(*floats)], dtype=arr.dtype)
+      elif typ is np.ndarray and isinstance(val, str):
+        arr = getattr(obj, attr)
+        val = np.array([float(p) for p in val.strip("[]").split()], dtype=arr.dtype)
       else:
         val = typ(val)
 


### PR DESCRIPTION
updates for testspeed overrides, the following now work:
`mjwarp-testspeed benchmarks/humanoid/humanoid.xml --nconmax=24 --njmax=64 -o "opt.timestep=0.001"`

`mjwarp-testspeed benchmarks/humanoid/humanoid.xml --nconmax=24 --njmax=64 -o "opt.gravity=[0 0 -10]"`