### PR TITLE
CUDA support fix for cache_kernel numpy decorator

### DIFF
--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -806,6 +806,9 @@ class TileSet:
     adr = np.asarray(self.adr.numpy())
     return hash((self.size, adr.dtype.str, adr.shape, adr.tobytes()))
 
+  def __cache_kernel_key__(self) -> int:
+    return self.size
+
 
 @dataclasses.dataclass
 class Callback:

--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -127,8 +127,6 @@ def cache_kernel(func):
   @functools.wraps(func)
   def wrapper(*args):
     def _hash_arg(a):
-      if hasattr(a, "size"):
-        return a.size
       if isinstance(a, list):
         return hash(tuple(a))
       return hash(a)

--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -17,6 +17,7 @@ import functools
 import inspect
 import warnings
 
+import numpy as np
 import warp as wp
 
 _STACK = None
@@ -122,16 +123,26 @@ def event_scope(fn, name: str = ""):
 _KERNEL_CACHE = {}
 
 
+def _normalize_cache_arg(a):
+  if isinstance(a, np.generic):
+    return _normalize_cache_arg(a.item())
+  if isinstance(a, tuple):
+    return tuple(_normalize_cache_arg(v) for v in a)
+  if isinstance(a, list):
+    return tuple(_normalize_cache_arg(v) for v in a)
+
+  cache_key = getattr(a, "__cache_kernel_key__", None)
+  if cache_key is not None:
+    return _normalize_cache_arg(cache_key())
+
+  return hash(a)
+
+
 def cache_kernel(func):
   # caching kernels to avoid crashes in graph_conditional code
   @functools.wraps(func)
   def wrapper(*args):
-    def _hash_arg(a):
-      if isinstance(a, list):
-        return hash(tuple(a))
-      return hash(a)
-
-    key = tuple(_hash_arg(a) for a in args) + (hash(func.__name__),)
+    key = tuple(_normalize_cache_arg(a) for a in args) + (hash(func.__name__),)
     if key not in _KERNEL_CACHE:
       _KERNEL_CACHE[key] = func(*args)
     return _KERNEL_CACHE[key]


### PR DESCRIPTION
This follows up on #1277/#1282.

Hello again sorry for the last PR, I should've done a better test. The earlier patch fixed the numpy-scalar cache collision, but I missed that removing the old fallback caused dense CUDA graph-capture paths to hash `TileSet` directly. I think this follow-up fixes both issues. 

This patch should fix both sides:
  - numpy scalars are keyed by value
  - `TileSet` exposes an explicit capture-safe cache key for `cache_kernel`
  - `TileSet.__hash__` remains unchanged

Hope this works better and let me know if the regression tests show otherwise.