### PR TITLE
`Option.hessian_incremental`: reuse Newton solver Hessian

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -200,6 +200,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     opt.contact_sensor_maxmatch = mjm.numeric_data[mjm.numeric_adr[contact_sensor_maxmatch_id]]
   else:
     opt.contact_sensor_maxmatch = 64
+  opt.hessian_incremental = False
 
   # place opt on device
   for f in dataclasses.fields(types.Option):
@@ -2029,7 +2030,13 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
       "AUTO": mujoco.mjtJacobian.mjJAC_AUTO,
     },
   }
-  mjw_only_fields = {"opt.broadphase", "opt.broadphase_filter", "opt.ls_parallel", "opt.graph_conditional"}
+  mjw_only_fields = {
+    "opt.broadphase",
+    "opt.broadphase_filter",
+    "opt.ls_parallel",
+    "opt.graph_conditional",
+    "opt.hessian_incremental",
+  }
   mj_only_fields = {"opt.jacobian"}
 
   if not isinstance(overrides, dict):

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -69,6 +69,7 @@ class SolverContext:
   beta: wp.array(dtype=float)
   h: wp.array3d(dtype=float)
   hfactor: wp.array3d(dtype=float)
+  hchange: wp.array(dtype=int)
 
 
 def create_inverse_context(m: types.Model, d: types.Data) -> InverseContext:
@@ -109,9 +110,10 @@ def create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
   nv_pad = m.nv_pad
   njmax = d.njmax
 
-  # Newton solver needs h; hfactor only needed if nv > _BLOCK_CHOLESKY_DIM
+  # Newton solver needs h; hfactor needed for blocked cholesky or hessian_incremental
   alloc_h = m.opt.solver == types.SolverType.NEWTON
-  alloc_hfactor = alloc_h and nv > _BLOCK_CHOLESKY_DIM
+  hessian_incremental = m.opt.hessian_incremental and m.opt.cone != types.ConeType.ELLIPTIC
+  alloc_hfactor = alloc_h and (nv > _BLOCK_CHOLESKY_DIM or hessian_incremental)
 
   return SolverContext(
     Jaref=wp.empty((nworld, njmax), dtype=float),
@@ -134,6 +136,9 @@ def create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     beta=wp.empty((nworld,), dtype=float),
     h=wp.zeros((nworld, nv_pad, nv_pad), dtype=float) if alloc_h else wp.empty((nworld, 0, 0), dtype=float),
     hfactor=wp.zeros((nworld, nv_pad, nv_pad), dtype=float) if alloc_hfactor else wp.empty((nworld, 0, 0), dtype=float),
+    # hchange initialized to 1 so the first iteration always computes the Hessian
+    # (init_context does not zero hchange before _update_constraint/_update_gradient)
+    hchange=wp.ones((nworld,), dtype=int) if (alloc_h and hessian_incremental) else wp.empty((0,), dtype=int),
   )
 
 
