### PR TITLE
Refactor size resolution to fix `naccdmax` default logic

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -801,7 +801,7 @@ def put_data(
     njmax: Number of constraints to allocate per world.  Constraint arrays are
            batched by world: no world may have more than njmax constraints.
     naconmax: Number of contacts to allocate for all worlds. Overrides nconmax.
-    naccdmax: Maximum number of CCD contacts. Defaults to naconmax unless.
+    naccdmax: Maximum number of CCD contacts. Defaults to naconmax.
 
   Returns:
     The data object containing the current state and output arrays (device).

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -451,18 +451,18 @@ class IOTest(parameterized.TestCase):
   def test_make_data_naccdmax_default(self):
     mjm = mujoco.MjModel.from_xml_string("<mujoco/>")
     data = mjwarp.make_data(mjm, naconmax=5, njmax=3, naccdmax=None)
-    self.assertEqual(data.naccdmax, 5, "naccdmax=None should default to naconmax when not explicitly set")
+    self.assertEqual(data.naccdmax, 5, "naccdmax=None should default to naconmax")
 
   def test_put_data_naccdmax_default(self):
     mjm = mujoco.MjModel.from_xml_string("<mujoco/>")
     mjd = mujoco.MjData(mjm)
     data = mjwarp.put_data(mjm, mjd, naconmax=5, njmax=3, naccdmax=None)
-    self.assertEqual(data.naccdmax, 5, "naccdmax=None should default to naconmax when not explicitly set")
+    self.assertEqual(data.naccdmax, 5, "naccdmax=None should default to naconmax")
 
   def test_make_data_naccdmax_from_nccdmax(self):
     mjm = mujoco.MjModel.from_xml_string("<mujoco/>")
     data = mjwarp.make_data(mjm, nconmax=5, nccdmax=3)
-    self.assertEqual(data.naccdmax, 3, "naccdmax from  nccdmax")
+    self.assertEqual(data.naccdmax, 3, "naccdmax from nccdmax")
 
   def test_put_data_naccdmax_from_nccdmax(self):
     mjm = mujoco.MjModel.from_xml_string("<mujoco/>")


### PR DESCRIPTION
For context, see https://github.com/google-deepmind/mujoco/pull/3096.