### PR TITLE
Fix cache_kernel hashing for numpy scalars

### DIFF
--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -127,8 +127,6 @@ def cache_kernel(func):
   @functools.wraps(func)
   def wrapper(*args):
     def _hash_arg(a):
-      if hasattr(a, "size"):
-        return a.size
       if isinstance(a, list):
         return hash(tuple(a))
       return hash(a)


### PR DESCRIPTION
This PR fixes #1277. After doing some digging, I'm pretty sure the `hasattr(a, "size")` branch in `_hash_arg` used `TileSet.size` as a cache key. I guess luckily #1276 was merged recently cause now `TileSet` has a proper `__hash__`. Since this exists, I am pretty sure these two lines are redundant and causes numpy scalar collisions. Feel free to double check my analysis in case this is used somewhere else in pipeline where I can't find.