@@ -1743,131 +1748,150 @@ def update_constraint_init_cost(
   ctx_cost_out[worldid] = 0.0
 
 
-@wp.kernel
-def update_constraint_efc(
-  # Model:
-  opt_impratio_invsqrt: wp.array(dtype=float),
-  # Data in:
-  ne_in: wp.array(dtype=int),
-  nf_in: wp.array(dtype=int),
-  nefc_in: wp.array(dtype=int),
-  contact_friction_in: wp.array(dtype=types.vec5),
-  contact_dim_in: wp.array(dtype=int),
-  contact_efc_address_in: wp.array2d(dtype=int),
-  efc_type_in: wp.array2d(dtype=int),
-  efc_id_in: wp.array2d(dtype=int),
-  efc_D_in: wp.array2d(dtype=float),
-  efc_frictionloss_in: wp.array2d(dtype=float),
-  nacon_in: wp.array(dtype=int),
-  # In:
-  ctx_Jaref_in: wp.array2d(dtype=float),
-  ctx_done_in: wp.array(dtype=bool),
-  # Data out:
-  efc_force_out: wp.array2d(dtype=float),
-  efc_state_out: wp.array2d(dtype=int),
-  # Out:
-  ctx_cost_out: wp.array(dtype=float),
-):
-  worldid, efcid = wp.tid()
+@cache_kernel
+def update_constraint_efc(hessian_incremental: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    opt_impratio_invsqrt: wp.array(dtype=float),
+    # Data in:
+    ne_in: wp.array(dtype=int),
+    nf_in: wp.array(dtype=int),
+    nefc_in: wp.array(dtype=int),
+    contact_friction_in: wp.array(dtype=types.vec5),
+    contact_dim_in: wp.array(dtype=int),
+    contact_efc_address_in: wp.array2d(dtype=int),
+    efc_type_in: wp.array2d(dtype=int),
+    efc_id_in: wp.array2d(dtype=int),
+    efc_D_in: wp.array2d(dtype=float),
+    efc_frictionloss_in: wp.array2d(dtype=float),
+    efc_state_in: wp.array2d(dtype=int),
+    nacon_in: wp.array(dtype=int),
+    # In:
+    ctx_Jaref_in: wp.array2d(dtype=float),
+    ctx_done_in: wp.array(dtype=bool),
+    # Data out:
+    efc_force_out: wp.array2d(dtype=float),
+    efc_state_out: wp.array2d(dtype=int),
+    # Out:
+    ctx_cost_out: wp.array(dtype=float),
+    hchange_out: wp.array(dtype=int),
+  ):
+    worldid, efcid = wp.tid()
 
-  if efcid >= nefc_in[worldid]:
-    return
-
-  if ctx_done_in[worldid]:
-    return
-
-  efc_D = efc_D_in[worldid, efcid]
-  Jaref = ctx_Jaref_in[worldid, efcid]
-
-  ne = ne_in[worldid]
-  nf = nf_in[worldid]
-
-  if efcid < ne:
-    # equality
-    efc_force_out[worldid, efcid] = -efc_D * Jaref
-    efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC
-    wp.atomic_add(ctx_cost_out, worldid, 0.5 * efc_D * Jaref * Jaref)
-  elif efcid < ne + nf:
-    # friction
-    f = efc_frictionloss_in[worldid, efcid]
-    rf = math.safe_div(f, efc_D)
-    if Jaref <= -rf:
-      efc_force_out[worldid, efcid] = f
-      efc_state_out[worldid, efcid] = types.ConstraintState.LINEARNEG
-      wp.atomic_add(ctx_cost_out, worldid, -f * (0.5 * rf + Jaref))
-    elif Jaref >= rf:
-      efc_force_out[worldid, efcid] = -f
-      efc_state_out[worldid, efcid] = types.ConstraintState.LINEARPOS
-      wp.atomic_add(ctx_cost_out, worldid, -f * (0.5 * rf - Jaref))
-    else:
-      efc_force_out[worldid, efcid] = -efc_D * Jaref
-      efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC
-      wp.atomic_add(ctx_cost_out, worldid, 0.5 * efc_D * Jaref * Jaref)
-  elif efc_type_in[worldid, efcid] != types.ConstraintType.CONTACT_ELLIPTIC:
-    # limit, frictionless contact, pyramidal friction cone contact
-    if Jaref >= 0.0:
-      efc_force_out[worldid, efcid] = 0.0
-      efc_state_out[worldid, efcid] = types.ConstraintState.SATISFIED
-    else:
-      efc_force_out[worldid, efcid] = -efc_D * Jaref
-      efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC
-      wp.atomic_add(ctx_cost_out, worldid, 0.5 * efc_D * Jaref * Jaref)
-  else:  # elliptic friction cone contact
-    conid = efc_id_in[worldid, efcid]
-
-    if conid >= nacon_in[0]:
+    if efcid >= nefc_in[worldid]:
       return
 
-    dim = contact_dim_in[conid]
-    friction = contact_friction_in[conid]
-    mu = friction[0] * opt_impratio_invsqrt[worldid]
-
-    efcid0 = contact_efc_address_in[conid, 0]
-    if efcid0 < 0:
+    if ctx_done_in[worldid]:
       return
 
-    N = ctx_Jaref_in[worldid, efcid0] * mu
+    # read old state before computing new state
+    if wp.static(hessian_incremental):
+      old_state = efc_state_in[worldid, efcid]
 
-    ufrictionj = float(0.0)
-    TT = float(0.0)
-    for j in range(1, dim):
-      efcidj = contact_efc_address_in[conid, j]
-      if efcidj < 0:
-        return
-      frictionj = friction[j - 1]
-      uj = ctx_Jaref_in[worldid, efcidj] * frictionj
-      TT += uj * uj
-      if efcid == efcidj:
-        ufrictionj = uj * frictionj
+    efc_D = efc_D_in[worldid, efcid]
+    Jaref = ctx_Jaref_in[worldid, efcid]
 
-    if TT <= 0.0:
-      T = 0.0
-    else:
-      T = wp.sqrt(TT)
+    ne = ne_in[worldid]
+    nf = nf_in[worldid]
 
-    # top zone
-    if (N >= mu * T) or ((T <= 0.0) and (N >= 0.0)):
-      efc_force_out[worldid, efcid] = 0.0
-      efc_state_out[worldid, efcid] = types.ConstraintState.SATISFIED
-    # bottom zone
-    elif (mu * N + T <= 0.0) or ((T <= 0.0) and (N < 0.0)):
+    new_state = -1
+
+    if efcid < ne:
+      # equality
       efc_force_out[worldid, efcid] = -efc_D * Jaref
-      efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC
+      new_state = types.ConstraintState.QUADRATIC.value
       wp.atomic_add(ctx_cost_out, worldid, 0.5 * efc_D * Jaref * Jaref)
-    # middle zone
-    else:
-      dm = math.safe_div(efc_D_in[worldid, efcid0], mu * mu * (1.0 + mu * mu))
-      nmt = N - mu * T
-
-      force = -dm * nmt * mu
-
-      if efcid == efcid0:
-        efc_force_out[worldid, efcid] = force
-        wp.atomic_add(ctx_cost_out, worldid, 0.5 * dm * nmt * nmt)
+    elif efcid < ne + nf:
+      # friction
+      f = efc_frictionloss_in[worldid, efcid]
+      rf = math.safe_div(f, efc_D)
+      if Jaref <= -rf:
+        efc_force_out[worldid, efcid] = f
+        new_state = types.ConstraintState.LINEARNEG.value
+        wp.atomic_add(ctx_cost_out, worldid, -f * (0.5 * rf + Jaref))
+      elif Jaref >= rf:
+        efc_force_out[worldid, efcid] = -f
+        new_state = types.ConstraintState.LINEARPOS.value
+        wp.atomic_add(ctx_cost_out, worldid, -f * (0.5 * rf - Jaref))
       else:
-        efc_force_out[worldid, efcid] = -math.safe_div(force, T) * ufrictionj
+        efc_force_out[worldid, efcid] = -efc_D * Jaref
+        new_state = types.ConstraintState.QUADRATIC.value
+        wp.atomic_add(ctx_cost_out, worldid, 0.5 * efc_D * Jaref * Jaref)
+    elif efc_type_in[worldid, efcid] != types.ConstraintType.CONTACT_ELLIPTIC:
+      # limit, frictionless contact, pyramidal friction cone contact
+      if Jaref >= 0.0:
+        efc_force_out[worldid, efcid] = 0.0
+        new_state = types.ConstraintState.SATISFIED.value
+      else:
+        efc_force_out[worldid, efcid] = -efc_D * Jaref
+        new_state = types.ConstraintState.QUADRATIC.value
+        wp.atomic_add(ctx_cost_out, worldid, 0.5 * efc_D * Jaref * Jaref)
+    else:  # elliptic friction cone contact
+      conid = efc_id_in[worldid, efcid]
 
-      efc_state_out[worldid, efcid] = types.ConstraintState.CONE
+      if conid >= nacon_in[0]:
+        return
+
+      dim = contact_dim_in[conid]
+      friction = contact_friction_in[conid]
+      mu = friction[0] * opt_impratio_invsqrt[worldid]
+
+      efcid0 = contact_efc_address_in[conid, 0]
+      if efcid0 < 0:
+        return
+
+      N = ctx_Jaref_in[worldid, efcid0] * mu
+
+      ufrictionj = float(0.0)
+      TT = float(0.0)
+      for j in range(1, dim):
+        efcidj = contact_efc_address_in[conid, j]
+        if efcidj < 0:
+          return
+        frictionj = friction[j - 1]
+        uj = ctx_Jaref_in[worldid, efcidj] * frictionj
+        TT += uj * uj
+        if efcid == efcidj:
+          ufrictionj = uj * frictionj
+
+      if TT <= 0.0:
+        T = 0.0
+      else:
+        T = wp.sqrt(TT)
+
+      # top zone
+      if (N >= mu * T) or ((T <= 0.0) and (N >= 0.0)):
+        efc_force_out[worldid, efcid] = 0.0
+        new_state = types.ConstraintState.SATISFIED.value
+      # bottom zone
+      elif (mu * N + T <= 0.0) or ((T <= 0.0) and (N < 0.0)):
+        efc_force_out[worldid, efcid] = -efc_D * Jaref
+        new_state = types.ConstraintState.QUADRATIC.value
+        wp.atomic_add(ctx_cost_out, worldid, 0.5 * efc_D * Jaref * Jaref)
+      # middle zone
+      else:
+        dm = math.safe_div(efc_D_in[worldid, efcid0], mu * mu * (1.0 + mu * mu))
+        nmt = N - mu * T
+
+        force = -dm * nmt * mu
+
+        if efcid == efcid0:
+          efc_force_out[worldid, efcid] = force
+          wp.atomic_add(ctx_cost_out, worldid, 0.5 * dm * nmt * nmt)
+        else:
+          efc_force_out[worldid, efcid] = -math.safe_div(force, T) * ufrictionj
+
+        new_state = types.ConstraintState.CONE.value
+
+    efc_state_out[worldid, efcid] = new_state
+
+    # detect state change for Hessian reuse
+    if wp.static(hessian_incremental):
+      if new_state != old_state:
+        wp.atomic_max(hchange_out, worldid, 1)
+
+  return kernel
 
 
 @wp.kernel
@@ -1946,8 +1970,13 @@ def _update_constraint(m: types.Model, d: types.Data, ctx: SolverContext | Inver
     outputs=[ctx.gauss, ctx.cost, ctx.prev_cost],
   )
 
+  # InverseContext does not have hchange and never uses hessian_incremental;
+  # guard is needed because init_context accepts SolverContext | InverseContext
+  hessian_incremental = hasattr(ctx, "hchange") and ctx.hchange.size > 0
+  hchange = ctx.hchange if hessian_incremental else wp.empty((0,), dtype=int)
+
   wp.launch(
-    update_constraint_efc,
+    update_constraint_efc(hessian_incremental),
     dim=(d.nworld, d.njmax),
     inputs=[
       m.opt.impratio_invsqrt,
@@ -1961,11 +1990,12 @@ def _update_constraint(m: types.Model, d: types.Data, ctx: SolverContext | Inver
       d.efc.id,
       d.efc.D,
       d.efc.frictionloss,
+      d.efc.state,
       d.nacon,
       ctx.Jaref,
       ctx.done,
     ],
-    outputs=[d.efc.force, d.efc.state, ctx.cost],
+    outputs=[d.efc.force, d.efc.state, ctx.cost, hchange],
   )
 
   # qfrc_constraint = efc_J.T @ efc_force
@@ -2031,26 +2061,35 @@ def update_gradient_grad(
   wp.atomic_add(ctx_grad_dot_out, worldid, grad * grad)
 
 
-@wp.kernel
-def update_gradient_set_h_qM_lower_sparse(
-  # Model:
-  qM_fullm_i: wp.array(dtype=int),
-  qM_fullm_j: wp.array(dtype=int),
-  # Data in:
-  qM_in: wp.array3d(dtype=float),
-  # In:
-  ctx_done_in: wp.array(dtype=bool),
-  # Out:
-  ctx_h_out: wp.array3d(dtype=float),
-):
-  worldid, elementid = wp.tid()
+@cache_kernel
+def update_gradient_set_h_qM_lower_sparse(hessian_incremental: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    qM_fullm_i: wp.array(dtype=int),
+    qM_fullm_j: wp.array(dtype=int),
+    # Data in:
+    qM_in: wp.array3d(dtype=float),
+    # In:
+    ctx_done_in: wp.array(dtype=bool),
+    hchange_in: wp.array(dtype=int),
+    # Out:
+    ctx_h_out: wp.array3d(dtype=float),
+  ):
+    worldid, elementid = wp.tid()
 
-  if ctx_done_in[worldid]:
-    return
+    if ctx_done_in[worldid]:
+      return
 
-  i = qM_fullm_i[elementid]
-  j = qM_fullm_j[elementid]
-  ctx_h_out[worldid, i, j] += qM_in[worldid, 0, elementid]
+    if wp.static(hessian_incremental):
+      if hchange_in[worldid] == 0:
+        return
+
+    i = qM_fullm_i[elementid]
+    j = qM_fullm_j[elementid]
+    ctx_h_out[worldid, i, j] += qM_in[worldid, 0, elementid]
+
+  return kernel
 
 
 @wp.func
@@ -2070,7 +2109,7 @@ def active_check(tid: int, threshold: int) -> float:
 
 
 @cache_kernel
-def update_gradient_JTDAJ_sparse_tiled(tile_size: int, njmax: int):
+def update_gradient_JTDAJ_sparse_tiled(tile_size: int, njmax: int, hessian_incremental: bool):
   TILE_SIZE = tile_size
 
   @wp.kernel(module="unique", enable_backward=False)
@@ -2082,6 +2121,7 @@ def update_gradient_JTDAJ_sparse_tiled(tile_size: int, njmax: int):
     efc_state_in: wp.array2d(dtype=int),
     # In:
     ctx_done_in: wp.array(dtype=bool),
+    hchange_in: wp.array(dtype=int),
     # Out:
     ctx_h_out: wp.array3d(dtype=float),
   ):
@@ -2089,6 +2129,10 @@ def update_gradient_JTDAJ_sparse_tiled(tile_size: int, njmax: int):
 
     if ctx_done_in[worldid]:
       return
+
+    if wp.static(hessian_incremental):
+      if hchange_in[worldid] == 0:
+        return
 
     nefc = nefc_in[worldid]
 
@@ -2140,7 +2184,7 @@ def update_gradient_JTDAJ_sparse_tiled(tile_size: int, njmax: int):
 
 
 @cache_kernel
-def update_gradient_JTDAJ_dense_tiled(nv_padded: int, tile_size: int, njmax: int):
+def update_gradient_JTDAJ_dense_tiled(nv_padded: int, tile_size: int, njmax: int, hessian_incremental: bool):
   if njmax < tile_size:
     tile_size = njmax
 
@@ -2156,6 +2200,7 @@ def update_gradient_JTDAJ_dense_tiled(nv_padded: int, tile_size: int, njmax: int
     efc_state_in: wp.array2d(dtype=int),
     # In:
     ctx_done_in: wp.array(dtype=bool),
+    hchange_in: wp.array(dtype=int),
     # Out:
     ctx_h_out: wp.array3d(dtype=float),
   ):
@@ -2163,6 +2208,10 @@ def update_gradient_JTDAJ_dense_tiled(nv_padded: int, tile_size: int, njmax: int
 
     if ctx_done_in[worldid]:
       return
+
+    if wp.static(hessian_incremental):
+      if hchange_in[worldid] == 0:
+        return
 
     nefc = nefc_in[worldid]
 
@@ -2342,14 +2391,17 @@ def update_gradient_JTCJ(
 
 
 @cache_kernel
-def update_gradient_cholesky(tile_size: int):
+def update_gradient_cholesky(tile_size: int, hessian_incremental: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # In:
     ctx_grad_in: wp.array2d(dtype=float),
     h_in: wp.array3d(dtype=float),
     ctx_done_in: wp.array(dtype=bool),
+    hchange_in: wp.array(dtype=int),
+    hfactor_in: wp.array3d(dtype=float),
     # Out:
+    hfactor_out: wp.array3d(dtype=float),
     ctx_Mgrad_out: wp.array2d(dtype=float),
   ):
     worldid = wp.tid()
@@ -2358,8 +2410,19 @@ def update_gradient_cholesky(tile_size: int):
     if ctx_done_in[worldid]:
       return
 
-    mat_tile = wp.tile_load(h_in[worldid], shape=(TILE_SIZE, TILE_SIZE))
-    fact_tile = wp.tile_cholesky(mat_tile)
+    if wp.static(hessian_incremental):
+      if hchange_in[worldid] != 0:
+        # factor h and store
+        mat_tile = wp.tile_load(h_in[worldid], shape=(TILE_SIZE, TILE_SIZE))
+        fact_tile = wp.tile_cholesky(mat_tile)
+        wp.tile_store(hfactor_out[worldid], fact_tile)
+      else:
+        # reuse stored factor
+        fact_tile = wp.tile_load(hfactor_in[worldid], shape=(TILE_SIZE, TILE_SIZE))
+    else:
+      mat_tile = wp.tile_load(h_in[worldid], shape=(TILE_SIZE, TILE_SIZE))
+      fact_tile = wp.tile_cholesky(mat_tile)
+
     input_tile = wp.tile_load(ctx_grad_in[worldid], shape=TILE_SIZE)
     output_tile = wp.tile_cholesky_solve(fact_tile, input_tile)
     wp.tile_store(ctx_Mgrad_out[worldid], output_tile)
@@ -2368,11 +2431,12 @@ def update_gradient_cholesky(tile_size: int):
 
 
 @cache_kernel
-def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
+def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int, hessian_incremental: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # In:
     ctx_done_in: wp.array(dtype=bool),
+    hchange_in: wp.array(dtype=int),
     ctx_grad_in: wp.array3d(dtype=float),
     ctx_h_in: wp.array3d(dtype=float),
     ctx_hfactor: wp.array3d(dtype=float),
@@ -2385,12 +2449,12 @@ def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
     if ctx_done_in[worldid]:
       return
 
-    # We need matrix size both as a runtime input as well as a static input:
-    # static input is needed to specify the tile sizes for the compiler
-    # runtime input is needed for the loop bounds, otherwise warp will unroll
-    # unconditionally leading to shared memory capacity issues.
+    if wp.static(hessian_incremental):
+      if hchange_in[worldid] != 0:
+        wp.static(create_blocked_cholesky_func(TILE_SIZE))(ctx_h_in[worldid], matrix_size, ctx_hfactor[worldid])
+    else:
+      wp.static(create_blocked_cholesky_func(TILE_SIZE))(ctx_h_in[worldid], matrix_size, ctx_hfactor[worldid])
 
-    wp.static(create_blocked_cholesky_func(TILE_SIZE))(ctx_h_in[worldid], matrix_size, ctx_hfactor[worldid])
     wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
       ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
     )
@@ -2398,15 +2462,31 @@ def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
   return kernel
 
 
-@wp.kernel
-def padding_h(nv: int, ctx_done_in: wp.array(dtype=bool), ctx_h_out: wp.array3d(dtype=float)):
-  worldid, elementid = wp.tid()
+@cache_kernel
+def padding_h(hessian_incremental: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    # In:
+    ctx_done_in: wp.array(dtype=bool),
+    hchange_in: wp.array(dtype=int),
+    # Out:
+    ctx_h_out: wp.array3d(dtype=float),
+  ):
+    worldid, elementid = wp.tid()
 
-  if ctx_done_in[worldid]:
-    return
+    if ctx_done_in[worldid]:
+      return
 
-  dofid = nv + elementid
-  ctx_h_out[worldid, dofid, dofid] = 1.0
+    if wp.static(hessian_incremental):
+      if hchange_in[worldid] == 0:
+        return
+
+    dofid = nv + elementid
+    ctx_h_out[worldid, dofid, dofid] = 1.0
+
+  return kernel
 
 
 def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
@@ -2420,6 +2500,8 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
     outputs=[ctx.grad, ctx.grad_dot],
   )
 
+  hessian_incremental = m.opt.hessian_incremental and m.opt.cone != types.ConeType.ELLIPTIC
+
   if m.opt.solver == types.SolverType.CG:
     smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
   elif m.opt.solver == types.SolverType.NEWTON:
@@ -2428,7 +2510,7 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
       num_blocks_ceil = ceil(m.nv / types.TILE_SIZE_JTDAJ_SPARSE)
       lower_triangle_dim = int(num_blocks_ceil * (num_blocks_ceil + 1) / 2)
       wp.launch_tiled(
-        update_gradient_JTDAJ_sparse_tiled(types.TILE_SIZE_JTDAJ_SPARSE, d.njmax),
+        update_gradient_JTDAJ_sparse_tiled(types.TILE_SIZE_JTDAJ_SPARSE, d.njmax, hessian_incremental),
         dim=(d.nworld, lower_triangle_dim),
         inputs=[
           d.nefc,
@@ -2436,21 +2518,22 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
           d.efc.D,
           d.efc.state,
           ctx.done,
+          ctx.hchange,
         ],
         outputs=[ctx.h],
         block_dim=m.block_dim.update_gradient_JTDAJ_sparse,
       )
 
       wp.launch(
-        update_gradient_set_h_qM_lower_sparse,
+        update_gradient_set_h_qM_lower_sparse(hessian_incremental),
         dim=(d.nworld, m.qM_fullm_i.size),
-        inputs=[m.qM_fullm_i, m.qM_fullm_j, d.qM, ctx.done],
+        inputs=[m.qM_fullm_i, m.qM_fullm_j, d.qM, ctx.done, ctx.hchange],
         outputs=[ctx.h],
       )
     else:
       nv_padded = d.efc.J.shape[2]
       wp.launch_tiled(
-        update_gradient_JTDAJ_dense_tiled(nv_padded, types.TILE_SIZE_JTDAJ_DENSE, d.njmax),
+        update_gradient_JTDAJ_dense_tiled(nv_padded, types.TILE_SIZE_JTDAJ_DENSE, d.njmax, hessian_incremental),
         dim=d.nworld,
         inputs=[
           d.nefc,
@@ -2459,6 +2542,7 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
           d.efc.D,
           d.efc.state,
           ctx.done,
+          ctx.hchange,
         ],
         outputs=[ctx.h],
         block_dim=m.block_dim.update_gradient_JTDAJ_dense,
@@ -2516,24 +2600,24 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
 
     if m.nv <= _BLOCK_CHOLESKY_DIM:
       wp.launch_tiled(
-        update_gradient_cholesky(m.nv),
+        update_gradient_cholesky(m.nv, hessian_incremental),
         dim=d.nworld,
-        inputs=[ctx.grad, ctx.h, ctx.done],
-        outputs=[ctx.Mgrad],
+        inputs=[ctx.grad, ctx.h, ctx.done, ctx.hchange, ctx.hfactor],
+        outputs=[ctx.hfactor, ctx.Mgrad],
         block_dim=m.block_dim.update_gradient_cholesky,
       )
     else:
       wp.launch(
-        padding_h,
+        padding_h(hessian_incremental),
         dim=(d.nworld, m.nv_pad - m.nv),
-        inputs=[m.nv, ctx.done],
+        inputs=[m.nv, ctx.done, ctx.hchange],
         outputs=[ctx.h],
       )
 
       wp.launch_tiled(
-        update_gradient_cholesky_blocked(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad),
+        update_gradient_cholesky_blocked(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad, hessian_incremental),
         dim=d.nworld,
-        inputs=[ctx.done, ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)), ctx.h, ctx.hfactor],
+        inputs=[ctx.done, ctx.hchange, ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)), ctx.h, ctx.hfactor],
         outputs=[ctx.Mgrad.reshape(shape=(d.nworld, ctx.Mgrad.shape[1], 1))],
         block_dim=m.block_dim.update_gradient_cholesky_blocked,
       )
