### PR TITLE
Fix put_data crash when nefc=0 for dense models

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -889,7 +889,9 @@ def put_data(
 
   efc = types.Constraint(**efc_kwargs)
 
-  if mujoco.mj_isSparse(mjm):
+  if mjd.nefc == 0:
+    efc_j = np.zeros((0, mjm.nv))
+  elif mujoco.mj_isSparse(mjm):
     efc_j = np.zeros((mjd.nefc, mjm.nv))
     mujoco.mju_sparse2dense(efc_j, mjd.efc_J, mjd.efc_J_rownnz, mjd.efc_J_rowadr, mjd.efc_J_colind)
   else:


### PR DESCRIPTION
Tendons with `frictionloss > 0` cause MuJoCo to pre-allocate `efc_J` with size `nv` even when `nefc=0`. This makes `put_data` crash with `ValueError: cannot reshape array of size N into shape (0, N)` on the dense code path. This fix short-circuits to `np.zeros((0, nv))` when `nefc == 0` before the sparse/dense branch.