### PR TITLE
fix OOB in _equality_flex when SPARSE_CONSTRAINT_JACOBIAN is False

### DIFF
--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -24,6 +24,7 @@ from mujoco_warp._src.types import ContactType
 from mujoco_warp._src.types import DisableBit
 from mujoco_warp._src.types import vec5
 from mujoco_warp._src.types import vec11
+from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
@@ -596,95 +597,109 @@ def _equality_tendon(
   )
 
 
-@wp.kernel
-def _equality_flex(
-  # Model:
-  nv: int,
-  opt_timestep: wp.array(dtype=float),
-  opt_disableflags: int,
-  flexedge_length0: wp.array(dtype=float),
-  flexedge_invweight0: wp.array(dtype=float),
-  flexedge_J_rownnz: wp.array(dtype=int),
-  flexedge_J_rowadr: wp.array(dtype=int),
-  flexedge_J_colind: wp.array(dtype=int),
-  eq_solref: wp.array2d(dtype=wp.vec2),
-  eq_solimp: wp.array2d(dtype=vec5),
-  is_sparse: bool,
-  eq_flex_adr: wp.array(dtype=int),
-  # Data in:
-  qvel_in: wp.array2d(dtype=float),
-  flexedge_J_in: wp.array3d(dtype=float),
-  flexedge_length_in: wp.array2d(dtype=float),
-  njmax_in: int,
-  # Data out:
-  ne_out: wp.array(dtype=int),
-  nefc_out: wp.array(dtype=int),
-  efc_type_out: wp.array2d(dtype=int),
-  efc_id_out: wp.array2d(dtype=int),
-  efc_J_rownnz_out: wp.array2d(dtype=int),
-  efc_J_rowadr_out: wp.array2d(dtype=int),
-  efc_J_colind_out: wp.array3d(dtype=int),
-  efc_J_out: wp.array3d(dtype=float),
-  efc_pos_out: wp.array2d(dtype=float),
-  efc_margin_out: wp.array2d(dtype=float),
-  efc_D_out: wp.array2d(dtype=float),
-  efc_vel_out: wp.array2d(dtype=float),
-  efc_aref_out: wp.array2d(dtype=float),
-  efc_frictionloss_out: wp.array2d(dtype=float),
-):
-  worldid, eqflexid, edgeid = wp.tid()
-  eqid = eq_flex_adr[eqflexid]
+@cache_kernel
+def _equality_flex(is_sparse: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array(dtype=float),
+    opt_disableflags: int,
+    flexedge_length0: wp.array(dtype=float),
+    flexedge_invweight0: wp.array(dtype=float),
+    flexedge_J_rownnz: wp.array(dtype=int),
+    flexedge_J_rowadr: wp.array(dtype=int),
+    flexedge_J_colind: wp.array(dtype=int),
+    eq_solref: wp.array2d(dtype=wp.vec2),
+    eq_solimp: wp.array2d(dtype=vec5),
+    eq_flex_adr: wp.array(dtype=int),
+    # Data in:
+    qvel_in: wp.array2d(dtype=float),
+    flexedge_J_in: wp.array3d(dtype=float),
+    flexedge_length_in: wp.array2d(dtype=float),
+    njmax_in: int,
+    # Data out:
+    ne_out: wp.array(dtype=int),
+    nefc_out: wp.array(dtype=int),
+    efc_type_out: wp.array2d(dtype=int),
+    efc_id_out: wp.array2d(dtype=int),
+    efc_J_rownnz_out: wp.array2d(dtype=int),
+    efc_J_rowadr_out: wp.array2d(dtype=int),
+    efc_J_colind_out: wp.array3d(dtype=int),
+    efc_J_out: wp.array3d(dtype=float),
+    efc_pos_out: wp.array2d(dtype=float),
+    efc_margin_out: wp.array2d(dtype=float),
+    efc_D_out: wp.array2d(dtype=float),
+    efc_vel_out: wp.array2d(dtype=float),
+    efc_aref_out: wp.array2d(dtype=float),
+    efc_frictionloss_out: wp.array2d(dtype=float),
+  ):
+    worldid, eqflexid, edgeid = wp.tid()
+    eqid = eq_flex_adr[eqflexid]
 
-  wp.atomic_add(ne_out, worldid, 1)
-  efcid = wp.atomic_add(nefc_out, worldid, 1)
+    wp.atomic_add(ne_out, worldid, 1)
+    efcid = wp.atomic_add(nefc_out, worldid, 1)
 
-  if efcid >= njmax_in:
-    return
+    if efcid >= njmax_in:
+      return
 
-  pos = flexedge_length_in[worldid, edgeid] - flexedge_length0[edgeid]
-  solref = eq_solref[worldid % eq_solref.shape[0], eqid]
-  solimp = eq_solimp[worldid % eq_solimp.shape[0], eqid]
+    pos = flexedge_length_in[worldid, edgeid] - flexedge_length0[edgeid]
+    solref = eq_solref[worldid % eq_solref.shape[0], eqid]
+    solimp = eq_solimp[worldid % eq_solimp.shape[0], eqid]
 