@@ -2684,6 +2768,11 @@ def _solver_iteration(
       inputs=[ctx.grad, ctx.Mgrad, ctx.done],
       outputs=[ctx.prev_grad, ctx.prev_Mgrad],
     )
+
+  # clear hchange for state-change detection in this iteration
+  hessian_incremental = m.opt.hessian_incremental and m.opt.cone != types.ConeType.ELLIPTIC
+  if hessian_incremental:
+    ctx.hchange.zero_()
 
   _update_constraint(m, d, ctx)
   _update_gradient(m, d, ctx)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -487,6 +487,77 @@ class SolverTest(parameterized.TestCase):
       world2_forces = np.concatenate([world2_eq_forces, world2_ineq_forces])
       _assert_eq(world2_forces, mjd2.efc_force, "efc_force2")
 
+  @parameterized.parameters(
+    (mujoco.mjtJacobian.mjJAC_DENSE, False),
+    (mujoco.mjtJacobian.mjJAC_SPARSE, True),
+  )
+  def test_hessian_incremental(self, jacobian, ls_parallel):
+    """Tests that hessian_incremental=True produces identical results to False."""
+    _, _, m, d = test_data.fixture(
+      "constraints.xml",
+      keyframe=2,
+      overrides={
+        "opt.jacobian": jacobian,
+        "opt.cone": ConeType.PYRAMIDAL,
+        "opt.solver": SolverType.NEWTON,
+        "opt.iterations": 5,
+        "opt.ls_iterations": 10,
+        "opt.ls_parallel": ls_parallel,
+      },
+    )
+
+    m.opt.hessian_incremental = False
+    mjw.solve(m, d)
+
+    # Solve with hessian_incremental
+    _, _, m_inc, d_inc = test_data.fixture(
+      "constraints.xml",
+      keyframe=2,
+      overrides={
+        "opt.jacobian": jacobian,
+        "opt.cone": ConeType.PYRAMIDAL,
+        "opt.solver": SolverType.NEWTON,
+        "opt.iterations": 5,
+        "opt.ls_iterations": 10,
+        "opt.ls_parallel": ls_parallel,
+      },
+    )
+    m_inc.opt.hessian_incremental = True
+    mjw.solve(m_inc, d_inc)
+
+    solver_niter = d_inc.solver_niter.numpy()[0]
+    self.assertEqual(solver_niter, d.solver_niter.numpy()[0])
+    self.assertGreater(solver_niter, 1)
+    _assert_eq(d_inc.qacc.numpy(), d.qacc.numpy(), "qacc_incremental")
+    _assert_eq(d_inc.qfrc_constraint.numpy(), d.qfrc_constraint.numpy(), "qfrc_constraint_incremental")
+    nefc = d.nefc.numpy()[0]
+    _assert_eq(d_inc.efc.force.numpy()[0, :nefc], d.efc.force.numpy()[0, :nefc], "efc_force_incremental")
+
+  def test_hessian_incremental_state_change(self):
+    """Tests that hchange is correctly detected when constraint states change."""
+    _, _, m, d = test_data.fixture(
+      "constraints.xml",
+      keyframe=2,
+      overrides={
+        "opt.cone": ConeType.PYRAMIDAL,
+        "opt.solver": SolverType.NEWTON,
+        "opt.iterations": 5,
+        "opt.ls_iterations": 10,
+        "opt.hessian_incremental": True,
+      },
+    )
+
+    d.qacc.zero_()
+
+    ctx = solver.create_solver_context(m, d)
+
+    # hchange should start as 1 (forcing first Hessian computation)
+    self.assertEqual(ctx.hchange.numpy()[0], 1)
+
+    # After solving, hchange should be 0 (reuse hessian)
+    solver._solve(m, d, ctx)
+    self.assertEqual(ctx.hchange.numpy()[0], 0)
+
   def test_frictionloss(self):
     """Tests solver with frictionloss."""
     for keyframe in range(3):

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -710,6 +710,7 @@ class Option:
       zeros out the contacts at each step)
     contact_sensor_maxmatch: max number of contacts considered by contact sensor matching criteria
                              contacts matched after this value is exceded will be ignored
