### PR TITLE
Fix TileSet dataclass behavior

### DIFF
--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -17,6 +17,7 @@ import enum
 from typing import Callable
 
 import mujoco
+import numpy as np
 import warp as wp
 
 MJ_MINVAL = mujoco.mjMINVAL
@@ -795,6 +796,15 @@ class TileSet:
 
   adr: wp.array(dtype=int)
   size: int
+
+  def __eq__(self, other) -> bool:
+    if self.__class__ is not other.__class__:
+      return NotImplemented
+    return self.size == other.size and np.array_equal(np.asarray(self.adr.numpy()), np.asarray(other.adr.numpy()))
+
+  def __hash__(self) -> int:
+    adr = np.asarray(self.adr.numpy())
+    return hash((self.size, adr.dtype.str, adr.shape, adr.tobytes()))
 
 
 @dataclasses.dataclass

--- a/mujoco_warp/_src/types_test.py
+++ b/mujoco_warp/_src/types_test.py
@@ -18,6 +18,7 @@
 import dataclasses
 
 import mujoco
+import numpy as np
 import warp as wp
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -25,9 +26,20 @@ from absl.testing import parameterized
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import Option
+from mujoco_warp._src.types import TileSet
 
 
 class TypesTest(parameterized.TestCase):
+  @parameterized.parameters(1, 3)
+  def test_tileset_structural_equality_and_hash(self, count):
+    tile_a = TileSet(wp.array(np.arange(count) * 6, dtype=int), 16)
+    tile_b = TileSet(wp.array(np.arange(count) * 6, dtype=int), 16)
+    tile_c = TileSet(wp.array(np.arange(count) * 6 + 1, dtype=int), 16)
+
+    self.assertEqual(tile_a, tile_b)
+    self.assertEqual(hash(tile_a), hash(tile_b))
+    self.assertNotEqual(tile_a, tile_c)
+
   @parameterized.parameters((mujoco.MjOption, Option), (mujoco.MjModel, Model), (mujoco.MjData, Data))
   def test_field_order(self, mj_class, mjw_class):
     """Tests that MJW field order matches MuJoCo, and all warp-only fields are at the end."""


### PR DESCRIPTION
## Summary

`TileSet` is a structural descriptor for tiled matrix layout metadata. Right now,  it relies on the default `dataclass` behavior, which means two independently constructed but semantically identical `TileSet`s do not compare equal, and `TileSet` is also unhashable.

That becomes a problem for downstream consumers that treat `TileSet` as structural metadata. Equivalent models built from separate compiles should compare equal when their tile layouts match.

A minimal repro is:

```python
import numpy as np
import warp as wp

from mujoco_warp._src.types import TileSet

wp.init()

for count in (1, 3):
    a = TileSet(wp.array(np.arange(count) * 6, dtype=int), 16)
    b = TileSet(wp.array(np.arange(count) * 6, dtype=int), 16)

    print(f"count={count}")
    print("equal:", a == b)
    print("hashes_equal:", hash(a) == hash(b))
```

## Fix
Define structural `TileSet.__eq__ `and `TileSet.__hash__` in terms of: `size` and `the value of adr`.
For hashing, this patch uses `(size, adr.dtype.str, adr.shape, adr.tobytes())`, so equal tile layouts hash equal.