### PR TITLE
Skip Cholesky refactorization when no constraints changed

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2785,6 +2785,37 @@ def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
   return kernel
 
 
+@cache_kernel
+def update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size: int):
+  """Like update_gradient_cholesky_blocked but skips factorization per-world when no constraints changed."""
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # In:
+    ctx_done_in: wp.array[bool],
+    ctx_grad_in: wp.array3d[float],
+    ctx_h_in: wp.array3d[float],
+    changed_count_in: wp.array[int],
+    ctx_hfactor: wp.array3d[float],
+    # Out:
+    ctx_Mgrad_out: wp.array3d[float],
+  ):
+    worldid = wp.tid()
+    TILE_SIZE = wp.static(tile_size)
+
+    if ctx_done_in[worldid]:
+      return
+
+    if changed_count_in[worldid] > 0:
+      wp.static(create_blocked_cholesky_func(TILE_SIZE))(ctx_h_in[worldid], matrix_size, ctx_hfactor[worldid])
+
+    wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
+      ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
+    )
+
+  return kernel
+
+
 @wp.kernel
 def padding_h(nv: int, ctx_done_in: wp.array[bool], ctx_h_out: wp.array3d[float]):
   worldid, elementid = wp.tid()
@@ -2796,8 +2827,12 @@ def padding_h(nv: int, ctx_done_in: wp.array[bool], ctx_h_out: wp.array3d[float]
   ctx_h_out[worldid, dofid, dofid] = 1.0
 
 
-def _cholesky_factorize_solve(m: types.Model, d: types.Data, ctx: SolverContext):
-  """Cholesky factorize ctx.h and solve for Mgrad."""
+def _cholesky_factorize_solve(m: types.Model, d: types.Data, ctx: SolverContext, skip_unchanged: bool = False):
+  """Cholesky factorize ctx.h and solve for Mgrad.
+
+  If skip_unchanged is True (blocked path only), worlds where no constraints
+  changed reuse the cached L in hfactor instead of refactorizing.
+  """
   if m.nv <= _BLOCK_CHOLESKY_DIM:
     wp.launch_tiled(
       update_gradient_cholesky(m.nv),
@@ -2814,13 +2849,22 @@ def _cholesky_factorize_solve(m: types.Model, d: types.Data, ctx: SolverContext)
       outputs=[ctx.h],
     )
 
-    wp.launch_tiled(
-      update_gradient_cholesky_blocked(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad),
-      dim=d.nworld,
-      inputs=[ctx.done, ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)), ctx.h, ctx.hfactor],
-      outputs=[ctx.Mgrad.reshape(shape=(d.nworld, ctx.Mgrad.shape[1], 1))],
-      block_dim=m.block_dim.update_gradient_cholesky_blocked,
-    )
+    if skip_unchanged:
+      wp.launch_tiled(
+        update_gradient_cholesky_blocked_skip_unchanged(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad),
+        dim=d.nworld,
+        inputs=[ctx.done, ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)), ctx.h, ctx.changed_efc_count, ctx.hfactor],
+        outputs=[ctx.Mgrad.reshape(shape=(d.nworld, ctx.Mgrad.shape[1], 1))],
+        block_dim=m.block_dim.update_gradient_cholesky_blocked,
+      )
+    else:
+      wp.launch_tiled(
+        update_gradient_cholesky_blocked(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad),
+        dim=d.nworld,
+        inputs=[ctx.done, ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)), ctx.h, ctx.hfactor],
+        outputs=[ctx.Mgrad.reshape(shape=(d.nworld, ctx.Mgrad.shape[1], 1))],
+        block_dim=m.block_dim.update_gradient_cholesky_blocked,
+      )
 
 
 @wp.kernel
@@ -3055,7 +3099,7 @@ def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverConte
       outputs=[ctx.h],
     )
 
-  _cholesky_factorize_solve(m, d, ctx)
+  _cholesky_factorize_solve(m, d, ctx, skip_unchanged=True)
 
 
 @wp.kernel

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2774,7 +2774,6 @@ def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
   return kernel
 
 
-@cache_kernel
 def update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size: int):
   """Blocked Cholesky that skips factorization when no constraints changed."""
 
@@ -2820,7 +2819,7 @@ def _cholesky_factorize_solve(m: types.Model, d: types.Data, ctx: SolverContext,
   """Cholesky factorize ctx.h and solve for Mgrad.
 
   If skip_unchanged is True (blocked path only), worlds where no constraints
-  changed reuse the cached L in hfactor instead of refactorizing.
+  changed reuse the cached factorization in hfactor instead of refactorizing.
   """
   if m.nv <= _BLOCK_CHOLESKY_DIM:
     wp.launch_tiled(

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2787,7 +2787,7 @@ def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
 
 @cache_kernel
 def update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size: int):
-  """Like update_gradient_cholesky_blocked but skips factorization per-world when no constraints changed."""
+  """Blocked Cholesky that skips factorization when no constraints changed."""
 
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(


### PR DESCRIPTION
## Summary

- In the incremental Newton solver (pyramidal cone), ~88% of solver iterations have zero constraint state changes. The blocked Cholesky path previously refactorized H every iteration even when H was unchanged.
- Since the blocked path already caches L in `hfactor`, add a per-world check on `changed_efc_count` and skip the factorization when it's zero, going straight to the forward/backward substitution solve.
- Only affects the blocked path (nv > 32). The tiled path (nv ≤ 32) is unchanged.

## Benchmarks (RTX PRO 6000 Blackwell, 8192 worlds)

| Model | nv | Solver kernel speedup | Step speedup |
|---|---|---|---|
| three_humanoids | 81 | 1.9x | ~2% |
| G1 on plane | 35 | 1.3x | ~2% |
| humanoid | 27 | unchanged (tiled path) | unchanged |

Kernel-level nsys breakdown (three_humanoids, 50 steps):
- `cholesky_blocked` (always factorize): 83.3ms (294 calls) → 23.8ms (50 init calls)
- `cholesky_blocked_skip_unchanged`: 43.2ms (243 solver-iteration calls)
- **Net Cholesky savings: -16.3ms**

## Test plan

- [x] `forward_test.py` — 60/60 passed
- [ ] Full CI