### PR TITLE
Fix the box normal count for edge features in collision_gjk

### DIFF
--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -1663,7 +1663,7 @@ def _box_normals(
     # c is 1 if edge is diagonal of a box face
     # c is 2 if edge is an external edge of box
     if c == 1 or c == 2:
-      return 2
+      return c
     return _box_normals2(mat, dir, normal_out, index_out)
 
   if feature_dim == 1:


### PR DESCRIPTION
This PR fixes a typo in `_box_normals` that causes it to return a count of 2 when only 1 normal was written.

The caller (`_aligned_faces`) reads the unwritten slot from a `wp.empty()` workspace array, which may contain heap garbage that passes the dot-product threshold in `_aligned_faces`, producing corrupted contact positions and NaN in qpos.