### PR TITLE
revert changes to cache_kernel

### DIFF
--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -127,6 +127,8 @@ def cache_kernel(func):
   @functools.wraps(func)
   def wrapper(*args):
     def _hash_arg(a):
+      if hasattr(a, "size"):
+        return a.size
       if isinstance(a, list):
         return hash(tuple(a))
       return hash(a)


### PR DESCRIPTION
revert changes to `cache_kernel` from #1282 since these changes result in test failures that are not captured by the github ci since tests are run on cpu and not gpu. 