### PR TITLE
Remove cache_kernel decorator

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -42,7 +42,6 @@ from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import mat43
 from mujoco_warp._src.types import mat63
 from mujoco_warp._src.types import vec5
-from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 # TODO(team): improve compile time to enable backward pass
@@ -154,7 +153,6 @@ def _hfield_filter(
     return False, xmin, xmax, ymin, ymax, zmin, zmax
 
 
-@cache_kernel
 def ccd_hfield_kernel_builder(
   geomtype1: int,
   geomtype2: int,
@@ -697,7 +695,6 @@ def ccd_hfield_kernel_builder(
   return ccd_hfield_kernel
 
 
-@cache_kernel
 def ccd_kernel_builder(
   geomtype1: int,
   geomtype2: int,

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -34,7 +34,6 @@ from mujoco_warp._src.types import GeomType
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import mat23
 from mujoco_warp._src.types import mat63
-from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
@@ -442,7 +441,6 @@ def _sap_range(
   range_out[worldid, geomid] = limit - geomid
 
 
-@cache_kernel
 def _sap_broadphase(opt_broadphase_filter: int, ngeom_aabb: int, ngeom_rbound: int, ngeom_margin: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -643,7 +641,6 @@ def sap_broadphase(m: Model, d: Data, ctx: CollisionContext):
   )
 
 
-@cache_kernel
 def _nxn_broadphase(opt_broadphase_filter: int, ngeom_aabb: int, ngeom_rbound: int, ngeom_margin: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(

--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -42,7 +42,6 @@ from mujoco_warp._src.types import GeomType
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import mat43
 from mujoco_warp._src.types import vec5
-from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
@@ -1297,7 +1296,6 @@ _PRIMITIVE_COLLISIONS = {
 }
 
 
-@cache_kernel
 def _primitive_narrowphase(primitive_collisions_types, primitive_collisions_func):
   @wp.kernel(module="unique", enable_backward=False)
   def primitive_narrowphase(

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -23,7 +23,6 @@ from mujoco_warp._src.types import ContactType
 from mujoco_warp._src.types import DisableBit
 from mujoco_warp._src.types import vec5
 from mujoco_warp._src.types import vec11
-from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
@@ -673,7 +672,6 @@ def _equality_tendon(
   )
 
 
-@cache_kernel
 def _equality_flex(is_sparse: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -42,7 +42,6 @@ from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import TileSet
 from mujoco_warp._src.types import TrnType
 from mujoco_warp._src.types import vec10f
-from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
@@ -290,7 +289,6 @@ def _euler_damp_qfrc_sparse(
   qM_integration_out[worldid, 0, adr] += timestep * dof_damping[worldid % dof_damping.shape[0], tid]
 
 
-@cache_kernel
 def _tile_euler_dense(tile: TileSet):
   @wp.kernel(module="unique", enable_backward=False)
   def euler_dense(

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -44,7 +44,6 @@ from mujoco_warp._src.types import vec8
 from mujoco_warp._src.types import vec8i
 from mujoco_warp._src.types import vec_pluginattr
 from mujoco_warp._src.util_misc import inside_geom
-from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
@@ -2406,7 +2405,6 @@ def _contact_match(
   sensor_contact_direction_out[worldid, contactsensorid, contactmatchid] = dir
 
 
-@cache_kernel
 def _contact_sort(maxmatch: int):
   @wp.kernel(module="unique", enable_backward=False)
   def contact_sort(
@@ -2892,7 +2890,6 @@ def energy_pos(m: Model, d: Data):
     # TODO(team): flex
 
 
-@cache_kernel
 def _energy_vel_kinetic(nv: int):
   @wp.kernel(module="unique", enable_backward=False)
   def energy_vel_kinetic(

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -35,7 +35,6 @@ from mujoco_warp._src.types import WrapType
 from mujoco_warp._src.types import vec5
 from mujoco_warp._src.types import vec10
 from mujoco_warp._src.types import vec11
-from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
@@ -1064,7 +1063,6 @@ def _factor_i_sparse(m: Model, d: Data, M: wp.array3d[float], L: wp.array3d[floa
   wp.launch(_qLDiag_div, dim=(d.nworld, m.nv), inputs=[m.M_rownnz, m.M_rowadr, L], outputs=[D])
 
 
-@cache_kernel
 def _tile_cholesky_factorize(tile: TileSet):
   """Returns a kernel for dense Cholesky factorization of a tile."""
 
@@ -2693,7 +2691,6 @@ def transmission(m: Model, d: Data):
     )
 
 
-@cache_kernel
 def _solve_LD_sparse_fused(nv: int, nlevels: int):
   """Fused sparse backsubstitution: UP + diag + DOWN in one kernel."""
 
@@ -2779,7 +2776,6 @@ def _solve_LD_sparse(
   )
 
 
-@cache_kernel
 def _tile_cholesky_solve(tile: TileSet):
   """Returns a kernel for dense Cholesky backsubstitution of a tile."""
 
@@ -2857,7 +2853,6 @@ def solve_m(m: Model, d: Data, x: wp.array2d[float], y: wp.array2d[float]):
   solve_LD(m, d, d.qLD, d.qLDiagInv, x, y)
 
 
-@cache_kernel
 def _tile_cholesky_factorize_solve(tile: TileSet):
   """Returns a kernel for dense Cholesky factorization and backsubstitution of a tile."""
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -25,7 +25,6 @@ from mujoco_warp._src import support
 from mujoco_warp._src import types
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_func
-from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 from mujoco_warp._src.warp_util import scoped_mathdx_gemm_disabled
 
@@ -883,7 +882,6 @@ def _compute_efc_eval_pt_3alphas_elliptic(
 # =============================================================================
 
 
-@cache_kernel
 def linesearch_iterative(ls_iterations: int, cone_type: types.ConeType, fuse_jv: bool, is_sparse: bool):
   """Factory for iterative linesearch kernel.
 
@@ -1410,7 +1408,6 @@ def linesearch_zero_jv(
   ctx_jv_out[worldid, efcid] = 0.0
 
 
-@cache_kernel
 def linesearch_jv_fused(is_sparse: bool, nv: int, dofs_per_thread: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -1471,7 +1468,6 @@ def linesearch_jv_fused(is_sparse: bool, nv: int, dofs_per_thread: int):
   return kernel
 
 
-@cache_kernel
 def linesearch_prepare_gauss(nv: int, dofs_per_thread: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -1719,7 +1715,6 @@ def solve_init_efc(
   ctx_search_dot_out[worldid] = 0.0
 
 
-@cache_kernel
 def solve_init_jaref(is_sparse: bool, nv: int, dofs_per_thread: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -1802,7 +1797,6 @@ def update_constraint_init_cost(
   ctx_cost_out[worldid] = 0.0
 
 
-@cache_kernel
 def update_constraint_efc(track_changes: bool):
   TRACK_CHANGES = track_changes
 
@@ -2010,7 +2004,6 @@ def update_constraint_init_qfrc_constraint_dense(
   qfrc_constraint_out[worldid, dofid] = sum_qfrc
 
 
-@cache_kernel
 def update_constraint_gauss_cost(nv: int, dofs_per_thread: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -2294,7 +2287,6 @@ def active_check(tid: int, threshold: int) -> float:
     return 1.0
 
 
-@cache_kernel
 def update_gradient_JTDAJ_sparse_tiled(tile_size: int, njmax: int):
   TILE_SIZE = tile_size
 
@@ -2364,7 +2356,6 @@ def update_gradient_JTDAJ_sparse_tiled(tile_size: int, njmax: int):
   return kernel
 
 
-@cache_kernel
 def update_gradient_JTDAJ_dense_tiled(nv_pad: int, tile_size: int, njmax: int):
   if njmax < tile_size:
     tile_size = njmax
@@ -2728,7 +2719,6 @@ def update_gradient_JTCJ_dense(
     ctx_h_out[worldid, dof1id, dof2id] += h
 
 
-@cache_kernel
 def update_gradient_cholesky(tile_size: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -2754,7 +2744,6 @@ def update_gradient_cholesky(tile_size: int):
   return kernel
 
 
-@cache_kernel
 def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -27,7 +27,6 @@ from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import State
 from mujoco_warp._src.types import vec5
 from mujoco_warp._src.types import vec10f
-from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
@@ -64,7 +63,6 @@ def next_act(
   return act
 
 
-@cache_kernel
 def mul_m_sparse(check_skip: bool):
   @wp.kernel(module="unique")
   def _mul_m_sparse(
@@ -101,7 +99,6 @@ def mul_m_sparse(check_skip: bool):
   return _mul_m_sparse
 
 
-@cache_kernel
 def mul_m_dense(nv: int, check_skip: bool):
   """Simple SIMT dense matmul: one thread per output element."""
 
@@ -432,7 +429,6 @@ def jac_dof(
   return jacp, jacr
 
 
-@cache_kernel
 def _make_jac_kernel(has_jacp: bool, has_jacr: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def _jac(

--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -119,28 +119,6 @@ def event_scope(fn, name: str = ""):
   return wrapper
 
 
-_KERNEL_CACHE = {}
-
-
-def cache_kernel(func):
-  # caching kernels to avoid crashes in graph_conditional code
-  @functools.wraps(func)
-  def wrapper(*args):
-    def _hash_arg(a):
-      if hasattr(a, "size"):
-        return a.size
-      if isinstance(a, list):
-        return hash(tuple(a))
-      return hash(a)
-
-    key = tuple(_hash_arg(a) for a in args) + (hash(func.__name__),)
-    if key not in _KERNEL_CACHE:
-      _KERNEL_CACHE[key] = func(*args)
-    return _KERNEL_CACHE[key]
-
-  return wrapper
-
-
 def check_toolkit_driver():
   wp.init()
   if wp.get_device().is_cuda:


### PR DESCRIPTION
## Summary

Remove the `cache_kernel` decorator, its `_KERNEL_CACHE` dict, and all usages. Warp's `module="unique"` kernel dedup handles these cases natively.

## Test plan

All tests on GPU (NVIDIA RTX PRO 6000 Blackwell, sm_120):

- [x] Full test suite: **727 passed, 0 failed, 7 skipped**
- [x] Full test suite `-n 2`: **727 passed, 0 failed, 7 skipped**
- [x] Humanoid benchmark (8192 worlds, 5 runs): no regression (+0.14%, within noise)
- [x] `pre-commit` passes