### PR TITLE
fix OOB in _euler_damp_qfrc_sparse for unbatched dof_damping

### DIFF
--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -285,7 +285,7 @@ def _euler_damp_qfrc_sparse(
   timestep = opt_timestep[worldid % opt_timestep.shape[0]]
 
   adr = dof_Madr[tid]
-  qM_integration_out[worldid, 0, adr] += timestep * dof_damping[worldid, tid]
+  qM_integration_out[worldid, 0, adr] += timestep * dof_damping[worldid % dof_damping.shape[0], tid]
 
 
 @cache_kernel


### PR DESCRIPTION
## Summary
- `dof_damping` has shape `(1, nv)` (unbatched) but `_euler_damp_qfrc_sparse` indexed it with `worldid` directly, causing OOB when `nworld > 1`
- Apply `worldid % dof_damping.shape[0]` modulo, matching the pattern already used for `opt_timestep` on the preceding line

Same class of bug as #1185 (`dof_armature` in `_qM_sparse`).

## Test plan
- [x] Cloth benchmark debug mode (`wp.config.mode = "debug"`, nworld=32): `_euler_damp_qfrc_sparse` triggers device-side assert without fix, passes with fix
- [x] Pre-commit (ruff, kernel-analyzer) passes