+    hessian_incremental: if True, reuse Hessian factorization when constraint states don't change
   """
 
   timestep: array("*", float)
@@ -740,6 +741,7 @@ class Option:
   graph_conditional: bool
   run_collision_detection: bool
   contact_sensor_maxmatch: int
+  hessian_incremental: bool
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
introduces a new option `hessian_incremental`
- if True, skip recomputing Newton solver Hessian and factorization if there are no constraint state changes and the friction cone is pyramidal
- defaults to False (the changes introduced are statically compiled out for this default case)

future work might perform a partial (ie, "incremental") Hessian update for constraints that changes state between iterations #868  

## Hessian Reuse: Pyramidal vs Elliptic Friction Cones

### Pyramidal Friction Cones

The Hessian is **exactly the same** (numerically identical) when the constraint state doesn't change.

**H = M + J'DJ** where:
- **M** (inertia matrix) — fixed during solver iterations
- **J** (constraint Jacobian) — fixed during solver iterations
- **D** — diagonal: `D[i] = efc_D[i]` if `efc_state[i] == QUADRATIC`, else `0`

Since `efc_D` and `J` are constant during the solve, the only thing that can change `H` is the active set (state). If no states change, `H` is bit-for-bit identical, so reusing the factorization is **exact**.

### Elliptic Friction Cones

The Hessian **changes every iteration** even when states don't change.

**H = M + J'DJ + J'CJ** where:
- **C** — local contact-space Hessian that depends on `Jaref` (constraint forces)

Since `Jaref` changes every iteration, `C` changes, and `H` changes. MuJoCo C handles this by always recomputing the cone contribution via `HessianCone()`, even during incremental updates (`HessianIncremental`).

---

# benchmarking

## humanoid
there is a regression in sps with `hessian_incremental=True`. by default this option is False and the code paths it introduces in kernels are statically compiled out

```
mjwarp-testspeed benchmarks/humanoid/humanoid.xml --nworld=8192 --nconmax=24 --njmax=64 --measure_solver -o "opt.hessian_incremental=True"
```

```
Loading model from: benchmarks/humanoid/humanoid.xml...

Model
  nq: 28 nv: 27 nu: 21 nbody: 17 ngeom: 20
Option
  integrator: EULER
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: False
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 196608 njmax: 64
Rolling out 1000 steps at dt = 0.005...

Summary for 8192 parallel rollouts

Total JIT time: 5.51 s
Total simulation time: 2.13 s
Total steps per second: 3,847,234
Total realtime factor: 19,236.17 x
Total time per step: 259.93 ns
Total converged worlds: 8192 / 8192

solver niter:

mean     std       min  max
---------------------------
1.95793  0.989167    1    7
1.81541  0.859254    1    7
1.27616   0.54664    1    8
1.27646  0.606441    1    9
1.34046  0.619863    1    7
1.31976  0.570518    1    7
1.38068  0.635652    1    8
 1.3889  0.636862    1    8
1.35166  0.606857    1    8
1.34638   0.60119    1    8
```

```
mjwarp-testspeed benchmarks/humanoid/humanoid.xml --nworld=8192 --nconmax=24 --njmax=64 --measure_solver
```

this pr
```
Loading model from: benchmarks/humanoid/humanoid.xml...

Model
  nq: 28 nv: 27 nu: 21 nbody: 17 ngeom: 20
Option
  integrator: EULER
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: False
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 196608 njmax: 64
Rolling out 1000 steps at dt = 0.005...

Summary for 8192 parallel rollouts

Total JIT time: 0.32 s
Total simulation time: 2.11 s
Total steps per second: 3,891,258
Total realtime factor: 19,456.29 x
Total time per step: 256.99 ns
Total converged worlds: 8192 / 8192

solver niter:

mean     std       min  max
---------------------------
1.95734   0.98874    1    7
1.81535  0.859507    1    7
 1.2762  0.546758    1    8
1.27692  0.607433    1    8
1.34031  0.619681    1    7
1.31976  0.570874    1    8
1.38045  0.635035    1    8
1.38852   0.63662    1    7
1.35115  0.605678    1    8
1.34617  0.600433    1    8
```

fc9158989525538db53a2a8c3c0f156cbfeca911
```
Loading model from: benchmarks/humanoid/humanoid.xml...

Model
  nq: 28 nv: 27 nu: 21 nbody: 17 ngeom: 20
Option
  integrator: EULER
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: False
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 196608 njmax: 64
Rolling out 1000 steps at dt = 0.005...

Summary for 8192 parallel rollouts

Total JIT time: 4.87 s
Total simulation time: 2.11 s
Total steps per second: 3,886,316
Total realtime factor: 19,431.58 x
Total time per step: 257.31 ns
Total converged worlds: 8192 / 8192

solver niter:

mean     std       min  max
---------------------------
1.95686   0.98867    1    8
1.81555  0.859427    1    7
1.27603  0.546625    1    8
1.27651  0.606573    1    9
1.33996  0.619563    1    7
1.31944  0.570179    1    7
1.38081  0.635579    1    7
1.38827  0.636884    1    8
1.35096  0.605775    1    8
1.34593  0.600463    1    9
```

**humanoid tl;dr**: 
- `hessian_incremental=True` is less performance for the humanoid benchmark
- `hessian_incremental=False` (the default setting) does not introduce regressions for humanoid benchmark

## three humanoids

```
mjwarp-testspeed benchmarks/humanoid/three_humanoids.xml --nworld=8192 --nconmax=100 --njmax=192 --measure_solver
```

fc9158989525538db53a2a8c3c0f156cbfeca911

```
Loading model from: benchmarks/humanoid/three_humanoids.xml...

Model
  nq: 84 nv: 81 nu: 63 nbody: 49 ngeom: 58
Option
  integrator: EULER
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: True
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 819200 njmax: 192
Rolling out 1000 steps at dt = 0.005...

Summary for 8192 parallel rollouts

Total JIT time: 2.85 s
Total simulation time: 19.98 s
Total steps per second: 409,982
Total realtime factor: 2,049.91 x
Total time per step: 2439.13 ns
Total converged worlds: 8192 / 8192

solver niter:

mean     std       min  max
---------------------------
2.49598   1.09819    1    9
2.62862   1.02448    1    8
 3.1477   1.00022    1   11
3.21864   1.07081    1   11
 2.9236   1.10734    1    9
2.74697   1.10938    1   10
2.40425  0.999868    1    9
2.20526  0.940744    1    9
2.09753  0.899411    1    8
2.05472  0.885815    1    8
```

this pr
```
Loading model from: benchmarks/humanoid/three_humanoids.xml...

Model
  nq: 84 nv: 81 nu: 63 nbody: 49 ngeom: 58
Option
  integrator: EULER
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: True
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 819200 njmax: 192
Rolling out 1000 steps at dt = 0.005...

Summary for 8192 parallel rollouts

Total JIT time: 0.43 s
Total simulation time: 20.11 s
Total steps per second: 407,410
Total realtime factor: 2,037.05 x
Total time per step: 2454.53 ns
Total converged worlds: 8192 / 8192

solver niter:

mean     std       min  max
---------------------------
2.49565   1.09798    1    9
2.62806   1.02384    1    9
3.14758   1.00054    1   11
3.21788   1.07067    1   10
2.92227   1.11001    1   10
2.74801   1.10806    1   10
2.40815   1.00192    1    9
2.20487  0.939022    1    8
2.09918  0.903772    1    7
2.05776  0.887822    1    8
```

```
mjwarp-testspeed benchmarks/humanoid/three_humanoids.xml --nworld=8192 --nconmax=100 --njmax=192 --measure_solver -o "opt.hessian_incremental=True"
```

```
Loading model from: benchmarks/humanoid/three_humanoids.xml...

Model
  nq: 84 nv: 81 nu: 63 nbody: 49 ngeom: 58
Option
  integrator: EULER
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: True
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 819200 njmax: 192
Rolling out 1000 steps at dt = 0.005...

Summary for 8192 parallel rollouts

Total JIT time: 12.53 s
Total simulation time: 18.22 s
Total steps per second: 449,648
Total realtime factor: 2,248.24 x
Total time per step: 2223.96 ns
Total converged worlds: 8192 / 8192

solver niter:

mean     std       min  max
---------------------------
2.49599    1.0983    1    9
 2.6285   1.02436    1    9
3.14708  0.999085    1   11
3.21891   1.07185    1   10
2.92411   1.10796    1   10
2.75173   1.10806    1   12
2.40746  0.998896    1    9
2.20405  0.937821    1    8
2.09404  0.902663    1    8
2.05114  0.888178    1    8
```

**three humanoids tl;dr**: significant improvement in sps: 407,410 -> 449,648