### PR TITLE
Fix heightfield scene BVH bounds missing upper z-range

### DIFF
--- a/mujoco_warp/_src/bvh.py
+++ b/mujoco_warp/_src/bvh.py
@@ -184,6 +184,7 @@ def _compute_bvh_bounds(
   enabled_geom_ids: wp.array(dtype=int),
   mesh_bounds_size: wp.array(dtype=wp.vec3),
   hfield_bounds_size: wp.array(dtype=wp.vec3),
+  hfield_bounds_center: wp.array(dtype=wp.vec3),
   # Out:
   lower_out: wp.array(dtype=wp.vec3),
   upper_out: wp.array(dtype=wp.vec3),
@@ -215,7 +216,8 @@ def _compute_bvh_bounds(
     lower_bound, upper_bound = _compute_box_bounds(pos, rot, size)
   elif type == GeomType.HFIELD:
     size = hfield_bounds_size[geom_dataid[geom_id]]
-    lower_bound, upper_bound = _compute_box_bounds(pos, rot, size)
+    center = hfield_bounds_center[geom_dataid[geom_id]]
+    lower_bound, upper_bound = _compute_box_bounds(pos + rot @ center, rot, size)
 
   lower_out[world_id * bvh_ngeom + geom_local_id] = lower_bound
   upper_out[world_id * bvh_ngeom + geom_local_id] = upper_bound
@@ -255,6 +257,7 @@ def build_scene_bvh(mjm: mujoco.MjModel, mjd: mujoco.MjData, rc: RenderContext, 
       rc.enabled_geom_ids,
       rc.mesh_bounds_size,
       rc.hfield_bounds_size,
+      rc.hfield_bounds_center,
       rc.lower,
       rc.upper,
       rc.group,
@@ -289,6 +292,7 @@ def refit_scene_bvh(m: Model, d: Data, rc: RenderContext):
       rc.enabled_geom_ids,
       rc.mesh_bounds_size,
       rc.hfield_bounds_size,
+      rc.hfield_bounds_center,
       rc.lower,
       rc.upper,
       rc.group,
@@ -457,7 +461,7 @@ def build_hfield_bvh(
   hfieldid: int,
   constructor: str = "sah",
   leaf_size: int = 2,
-) -> tuple[wp.Mesh, wp.vec3]:
+) -> tuple[wp.Mesh, wp.vec3, wp.vec3]:
   """Create a Warp mesh BVH from heightfield data."""
   nr = mjm.hfield_nrow[hfieldid]
   nc = mjm.hfield_ncol[hfieldid]
@@ -482,6 +486,7 @@ def build_hfield_bvh(
   pmin = np.min(points, axis=0)
   pmax = np.max(points, axis=0)
   half = 0.5 * (pmax - pmin)
+  center = 0.5 * (pmin + pmax)
 
   points = wp.array(points, dtype=wp.vec3)
   indices = wp.array(indices, dtype=wp.int32)
@@ -493,7 +498,7 @@ def build_hfield_bvh(
     bvh_leaf_size=leaf_size,
   )
 
-  return mesh, half
+  return mesh, half, center
 
 
 @wp.kernel

--- a/mujoco_warp/_src/bvh_test.py
+++ b/mujoco_warp/_src/bvh_test.py
@@ -36,6 +36,7 @@ class MinimalRenderContext:
   enabled_geom_ids: wp.array
   mesh_bounds_size: wp.array
   hfield_bounds_size: wp.array
+  hfield_bounds_center: wp.array
   lower: wp.array
   upper: wp.array
   group: wp.array
@@ -56,6 +57,7 @@ def _create_minimal_context(mjm, nworld, enabled_geom_groups=None):
     enabled_geom_ids=wp.array(geom_enabled_idx, dtype=int),
     mesh_bounds_size=wp.zeros(max(mjm.nmesh, 1), dtype=wp.vec3),
     hfield_bounds_size=wp.zeros(max(mjm.nhfield, 1), dtype=wp.vec3),
+    hfield_bounds_center=wp.zeros(max(mjm.nhfield, 1), dtype=wp.vec3),
     lower=wp.zeros(nworld * bvh_ngeom, dtype=wp.vec3),
     upper=wp.zeros(nworld * bvh_ngeom, dtype=wp.vec3),
     group=wp.zeros(nworld * bvh_ngeom, dtype=int),
@@ -82,6 +84,7 @@ class BvhTest(absltest.TestCase):
         rc.enabled_geom_ids,
         rc.mesh_bounds_size,
         rc.hfield_bounds_size,
+        rc.hfield_bounds_center,
         rc.lower,
         rc.upper,
         rc.group,
@@ -111,6 +114,7 @@ class BvhTest(absltest.TestCase):
         rc.enabled_geom_ids,
         rc.mesh_bounds_size,
         rc.hfield_bounds_size,
+        rc.hfield_bounds_center,
         rc.lower,
         rc.upper,
         rc.group,
@@ -192,10 +196,11 @@ class BvhTest(absltest.TestCase):
     """Tests that build_hfield_bvh creates a valid BVH."""
     mjm, mjd, m, d = test_data.fixture("ray.xml")
 
-    hmesh, half = bvh.build_hfield_bvh(mjm, 0)
+    hmesh, half, center = bvh.build_hfield_bvh(mjm, 0)
 
     self.assertNotEqual(hmesh.id, wp.uint64(0), "hfield id")
     self.assertFalse(np.array_equal(np.array(half), np.array([0.0, 0.0, 0.0])), "hfield half size")
+    self.assertFalse(np.array_equal(np.array(center), np.array([0.0, 0.0, 0.0])), "hfield center")
 
   def test_accumulate_flex_vertex_normals(self):
     """Tests flex vertex normal accumulation kernel."""

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2194,15 +2194,18 @@ def create_render_context(
   hfield_registry = {}
   hfield_bvh_id = [wp.uint64(0) for _ in range(nhfield)]
   hfield_bounds_size = [wp.vec3(0.0, 0.0, 0.0) for _ in range(nhfield)]
+  hfield_bounds_center = [wp.vec3(0.0, 0.0, 0.0) for _ in range(nhfield)]
 
   for hid in used_hfield_id:
-    hmesh, hhalf = bvh.build_hfield_bvh(mjm, hid)
+    hmesh, hhalf, hcenter = bvh.build_hfield_bvh(mjm, hid)
     hfield_registry[hmesh.id] = hmesh
     hfield_bvh_id[hid] = hmesh.id
     hfield_bounds_size[hid] = hhalf
+    hfield_bounds_center[hid] = hcenter
 
   hfield_bvh_id_arr = wp.array(hfield_bvh_id, dtype=wp.uint64)
   hfield_bounds_size_arr = wp.array(hfield_bounds_size, dtype=wp.vec3)
+  hfield_bounds_center_arr = wp.array(hfield_bounds_center, dtype=wp.vec3)
 
   # Flex BVHs
   flex_bvh_id = wp.uint64(0)
@@ -2367,6 +2370,7 @@ def create_render_context(
     hfield_registry=hfield_registry,
     hfield_bvh_id=hfield_bvh_id_arr,
     hfield_bounds_size=hfield_bounds_size_arr,
+    hfield_bounds_center=hfield_bounds_center_arr,
     flex_mesh=flex_mesh,
     flex_rgba=wp.array(mjm.flex_rgba, dtype=wp.vec4),
     flex_bvh_id=flex_bvh_id,

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1779,7 +1779,8 @@ class RenderContext:
     textures_registry: texture registry
     hfield_registry: hfield BVH id to warp mesh mapping
     hfield_bvh_id: hfield BVH ids
-    hfield_bounds_size: hfield bounds size
+    hfield_bounds_size: hfield bounds half-extents
+    hfield_bounds_center: hfield bounds center offset in local frame
     flex_mesh: flex mesh
     flex_rgba: flex rgba
     flex_bvh_id: flex BVH id
@@ -1835,6 +1836,7 @@ class RenderContext:
   hfield_registry: dict
   hfield_bvh_id: array("nhfield", wp.uint64)
   hfield_bounds_size: array("nhfield", wp.vec3)
+  hfield_bounds_center: array("nhfield", wp.vec3)
   flex_mesh: wp.Mesh
   flex_rgba: array("nflex", wp.vec4)
   flex_bvh_id: wp.uint64


### PR DESCRIPTION
The scene-level BVH bounds for heightfield geoms were computed with `_compute_box_bounds(pos, rot, size)`, which creates an AABB symmetric around the geom position. Heightfield mesh z-values range from 0 to max_z (not centered at origin), so the upper half of the surface fell outside the bounding volume and rays missed it.

Fix by tracking the mesh center offset in local coordinates and offsetting the AABB center accordingly: `_compute_box_bounds(pos + rot @ center, rot, size)`.