### PR TITLE
Fix heightfield scene BVH bounds missing upper z-range

### DIFF
--- a/mujoco_warp/_src/bvh.py
+++ b/mujoco_warp/_src/bvh.py
@@ -215,7 +215,8 @@ def _compute_bvh_bounds(
     lower_bound, upper_bound = _compute_box_bounds(pos, rot, size)
   elif type == GeomType.HFIELD:
     size = hfield_bounds_size[geom_dataid[geom_id]]
-    lower_bound, upper_bound = _compute_box_bounds(pos, rot, size)
+    hfield_center = pos + rot[:, 2] * size[2]
+    lower_bound, upper_bound = _compute_box_bounds(hfield_center, rot, size)
 
   lower_out[world_id * bvh_ngeom + geom_local_id] = lower_bound
   upper_out[world_id * bvh_ngeom + geom_local_id] = upper_bound

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1781,7 +1781,7 @@ class RenderContext:
     textures_registry: texture registry
     hfield_registry: hfield BVH id to warp mesh mapping
     hfield_bvh_id: hfield BVH ids
-    hfield_bounds_size: hfield bounds size
+    hfield_bounds_size: hfield bounds half-extents
     flex_mesh: flex mesh
     flex_rgba: flex rgba
     flex_bvh_id: flex BVH id


### PR DESCRIPTION
The scene-level BVH bounds for heightfield geoms were computed with `_compute_box_bounds(pos, rot, size)`, which creates an AABB symmetric around the geom position. However, heightfield mesh vertices have z-values in `[0, max_z]`, extending upward from the geom origin rather than being centered on it. This caused the upper half of the surface to fall outside the bounding volume, so rays aimed at the top of the heightfield skipped intersection entirely.

Fix by offsetting the AABB center in-place using the existing half-extent. Since hfield z-values start at 0, `size[2]` (the z half-extent) equals the center offset:

```python
hfield_center = pos + rot @ wp.vec3(0.0, 0.0, size[2])
_compute_box_bounds(hfield_center, rot, size)
```

This is a minimal 2-line change in `_compute_bvh_bounds` with no new arrays, fields, or plumbing required.

In local coordinates:

- Mesh z range: `[0, max_z]`
- Old AABB z range: `[-max_z/2, +max_z/2]` (centered at geom origin, misses the top half)
- New AABB z range: `[0, max_z]` (centered at `max_z/2`, tight fit)

**Note:** This works because MuJoCo's compiler always normalizes hfield_data to [0, 1] by subtracting the minimum value ([ref](https://mujoco.readthedocs.io/en/stable/XMLreference.html#asset-hfield)), so pmin_z = 0 and center_z = half_z = size[2].

Thanks to @slambert-bd for flagging this.