-  Jqvel = float(0.0)
+    Jqvel = float(0.0)
 
-  rownnz = flexedge_J_rownnz[edgeid]
-  flex_rowadr = flexedge_J_rowadr[edgeid]
-  efc_J_rownnz_out[worldid, efcid] = rownnz
-  efc_rowadr = efcid * nv
-  efc_J_rowadr_out[worldid, efcid] = efc_rowadr
-  for i in range(rownnz):
-    flex_sparseid = flex_rowadr + i
-    efc_sparseid = efc_rowadr + i
-    colind = flexedge_J_colind[flex_sparseid]
-    J = flexedge_J_in[worldid, 0, flex_sparseid]
-    efc_J_colind_out[worldid, 0, efc_sparseid] = colind
-    efc_J_out[worldid, 0, efc_sparseid] = J
-    Jqvel += J * qvel_in[worldid, colind]
+    rownnz = flexedge_J_rownnz[edgeid]
+    flex_rowadr = flexedge_J_rowadr[edgeid]
 
-  _efc_row(
-    opt_disableflags,
-    worldid,
-    opt_timestep[worldid % opt_timestep.shape[0]],
-    efcid,
-    pos,
-    pos,
-    flexedge_invweight0[edgeid],
-    solref,
-    solimp,
-    0.0,
-    Jqvel,
-    0.0,
-    ConstraintType.EQUALITY,
-    eqid,
-    efc_type_out,
-    efc_id_out,
-    efc_pos_out,
-    efc_margin_out,
-    efc_D_out,
-    efc_vel_out,
-    efc_aref_out,
-    efc_frictionloss_out,
-  )
+    if wp.static(is_sparse):
+      efc_J_rownnz_out[worldid, efcid] = rownnz
+      efc_rowadr = efcid * nv
+      efc_J_rowadr_out[worldid, efcid] = efc_rowadr
+      for i in range(rownnz):
+        flex_sparseid = flex_rowadr + i
+        efc_sparseid = efc_rowadr + i
+        colind = flexedge_J_colind[flex_sparseid]
+        J = flexedge_J_in[worldid, 0, flex_sparseid]
+        efc_J_colind_out[worldid, 0, efc_sparseid] = colind
+        efc_J_out[worldid, 0, efc_sparseid] = J
+        Jqvel += J * qvel_in[worldid, colind]
+    else:
+      for i in range(nv):
+        efc_J_out[worldid, efcid, i] = 0.0
+      for i in range(rownnz):
+        flex_sparseid = flex_rowadr + i
+        colind = flexedge_J_colind[flex_sparseid]
+        J = flexedge_J_in[worldid, 0, flex_sparseid]
+        efc_J_out[worldid, efcid, colind] = J
+        Jqvel += J * qvel_in[worldid, colind]
+
+    _efc_row(
+      opt_disableflags,
+      worldid,
+      opt_timestep[worldid % opt_timestep.shape[0]],
+      efcid,
+      pos,
+      pos,
+      flexedge_invweight0[edgeid],
+      solref,
+      solimp,
+      0.0,
+      Jqvel,
+      0.0,
+      ConstraintType.EQUALITY,
+      eqid,
+      efc_type_out,
+      efc_id_out,
+      efc_pos_out,
+      efc_margin_out,
+      efc_D_out,
+      efc_vel_out,
+      efc_aref_out,
+      efc_frictionloss_out,
+    )
+
+  return kernel
 
 
 @wp.kernel
@@ -2179,7 +2194,7 @@ def make_constraint(m: types.Model, d: types.Data):
       )
 
       wp.launch(
-        _equality_flex,
+        _equality_flex(SPARSE_CONSTRAINT_JACOBIAN),
         dim=(d.nworld, m.eq_flex_adr.size, m.nflexedge),
         inputs=[
           m.nv,
@@ -2192,7 +2207,6 @@ def make_constraint(m: types.Model, d: types.Data):
           m.flexedge_J_colind,
           m.eq_solref,
           m.eq_solimp,
-          SPARSE_CONSTRAINT_JACOBIAN,
           m.eq_flex_adr,
           d.qvel,
           d.flexedge_J,


### PR DESCRIPTION
## Summary
- `_equality_flex` unconditionally wrote to `efc_J_rownnz_out` and `efc_J_rowadr_out`, but when `SPARSE_CONSTRAINT_JACOBIAN = False` these arrays have shape `(nworld, 0)` — any write is out-of-bounds
- Add `wp.static(is_sparse)` branching: sparse path copies sparse metadata to `efc_J`, dense path scatters sparse `flexedge_J` entries into dense `efc_J`
- Convert `_equality_flex` to `@cache_kernel` factory pattern so `is_sparse` is a closure variable for compile-time branch elimination, consistent with solver.py

## Test plan
- [x] Cloth benchmark (`benchmarks/cloth/scene.xml`, nworld=32) crashes without fix, passes with fix (10 steps)
- [x] All 50 constraint tests pass (`constraint_test.py`)
- [x] Pre-commit (ruff, kernel-analyzer) passes