### PR TITLE
Fix mujoco nightly breakages: ten_J sparse format and MjOption field reorder

### DIFF
--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -28,6 +28,7 @@ from mujoco_warp import EnableBit
 from mujoco_warp import GainType
 from mujoco_warp import IntegratorType
 from mujoco_warp import test_data
+from mujoco_warp._src.util_pkg import check_version
 
 # tolerance for difference between MuJoCo and mjwarp smooth calculations - mostly
 # due to float precision
@@ -426,10 +427,14 @@ class ForwardTest(parameterized.TestCase):
         actuator_moment = np.zeros((mjm.nu, mjm.nv))
         mujoco.mju_sparse2dense(actuator_moment, mjd.actuator_moment, mjd.moment_rownnz, mjd.moment_rowadr, mjd.moment_colind)
         mjd_arr = actuator_moment
-      elif arr == "ten_J" and mjm.ntendon:
-        ten_J = np.zeros((mjm.ntendon, mjm.nv))
-        mujoco.mju_sparse2dense(ten_J, mjd.ten_J, mjd.ten_J_rownnz, mjd.ten_J_rowadr, mjd.ten_J_colind)
-        mjd_arr = ten_J
+      elif arr == "ten_J":
+        if check_version("mujoco>=3.5.1.dev872479828"):
+          ten_J = np.zeros((mjm.ntendon, mjm.nv))
+          if mjm.ntendon:
+            mujoco.mju_sparse2dense(ten_J, mjd.ten_J, mjd.ten_J_rownnz, mjd.ten_J_rowadr, mjd.ten_J_colind)
+          mjd_arr = ten_J
+        else:
+          mjd_arr = mjd.ten_J.reshape((mjm.ntendon, mjm.nv))
       elif arr == "efc_J" or arr == "efc_id":
         # Already checked earlier
         continue

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -983,13 +983,13 @@ def put_data(
 
   d.flexedge_J = wp.array(np.tile(mjd.flexedge_J.reshape(-1), (nworld, 1)).reshape((nworld, 1, -1)), dtype=float)
 
-  if mujoco.mj_isSparse(mjm):
-    ten_J = np.zeros((mjm.ntendon, mjm.nv))
-    mujoco.mju_sparse2dense(ten_J, mjd.ten_J.reshape(-1), mjd.ten_J_rownnz, mjd.ten_J_rowadr, mjd.ten_J_colind.reshape(-1))
-    d.ten_J = wp.array(np.full((nworld, mjm.ntendon, mjm.nv), ten_J), dtype=float)
+  ten_J = np.zeros((mjm.ntendon, mjm.nv))
+  if mujoco.mj_isSparse(mjm) or check_version("mujoco>=3.5.1.dev872479828"):
+    if mjm.ntendon:
+      mujoco.mju_sparse2dense(ten_J, mjd.ten_J.reshape(-1), mjd.ten_J_rownnz, mjd.ten_J_rowadr, mjd.ten_J_colind.reshape(-1))
   else:
     ten_J = mjd.ten_J.reshape((mjm.ntendon, mjm.nv))
-    d.ten_J = wp.array(np.full((nworld, mjm.ntendon, mjm.nv), ten_J), dtype=float)
+  d.ten_J = wp.array(np.full((nworld, mjm.ntendon, mjm.nv), ten_J), dtype=float)
 
   # TODO(taylorhowell): sparse actuator_moment
   actuator_moment = np.zeros((mjm.nu, mjm.nv))

--- a/mujoco_warp/_src/passive.py
+++ b/mujoco_warp/_src/passive.py
@@ -266,9 +266,9 @@ def _gravity_force(
 @wp.kernel
 def _fluid_force(
   # Model:
+  opt_wind: wp.array(dtype=wp.vec3),
   opt_density: wp.array(dtype=float),
   opt_viscosity: wp.array(dtype=float),
-  opt_wind: wp.array(dtype=wp.vec3),
   body_rootid: wp.array(dtype=int),
   body_geomnum: wp.array(dtype=int),
   body_geomadr: wp.array(dtype=int),
@@ -498,9 +498,9 @@ def _fluid(m: Model, d: Data):
     _fluid_force,
     dim=(d.nworld, m.nbody),
     inputs=[
+      m.opt.wind,
       m.opt.density,
       m.opt.viscosity,
-      m.opt.wind,
       m.body_rootid,
       m.body_geomnum,
       m.body_geomadr,

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -25,6 +25,7 @@ import mujoco_warp as mjw
 from mujoco_warp import ConeType
 from mujoco_warp import DisableBit
 from mujoco_warp import test_data
+from mujoco_warp._src.util_pkg import check_version
 
 # tolerance for difference between MuJoCo and MJWarp smooth calculations - mostly
 # due to float precision
@@ -400,7 +401,12 @@ class SmoothTest(parameterized.TestCase):
     mjw.transmission(m, d)
 
     _assert_eq(d.ten_length.numpy()[0], mjd.ten_length, "ten_length")
-    _assert_eq(d.ten_J.numpy()[0], mjd.ten_J.reshape((mjm.ntendon, mjm.nv)), "ten_J")
+    if check_version("mujoco>=3.5.1.dev872479828"):
+      ten_J = np.zeros((mjm.ntendon, mjm.nv))
+      mujoco.mju_sparse2dense(ten_J, mjd.ten_J.reshape(-1), mjd.ten_J_rownnz, mjd.ten_J_rowadr, mjd.ten_J_colind.reshape(-1))
+    else:
+      ten_J = mjd.ten_J.reshape((mjm.ntendon, mjm.nv))
+    _assert_eq(d.ten_J.numpy()[0], ten_J, "ten_J")
     _assert_eq(d.wrap_xpos.numpy()[0], mjd.wrap_xpos, "wrap_xpos")
     _assert_eq(d.wrap_obj.numpy()[0], mjd.wrap_obj, "wrap_obj")
     _assert_eq(d.ten_wrapnum.numpy()[0], mjd.ten_wrapnum, "ten_wrapnum")

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -682,11 +682,11 @@ class Option:
     tolerance: main solver tolerance
     ls_tolerance: CG/Newton linesearch tolerance
     ccd_tolerance: convex collision detection tolerance
-    density: density of medium
-    viscosity: viscosity of medium
     gravity: gravitational acceleration
     wind: wind (for lift, drag, and viscosity)
     magnetic: global magnetic flux
+    density: density of medium
+    viscosity: viscosity of medium
     integrator: integration mode (IntegratorType)
     cone: type of friction cone (ConeType)
     solver: solver algorithm (SolverType)
@@ -716,11 +716,11 @@ class Option:
   tolerance: array("*", float)
   ls_tolerance: array("*", float)
   ccd_tolerance: array("*", float)
-  density: array("*", float)
-  viscosity: array("*", float)
   gravity: array("*", wp.vec3)
   wind: array("*", wp.vec3)
   magnetic: array("*", wp.vec3)
+  density: array("*", float)
+  viscosity: array("*", float)
   integrator: int
   cone: int
   solver: int

--- a/mujoco_warp/_src/types_test.py
+++ b/mujoco_warp/_src/types_test.py
@@ -25,6 +25,7 @@ from absl.testing import parameterized
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import Option
+from mujoco_warp._src.util_pkg import check_version
 
 
 class TypesTest(parameterized.TestCase):
@@ -45,6 +46,11 @@ class TypesTest(parameterized.TestCase):
       # TODO(team): remove this reordering after MjData._all_fields order is fixed
       # there's a bug in _all_fields where solver_niter is in the wrong place
       mj_fields.insert(0, mj_fields.pop(mj_fields.index("solver_niter")))
+    elif mjw_class is Option:
+      if check_version("mujoco<3.5.1.dev869760513"):
+        # density/viscosity moved after magnetic in mujoco 3.5.1.dev869760513
+        for f in ("viscosity", "density"):
+          mj_fields.insert(mj_fields.index("magnetic") + 1, mj_fields.pop(mj_fields.index(f)))
 
     mj_set, mjw_set = set(mj_fields), set(mjw_fields)
 


### PR DESCRIPTION
## Summary

Two breaking changes in mujoco nightly require version-guarded fixes:

### 1. `ten_J` always sparse (since `3.5.1.dev872479828`)

`mjd.ten_J` is now stored in sparse format for all models, not just sparse ones. Previously, non-sparse models stored `ten_J` as a dense array that could be reshaped to `(ntendon, nv)`.

**Fix:** Updated `put_data` in `io.py` to always use `mju_sparse2dense` when mujoco version >= `3.5.1.dev872479828`, with version guard for backward compatibility. Updated corresponding test assertions in `smooth_test.py` and `forward_test.py`.

### 2. `MjOption` field reorder (since `3.5.1.dev869760513`)

`density` and `viscosity` fields moved from before `gravity` to after `magnetic` in `MjOption._all_fields`.

**Fix:** Reordered fields in `types.Option` dataclass to match the new order, with backward-compat version guard in `types_test.py`.

### Verification

- Breaking versions confirmed via bisection of 35 nightly builds from py.mujoco.org
- All 619 tests pass, 5 skipped

### Files changed

- `mujoco_warp/_src/io.py` — version-guarded `ten_J` sparse handling in `put_data`
- `mujoco_warp/_src/types.py` — reordered `density`/`viscosity` fields in `Option`
- `mujoco_warp/_src/types_test.py` — backward-compat guard for old field order
- `mujoco_warp/_src/smooth_test.py` — version-guarded `ten_J` test assertion
- `mujoco_warp/_src/forward_test.py` — version-guarded `ten_J` test assertion