### PR TITLE
fix OOB in _qM_sparse for unbatched dof_armature

### DIFF
--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -819,7 +819,7 @@ def _qM_sparse(
   bodyid = dof_bodyid[dofid]
 
   # init M(i,i) with armature inertia
-  qM_out[worldid, 0, madr_ij] = dof_armature[worldid, dofid]
+  qM_out[worldid, 0, madr_ij] = dof_armature[worldid % dof_armature.shape[0], dofid]
 
   # precompute buf = crb_body_i * cdof_i
   buf = math.inert_vec(crb_in[worldid, bodyid], cdof_in[worldid, dofid])


### PR DESCRIPTION
## Summary
- `_qM_sparse` indexed `dof_armature[worldid, dofid]` without accounting for the array being unbatched (shape `(1, nv)`), causing an out-of-bounds access when `nworld > 1`
- Applied `worldid % dof_armature.shape[0]` to match the pattern already used in `_qM_dense`

## Test plan
- Run cloth benchmark (`benchmarks/cloth/scene.xml`) with `nworld=32` in Warp debug mode (`wp.config.mode = "debug"`) — the assertion in `array.h:452` on `dof_armature` no longer fires