### PR TITLE
Determinism support 2/N

### DIFF
--- a/mujoco_warp/_src/benchmark.py
+++ b/mujoco_warp/_src/benchmark.py
@@ -92,6 +92,7 @@ def benchmark(
   event_trace: bool = False,
   measure_alloc: bool = False,
   measure_solver_niter: bool = False,
+  use_cuda_graph: bool = True,
   render_context: RenderContext | None = None,
 ) -> Tuple[float, float, dict, list, list, list, int]:
   """Benchmark a function of Model and Data.
@@ -105,6 +106,7 @@ def benchmark(
     event_trace: If True, time routines decorated with @event_scope.
     measure_alloc: If True, record number of contacts and constraints.
     measure_solver_niter: If True, record the number of solver iterations.
+    use_cuda_graph: If True, capture and replay fn as a CUDA graph.
     render_context: The render context to use for rendering.
 
   Returns:
@@ -121,20 +123,27 @@ def benchmark(
   center = wp.array([], dtype=wp.float32)
 
   with warp_util.EventTracer(enabled=event_trace) as tracer:
-    # capture the whole function as a CUDA graph
     jit_beg = time.perf_counter()
-
-    if render_context is not None:
-      with wp.ScopedCapture() as capture:
-        fn(m, d, render_context)
+    graph = None
+    if use_cuda_graph:
+      # Capture the whole function as a CUDA graph.
+      if render_context is not None:
+        with wp.ScopedCapture() as capture:
+          fn(m, d, render_context)
+      else:
+        with wp.ScopedCapture() as capture:
+          fn(m, d)
+      graph = capture.graph
     else:
-      with wp.ScopedCapture() as capture:
+      # Run one uncaptured warmup step to trigger JIT compilation.
+      if render_context is not None:
+        fn(m, d, render_context)
+      else:
         fn(m, d)
+      wp.synchronize()
 
     jit_end = time.perf_counter()
     jit_duration = jit_end - jit_beg
-
-    graph = capture.graph
 
     time_vec = np.zeros(nstep)
     for i in range(nstep):
@@ -150,7 +159,12 @@ def benchmark(
         wp.synchronize()
 
         run_beg = time.perf_counter()
-        wp.capture_launch(graph)
+        if use_cuda_graph:
+          wp.capture_launch(graph)
+        elif render_context is not None:
+          fn(m, d, render_context)
+        else:
+          fn(m, d)
         wp.synchronize()
         run_end = time.perf_counter()
 

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -48,6 +48,211 @@ def _zero_constraint_counts(
   efc_nnz_out[worldid] = 0
 
 
+# ============================================================================
+# Deterministic constraint row allocation (opt.deterministic=True)
+#
+# Replaces the racy `wp.atomic_add(nefc_out, worldid, N)` slot allocation in
+# each constraint kernel with a deterministic count->scan->emit pipeline so
+# that d.efc.* rows land at the same position on every run of the same input.
+# Each kernel gets a paired _<name>_count kernel that writes per-thread row
+# counts and sparse nnz counts into (nworld, N) scratch arrays; a per-world
+# exclusive scan then converts counts to offsets and bumps d.nefc / efc_nnz
+# by the per-world totals; the emit kernel reads `base + offset` in place of
+# the old atomic_add result.
+# ============================================================================
+
+
+@wp.kernel
+def _per_world_exclusive_scan_2d(
+  # In:
+  counts_in: wp.array2d[int],  # (nworld, N)
+  nnz_counts_in: wp.array2d[int],  # (nworld, N)
+  # Out:
+  offsets_out: wp.array2d[int],  # (nworld, N)
+  nnz_offsets_out: wp.array2d[int],  # (nworld, N)
+  base_out: wp.array[int],  # (nworld,) snapshot of nefc_inout before bump
+  nnz_base_out: wp.array[int],  # (nworld,) snapshot of efc_nnz_inout before bump
+  # InOut:
+  nefc_inout: wp.array[int],
+  efc_nnz_inout: wp.array[int],
+):
+  worldid = wp.tid()
+
+  # snapshot the pre-bump totals so downstream emit kernels can read a stable base
+  base_out[worldid] = nefc_inout[worldid]
+  nnz_base_out[worldid] = efc_nnz_inout[worldid]
+
+  acc = int(0)
+  acc_nnz = int(0)
+  n = counts_in.shape[1]
+  for i in range(n):
+    offsets_out[worldid, i] = acc
+    nnz_offsets_out[worldid, i] = acc_nnz
+    acc += counts_in[worldid, i]
+    acc_nnz += nnz_counts_in[worldid, i]
+
+  nefc_inout[worldid] += acc
+  efc_nnz_inout[worldid] += acc_nnz
+
+
+@wp.kernel
+def _contact_world_boundaries(
+  # In:
+  contact_worldid_in: wp.array[int],
+  nacon_in: wp.array[int],
+  # Out:
+  world_start_out: wp.array[int],  # (nworld,)
+  world_end_out: wp.array[int],  # (nworld,)
+):
+  worldid = wp.tid()
+  nacon = nacon_in[0]
+  start = int(-1)
+  end = int(0)
+  for cid in range(nacon):
+    w = contact_worldid_in[cid]
+    if w == worldid:
+      if start < 0:
+        start = cid
+      end = cid + 1
+  if start < 0:
+    start = 0
+    end = 0
+  world_start_out[worldid] = start
+  world_end_out[worldid] = end
+
+
+@wp.kernel
+def _contact_per_world_scan(
+  # In:
+  counts_in: wp.array2d[int],  # (naconmax, nsubdim)
+  nnz_counts_in: wp.array2d[int],  # (naconmax, nsubdim)
+  world_start_in: wp.array[int],  # (nworld,)
+  world_end_in: wp.array[int],  # (nworld,)
+  # Out:
+  offsets_out: wp.array2d[int],  # (naconmax, nsubdim)
+  nnz_offsets_out: wp.array2d[int],  # (naconmax, nsubdim)
+  base_out: wp.array[int],  # (nworld,)
+  nnz_base_out: wp.array[int],  # (nworld,)
+  # InOut:
+  nefc_inout: wp.array[int],
+  efc_nnz_inout: wp.array[int],
+):
+  worldid = wp.tid()
+
+  base_out[worldid] = nefc_inout[worldid]
+  nnz_base_out[worldid] = efc_nnz_inout[worldid]
+
+  acc = int(0)
+  acc_nnz = int(0)
+  start = world_start_in[worldid]
+  end = world_end_in[worldid]
+  nsub = counts_in.shape[1]
+  for cid in range(start, end):
+    for sub in range(nsub):
+      offsets_out[cid, sub] = acc
+      nnz_offsets_out[cid, sub] = acc_nnz
+      acc += counts_in[cid, sub]
+      acc_nnz += nnz_counts_in[cid, sub]
+
+  nefc_inout[worldid] += acc
+  efc_nnz_inout[worldid] += acc_nnz
+
+
+@wp.func
+def _dof_tree_rownnz(
+  body_weldid: wp.array[int],
+  body_dofadr: wp.array[int],
+  body_dofnum: wp.array[int],
+  dof_parentid: wp.array[int],
+  body1: int,
+  body2: int,
+) -> int:
+  """Counts non-zeros in a 2-body (body1, body2) Jacobian row by walking the
+  dof parent tree. Matches the rownnz walk used in _equality_connect and
+  _equality_weld (continues through common dofs)."""
+  b1 = body_weldid[body1]
+  b2 = body_weldid[body2]
+  pda1 = int(body_dofadr[b1] + body_dofnum[b1] - 1)
+  pda2 = int(body_dofadr[b2] + body_dofnum[b2] - 1)
+  rownnz = int(0)
+  while pda1 >= 0 or pda2 >= 0:
+    da = wp.max(pda1, pda2)
+    if pda1 == da:
+      pda1 = dof_parentid[pda1]
+    if pda2 == da:
+      pda2 = dof_parentid[pda2]
+    rownnz += 1
+  return rownnz
+
+
+@wp.func
+def _contact_dof_tree_rownnz(
+  body_weldid: wp.array[int],
+  body_dofadr: wp.array[int],
+  body_dofnum: wp.array[int],
+  dof_parentid: wp.array[int],
+  body1: int,
+  body2: int,
+) -> int:
+  """Counts non-zeros in a 2-body contact Jacobian row by walking the dof
+  parent tree. Breaks on common dofs — matches the rownnz walk used in
+  _contact_pyramidal and _contact_elliptic."""
+  b1 = body_weldid[body1]
+  b2 = body_weldid[body2]
+  pda1 = int(body_dofadr[b1] + body_dofnum[b1] - 1)
+  pda2 = int(body_dofadr[b2] + body_dofnum[b2] - 1)
+  rownnz = int(0)
+  while pda1 >= 0 or pda2 >= 0:
+    da = wp.max(pda1, pda2)
+    # skip common dofs
+    if pda1 == da and pda2 == da:
+      break
+    if pda1 == da:
+      pda1 = dof_parentid[pda1]
+    if pda2 == da:
+      pda2 = dof_parentid[pda2]
+    rownnz += 1
+  return rownnz
+
+
+@wp.func
+def _tendon_merge_rownnz(
+  nv: int,
+  ten_J_rownnz: wp.array[int],
+  ten_J_rowadr: wp.array[int],
+  ten_J_colind: wp.array[int],
+  obj1id: int,
+  obj2id: int,
+  has_obj2: bool,
+) -> int:
+  """Counts unique dofs across two tendon Jacobians — matches the rownnz
+  walk in _equality_tendon (upper bound for slot reservation)."""
+  rownnz1 = ten_J_rownnz[obj1id]
+  rowadr1 = ten_J_rowadr[obj1id]
+  rownnz2 = int(0)
+  rowadr2 = int(0)
+  if has_obj2:
+    rownnz2 = ten_J_rownnz[obj2id]
+    rowadr2 = ten_J_rowadr[obj2id]
+
+  p1 = int(0)
+  p2 = int(0)
+  rownnz = int(0)
+  while p1 < rownnz1 or p2 < rownnz2:
+    col1 = nv
+    col2 = nv
+    if p1 < rownnz1:
+      col1 = ten_J_colind[rowadr1 + p1]
+    if p2 < rownnz2:
+      col2 = ten_J_colind[rowadr2 + p2]
+    if col1 <= col2:
+      p1 += 1
+    if col2 <= col1:
+      p2 += 1
+    rownnz += 1
+  return rownnz
+
+
 @wp.func
 def _efc_row(
   # Model:
@@ -121,234 +326,460 @@ def _efc_row(
 
 
 @wp.kernel
-def _equality_connect(
+def _equality_connect_count(
   # Model:
-  nv: int,
   nsite: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  body_parentid: wp.array[int],
-  body_rootid: wp.array[int],
   body_weldid: wp.array[int],
   body_dofnum: wp.array[int],
   body_dofadr: wp.array[int],
-  body_invweight0: wp.array2d[wp.vec2],
-  dof_bodyid: wp.array[int],
   dof_parentid: wp.array[int],
   site_bodyid: wp.array[int],
   eq_obj1id: wp.array[int],
   eq_obj2id: wp.array[int],
   eq_objtype: wp.array[int],
-  eq_solref: wp.array2d[wp.vec2],
-  eq_solimp: wp.array2d[vec5],
-  eq_data: wp.array2d[vec11],
   is_sparse: bool,
   eq_connect_adr: wp.array[int],
   # Data in:
-  qvel_in: wp.array2d[float],
   eq_active_in: wp.array2d[bool],
-  xpos_in: wp.array2d[wp.vec3],
-  xmat_in: wp.array2d[wp.mat33],
-  site_xpos_in: wp.array2d[wp.vec3],
-  subtree_com_in: wp.array2d[wp.vec3],
-  cdof_in: wp.array2d[wp.spatial_vector],
-  njmax_in: int,
-  njmax_nnz_in: int,
-  # Data out:
-  ne_out: wp.array[int],
-  nefc_out: wp.array[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
   # Out:
-  efc_nnz_out: wp.array[int],
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
 ):
-  """Calculates constraint rows for connect equality constraints."""
   worldid, eqconnectid = wp.tid()
   eqid = eq_connect_adr[eqconnectid]
-
   if not eq_active_in[worldid, eqid]:
+    efcid_count_out[worldid, eqconnectid] = 0
+    nnz_count_out[worldid, eqconnectid] = 0
     return
-
-  wp.atomic_add(ne_out, worldid, 3)
-  efcid = wp.atomic_add(nefc_out, worldid, 3)
-
-  if efcid >= njmax_in - 3:
-    return
-
-  efcid0 = efcid + 0
-  efcid1 = efcid + 1
-  efcid2 = efcid + 2
-
-  data = eq_data[worldid % eq_data.shape[0], eqid]
-  anchor1 = wp.vec3f(data[0], data[1], data[2])
-  anchor2 = wp.vec3f(data[3], data[4], data[5])
-
-  obj1id = eq_obj1id[eqid]
-  obj2id = eq_obj2id[eqid]
-
-  if nsite > 0 and eq_objtype[eqid] == types.ObjType.SITE:
-    body1 = site_bodyid[obj1id]
-    body2 = site_bodyid[obj2id]
-    pos1 = site_xpos_in[worldid, obj1id]
-    pos2 = site_xpos_in[worldid, obj2id]
-  else:
-    body1 = obj1id
-    body2 = obj2id
-    pos1 = xpos_in[worldid, body1] + xmat_in[worldid, body1] @ anchor1
-    pos2 = xpos_in[worldid, body2] + xmat_in[worldid, body2] @ anchor2
-
-  # error is difference in global positions
-  pos = pos1 - pos2
-
-  # compute Jacobian difference (opposite of contact: 0 - 1)
-  Jqvel = wp.vec3f(0.0, 0.0, 0.0)
-
+  efcid_count_out[worldid, eqconnectid] = 3
   if is_sparse:
-    # TODO(team): pre-compute number of non-zeros
-    body1 = body_weldid[body1]
-    body2 = body_weldid[body2]
-
-    da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
-    da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
-
-    # count non-zeros
-    pda1 = da1
-    pda2 = da2
-    rownnz = int(0)
-    while pda1 >= 0 or pda2 >= 0:
-      da = wp.max(pda1, pda2)
-      if pda1 == da:
-        pda1 = dof_parentid[pda1]
-      if pda2 == da:
-        pda2 = dof_parentid[pda2]
-      rownnz += 1
-
-    # get rowadr
-    rowadr = wp.atomic_add(efc_nnz_out, worldid, 3 * rownnz)
-    if rowadr + 3 * rownnz > njmax_nnz_in:
-      return
-    efc_J_rowadr_out[worldid, efcid0] = rowadr
-    efc_J_rowadr_out[worldid, efcid1] = rowadr + rownnz
-    efc_J_rowadr_out[worldid, efcid2] = rowadr + 2 * rownnz
-
-    efc_J_rownnz_out[worldid, efcid0] = rownnz
-    efc_J_rownnz_out[worldid, efcid1] = rownnz
-    efc_J_rownnz_out[worldid, efcid2] = rownnz
-
-    # compute J and colind
-    nnz = int(0)
-    while da1 >= 0 or da2 >= 0:
-      da = wp.max(da1, da2)
-      if da1 == da:
-        da1 = dof_parentid[da1]
-      if da2 == da:
-        da2 = dof_parentid[da2]
-
-      jacp1, _ = support.jac_dof(
-        body_parentid,
-        body_rootid,
-        dof_bodyid,
-        subtree_com_in,
-        cdof_in,
-        pos1,
-        body1,
-        da,
-        worldid,
-      )
-      jacp2, _ = support.jac_dof(
-        body_parentid,
-        body_rootid,
-        dof_bodyid,
-        subtree_com_in,
-        cdof_in,
-        pos2,
-        body2,
-        da,
-        worldid,
-      )
-      j1mj2 = jacp1 - jacp2
-
-      sparseid0 = rowadr + nnz
-      sparseid1 = rowadr + rownnz + nnz
-      sparseid2 = rowadr + 2 * rownnz + nnz
-
-      efc_J_colind_out[worldid, 0, sparseid0] = da
-      efc_J_colind_out[worldid, 0, sparseid1] = da
-      efc_J_colind_out[worldid, 0, sparseid2] = da
-
-      efc_J_out[worldid, 0, sparseid0] = j1mj2[0]
-      efc_J_out[worldid, 0, sparseid1] = j1mj2[1]
-      efc_J_out[worldid, 0, sparseid2] = j1mj2[2]
-
-      Jqvel += j1mj2 * qvel_in[worldid, da]
-
-      nnz += 1
+    obj1id = eq_obj1id[eqid]
+    obj2id = eq_obj2id[eqid]
+    if nsite > 0 and eq_objtype[eqid] == types.ObjType.SITE:
+      body1 = site_bodyid[obj1id]
+      body2 = site_bodyid[obj2id]
+    else:
+      body1 = obj1id
+      body2 = obj2id
+    rownnz = _dof_tree_rownnz(
+      body_weldid, body_dofadr, body_dofnum, dof_parentid, body1, body2
+    )
+    nnz_count_out[worldid, eqconnectid] = 3 * rownnz
   else:
-    # TODO(team): dof tree traversal
-    for dofid in range(nv):
-      jacp1, _ = support.jac_dof(
-        body_parentid,
-        body_rootid,
-        dof_bodyid,
-        subtree_com_in,
-        cdof_in,
-        pos1,
-        body1,
-        dofid,
+    nnz_count_out[worldid, eqconnectid] = 0
+
+
+def _equality_connect(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    nsite: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    body_parentid: wp.array[int],
+    body_rootid: wp.array[int],
+    body_weldid: wp.array[int],
+    body_dofnum: wp.array[int],
+    body_dofadr: wp.array[int],
+    body_invweight0: wp.array2d[wp.vec2],
+    dof_bodyid: wp.array[int],
+    dof_parentid: wp.array[int],
+    site_bodyid: wp.array[int],
+    eq_obj1id: wp.array[int],
+    eq_obj2id: wp.array[int],
+    eq_objtype: wp.array[int],
+    eq_solref: wp.array2d[wp.vec2],
+    eq_solimp: wp.array2d[vec5],
+    eq_data: wp.array2d[vec11],
+    eq_connect_adr: wp.array[int],
+    # Data in:
+    qvel_in: wp.array2d[float],
+    eq_active_in: wp.array2d[bool],
+    xpos_in: wp.array2d[wp.vec3],
+    xmat_in: wp.array2d[wp.mat33],
+    site_xpos_in: wp.array2d[wp.vec3],
+    subtree_com_in: wp.array2d[wp.vec3],
+    cdof_in: wp.array2d[wp.spatial_vector],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data out:
+    ne_out: wp.array[int],
+    nefc_out: wp.array[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    """Calculates constraint rows for connect equality constraints."""
+    worldid, eqconnectid = wp.tid()
+    eqid = eq_connect_adr[eqconnectid]
+
+    if not eq_active_in[worldid, eqid]:
+      return
+
+    wp.atomic_add(ne_out, worldid, 3)
+
+    if wp.static(deterministic):
+      efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, eqconnectid]
+    else:
+      efcid = wp.atomic_add(nefc_out, worldid, 3)
+
+    if efcid >= njmax_in - 3:
+      return
+
+    efcid0 = efcid + 0
+    efcid1 = efcid + 1
+    efcid2 = efcid + 2
+
+    data = eq_data[worldid % eq_data.shape[0], eqid]
+    anchor1 = wp.vec3f(data[0], data[1], data[2])
+    anchor2 = wp.vec3f(data[3], data[4], data[5])
+
+    obj1id = eq_obj1id[eqid]
+    obj2id = eq_obj2id[eqid]
+
+    if nsite > 0 and eq_objtype[eqid] == types.ObjType.SITE:
+      body1 = site_bodyid[obj1id]
+      body2 = site_bodyid[obj2id]
+      pos1 = site_xpos_in[worldid, obj1id]
+      pos2 = site_xpos_in[worldid, obj2id]
+    else:
+      body1 = obj1id
+      body2 = obj2id
+      pos1 = xpos_in[worldid, body1] + xmat_in[worldid, body1] @ anchor1
+      pos2 = xpos_in[worldid, body2] + xmat_in[worldid, body2] @ anchor2
+
+    # error is difference in global positions
+    pos = pos1 - pos2
+
+    # compute Jacobian difference (opposite of contact: 0 - 1)
+    Jqvel = wp.vec3f(0.0, 0.0, 0.0)
+
+    if wp.static(is_sparse):
+      body1 = body_weldid[body1]
+      body2 = body_weldid[body2]
+
+      da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
+      da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
+
+      # count non-zeros
+      pda1 = da1
+      pda2 = da2
+      rownnz = int(0)
+      while pda1 >= 0 or pda2 >= 0:
+        da = wp.max(pda1, pda2)
+        if pda1 == da:
+          pda1 = dof_parentid[pda1]
+        if pda2 == da:
+          pda2 = dof_parentid[pda2]
+        rownnz += 1
+
+      # get rowadr
+      if wp.static(deterministic):
+        rowadr = nnz_base_in[worldid] + nnz_offsets_in[worldid, eqconnectid]
+      else:
+        rowadr = wp.atomic_add(efc_nnz_out, worldid, 3 * rownnz)
+      if rowadr + 3 * rownnz > njmax_nnz_in:
+        return
+      efc_J_rowadr_out[worldid, efcid0] = rowadr
+      efc_J_rowadr_out[worldid, efcid1] = rowadr + rownnz
+      efc_J_rowadr_out[worldid, efcid2] = rowadr + 2 * rownnz
+
+      efc_J_rownnz_out[worldid, efcid0] = rownnz
+      efc_J_rownnz_out[worldid, efcid1] = rownnz
+      efc_J_rownnz_out[worldid, efcid2] = rownnz
+
+      # compute J and colind
+      nnz = int(0)
+      while da1 >= 0 or da2 >= 0:
+        da = wp.max(da1, da2)
+        if da1 == da:
+          da1 = dof_parentid[da1]
+        if da2 == da:
+          da2 = dof_parentid[da2]
+
+        jacp1, _ = support.jac_dof(
+          body_parentid,
+          body_rootid,
+          dof_bodyid,
+          subtree_com_in,
+          cdof_in,
+          pos1,
+          body1,
+          da,
+          worldid,
+        )
+        jacp2, _ = support.jac_dof(
+          body_parentid,
+          body_rootid,
+          dof_bodyid,
+          subtree_com_in,
+          cdof_in,
+          pos2,
+          body2,
+          da,
+          worldid,
+        )
+        j1mj2 = jacp1 - jacp2
+
+        sparseid0 = rowadr + nnz
+        sparseid1 = rowadr + rownnz + nnz
+        sparseid2 = rowadr + 2 * rownnz + nnz
+
+        efc_J_colind_out[worldid, 0, sparseid0] = da
+        efc_J_colind_out[worldid, 0, sparseid1] = da
+        efc_J_colind_out[worldid, 0, sparseid2] = da
+
+        efc_J_out[worldid, 0, sparseid0] = j1mj2[0]
+        efc_J_out[worldid, 0, sparseid1] = j1mj2[1]
+        efc_J_out[worldid, 0, sparseid2] = j1mj2[2]
+
+        Jqvel += j1mj2 * qvel_in[worldid, da]
+
+        nnz += 1
+    else:
+      # TODO(team): dof tree traversal
+      for dofid in range(nv):
+        jacp1, _ = support.jac_dof(
+          body_parentid,
+          body_rootid,
+          dof_bodyid,
+          subtree_com_in,
+          cdof_in,
+          pos1,
+          body1,
+          dofid,
+          worldid,
+        )
+        jacp2, _ = support.jac_dof(
+          body_parentid,
+          body_rootid,
+          dof_bodyid,
+          subtree_com_in,
+          cdof_in,
+          pos2,
+          body2,
+          dofid,
+          worldid,
+        )
+        j1mj2 = jacp1 - jacp2
+
+        efc_J_out[worldid, efcid0, dofid] = j1mj2[0]
+        efc_J_out[worldid, efcid1, dofid] = j1mj2[1]
+        efc_J_out[worldid, efcid2, dofid] = j1mj2[2]
+
+        Jqvel += j1mj2 * qvel_in[worldid, dofid]
+
+    body_invweight0_id = worldid % body_invweight0.shape[0]
+    invweight = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
+    pos_imp = wp.length(pos)
+
+    solref = eq_solref[worldid % eq_solref.shape[0], eqid]
+    solimp = eq_solimp[worldid % eq_solimp.shape[0], eqid]
+    timestep = opt_timestep[worldid % opt_timestep.shape[0]]
+
+    for i in range(3):
+      efcidi = efcid + i
+
+      _efc_row(
+        opt_disableflags,
         worldid,
+        timestep,
+        efcidi,
+        pos[i],
+        pos_imp,
+        invweight,
+        solref,
+        solimp,
+        0.0,
+        Jqvel[i],
+        0.0,
+        ConstraintType.EQUALITY,
+        eqid,
+        efc_type_out,
+        efc_id_out,
+        efc_pos_out,
+        efc_margin_out,
+        efc_D_out,
+        efc_vel_out,
+        efc_aref_out,
+        efc_frictionloss_out,
       )
-      jacp2, _ = support.jac_dof(
-        body_parentid,
-        body_rootid,
-        dof_bodyid,
-        subtree_com_in,
-        cdof_in,
-        pos2,
-        body2,
-        dofid,
-        worldid,
-      )
-      j1mj2 = jacp1 - jacp2
 
-      efc_J_out[worldid, efcid0, dofid] = j1mj2[0]
-      efc_J_out[worldid, efcid1, dofid] = j1mj2[1]
-      efc_J_out[worldid, efcid2, dofid] = j1mj2[2]
+  return kernel
 
-      Jqvel += j1mj2 * qvel_in[worldid, dofid]
 
-  body_invweight0_id = worldid % body_invweight0.shape[0]
-  invweight = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
-  pos_imp = wp.length(pos)
+@wp.kernel
+def _equality_joint_count(
+  # Model:
+  eq_obj2id: wp.array[int],
+  is_sparse: bool,
+  eq_jnt_adr: wp.array[int],
+  # Data in:
+  eq_active_in: wp.array2d[bool],
+  # Out:
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
+):
+  worldid, eqjntid = wp.tid()
+  eqid = eq_jnt_adr[eqjntid]
+  if not eq_active_in[worldid, eqid]:
+    efcid_count_out[worldid, eqjntid] = 0
+    nnz_count_out[worldid, eqjntid] = 0
+    return
+  efcid_count_out[worldid, eqjntid] = 1
+  if is_sparse:
+    if eq_obj2id[eqid] > -1:
+      nnz_count_out[worldid, eqjntid] = 2
+    else:
+      nnz_count_out[worldid, eqjntid] = 1
+  else:
+    nnz_count_out[worldid, eqjntid] = 0
 
-  solref = eq_solref[worldid % eq_solref.shape[0], eqid]
-  solimp = eq_solimp[worldid % eq_solimp.shape[0], eqid]
-  timestep = opt_timestep[worldid % opt_timestep.shape[0]]
 
-  for i in range(3):
-    efcidi = efcid + i
+def _equality_joint(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    qpos0: wp.array2d[float],
+    jnt_qposadr: wp.array[int],
+    jnt_dofadr: wp.array[int],
+    dof_invweight0: wp.array2d[float],
+    eq_obj1id: wp.array[int],
+    eq_obj2id: wp.array[int],
+    eq_solref: wp.array2d[wp.vec2],
+    eq_solimp: wp.array2d[vec5],
+    eq_data: wp.array2d[vec11],
+    eq_jnt_adr: wp.array[int],
+    # Data in:
+    qpos_in: wp.array2d[float],
+    qvel_in: wp.array2d[float],
+    eq_active_in: wp.array2d[bool],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data out:
+    ne_out: wp.array[int],
+    nefc_out: wp.array[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    worldid, eqjntid = wp.tid()
+    eqid = eq_jnt_adr[eqjntid]
 
+    if not eq_active_in[worldid, eqid]:
+      return
+
+    wp.atomic_add(ne_out, worldid, 1)
+
+    if wp.static(deterministic):
+      efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, eqjntid]
+    else:
+      efcid = wp.atomic_add(nefc_out, worldid, 1)
+
+    if efcid >= njmax_in:
+      return
+
+    jntid_1 = eq_obj1id[eqid]
+    jntid_2 = eq_obj2id[eqid]
+    data = eq_data[worldid % eq_data.shape[0], eqid]
+    dofadr1 = jnt_dofadr[jntid_1]
+    qposadr1 = jnt_qposadr[jntid_1]
+    qpos0_id = worldid % qpos0.shape[0]
+    dof_invweight0_id = worldid % dof_invweight0.shape[0]
+
+    if wp.static(is_sparse):
+      if jntid_2 > -1:
+        rownnz = 2
+      else:
+        rownnz = 1
+      efc_J_rownnz_out[worldid, efcid] = rownnz
+      if wp.static(deterministic):
+        rowadr = nnz_base_in[worldid] + nnz_offsets_in[worldid, eqjntid]
+      else:
+        rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz)
+      if rowadr + rownnz > njmax_nnz_in:
+        return
+      efc_J_rowadr_out[worldid, efcid] = rowadr
+      efc_J_colind_out[worldid, 0, rowadr] = dofadr1
+      efc_J_out[worldid, 0, rowadr] = 1.0
+    else:
+      for i in range(nv):
+        efc_J_out[worldid, efcid, i] = 0.0
+      efc_J_out[worldid, efcid, dofadr1] = 1.0
+
+    if jntid_2 > -1:
+      # Two joint constraint
+      qposadr2 = jnt_qposadr[jntid_2]
+      dofadr2 = jnt_dofadr[jntid_2]
+      dif = qpos_in[worldid, qposadr2] - qpos0[qpos0_id, qposadr2]
+
+      # Horner's method for polynomials
+      rhs = data[0] + dif * (data[1] + dif * (data[2] + dif * (data[3] + dif * data[4])))
+      deriv_2 = data[1] + dif * (2.0 * data[2] + dif * (3.0 * data[3] + dif * 4.0 * data[4]))
+
+      pos = qpos_in[worldid, qposadr1] - qpos0[qpos0_id, qposadr1] - rhs
+      Jqvel = qvel_in[worldid, dofadr1] - qvel_in[worldid, dofadr2] * deriv_2
+      invweight = dof_invweight0[dof_invweight0_id, dofadr1] + dof_invweight0[dof_invweight0_id, dofadr2]
+
+      if wp.static(is_sparse):
+        sparseid = rowadr + 1
+        efc_J_colind_out[worldid, 0, sparseid] = dofadr2
+        efc_J_out[worldid, 0, sparseid] = -deriv_2
+      else:
+        efc_J_out[worldid, efcid, dofadr2] = -deriv_2
+    else:
+      # Single joint constraint
+      pos = qpos_in[worldid, qposadr1] - qpos0[qpos0_id, qposadr1] - data[0]
+      Jqvel = qvel_in[worldid, dofadr1]
+      invweight = dof_invweight0[dof_invweight0_id, dofadr1]
+
+    # Update constraint parameters
     _efc_row(
       opt_disableflags,
       worldid,
-      timestep,
-      efcidi,
-      pos[i],
-      pos_imp,
+      opt_timestep[worldid % opt_timestep.shape[0]],
+      efcid,
+      pos,
+      pos,
       invweight,
-      solref,
-      solimp,
+      eq_solref[worldid % eq_solref.shape[0], eqid],
+      eq_solimp[worldid % eq_solimp.shape[0], eqid],
       0.0,
-      Jqvel[i],
+      Jqvel,
       0.0,
       ConstraintType.EQUALITY,
       eqid,
@@ -362,317 +793,265 @@ def _equality_connect(
       efc_frictionloss_out,
     )
 
-
-@wp.kernel
-def _equality_joint(
-  # Model:
-  nv: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  qpos0: wp.array2d[float],
-  jnt_qposadr: wp.array[int],
-  jnt_dofadr: wp.array[int],
-  dof_invweight0: wp.array2d[float],
-  eq_obj1id: wp.array[int],
-  eq_obj2id: wp.array[int],
-  eq_solref: wp.array2d[wp.vec2],
-  eq_solimp: wp.array2d[vec5],
-  eq_data: wp.array2d[vec11],
-  is_sparse: bool,
-  eq_jnt_adr: wp.array[int],
-  # Data in:
-  qpos_in: wp.array2d[float],
-  qvel_in: wp.array2d[float],
-  eq_active_in: wp.array2d[bool],
-  njmax_in: int,
-  njmax_nnz_in: int,
-  # Data out:
-  ne_out: wp.array[int],
-  nefc_out: wp.array[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
-  # Out:
-  efc_nnz_out: wp.array[int],
-):
-  worldid, eqjntid = wp.tid()
-  eqid = eq_jnt_adr[eqjntid]
-
-  if not eq_active_in[worldid, eqid]:
-    return
-
-  wp.atomic_add(ne_out, worldid, 1)
-  efcid = wp.atomic_add(nefc_out, worldid, 1)
-
-  if efcid >= njmax_in:
-    return
-
-  jntid_1 = eq_obj1id[eqid]
-  jntid_2 = eq_obj2id[eqid]
-  data = eq_data[worldid % eq_data.shape[0], eqid]
-  dofadr1 = jnt_dofadr[jntid_1]
-  qposadr1 = jnt_qposadr[jntid_1]
-  qpos0_id = worldid % qpos0.shape[0]
-  dof_invweight0_id = worldid % dof_invweight0.shape[0]
-
-  if is_sparse:
-    if jntid_2 > -1:
-      rownnz = 2
-    else:
-      rownnz = 1
-    efc_J_rownnz_out[worldid, efcid] = rownnz
-    rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz)
-    if rowadr + rownnz > njmax_nnz_in:
-      return
-    efc_J_rowadr_out[worldid, efcid] = rowadr
-    efc_J_colind_out[worldid, 0, rowadr] = dofadr1
-    efc_J_out[worldid, 0, rowadr] = 1.0
-  else:
-    for i in range(nv):
-      efc_J_out[worldid, efcid, i] = 0.0
-    efc_J_out[worldid, efcid, dofadr1] = 1.0
-
-  if jntid_2 > -1:
-    # Two joint constraint
-    qposadr2 = jnt_qposadr[jntid_2]
-    dofadr2 = jnt_dofadr[jntid_2]
-    dif = qpos_in[worldid, qposadr2] - qpos0[qpos0_id, qposadr2]
-
-    # Horner's method for polynomials
-    rhs = data[0] + dif * (data[1] + dif * (data[2] + dif * (data[3] + dif * data[4])))
-    deriv_2 = data[1] + dif * (2.0 * data[2] + dif * (3.0 * data[3] + dif * 4.0 * data[4]))
-
-    pos = qpos_in[worldid, qposadr1] - qpos0[qpos0_id, qposadr1] - rhs
-    Jqvel = qvel_in[worldid, dofadr1] - qvel_in[worldid, dofadr2] * deriv_2
-    invweight = dof_invweight0[dof_invweight0_id, dofadr1] + dof_invweight0[dof_invweight0_id, dofadr2]
-
-    if is_sparse:
-      sparseid = rowadr + 1
-      efc_J_colind_out[worldid, 0, sparseid] = dofadr2
-      efc_J_out[worldid, 0, sparseid] = -deriv_2
-    else:
-      efc_J_out[worldid, efcid, dofadr2] = -deriv_2
-  else:
-    # Single joint constraint
-    pos = qpos_in[worldid, qposadr1] - qpos0[qpos0_id, qposadr1] - data[0]
-    Jqvel = qvel_in[worldid, dofadr1]
-    invweight = dof_invweight0[dof_invweight0_id, dofadr1]
-
-  # Update constraint parameters
-  _efc_row(
-    opt_disableflags,
-    worldid,
-    opt_timestep[worldid % opt_timestep.shape[0]],
-    efcid,
-    pos,
-    pos,
-    invweight,
-    eq_solref[worldid % eq_solref.shape[0], eqid],
-    eq_solimp[worldid % eq_solimp.shape[0], eqid],
-    0.0,
-    Jqvel,
-    0.0,
-    ConstraintType.EQUALITY,
-    eqid,
-    efc_type_out,
-    efc_id_out,
-    efc_pos_out,
-    efc_margin_out,
-    efc_D_out,
-    efc_vel_out,
-    efc_aref_out,
-    efc_frictionloss_out,
-  )
+  return kernel
 
 
 @wp.kernel
-def _equality_tendon(
+def _equality_tendon_count(
   # Model:
   nv: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
   eq_obj1id: wp.array[int],
   eq_obj2id: wp.array[int],
-  eq_solref: wp.array2d[wp.vec2],
-  eq_solimp: wp.array2d[vec5],
-  eq_data: wp.array2d[vec11],
   ten_J_rownnz: wp.array[int],
   ten_J_rowadr: wp.array[int],
   ten_J_colind: wp.array[int],
-  tendon_length0: wp.array2d[float],
-  tendon_invweight0: wp.array2d[float],
   is_sparse: bool,
   eq_ten_adr: wp.array[int],
   # Data in:
-  qvel_in: wp.array2d[float],
   eq_active_in: wp.array2d[bool],
-  ten_J_in: wp.array2d[float],
-  ten_length_in: wp.array2d[float],
-  njmax_in: int,
-  njmax_nnz_in: int,
-  # Data out:
-  ne_out: wp.array[int],
-  nefc_out: wp.array[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
   # Out:
-  efc_nnz_out: wp.array[int],
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
 ):
   worldid, eqtenid = wp.tid()
   eqid = eq_ten_adr[eqtenid]
-
   if not eq_active_in[worldid, eqid]:
+    efcid_count_out[worldid, eqtenid] = 0
+    nnz_count_out[worldid, eqtenid] = 0
     return
-
-  wp.atomic_add(ne_out, worldid, 1)
-  efcid = wp.atomic_add(nefc_out, worldid, 1)
-
-  if efcid >= njmax_in:
-    return
-
-  obj1id = eq_obj1id[eqid]
-  obj2id = eq_obj2id[eqid]
-
-  data = eq_data[worldid % eq_data.shape[0], eqid]
-  solref = eq_solref[worldid % eq_solref.shape[0], eqid]
-  solimp = eq_solimp[worldid % eq_solimp.shape[0], eqid]
-  tendon_length0_id = worldid % tendon_length0.shape[0]
-  tendon_invweight0_id = worldid % tendon_invweight0.shape[0]
-  pos1 = ten_length_in[worldid, obj1id] - tendon_length0[tendon_length0_id, obj1id]
-
-  if obj2id > -1:
-    invweight = tendon_invweight0[tendon_invweight0_id, obj1id] + tendon_invweight0[tendon_invweight0_id, obj2id]
-
-    pos2 = ten_length_in[worldid, obj2id] - tendon_length0[tendon_length0_id, obj2id]
-
-    dif = pos2
-    dif2 = dif * dif
-    dif3 = dif2 * dif
-    dif4 = dif3 * dif
-
-    pos = pos1 - (data[0] + data[1] * dif + data[2] * dif2 + data[3] * dif3 + data[4] * dif4)
-    deriv = data[1] + 2.0 * data[2] * dif + 3.0 * data[3] * dif2 + 4.0 * data[4] * dif3
+  efcid_count_out[worldid, eqtenid] = 1
+  if is_sparse:
+    obj1id = eq_obj1id[eqid]
+    obj2id = eq_obj2id[eqid]
+    has_obj2 = obj2id > -1
+    nnz_count_out[worldid, eqtenid] = _tendon_merge_rownnz(
+      nv, ten_J_rownnz, ten_J_rowadr, ten_J_colind, obj1id, obj2id, has_obj2
+    )
   else:
-    invweight = tendon_invweight0[tendon_invweight0_id, obj1id]
-    pos = pos1 - data[0]
-    deriv = 0.0
+    nnz_count_out[worldid, eqtenid] = 0
 
-  rownnz1 = ten_J_rownnz[obj1id]
-  rowadr1 = ten_J_rowadr[obj1id]
-  rownnz2 = 0
-  rowadr2 = 0
 
-  if deriv != 0.0:
-    rownnz2 = ten_J_rownnz[obj2id]
-    rowadr2 = ten_J_rowadr[obj2id]
+def _equality_tendon(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    eq_obj1id: wp.array[int],
+    eq_obj2id: wp.array[int],
+    eq_solref: wp.array2d[wp.vec2],
+    eq_solimp: wp.array2d[vec5],
+    eq_data: wp.array2d[vec11],
+    ten_J_rownnz: wp.array[int],
+    ten_J_rowadr: wp.array[int],
+    ten_J_colind: wp.array[int],
+    tendon_length0: wp.array2d[float],
+    tendon_invweight0: wp.array2d[float],
+    eq_ten_adr: wp.array[int],
+    # Data in:
+    qvel_in: wp.array2d[float],
+    eq_active_in: wp.array2d[bool],
+    ten_J_in: wp.array2d[float],
+    ten_length_in: wp.array2d[float],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data out:
+    ne_out: wp.array[int],
+    nefc_out: wp.array[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    worldid, eqtenid = wp.tid()
+    eqid = eq_ten_adr[eqtenid]
 
-  if is_sparse:
-    # TODO(team): pre-compute rownnz
-    # count unique dofs
-    p1, p2 = int(0), int(0)
-    rownnz = int(0)
-    while p1 < rownnz1 or p2 < rownnz2:
-      col1 = nv
-      col2 = nv
-      if p1 < rownnz1:
-        col1 = ten_J_colind[rowadr1 + p1]
-      if p2 < rownnz2:
-        col2 = ten_J_colind[rowadr2 + p2]
-      if col1 <= col2:
-        p1 += 1
-      if col2 <= col1:
-        p2 += 1
-      rownnz += 1
-
-    rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz)
-    if rowadr + rownnz > njmax_nnz_in:
+    if not eq_active_in[worldid, eqid]:
       return
-    efc_J_rowadr_out[worldid, efcid] = rowadr
 
-  ptr1 = int(0)
-  ptr2 = int(0)
+    wp.atomic_add(ne_out, worldid, 1)
 
-  Jqvel = float(0.0)
-
-  nnz = int(0)
-  for i in range(nv):
-    J1 = float(0.0)
-    if ptr1 < rownnz1:
-      sparseid1 = rowadr1 + ptr1
-      if ten_J_colind[sparseid1] == i:
-        J1 = ten_J_in[worldid, sparseid1]
-        ptr1 += 1
-
-    J = J1
-    if deriv != 0.0:
-      J2 = float(0.0)
-      if ptr2 < rownnz2:
-        sparseid2 = rowadr2 + ptr2
-        if ten_J_colind[sparseid2] == i:
-          J2 = ten_J_in[worldid, sparseid2]
-          ptr2 += 1
-      J += J2 * -deriv
-
-    if is_sparse:
-      if J != 0.0:
-        sparseid = rowadr + nnz
-        efc_J_colind_out[worldid, 0, sparseid] = i
-        efc_J_out[worldid, 0, sparseid] = J
-        nnz += 1
+    if wp.static(deterministic):
+      efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, eqtenid]
     else:
-      efc_J_out[worldid, efcid, i] = J
+      efcid = wp.atomic_add(nefc_out, worldid, 1)
 
-    Jqvel += J * qvel_in[worldid, i]
+    if efcid >= njmax_in:
+      return
 
+    obj1id = eq_obj1id[eqid]
+    obj2id = eq_obj2id[eqid]
+
+    data = eq_data[worldid % eq_data.shape[0], eqid]
+    solref = eq_solref[worldid % eq_solref.shape[0], eqid]
+    solimp = eq_solimp[worldid % eq_solimp.shape[0], eqid]
+    tendon_length0_id = worldid % tendon_length0.shape[0]
+    tendon_invweight0_id = worldid % tendon_invweight0.shape[0]
+    pos1 = ten_length_in[worldid, obj1id] - tendon_length0[tendon_length0_id, obj1id]
+
+    if obj2id > -1:
+      invweight = tendon_invweight0[tendon_invweight0_id, obj1id] + tendon_invweight0[tendon_invweight0_id, obj2id]
+
+      pos2 = ten_length_in[worldid, obj2id] - tendon_length0[tendon_length0_id, obj2id]
+
+      dif = pos2
+      dif2 = dif * dif
+      dif3 = dif2 * dif
+      dif4 = dif3 * dif
+
+      pos = pos1 - (data[0] + data[1] * dif + data[2] * dif2 + data[3] * dif3 + data[4] * dif4)
+      deriv = data[1] + 2.0 * data[2] * dif + 3.0 * data[3] * dif2 + 4.0 * data[4] * dif3
+    else:
+      invweight = tendon_invweight0[tendon_invweight0_id, obj1id]
+      pos = pos1 - data[0]
+      deriv = 0.0
+
+    rownnz1 = ten_J_rownnz[obj1id]
+    rowadr1 = ten_J_rowadr[obj1id]
+    rownnz2 = 0
+    rowadr2 = 0
+
+    if deriv != 0.0:
+      rownnz2 = ten_J_rownnz[obj2id]
+      rowadr2 = ten_J_rowadr[obj2id]
+
+    if wp.static(is_sparse):
+      # count unique dofs (upper bound for slot reservation)
+      p1, p2 = int(0), int(0)
+      rownnz_upper = int(0)
+      while p1 < rownnz1 or p2 < rownnz2:
+        col1 = nv
+        col2 = nv
+        if p1 < rownnz1:
+          col1 = ten_J_colind[rowadr1 + p1]
+        if p2 < rownnz2:
+          col2 = ten_J_colind[rowadr2 + p2]
+        if col1 <= col2:
+          p1 += 1
+        if col2 <= col1:
+          p2 += 1
+        rownnz_upper += 1
+
+      if wp.static(deterministic):
+        rowadr = nnz_base_in[worldid] + nnz_offsets_in[worldid, eqtenid]
+      else:
+        rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz_upper)
+      if rowadr + rownnz_upper > njmax_nnz_in:
+        return
+      efc_J_rowadr_out[worldid, efcid] = rowadr
+
+    ptr1 = int(0)
+    ptr2 = int(0)
+
+    Jqvel = float(0.0)
+
+    nnz = int(0)
+    for i in range(nv):
+      J1 = float(0.0)
+      if ptr1 < rownnz1:
+        sparseid1 = rowadr1 + ptr1
+        if ten_J_colind[sparseid1] == i:
+          J1 = ten_J_in[worldid, sparseid1]
+          ptr1 += 1
+
+      J = J1
+      if deriv != 0.0:
+        J2 = float(0.0)
+        if ptr2 < rownnz2:
+          sparseid2 = rowadr2 + ptr2
+          if ten_J_colind[sparseid2] == i:
+            J2 = ten_J_in[worldid, sparseid2]
+            ptr2 += 1
+        J += J2 * -deriv
+
+      if wp.static(is_sparse):
+        if J != 0.0:
+          sparseid = rowadr + nnz
+          efc_J_colind_out[worldid, 0, sparseid] = i
+          efc_J_out[worldid, 0, sparseid] = J
+          nnz += 1
+      else:
+        efc_J_out[worldid, efcid, i] = J
+
+      Jqvel += J * qvel_in[worldid, i]
+
+    if wp.static(is_sparse):
+      efc_J_rownnz_out[worldid, efcid] = nnz
+
+    _efc_row(
+      opt_disableflags,
+      worldid,
+      opt_timestep[worldid % opt_timestep.shape[0]],
+      efcid,
+      pos,
+      pos,
+      invweight,
+      solref,
+      solimp,
+      0.0,
+      Jqvel,
+      0.0,
+      ConstraintType.EQUALITY,
+      eqid,
+      efc_type_out,
+      efc_id_out,
+      efc_pos_out,
+      efc_margin_out,
+      efc_D_out,
+      efc_vel_out,
+      efc_aref_out,
+      efc_frictionloss_out,
+    )
+
+  return kernel
+
+
+@wp.kernel
+def _equality_flex_count(
+  # Model:
+  flex_edgeadr: wp.array[int],
+  flex_edgenum: wp.array[int],
+  flexedge_J_rownnz: wp.array[int],
+  eq_obj1id: wp.array[int],
+  is_sparse: bool,
+  eq_flex_adr: wp.array[int],
+  # Out:
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
+):
+  worldid, eqflexid, edgeid = wp.tid()
+  # flatten (eqflexid, edgeid) into the 2D count buffer
+  nflexedge = efcid_count_out.shape[1] // eq_flex_adr.shape[0]
+  localid = eqflexid * nflexedge + edgeid
+  eqid = eq_flex_adr[eqflexid]
+  flexid = eq_obj1id[eqid]
+  if edgeid < flex_edgeadr[flexid] or edgeid >= flex_edgeadr[flexid] + flex_edgenum[flexid]:
+    efcid_count_out[worldid, localid] = 0
+    nnz_count_out[worldid, localid] = 0
+    return
+  efcid_count_out[worldid, localid] = 1
   if is_sparse:
-    efc_J_rownnz_out[worldid, efcid] = nnz
-
-  _efc_row(
-    opt_disableflags,
-    worldid,
-    opt_timestep[worldid % opt_timestep.shape[0]],
-    efcid,
-    pos,
-    pos,
-    invweight,
-    solref,
-    solimp,
-    0.0,
-    Jqvel,
-    0.0,
-    ConstraintType.EQUALITY,
-    eqid,
-    efc_type_out,
-    efc_id_out,
-    efc_pos_out,
-    efc_margin_out,
-    efc_D_out,
-    efc_vel_out,
-    efc_aref_out,
-    efc_frictionloss_out,
-  )
+    nnz_count_out[worldid, localid] = flexedge_J_rownnz[edgeid]
+  else:
+    nnz_count_out[worldid, localid] = 0
 
 
-def _equality_flex(is_sparse: bool):
+def _equality_flex(is_sparse: bool, deterministic: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
@@ -696,6 +1075,10 @@ def _equality_flex(is_sparse: bool):
     flexedge_length_in: wp.array2d[float],
     njmax_in: int,
     njmax_nnz_in: int,
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
     # Data out:
     ne_out: wp.array[int],
     nefc_out: wp.array[int],
@@ -720,8 +1103,16 @@ def _equality_flex(is_sparse: bool):
     if edgeid < flex_edgeadr[flexid] or edgeid >= flex_edgeadr[flexid] + flex_edgenum[flexid]:
       return
 
+    # flatten (eqflexid, edgeid) into the 2D offsets buffer
+    nflexedge = efcid_offsets_in.shape[1] // eq_flex_adr.shape[0]
+    localid = eqflexid * nflexedge + edgeid
+
     wp.atomic_add(ne_out, worldid, 1)
-    efcid = wp.atomic_add(nefc_out, worldid, 1)
+
+    if wp.static(deterministic):
+      efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, localid]
+    else:
+      efcid = wp.atomic_add(nefc_out, worldid, 1)
 
     if efcid >= njmax_in:
       return
@@ -737,7 +1128,10 @@ def _equality_flex(is_sparse: bool):
 
     if wp.static(is_sparse):
       efc_J_rownnz_out[worldid, efcid] = rownnz
-      efc_rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz)
+      if wp.static(deterministic):
+        efc_rowadr = nnz_base_in[worldid] + nnz_offsets_in[worldid, localid]
+      else:
+        efc_rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz)
       if efc_rowadr + rownnz > njmax_nnz_in:
         return
       efc_J_rowadr_out[worldid, efcid] = efc_rowadr
@@ -788,623 +1182,494 @@ def _equality_flex(is_sparse: bool):
 
 
 @wp.kernel
-def _equality_weld(
+def _equality_weld_count(
   # Model:
-  nv: int,
   nsite: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  body_parentid: wp.array[int],
-  body_rootid: wp.array[int],
   body_weldid: wp.array[int],
   body_dofnum: wp.array[int],
   body_dofadr: wp.array[int],
-  body_invweight0: wp.array2d[wp.vec2],
-  dof_bodyid: wp.array[int],
   dof_parentid: wp.array[int],
   site_bodyid: wp.array[int],
-  site_quat: wp.array2d[wp.quat],
   eq_obj1id: wp.array[int],
   eq_obj2id: wp.array[int],
   eq_objtype: wp.array[int],
-  eq_solref: wp.array2d[wp.vec2],
-  eq_solimp: wp.array2d[vec5],
-  eq_data: wp.array2d[vec11],
   is_sparse: bool,
   eq_wld_adr: wp.array[int],
   # Data in:
-  qvel_in: wp.array2d[float],
   eq_active_in: wp.array2d[bool],
-  xpos_in: wp.array2d[wp.vec3],
-  xquat_in: wp.array2d[wp.quat],
-  xmat_in: wp.array2d[wp.mat33],
-  site_xpos_in: wp.array2d[wp.vec3],
-  subtree_com_in: wp.array2d[wp.vec3],
-  cdof_in: wp.array2d[wp.spatial_vector],
-  njmax_in: int,
-  njmax_nnz_in: int,
-  # Data out:
-  ne_out: wp.array[int],
-  nefc_out: wp.array[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
   # Out:
-  efc_nnz_out: wp.array[int],
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
 ):
   worldid, eqweldid = wp.tid()
   eqid = eq_wld_adr[eqweldid]
-
   if not eq_active_in[worldid, eqid]:
+    efcid_count_out[worldid, eqweldid] = 0
+    nnz_count_out[worldid, eqweldid] = 0
     return
-
-  wp.atomic_add(ne_out, worldid, 6)
-  efcid = wp.atomic_add(nefc_out, worldid, 6)
-
-  if efcid >= njmax_in - 6:
-    return
-
-  efcid0 = efcid + 0
-  efcid1 = efcid + 1
-  efcid2 = efcid + 2
-  efcid3 = efcid + 3
-  efcid4 = efcid + 4
-  efcid5 = efcid + 5
-
-  is_site = eq_objtype[eqid] == types.ObjType.SITE and nsite > 0
-
-  obj1id = eq_obj1id[eqid]
-  obj2id = eq_obj2id[eqid]
-
-  data = eq_data[worldid % eq_data.shape[0], eqid]
-  anchor1 = wp.vec3(data[0], data[1], data[2])
-  anchor2 = wp.vec3(data[3], data[4], data[5])
-  relpose = wp.quat(data[6], data[7], data[8], data[9])
-  torquescale = data[10]
-
-  if is_site:
-    body1 = site_bodyid[obj1id]
-    body2 = site_bodyid[obj2id]
-    pos1 = site_xpos_in[worldid, obj1id]
-    pos2 = site_xpos_in[worldid, obj2id]
-
-    site_quat_id = worldid % site_quat.shape[0]
-    quat = math.mul_quat(xquat_in[worldid, body1], site_quat[site_quat_id, obj1id])
-    quat1 = math.quat_inv(math.mul_quat(xquat_in[worldid, body2], site_quat[site_quat_id, obj2id]))
-
-  else:
-    body1 = obj1id
-    body2 = obj2id
-    pos1 = xpos_in[worldid, body1] + xmat_in[worldid, body1] @ anchor2
-    pos2 = xpos_in[worldid, body2] + xmat_in[worldid, body2] @ anchor1
-
-    quat = math.mul_quat(xquat_in[worldid, body1], relpose)
-    quat1 = math.quat_inv(xquat_in[worldid, body2])
-
-  # compute Jacobian difference (opposite of contact: 0 - 1)
-  Jqvelp = wp.vec3f(0.0, 0.0, 0.0)
-  Jqvelr = wp.vec3f(0.0, 0.0, 0.0)
-
+  efcid_count_out[worldid, eqweldid] = 6
   if is_sparse:
-    # TODO(team): pre-compute number of non-zeros
-    body1 = body_weldid[body1]
-    body2 = body_weldid[body2]
-
-    da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
-    da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
-
-    # count non-zeros
-    pda1 = da1
-    pda2 = da2
-    rownnz = int(0)
-    while pda1 >= 0 or pda2 >= 0:
-      da = wp.max(pda1, pda2)
-      if pda1 == da:
-        pda1 = dof_parentid[da]
-      if pda2 == da:
-        pda2 = dof_parentid[da]
-      rownnz += 1
-
-    # get rowadr
-    rowadr = wp.atomic_add(efc_nnz_out, worldid, 6 * rownnz)
-    if rowadr + 6 * rownnz > njmax_nnz_in:
-      return
-    efc_J_rowadr_out[worldid, efcid0] = rowadr
-    efc_J_rowadr_out[worldid, efcid1] = rowadr + rownnz
-    efc_J_rowadr_out[worldid, efcid2] = rowadr + 2 * rownnz
-    efc_J_rowadr_out[worldid, efcid3] = rowadr + 3 * rownnz
-    efc_J_rowadr_out[worldid, efcid4] = rowadr + 4 * rownnz
-    efc_J_rowadr_out[worldid, efcid5] = rowadr + 5 * rownnz
-
-    efc_J_rownnz_out[worldid, efcid0] = rownnz
-    efc_J_rownnz_out[worldid, efcid1] = rownnz
-    efc_J_rownnz_out[worldid, efcid2] = rownnz
-    efc_J_rownnz_out[worldid, efcid3] = rownnz
-    efc_J_rownnz_out[worldid, efcid4] = rownnz
-    efc_J_rownnz_out[worldid, efcid5] = rownnz
-
-    # compute J and colind
-    nnz = int(0)
-    while da1 >= 0 or da2 >= 0:
-      da = wp.max(da1, da2)
-      if da1 == da:
-        da1 = dof_parentid[da]
-      if da2 == da:
-        da2 = dof_parentid[da]
-
-      jacp1, jacr1 = support.jac_dof(
-        body_parentid,
-        body_rootid,
-        dof_bodyid,
-        subtree_com_in,
-        cdof_in,
-        pos1,
-        body1,
-        da,
-        worldid,
-      )
-      jacp2, jacr2 = support.jac_dof(
-        body_parentid,
-        body_rootid,
-        dof_bodyid,
-        subtree_com_in,
-        cdof_in,
-        pos2,
-        body2,
-        da,
-        worldid,
-      )
-
-      jacdifp = jacp1 - jacp2
-
-      jacdifr = (jacr1 - jacr2) * torquescale
-      jacdifrq = math.mul_quat(math.quat_mul_axis(quat1, jacdifr), quat)
-      jacdifr = 0.5 * wp.vec3(jacdifrq[1], jacdifrq[2], jacdifrq[3])
-
-      sparseid0 = rowadr + nnz
-      sparseid1 = rowadr + rownnz + nnz
-      sparseid2 = rowadr + 2 * rownnz + nnz
-      sparseid3 = rowadr + 3 * rownnz + nnz
-      sparseid4 = rowadr + 4 * rownnz + nnz
-      sparseid5 = rowadr + 5 * rownnz + nnz
-
-      efc_J_colind_out[worldid, 0, sparseid0] = da
-      efc_J_colind_out[worldid, 0, sparseid1] = da
-      efc_J_colind_out[worldid, 0, sparseid2] = da
-      efc_J_colind_out[worldid, 0, sparseid3] = da
-      efc_J_colind_out[worldid, 0, sparseid4] = da
-      efc_J_colind_out[worldid, 0, sparseid5] = da
-
-      efc_J_out[worldid, 0, sparseid0] = jacdifp[0]
-      efc_J_out[worldid, 0, sparseid1] = jacdifp[1]
-      efc_J_out[worldid, 0, sparseid2] = jacdifp[2]
-      efc_J_out[worldid, 0, sparseid3] = jacdifr[0]
-      efc_J_out[worldid, 0, sparseid4] = jacdifr[1]
-      efc_J_out[worldid, 0, sparseid5] = jacdifr[2]
-
-      Jqvelp += jacdifp * qvel_in[worldid, da]
-      Jqvelr += jacdifr * qvel_in[worldid, da]
-
-      nnz += 1
+    obj1id = eq_obj1id[eqid]
+    obj2id = eq_obj2id[eqid]
+    if eq_objtype[eqid] == types.ObjType.SITE and nsite > 0:
+      body1 = site_bodyid[obj1id]
+      body2 = site_bodyid[obj2id]
+    else:
+      body1 = obj1id
+      body2 = obj2id
+    rownnz = _dof_tree_rownnz(
+      body_weldid, body_dofadr, body_dofnum, dof_parentid, body1, body2
+    )
+    nnz_count_out[worldid, eqweldid] = 6 * rownnz
   else:
-    for dofid in range(nv):
-      jacp1, jacr1 = support.jac_dof(
-        body_parentid,
-        body_rootid,
-        dof_bodyid,
-        subtree_com_in,
-        cdof_in,
-        pos1,
-        body1,
-        dofid,
+    nnz_count_out[worldid, eqweldid] = 0
+
+
+def _equality_weld(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    nsite: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    body_parentid: wp.array[int],
+    body_rootid: wp.array[int],
+    body_weldid: wp.array[int],
+    body_dofnum: wp.array[int],
+    body_dofadr: wp.array[int],
+    body_invweight0: wp.array2d[wp.vec2],
+    dof_bodyid: wp.array[int],
+    dof_parentid: wp.array[int],
+    site_bodyid: wp.array[int],
+    site_quat: wp.array2d[wp.quat],
+    eq_obj1id: wp.array[int],
+    eq_obj2id: wp.array[int],
+    eq_objtype: wp.array[int],
+    eq_solref: wp.array2d[wp.vec2],
+    eq_solimp: wp.array2d[vec5],
+    eq_data: wp.array2d[vec11],
+    eq_wld_adr: wp.array[int],
+    # Data in:
+    qvel_in: wp.array2d[float],
+    eq_active_in: wp.array2d[bool],
+    xpos_in: wp.array2d[wp.vec3],
+    xquat_in: wp.array2d[wp.quat],
+    xmat_in: wp.array2d[wp.mat33],
+    site_xpos_in: wp.array2d[wp.vec3],
+    subtree_com_in: wp.array2d[wp.vec3],
+    cdof_in: wp.array2d[wp.spatial_vector],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data out:
+    ne_out: wp.array[int],
+    nefc_out: wp.array[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    worldid, eqweldid = wp.tid()
+    eqid = eq_wld_adr[eqweldid]
+
+    if not eq_active_in[worldid, eqid]:
+      return
+
+    wp.atomic_add(ne_out, worldid, 6)
+
+    if wp.static(deterministic):
+      efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, eqweldid]
+    else:
+      efcid = wp.atomic_add(nefc_out, worldid, 6)
+
+    if efcid >= njmax_in - 6:
+      return
+
+    efcid0 = efcid + 0
+    efcid1 = efcid + 1
+    efcid2 = efcid + 2
+    efcid3 = efcid + 3
+    efcid4 = efcid + 4
+    efcid5 = efcid + 5
+
+    is_site = eq_objtype[eqid] == types.ObjType.SITE and nsite > 0
+
+    obj1id = eq_obj1id[eqid]
+    obj2id = eq_obj2id[eqid]
+
+    data = eq_data[worldid % eq_data.shape[0], eqid]
+    anchor1 = wp.vec3(data[0], data[1], data[2])
+    anchor2 = wp.vec3(data[3], data[4], data[5])
+    relpose = wp.quat(data[6], data[7], data[8], data[9])
+    torquescale = data[10]
+
+    if is_site:
+      body1 = site_bodyid[obj1id]
+      body2 = site_bodyid[obj2id]
+      pos1 = site_xpos_in[worldid, obj1id]
+      pos2 = site_xpos_in[worldid, obj2id]
+
+      site_quat_id = worldid % site_quat.shape[0]
+      quat = math.mul_quat(xquat_in[worldid, body1], site_quat[site_quat_id, obj1id])
+      quat1 = math.quat_inv(math.mul_quat(xquat_in[worldid, body2], site_quat[site_quat_id, obj2id]))
+
+    else:
+      body1 = obj1id
+      body2 = obj2id
+      pos1 = xpos_in[worldid, body1] + xmat_in[worldid, body1] @ anchor2
+      pos2 = xpos_in[worldid, body2] + xmat_in[worldid, body2] @ anchor1
+
+      quat = math.mul_quat(xquat_in[worldid, body1], relpose)
+      quat1 = math.quat_inv(xquat_in[worldid, body2])
+
+    # compute Jacobian difference (opposite of contact: 0 - 1)
+    Jqvelp = wp.vec3f(0.0, 0.0, 0.0)
+    Jqvelr = wp.vec3f(0.0, 0.0, 0.0)
+
+    if wp.static(is_sparse):
+      body1 = body_weldid[body1]
+      body2 = body_weldid[body2]
+
+      da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
+      da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
+
+      # count non-zeros
+      pda1 = da1
+      pda2 = da2
+      rownnz = int(0)
+      while pda1 >= 0 or pda2 >= 0:
+        da = wp.max(pda1, pda2)
+        if pda1 == da:
+          pda1 = dof_parentid[da]
+        if pda2 == da:
+          pda2 = dof_parentid[da]
+        rownnz += 1
+
+      # get rowadr
+      if wp.static(deterministic):
+        rowadr = nnz_base_in[worldid] + nnz_offsets_in[worldid, eqweldid]
+      else:
+        rowadr = wp.atomic_add(efc_nnz_out, worldid, 6 * rownnz)
+      if rowadr + 6 * rownnz > njmax_nnz_in:
+        return
+      efc_J_rowadr_out[worldid, efcid0] = rowadr
+      efc_J_rowadr_out[worldid, efcid1] = rowadr + rownnz
+      efc_J_rowadr_out[worldid, efcid2] = rowadr + 2 * rownnz
+      efc_J_rowadr_out[worldid, efcid3] = rowadr + 3 * rownnz
+      efc_J_rowadr_out[worldid, efcid4] = rowadr + 4 * rownnz
+      efc_J_rowadr_out[worldid, efcid5] = rowadr + 5 * rownnz
+
+      efc_J_rownnz_out[worldid, efcid0] = rownnz
+      efc_J_rownnz_out[worldid, efcid1] = rownnz
+      efc_J_rownnz_out[worldid, efcid2] = rownnz
+      efc_J_rownnz_out[worldid, efcid3] = rownnz
+      efc_J_rownnz_out[worldid, efcid4] = rownnz
+      efc_J_rownnz_out[worldid, efcid5] = rownnz
+
+      # compute J and colind
+      nnz = int(0)
+      while da1 >= 0 or da2 >= 0:
+        da = wp.max(da1, da2)
+        if da1 == da:
+          da1 = dof_parentid[da]
+        if da2 == da:
+          da2 = dof_parentid[da]
+
+        jacp1, jacr1 = support.jac_dof(
+          body_parentid,
+          body_rootid,
+          dof_bodyid,
+          subtree_com_in,
+          cdof_in,
+          pos1,
+          body1,
+          da,
+          worldid,
+        )
+        jacp2, jacr2 = support.jac_dof(
+          body_parentid,
+          body_rootid,
+          dof_bodyid,
+          subtree_com_in,
+          cdof_in,
+          pos2,
+          body2,
+          da,
+          worldid,
+        )
+
+        jacdifp = jacp1 - jacp2
+
+        jacdifr = (jacr1 - jacr2) * torquescale
+        jacdifrq = math.mul_quat(math.quat_mul_axis(quat1, jacdifr), quat)
+        jacdifr = 0.5 * wp.vec3(jacdifrq[1], jacdifrq[2], jacdifrq[3])
+
+        sparseid0 = rowadr + nnz
+        sparseid1 = rowadr + rownnz + nnz
+        sparseid2 = rowadr + 2 * rownnz + nnz
+        sparseid3 = rowadr + 3 * rownnz + nnz
+        sparseid4 = rowadr + 4 * rownnz + nnz
+        sparseid5 = rowadr + 5 * rownnz + nnz
+
+        efc_J_colind_out[worldid, 0, sparseid0] = da
+        efc_J_colind_out[worldid, 0, sparseid1] = da
+        efc_J_colind_out[worldid, 0, sparseid2] = da
+        efc_J_colind_out[worldid, 0, sparseid3] = da
+        efc_J_colind_out[worldid, 0, sparseid4] = da
+        efc_J_colind_out[worldid, 0, sparseid5] = da
+
+        efc_J_out[worldid, 0, sparseid0] = jacdifp[0]
+        efc_J_out[worldid, 0, sparseid1] = jacdifp[1]
+        efc_J_out[worldid, 0, sparseid2] = jacdifp[2]
+        efc_J_out[worldid, 0, sparseid3] = jacdifr[0]
+        efc_J_out[worldid, 0, sparseid4] = jacdifr[1]
+        efc_J_out[worldid, 0, sparseid5] = jacdifr[2]
+
+        Jqvelp += jacdifp * qvel_in[worldid, da]
+        Jqvelr += jacdifr * qvel_in[worldid, da]
+
+        nnz += 1
+    else:
+      for dofid in range(nv):
+        jacp1, jacr1 = support.jac_dof(
+          body_parentid,
+          body_rootid,
+          dof_bodyid,
+          subtree_com_in,
+          cdof_in,
+          pos1,
+          body1,
+          dofid,
+          worldid,
+        )
+        jacp2, jacr2 = support.jac_dof(
+          body_parentid,
+          body_rootid,
+          dof_bodyid,
+          subtree_com_in,
+          cdof_in,
+          pos2,
+          body2,
+          dofid,
+          worldid,
+        )
+
+        jacdifp = jacp1 - jacp2
+
+        efc_J_out[worldid, efcid0, dofid] = jacdifp[0]
+        efc_J_out[worldid, efcid1, dofid] = jacdifp[1]
+        efc_J_out[worldid, efcid2, dofid] = jacdifp[2]
+
+        jacdifr = (jacr1 - jacr2) * torquescale
+        jacdifrq = math.mul_quat(math.quat_mul_axis(quat1, jacdifr), quat)
+        jacdifr = 0.5 * wp.vec3(jacdifrq[1], jacdifrq[2], jacdifrq[3])
+
+        efc_J_out[worldid, efcid3, dofid] = jacdifr[0]
+        efc_J_out[worldid, efcid4, dofid] = jacdifr[1]
+        efc_J_out[worldid, efcid5, dofid] = jacdifr[2]
+
+        Jqvelp += jacdifp * qvel_in[worldid, dofid]
+        Jqvelr += jacdifr * qvel_in[worldid, dofid]
+
+    # error is difference in global position and orientation
+    cpos = pos1 - pos2
+
+    crotq = math.mul_quat(quat1, quat)  # copy axis components
+    crot = wp.vec3(crotq[1], crotq[2], crotq[3]) * torquescale
+
+    body_invweight0_id = worldid % body_invweight0.shape[0]
+    invweight_t = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
+
+    pos_imp = wp.sqrt(wp.length_sq(cpos) + wp.length_sq(crot))
+
+    solref = eq_solref[worldid % eq_solref.shape[0], eqid]
+    solimp = eq_solimp[worldid % eq_solimp.shape[0], eqid]
+
+    timestep = opt_timestep[worldid % opt_timestep.shape[0]]
+
+    for i in range(3):
+      _efc_row(
+        opt_disableflags,
         worldid,
+        timestep,
+        efcid + i,
+        cpos[i],
+        pos_imp,
+        invweight_t,
+        solref,
+        solimp,
+        0.0,
+        Jqvelp[i],
+        0.0,
+        ConstraintType.EQUALITY,
+        eqid,
+        efc_type_out,
+        efc_id_out,
+        efc_pos_out,
+        efc_margin_out,
+        efc_D_out,
+        efc_vel_out,
+        efc_aref_out,
+        efc_frictionloss_out,
       )
-      jacp2, jacr2 = support.jac_dof(
-        body_parentid,
-        body_rootid,
-        dof_bodyid,
-        subtree_com_in,
-        cdof_in,
-        pos2,
-        body2,
-        dofid,
+
+    invweight_r = body_invweight0[body_invweight0_id, body1][1] + body_invweight0[body_invweight0_id, body2][1]
+
+    for i in range(3):
+      _efc_row(
+        opt_disableflags,
         worldid,
+        timestep,
+        efcid + 3 + i,
+        crot[i],
+        pos_imp,
+        invweight_r,
+        solref,
+        solimp,
+        0.0,
+        Jqvelr[i],
+        0.0,
+        ConstraintType.EQUALITY,
+        eqid,
+        efc_type_out,
+        efc_id_out,
+        efc_pos_out,
+        efc_margin_out,
+        efc_D_out,
+        efc_vel_out,
+        efc_aref_out,
+        efc_frictionloss_out,
       )
 
-      jacdifp = jacp1 - jacp2
-
-      efc_J_out[worldid, efcid0, dofid] = jacdifp[0]
-      efc_J_out[worldid, efcid1, dofid] = jacdifp[1]
-      efc_J_out[worldid, efcid2, dofid] = jacdifp[2]
-
-      jacdifr = (jacr1 - jacr2) * torquescale
-      jacdifrq = math.mul_quat(math.quat_mul_axis(quat1, jacdifr), quat)
-      jacdifr = 0.5 * wp.vec3(jacdifrq[1], jacdifrq[2], jacdifrq[3])
-
-      efc_J_out[worldid, efcid3, dofid] = jacdifr[0]
-      efc_J_out[worldid, efcid4, dofid] = jacdifr[1]
-      efc_J_out[worldid, efcid5, dofid] = jacdifr[2]
-
-      Jqvelp += jacdifp * qvel_in[worldid, dofid]
-      Jqvelr += jacdifr * qvel_in[worldid, dofid]
-
-  # error is difference in global position and orientation
-  cpos = pos1 - pos2
-
-  crotq = math.mul_quat(quat1, quat)  # copy axis components
-  crot = wp.vec3(crotq[1], crotq[2], crotq[3]) * torquescale
-
-  body_invweight0_id = worldid % body_invweight0.shape[0]
-  invweight_t = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
-
-  pos_imp = wp.sqrt(wp.length_sq(cpos) + wp.length_sq(crot))
-
-  solref = eq_solref[worldid % eq_solref.shape[0], eqid]
-  solimp = eq_solimp[worldid % eq_solimp.shape[0], eqid]
-
-  timestep = opt_timestep[worldid % opt_timestep.shape[0]]
-
-  for i in range(3):
-    _efc_row(
-      opt_disableflags,
-      worldid,
-      timestep,
-      efcid + i,
-      cpos[i],
-      pos_imp,
-      invweight_t,
-      solref,
-      solimp,
-      0.0,
-      Jqvelp[i],
-      0.0,
-      ConstraintType.EQUALITY,
-      eqid,
-      efc_type_out,
-      efc_id_out,
-      efc_pos_out,
-      efc_margin_out,
-      efc_D_out,
-      efc_vel_out,
-      efc_aref_out,
-      efc_frictionloss_out,
-    )
-
-  invweight_r = body_invweight0[body_invweight0_id, body1][1] + body_invweight0[body_invweight0_id, body2][1]
-
-  for i in range(3):
-    _efc_row(
-      opt_disableflags,
-      worldid,
-      timestep,
-      efcid + 3 + i,
-      crot[i],
-      pos_imp,
-      invweight_r,
-      solref,
-      solimp,
-      0.0,
-      Jqvelr[i],
-      0.0,
-      ConstraintType.EQUALITY,
-      eqid,
-      efc_type_out,
-      efc_id_out,
-      efc_pos_out,
-      efc_margin_out,
-      efc_D_out,
-      efc_vel_out,
-      efc_aref_out,
-      efc_frictionloss_out,
-    )
+  return kernel
 
 
 @wp.kernel
-def _friction_dof(
+def _friction_dof_count(
   # Model:
-  nv: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  dof_solref: wp.array2d[wp.vec2],
-  dof_solimp: wp.array2d[vec5],
   dof_frictionloss: wp.array2d[float],
-  dof_invweight0: wp.array2d[float],
   is_sparse: bool,
-  # Data in:
-  qvel_in: wp.array2d[float],
-  njmax_in: int,
-  njmax_nnz_in: int,
-  # Data out:
-  nf_out: wp.array[int],
-  nefc_out: wp.array[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
   # Out:
-  efc_nnz_out: wp.array[int],
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
 ):
   worldid, dofid = wp.tid()
-
   dof_frictionloss_id = worldid % dof_frictionloss.shape[0]
-
   if dof_frictionloss[dof_frictionloss_id, dofid] <= 0.0:
+    efcid_count_out[worldid, dofid] = 0
+    nnz_count_out[worldid, dofid] = 0
     return
-
-  wp.atomic_add(nf_out, worldid, 1)
-  efcid = wp.atomic_add(nefc_out, worldid, 1)
-
-  if efcid >= njmax_in:
-    return
-
+  efcid_count_out[worldid, dofid] = 1
   if is_sparse:
-    efc_J_rownnz_out[worldid, efcid] = 1
-    rowadr = wp.atomic_add(efc_nnz_out, worldid, 1)
-    if rowadr + 1 > njmax_nnz_in:
-      return
-    efc_J_rowadr_out[worldid, efcid] = rowadr
-    efc_J_colind_out[worldid, 0, rowadr] = dofid
-    efc_J_out[worldid, 0, rowadr] = 1.0
+    nnz_count_out[worldid, dofid] = 1
   else:
-    for i in range(nv):
-      efc_J_out[worldid, efcid, i] = 0.0
-    efc_J_out[worldid, efcid, dofid] = 1.0
-
-  Jqvel = qvel_in[worldid, dofid]
-
-  dof_invweight0_id = worldid % dof_invweight0.shape[0]
-  dof_solref_id = worldid % dof_solref.shape[0]
-  dof_solimp_id = worldid % dof_solimp.shape[0]
-  _efc_row(
-    opt_disableflags,
-    worldid,
-    opt_timestep[worldid % opt_timestep.shape[0]],
-    efcid,
-    0.0,
-    0.0,
-    dof_invweight0[dof_invweight0_id, dofid],
-    dof_solref[dof_solref_id, dofid],
-    dof_solimp[dof_solimp_id, dofid],
-    0.0,
-    Jqvel,
-    dof_frictionloss[dof_frictionloss_id, dofid],
-    ConstraintType.FRICTION_DOF,
-    dofid,
-    efc_type_out,
-    efc_id_out,
-    efc_pos_out,
-    efc_margin_out,
-    efc_D_out,
-    efc_vel_out,
-    efc_aref_out,
-    efc_frictionloss_out,
-  )
+    nnz_count_out[worldid, dofid] = 0
 
 
-@wp.kernel
-def _friction_tendon(
-  # Model:
-  nv: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  ten_J_rownnz: wp.array[int],
-  ten_J_rowadr: wp.array[int],
-  ten_J_colind: wp.array[int],
-  tendon_solref_fri: wp.array2d[wp.vec2],
-  tendon_solimp_fri: wp.array2d[vec5],
-  tendon_frictionloss: wp.array2d[float],
-  tendon_invweight0: wp.array2d[float],
-  is_sparse: bool,
-  # Data in:
-  qvel_in: wp.array2d[float],
-  ten_J_in: wp.array2d[float],
-  njmax_in: int,
-  njmax_nnz_in: int,
-  # Data out:
-  nf_out: wp.array[int],
-  nefc_out: wp.array[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
-  # Out:
-  efc_nnz_out: wp.array[int],
-):
-  worldid, tenid = wp.tid()
+def _friction_dof(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    dof_solref: wp.array2d[wp.vec2],
+    dof_solimp: wp.array2d[vec5],
+    dof_frictionloss: wp.array2d[float],
+    dof_invweight0: wp.array2d[float],
+    # Data in:
+    qvel_in: wp.array2d[float],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data out:
+    nf_out: wp.array[int],
+    nefc_out: wp.array[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    worldid, dofid = wp.tid()
 
-  tendon_frictionloss_id = worldid % tendon_frictionloss.shape[0]
+    dof_frictionloss_id = worldid % dof_frictionloss.shape[0]
 
-  frictionloss = tendon_frictionloss[tendon_frictionloss_id, tenid]
-  if frictionloss <= 0.0:
-    return
-
-  wp.atomic_add(nf_out, worldid, 1)
-  efcid = wp.atomic_add(nefc_out, worldid, 1)
-
-  if efcid >= njmax_in:
-    return
-
-  Jqvel = float(0.0)
-
-  rownnz_tenJ = ten_J_rownnz[tenid]
-  rowadr_tenJ = ten_J_rowadr[tenid]
-  if is_sparse:
-    efc_J_rownnz_out[worldid, efcid] = rownnz_tenJ
-    rowadr_efc = wp.atomic_add(efc_nnz_out, worldid, rownnz_tenJ)
-    if rowadr_efc + rownnz_tenJ > njmax_nnz_in:
+    if dof_frictionloss[dof_frictionloss_id, dofid] <= 0.0:
       return
-    efc_J_rowadr_out[worldid, efcid] = rowadr_efc
 
-    for i in range(rownnz_tenJ):
-      sparseid_ten = rowadr_tenJ + i
-      sparseid_efc = rowadr_efc + i
-      colind = ten_J_colind[sparseid_ten]
-      J = ten_J_in[worldid, sparseid_ten]
-      efc_J_colind_out[worldid, 0, sparseid_efc] = colind
-      efc_J_out[worldid, 0, sparseid_efc] = J
-      Jqvel += J * qvel_in[worldid, colind]
-  else:
-    nnz = int(0)
-    colind = ten_J_colind[rowadr_tenJ]
-    for i in range(nv):
-      if nnz < rownnz_tenJ and i == colind:
-        J = ten_J_in[worldid, rowadr_tenJ + nnz]
-        efc_J_out[worldid, efcid, i] = J
-        Jqvel += J * qvel_in[worldid, i]
-        nnz += 1
-        if nnz < rownnz_tenJ:
-          colind = ten_J_colind[rowadr_tenJ + nnz]
-      else:
-        efc_J_out[worldid, efcid, i] = 0.0
+    wp.atomic_add(nf_out, worldid, 1)
 
-  tendon_invweight0_id = worldid % tendon_invweight0.shape[0]
-  tendon_solref_fri_id = worldid % tendon_solref_fri.shape[0]
-  tendon_solimp_fri_id = worldid % tendon_solimp_fri.shape[0]
-  _efc_row(
-    opt_disableflags,
-    worldid,
-    opt_timestep[worldid % opt_timestep.shape[0]],
-    efcid,
-    0.0,
-    0.0,
-    tendon_invweight0[tendon_invweight0_id, tenid],
-    tendon_solref_fri[tendon_solref_fri_id, tenid],
-    tendon_solimp_fri[tendon_solimp_fri_id, tenid],
-    0.0,
-    Jqvel,
-    frictionloss,
-    ConstraintType.FRICTION_TENDON,
-    tenid,
-    efc_type_out,
-    efc_id_out,
-    efc_pos_out,
-    efc_margin_out,
-    efc_D_out,
-    efc_vel_out,
-    efc_aref_out,
-    efc_frictionloss_out,
-  )
-
-
-@wp.kernel
-def _limit_slide_hinge(
-  # Model:
-  nv: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  jnt_qposadr: wp.array[int],
-  jnt_dofadr: wp.array[int],
-  jnt_solref: wp.array2d[wp.vec2],
-  jnt_solimp: wp.array2d[vec5],
-  jnt_range: wp.array2d[wp.vec2],
-  jnt_margin: wp.array2d[float],
-  dof_invweight0: wp.array2d[float],
-  is_sparse: bool,
-  jnt_limited_slide_hinge_adr: wp.array[int],
-  # Data in:
-  qpos_in: wp.array2d[float],
-  qvel_in: wp.array2d[float],
-  njmax_in: int,
-  njmax_nnz_in: int,
-  # Data out:
-  nl_out: wp.array[int],
-  nefc_out: wp.array[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
-  # Out:
-  efc_nnz_out: wp.array[int],
-):
-  worldid, jntlimitedid = wp.tid()
-  jntid = jnt_limited_slide_hinge_adr[jntlimitedid]
-  jnt_range_id = worldid % jnt_range.shape[0]
-  jntrange = jnt_range[jnt_range_id, jntid]
-
-  qpos = qpos_in[worldid, jnt_qposadr[jntid]]
-  jnt_margin_id = worldid % jnt_margin.shape[0]
-  jntmargin = jnt_margin[jnt_margin_id, jntid]
-  dist_min, dist_max = qpos - jntrange[0], jntrange[1] - qpos
-  pos = wp.min(dist_min, dist_max) - jntmargin
-  active = pos < 0
-
-  if active:
-    wp.atomic_add(nl_out, worldid, 1)
-    efcid = wp.atomic_add(nefc_out, worldid, 1)
+    if wp.static(deterministic):
+      efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, dofid]
+    else:
+      efcid = wp.atomic_add(nefc_out, worldid, 1)
 
     if efcid >= njmax_in:
       return
 
-    dofadr = jnt_dofadr[jntid]
-
-    J = float(dist_min < dist_max) * 2.0 - 1.0
-
-    if is_sparse:
+    if wp.static(is_sparse):
       efc_J_rownnz_out[worldid, efcid] = 1
-      rowadr = wp.atomic_add(efc_nnz_out, worldid, 1)
+      if wp.static(deterministic):
+        rowadr = nnz_base_in[worldid] + nnz_offsets_in[worldid, dofid]
+      else:
+        rowadr = wp.atomic_add(efc_nnz_out, worldid, 1)
       if rowadr + 1 > njmax_nnz_in:
         return
       efc_J_rowadr_out[worldid, efcid] = rowadr
-      efc_J_colind_out[worldid, 0, rowadr] = dofadr
-      efc_J_out[worldid, 0, rowadr] = J
+      efc_J_colind_out[worldid, 0, rowadr] = dofid
+      efc_J_out[worldid, 0, rowadr] = 1.0
     else:
       for i in range(nv):
         efc_J_out[worldid, efcid, i] = 0.0
-      efc_J_out[worldid, efcid, dofadr] = J
+      efc_J_out[worldid, efcid, dofid] = 1.0
 
-    Jqvel = J * qvel_in[worldid, dofadr]
+    Jqvel = qvel_in[worldid, dofid]
 
     dof_invweight0_id = worldid % dof_invweight0.shape[0]
-    jnt_solref_id = worldid % jnt_solref.shape[0]
-    jnt_solimp_id = worldid % jnt_solimp.shape[0]
+    dof_solref_id = worldid % dof_solref.shape[0]
+    dof_solimp_id = worldid % dof_solimp.shape[0]
     _efc_row(
       opt_disableflags,
       worldid,
       opt_timestep[worldid % opt_timestep.shape[0]],
       efcid,
-      pos,
-      pos,
-      dof_invweight0[dof_invweight0_id, dofadr],
-      jnt_solref[jnt_solref_id, jntid],
-      jnt_solimp[jnt_solimp_id, jntid],
-      jntmargin,
-      Jqvel,
       0.0,
-      ConstraintType.LIMIT_JOINT,
-      jntid,
+      0.0,
+      dof_invweight0[dof_invweight0_id, dofid],
+      dof_solref[dof_solref_id, dofid],
+      dof_solimp[dof_solimp_id, dofid],
+      0.0,
+      Jqvel,
+      dof_frictionloss[dof_frictionloss_id, dofid],
+      ConstraintType.FRICTION_DOF,
+      dofid,
       efc_type_out,
       efc_id_out,
       efc_pos_out,
@@ -1415,199 +1680,105 @@ def _limit_slide_hinge(
       efc_frictionloss_out,
     )
 
+  return kernel
+
 
 @wp.kernel
-def _limit_ball(
+def _friction_tendon_count(
   # Model:
-  nv: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  jnt_qposadr: wp.array[int],
-  jnt_dofadr: wp.array[int],
-  jnt_solref: wp.array2d[wp.vec2],
-  jnt_solimp: wp.array2d[vec5],
-  jnt_range: wp.array2d[wp.vec2],
-  jnt_margin: wp.array2d[float],
-  dof_invweight0: wp.array2d[float],
+  ten_J_rownnz: wp.array[int],
+  tendon_frictionloss: wp.array2d[float],
   is_sparse: bool,
-  jnt_limited_ball_adr: wp.array[int],
-  # Data in:
-  qpos_in: wp.array2d[float],
-  qvel_in: wp.array2d[float],
-  njmax_in: int,
-  njmax_nnz_in: int,
-  # Data out:
-  nl_out: wp.array[int],
-  nefc_out: wp.array[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
   # Out:
-  efc_nnz_out: wp.array[int],
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
 ):
-  worldid, jntlimitedid = wp.tid()
-  jntid = jnt_limited_ball_adr[jntlimitedid]
-  qposadr = jnt_qposadr[jntid]
+  worldid, tenid = wp.tid()
+  tendon_frictionloss_id = worldid % tendon_frictionloss.shape[0]
+  frictionloss = tendon_frictionloss[tendon_frictionloss_id, tenid]
+  if frictionloss <= 0.0:
+    efcid_count_out[worldid, tenid] = 0
+    nnz_count_out[worldid, tenid] = 0
+    return
+  efcid_count_out[worldid, tenid] = 1
+  if is_sparse:
+    nnz_count_out[worldid, tenid] = ten_J_rownnz[tenid]
+  else:
+    nnz_count_out[worldid, tenid] = 0
 
-  qpos = qpos_in[worldid]
-  jnt_quat = wp.quat(qpos[qposadr + 0], qpos[qposadr + 1], qpos[qposadr + 2], qpos[qposadr + 3])
-  jnt_quat = wp.normalize(jnt_quat)
-  axis_angle = math.quat_to_vel(jnt_quat)
-  jnt_range_id = worldid % jnt_range.shape[0]
-  jntrange = jnt_range[jnt_range_id, jntid]
-  axis, angle = math.normalize_with_norm(axis_angle)
-  jnt_margin_id = worldid % jnt_margin.shape[0]
-  jntmargin = jnt_margin[jnt_margin_id, jntid]
 
-  pos = wp.max(jntrange[0], jntrange[1]) - angle - jntmargin
-  active = pos < 0
+def _friction_tendon(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    ten_J_rownnz: wp.array[int],
+    ten_J_rowadr: wp.array[int],
+    ten_J_colind: wp.array[int],
+    tendon_solref_fri: wp.array2d[wp.vec2],
+    tendon_solimp_fri: wp.array2d[vec5],
+    tendon_frictionloss: wp.array2d[float],
+    tendon_invweight0: wp.array2d[float],
+    # Deterministic-mode inputs:
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data in:
+    qvel_in: wp.array2d[float],
+    ten_J_in: wp.array2d[float],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    # Data out:
+    nf_out: wp.array[int],
+    nefc_out: wp.array[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    worldid, tenid = wp.tid()
 
-  if active:
-    wp.atomic_add(nl_out, worldid, 1)
-    efcid = wp.atomic_add(nefc_out, worldid, 1)
+    tendon_frictionloss_id = worldid % tendon_frictionloss.shape[0]
 
-    if efcid >= njmax_in:
+    frictionloss = tendon_frictionloss[tendon_frictionloss_id, tenid]
+    if frictionloss <= 0.0:
       return
 
-    dofadr = jnt_dofadr[jntid]
-    dof0 = dofadr + 0
-    dof1 = dofadr + 1
-    dof2 = dofadr + 2
+    wp.atomic_add(nf_out, worldid, 1)
 
-    if is_sparse:
-      efc_J_rownnz_out[worldid, efcid] = 3
-      rowadr = wp.atomic_add(efc_nnz_out, worldid, 3)
-      if rowadr + 3 > njmax_nnz_in:
-        return
-      efc_J_rowadr_out[worldid, efcid] = rowadr
-
-      sparseid0 = rowadr + 0
-      sparseid1 = rowadr + 1
-      sparseid2 = rowadr + 2
-
-      efc_J_colind_out[worldid, 0, sparseid0] = dof0
-      efc_J_colind_out[worldid, 0, sparseid1] = dof1
-      efc_J_colind_out[worldid, 0, sparseid2] = dof2
-
-      efc_J_out[worldid, 0, sparseid0] = -axis[0]
-      efc_J_out[worldid, 0, sparseid1] = -axis[1]
-      efc_J_out[worldid, 0, sparseid2] = -axis[2]
+    if wp.static(deterministic):
+      efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, tenid]
     else:
-      for i in range(nv):
-        efc_J_out[worldid, efcid, i] = 0.0
-      efc_J_out[worldid, efcid, dof0] = -axis[0]
-      efc_J_out[worldid, efcid, dof1] = -axis[1]
-      efc_J_out[worldid, efcid, dof2] = -axis[2]
-
-    Jqvel = -axis[0] * qvel_in[worldid, dof0]
-    Jqvel -= axis[1] * qvel_in[worldid, dof1]
-    Jqvel -= axis[2] * qvel_in[worldid, dof2]
-
-    dof_invweight0_id = worldid % dof_invweight0.shape[0]
-    jnt_solref_id = worldid % jnt_solref.shape[0]
-    jnt_solimp_id = worldid % jnt_solimp.shape[0]
-    _efc_row(
-      opt_disableflags,
-      worldid,
-      opt_timestep[worldid % opt_timestep.shape[0]],
-      efcid,
-      pos,
-      pos,
-      dof_invweight0[dof_invweight0_id, dofadr],
-      jnt_solref[jnt_solref_id, jntid],
-      jnt_solimp[jnt_solimp_id, jntid],
-      jntmargin,
-      Jqvel,
-      0.0,
-      ConstraintType.LIMIT_JOINT,
-      jntid,
-      efc_type_out,
-      efc_id_out,
-      efc_pos_out,
-      efc_margin_out,
-      efc_D_out,
-      efc_vel_out,
-      efc_aref_out,
-      efc_frictionloss_out,
-    )
-
-
-@wp.kernel
-def _limit_tendon(
-  # Model:
-  nv: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  ten_J_rownnz: wp.array[int],
-  ten_J_rowadr: wp.array[int],
-  ten_J_colind: wp.array[int],
-  tendon_solref_lim: wp.array2d[wp.vec2],
-  tendon_solimp_lim: wp.array2d[vec5],
-  tendon_range: wp.array2d[wp.vec2],
-  tendon_margin: wp.array2d[float],
-  tendon_invweight0: wp.array2d[float],
-  is_sparse: bool,
-  tendon_limited_adr: wp.array[int],
-  # Data in:
-  qvel_in: wp.array2d[float],
-  ten_J_in: wp.array2d[float],
-  ten_length_in: wp.array2d[float],
-  njmax_in: int,
-  njmax_nnz_in: int,
-  # Data out:
-  nl_out: wp.array[int],
-  nefc_out: wp.array[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
-  # Out:
-  efc_nnz_out: wp.array[int],
-):
-  worldid, tenlimitedid = wp.tid()
-  tenid = tendon_limited_adr[tenlimitedid]
-
-  tendon_range_id = worldid % tendon_range.shape[0]
-  tenrange = tendon_range[tendon_range_id, tenid]
-  length = ten_length_in[worldid, tenid]
-  dist_min, dist_max = length - tenrange[0], tenrange[1] - length
-  tendon_margin_id = worldid % tendon_margin.shape[0]
-  tenmargin = tendon_margin[tendon_margin_id, tenid]
-  pos = wp.min(dist_min, dist_max) - tenmargin
-  active = pos < 0
-
-  if active:
-    wp.atomic_add(nl_out, worldid, 1)
-    efcid = wp.atomic_add(nefc_out, worldid, 1)
+      efcid = wp.atomic_add(nefc_out, worldid, 1)
 
     if efcid >= njmax_in:
       return
 
     Jqvel = float(0.0)
-    scl = float(dist_min < dist_max) * 2.0 - 1.0
 
     rownnz_tenJ = ten_J_rownnz[tenid]
     rowadr_tenJ = ten_J_rowadr[tenid]
-    if is_sparse:
+    if wp.static(is_sparse):
       efc_J_rownnz_out[worldid, efcid] = rownnz_tenJ
-      rowadr_efc = wp.atomic_add(efc_nnz_out, worldid, rownnz_tenJ)
+
+      if wp.static(deterministic):
+        rowadr_efc = nnz_base_in[worldid] + nnz_offsets_in[worldid, tenid]
+      else:
+        rowadr_efc = wp.atomic_add(efc_nnz_out, worldid, rownnz_tenJ)
+
       if rowadr_efc + rownnz_tenJ > njmax_nnz_in:
         return
       efc_J_rowadr_out[worldid, efcid] = rowadr_efc
@@ -1616,7 +1787,7 @@ def _limit_tendon(
         sparseid_ten = rowadr_tenJ + i
         sparseid_efc = rowadr_efc + i
         colind = ten_J_colind[sparseid_ten]
-        J = scl * ten_J_in[worldid, sparseid_ten]
+        J = ten_J_in[worldid, sparseid_ten]
         efc_J_colind_out[worldid, 0, sparseid_efc] = colind
         efc_J_out[worldid, 0, sparseid_efc] = J
         Jqvel += J * qvel_in[worldid, colind]
@@ -1625,7 +1796,7 @@ def _limit_tendon(
       colind = ten_J_colind[rowadr_tenJ]
       for i in range(nv):
         if nnz < rownnz_tenJ and i == colind:
-          J = scl * ten_J_in[worldid, rowadr_tenJ + nnz]
+          J = ten_J_in[worldid, rowadr_tenJ + nnz]
           efc_J_out[worldid, efcid, i] = J
           Jqvel += J * qvel_in[worldid, i]
           nnz += 1
@@ -1635,22 +1806,22 @@ def _limit_tendon(
           efc_J_out[worldid, efcid, i] = 0.0
 
     tendon_invweight0_id = worldid % tendon_invweight0.shape[0]
-    tendon_solref_lim_id = worldid % tendon_solref_lim.shape[0]
-    tendon_solimp_lim_id = worldid % tendon_solimp_lim.shape[0]
+    tendon_solref_fri_id = worldid % tendon_solref_fri.shape[0]
+    tendon_solimp_fri_id = worldid % tendon_solimp_fri.shape[0]
     _efc_row(
       opt_disableflags,
       worldid,
       opt_timestep[worldid % opt_timestep.shape[0]],
       efcid,
-      pos,
-      pos,
-      tendon_invweight0[tendon_invweight0_id, tenid],
-      tendon_solref_lim[tendon_solref_lim_id, tenid],
-      tendon_solimp_lim[tendon_solimp_lim_id, tenid],
-      tenmargin,
-      Jqvel,
       0.0,
-      ConstraintType.LIMIT_TENDON,
+      0.0,
+      tendon_invweight0[tendon_invweight0_id, tenid],
+      tendon_solref_fri[tendon_solref_fri_id, tenid],
+      tendon_solimp_fri[tendon_solimp_fri_id, tenid],
+      0.0,
+      Jqvel,
+      frictionloss,
+      ConstraintType.FRICTION_TENDON,
       tenid,
       efc_type_out,
       efc_id_out,
@@ -1662,96 +1833,566 @@ def _limit_tendon(
       efc_frictionloss_out,
     )
 
+  return kernel
+
 
 @wp.kernel
-def _contact_pyramidal(
+def _limit_slide_hinge_count(
   # Model:
-  nv: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  opt_impratio_invsqrt: wp.array[float],
-  body_parentid: wp.array[int],
-  body_rootid: wp.array[int],
+  jnt_qposadr: wp.array[int],
+  jnt_range: wp.array2d[wp.vec2],
+  jnt_margin: wp.array2d[float],
+  is_sparse: bool,
+  jnt_limited_slide_hinge_adr: wp.array[int],
+  # Data in:
+  qpos_in: wp.array2d[float],
+  # Out:
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
+):
+  worldid, jntlimitedid = wp.tid()
+  jntid = jnt_limited_slide_hinge_adr[jntlimitedid]
+  jnt_range_id = worldid % jnt_range.shape[0]
+  jntrange = jnt_range[jnt_range_id, jntid]
+  qpos = qpos_in[worldid, jnt_qposadr[jntid]]
+  jnt_margin_id = worldid % jnt_margin.shape[0]
+  jntmargin = jnt_margin[jnt_margin_id, jntid]
+  dist_min, dist_max = qpos - jntrange[0], jntrange[1] - qpos
+  pos = wp.min(dist_min, dist_max) - jntmargin
+  if pos < 0.0:
+    efcid_count_out[worldid, jntlimitedid] = 1
+    if is_sparse:
+      nnz_count_out[worldid, jntlimitedid] = 1
+    else:
+      nnz_count_out[worldid, jntlimitedid] = 0
+  else:
+    efcid_count_out[worldid, jntlimitedid] = 0
+    nnz_count_out[worldid, jntlimitedid] = 0
+
+
+def _limit_slide_hinge(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    jnt_qposadr: wp.array[int],
+    jnt_dofadr: wp.array[int],
+    jnt_solref: wp.array2d[wp.vec2],
+    jnt_solimp: wp.array2d[vec5],
+    jnt_range: wp.array2d[wp.vec2],
+    jnt_margin: wp.array2d[float],
+    dof_invweight0: wp.array2d[float],
+    jnt_limited_slide_hinge_adr: wp.array[int],
+    # Data in:
+    qpos_in: wp.array2d[float],
+    qvel_in: wp.array2d[float],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data out:
+    nl_out: wp.array[int],
+    nefc_out: wp.array[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    worldid, jntlimitedid = wp.tid()
+    jntid = jnt_limited_slide_hinge_adr[jntlimitedid]
+    jnt_range_id = worldid % jnt_range.shape[0]
+    jntrange = jnt_range[jnt_range_id, jntid]
+
+    qpos = qpos_in[worldid, jnt_qposadr[jntid]]
+    jnt_margin_id = worldid % jnt_margin.shape[0]
+    jntmargin = jnt_margin[jnt_margin_id, jntid]
+    dist_min, dist_max = qpos - jntrange[0], jntrange[1] - qpos
+    pos = wp.min(dist_min, dist_max) - jntmargin
+    active = pos < 0
+
+    if active:
+      wp.atomic_add(nl_out, worldid, 1)
+
+      if wp.static(deterministic):
+        efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, jntlimitedid]
+      else:
+        efcid = wp.atomic_add(nefc_out, worldid, 1)
+
+      if efcid >= njmax_in:
+        return
+
+      dofadr = jnt_dofadr[jntid]
+
+      J = float(dist_min < dist_max) * 2.0 - 1.0
+
+      if wp.static(is_sparse):
+        efc_J_rownnz_out[worldid, efcid] = 1
+        if wp.static(deterministic):
+          rowadr = nnz_base_in[worldid] + nnz_offsets_in[worldid, jntlimitedid]
+        else:
+          rowadr = wp.atomic_add(efc_nnz_out, worldid, 1)
+        if rowadr + 1 > njmax_nnz_in:
+          return
+        efc_J_rowadr_out[worldid, efcid] = rowadr
+        efc_J_colind_out[worldid, 0, rowadr] = dofadr
+        efc_J_out[worldid, 0, rowadr] = J
+      else:
+        for i in range(nv):
+          efc_J_out[worldid, efcid, i] = 0.0
+        efc_J_out[worldid, efcid, dofadr] = J
+
+      Jqvel = J * qvel_in[worldid, dofadr]
+
+      dof_invweight0_id = worldid % dof_invweight0.shape[0]
+      jnt_solref_id = worldid % jnt_solref.shape[0]
+      jnt_solimp_id = worldid % jnt_solimp.shape[0]
+      _efc_row(
+        opt_disableflags,
+        worldid,
+        opt_timestep[worldid % opt_timestep.shape[0]],
+        efcid,
+        pos,
+        pos,
+        dof_invweight0[dof_invweight0_id, dofadr],
+        jnt_solref[jnt_solref_id, jntid],
+        jnt_solimp[jnt_solimp_id, jntid],
+        jntmargin,
+        Jqvel,
+        0.0,
+        ConstraintType.LIMIT_JOINT,
+        jntid,
+        efc_type_out,
+        efc_id_out,
+        efc_pos_out,
+        efc_margin_out,
+        efc_D_out,
+        efc_vel_out,
+        efc_aref_out,
+        efc_frictionloss_out,
+      )
+
+  return kernel
+
+
+@wp.kernel
+def _limit_ball_count(
+  # Model:
+  jnt_qposadr: wp.array[int],
+  jnt_range: wp.array2d[wp.vec2],
+  jnt_margin: wp.array2d[float],
+  is_sparse: bool,
+  jnt_limited_ball_adr: wp.array[int],
+  # Data in:
+  qpos_in: wp.array2d[float],
+  # Out:
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
+):
+  worldid, jntlimitedid = wp.tid()
+  jntid = jnt_limited_ball_adr[jntlimitedid]
+  qposadr = jnt_qposadr[jntid]
+  qpos = qpos_in[worldid]
+  jnt_quat = wp.quat(qpos[qposadr + 0], qpos[qposadr + 1], qpos[qposadr + 2], qpos[qposadr + 3])
+  jnt_quat = wp.normalize(jnt_quat)
+  axis_angle = math.quat_to_vel(jnt_quat)
+  jnt_range_id = worldid % jnt_range.shape[0]
+  jntrange = jnt_range[jnt_range_id, jntid]
+  _, angle = math.normalize_with_norm(axis_angle)
+  jnt_margin_id = worldid % jnt_margin.shape[0]
+  jntmargin = jnt_margin[jnt_margin_id, jntid]
+  pos = wp.max(jntrange[0], jntrange[1]) - angle - jntmargin
+  if pos < 0.0:
+    efcid_count_out[worldid, jntlimitedid] = 1
+    if is_sparse:
+      nnz_count_out[worldid, jntlimitedid] = 3
+    else:
+      nnz_count_out[worldid, jntlimitedid] = 0
+  else:
+    efcid_count_out[worldid, jntlimitedid] = 0
+    nnz_count_out[worldid, jntlimitedid] = 0
+
+
+def _limit_ball(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    jnt_qposadr: wp.array[int],
+    jnt_dofadr: wp.array[int],
+    jnt_solref: wp.array2d[wp.vec2],
+    jnt_solimp: wp.array2d[vec5],
+    jnt_range: wp.array2d[wp.vec2],
+    jnt_margin: wp.array2d[float],
+    dof_invweight0: wp.array2d[float],
+    jnt_limited_ball_adr: wp.array[int],
+    # Data in:
+    qpos_in: wp.array2d[float],
+    qvel_in: wp.array2d[float],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data out:
+    nl_out: wp.array[int],
+    nefc_out: wp.array[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    worldid, jntlimitedid = wp.tid()
+    jntid = jnt_limited_ball_adr[jntlimitedid]
+    qposadr = jnt_qposadr[jntid]
+
+    qpos = qpos_in[worldid]
+    jnt_quat = wp.quat(qpos[qposadr + 0], qpos[qposadr + 1], qpos[qposadr + 2], qpos[qposadr + 3])
+    jnt_quat = wp.normalize(jnt_quat)
+    axis_angle = math.quat_to_vel(jnt_quat)
+    jnt_range_id = worldid % jnt_range.shape[0]
+    jntrange = jnt_range[jnt_range_id, jntid]
+    axis, angle = math.normalize_with_norm(axis_angle)
+    jnt_margin_id = worldid % jnt_margin.shape[0]
+    jntmargin = jnt_margin[jnt_margin_id, jntid]
+
+    pos = wp.max(jntrange[0], jntrange[1]) - angle - jntmargin
+    active = pos < 0
+
+    if active:
+      wp.atomic_add(nl_out, worldid, 1)
+
+      if wp.static(deterministic):
+        efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, jntlimitedid]
+      else:
+        efcid = wp.atomic_add(nefc_out, worldid, 1)
+
+      if efcid >= njmax_in:
+        return
+
+      dofadr = jnt_dofadr[jntid]
+      dof0 = dofadr + 0
+      dof1 = dofadr + 1
+      dof2 = dofadr + 2
+
+      if wp.static(is_sparse):
+        efc_J_rownnz_out[worldid, efcid] = 3
+        if wp.static(deterministic):
+          rowadr = nnz_base_in[worldid] + nnz_offsets_in[worldid, jntlimitedid]
+        else:
+          rowadr = wp.atomic_add(efc_nnz_out, worldid, 3)
+        if rowadr + 3 > njmax_nnz_in:
+          return
+        efc_J_rowadr_out[worldid, efcid] = rowadr
+
+        sparseid0 = rowadr + 0
+        sparseid1 = rowadr + 1
+        sparseid2 = rowadr + 2
+
+        efc_J_colind_out[worldid, 0, sparseid0] = dof0
+        efc_J_colind_out[worldid, 0, sparseid1] = dof1
+        efc_J_colind_out[worldid, 0, sparseid2] = dof2
+
+        efc_J_out[worldid, 0, sparseid0] = -axis[0]
+        efc_J_out[worldid, 0, sparseid1] = -axis[1]
+        efc_J_out[worldid, 0, sparseid2] = -axis[2]
+      else:
+        for i in range(nv):
+          efc_J_out[worldid, efcid, i] = 0.0
+        efc_J_out[worldid, efcid, dof0] = -axis[0]
+        efc_J_out[worldid, efcid, dof1] = -axis[1]
+        efc_J_out[worldid, efcid, dof2] = -axis[2]
+
+      Jqvel = -axis[0] * qvel_in[worldid, dof0]
+      Jqvel -= axis[1] * qvel_in[worldid, dof1]
+      Jqvel -= axis[2] * qvel_in[worldid, dof2]
+
+      dof_invweight0_id = worldid % dof_invweight0.shape[0]
+      jnt_solref_id = worldid % jnt_solref.shape[0]
+      jnt_solimp_id = worldid % jnt_solimp.shape[0]
+      _efc_row(
+        opt_disableflags,
+        worldid,
+        opt_timestep[worldid % opt_timestep.shape[0]],
+        efcid,
+        pos,
+        pos,
+        dof_invweight0[dof_invweight0_id, dofadr],
+        jnt_solref[jnt_solref_id, jntid],
+        jnt_solimp[jnt_solimp_id, jntid],
+        jntmargin,
+        Jqvel,
+        0.0,
+        ConstraintType.LIMIT_JOINT,
+        jntid,
+        efc_type_out,
+        efc_id_out,
+        efc_pos_out,
+        efc_margin_out,
+        efc_D_out,
+        efc_vel_out,
+        efc_aref_out,
+        efc_frictionloss_out,
+      )
+
+  return kernel
+
+
+@wp.kernel
+def _limit_tendon_count(
+  # Model:
+  ten_J_rownnz: wp.array[int],
+  tendon_range: wp.array2d[wp.vec2],
+  tendon_margin: wp.array2d[float],
+  is_sparse: bool,
+  tendon_limited_adr: wp.array[int],
+  # Data in:
+  ten_length_in: wp.array2d[float],
+  # Out:
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
+):
+  worldid, tenlimitedid = wp.tid()
+  tenid = tendon_limited_adr[tenlimitedid]
+  tendon_range_id = worldid % tendon_range.shape[0]
+  tenrange = tendon_range[tendon_range_id, tenid]
+  length = ten_length_in[worldid, tenid]
+  dist_min, dist_max = length - tenrange[0], tenrange[1] - length
+  tendon_margin_id = worldid % tendon_margin.shape[0]
+  tenmargin = tendon_margin[tendon_margin_id, tenid]
+  pos = wp.min(dist_min, dist_max) - tenmargin
+  if pos < 0.0:
+    efcid_count_out[worldid, tenlimitedid] = 1
+    if is_sparse:
+      nnz_count_out[worldid, tenlimitedid] = ten_J_rownnz[tenid]
+    else:
+      nnz_count_out[worldid, tenlimitedid] = 0
+  else:
+    efcid_count_out[worldid, tenlimitedid] = 0
+    nnz_count_out[worldid, tenlimitedid] = 0
+
+
+def _limit_tendon(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    ten_J_rownnz: wp.array[int],
+    ten_J_rowadr: wp.array[int],
+    ten_J_colind: wp.array[int],
+    tendon_solref_lim: wp.array2d[wp.vec2],
+    tendon_solimp_lim: wp.array2d[vec5],
+    tendon_range: wp.array2d[wp.vec2],
+    tendon_margin: wp.array2d[float],
+    tendon_invweight0: wp.array2d[float],
+    tendon_limited_adr: wp.array[int],
+    # Data in:
+    qvel_in: wp.array2d[float],
+    ten_J_in: wp.array2d[float],
+    ten_length_in: wp.array2d[float],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data out:
+    nl_out: wp.array[int],
+    nefc_out: wp.array[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    worldid, tenlimitedid = wp.tid()
+    tenid = tendon_limited_adr[tenlimitedid]
+
+    tendon_range_id = worldid % tendon_range.shape[0]
+    tenrange = tendon_range[tendon_range_id, tenid]
+    length = ten_length_in[worldid, tenid]
+    dist_min, dist_max = length - tenrange[0], tenrange[1] - length
+    tendon_margin_id = worldid % tendon_margin.shape[0]
+    tenmargin = tendon_margin[tendon_margin_id, tenid]
+    pos = wp.min(dist_min, dist_max) - tenmargin
+    active = pos < 0
+
+    if active:
+      wp.atomic_add(nl_out, worldid, 1)
+
+      if wp.static(deterministic):
+        efcid = nefc_base_in[worldid] + efcid_offsets_in[worldid, tenlimitedid]
+      else:
+        efcid = wp.atomic_add(nefc_out, worldid, 1)
+
+      if efcid >= njmax_in:
+        return
+
+      Jqvel = float(0.0)
+      scl = float(dist_min < dist_max) * 2.0 - 1.0
+
+      rownnz_tenJ = ten_J_rownnz[tenid]
+      rowadr_tenJ = ten_J_rowadr[tenid]
+      if wp.static(is_sparse):
+        efc_J_rownnz_out[worldid, efcid] = rownnz_tenJ
+        if wp.static(deterministic):
+          rowadr_efc = nnz_base_in[worldid] + nnz_offsets_in[worldid, tenlimitedid]
+        else:
+          rowadr_efc = wp.atomic_add(efc_nnz_out, worldid, rownnz_tenJ)
+        if rowadr_efc + rownnz_tenJ > njmax_nnz_in:
+          return
+        efc_J_rowadr_out[worldid, efcid] = rowadr_efc
+
+        for i in range(rownnz_tenJ):
+          sparseid_ten = rowadr_tenJ + i
+          sparseid_efc = rowadr_efc + i
+          colind = ten_J_colind[sparseid_ten]
+          J = scl * ten_J_in[worldid, sparseid_ten]
+          efc_J_colind_out[worldid, 0, sparseid_efc] = colind
+          efc_J_out[worldid, 0, sparseid_efc] = J
+          Jqvel += J * qvel_in[worldid, colind]
+      else:
+        nnz = int(0)
+        colind = ten_J_colind[rowadr_tenJ]
+        for i in range(nv):
+          if nnz < rownnz_tenJ and i == colind:
+            J = scl * ten_J_in[worldid, rowadr_tenJ + nnz]
+            efc_J_out[worldid, efcid, i] = J
+            Jqvel += J * qvel_in[worldid, i]
+            nnz += 1
+            if nnz < rownnz_tenJ:
+              colind = ten_J_colind[rowadr_tenJ + nnz]
+          else:
+            efc_J_out[worldid, efcid, i] = 0.0
+
+      tendon_invweight0_id = worldid % tendon_invweight0.shape[0]
+      tendon_solref_lim_id = worldid % tendon_solref_lim.shape[0]
+      tendon_solimp_lim_id = worldid % tendon_solimp_lim.shape[0]
+      _efc_row(
+        opt_disableflags,
+        worldid,
+        opt_timestep[worldid % opt_timestep.shape[0]],
+        efcid,
+        pos,
+        pos,
+        tendon_invweight0[tendon_invweight0_id, tenid],
+        tendon_solref_lim[tendon_solref_lim_id, tenid],
+        tendon_solimp_lim[tendon_solimp_lim_id, tenid],
+        tenmargin,
+        Jqvel,
+        0.0,
+        ConstraintType.LIMIT_TENDON,
+        tenid,
+        efc_type_out,
+        efc_id_out,
+        efc_pos_out,
+        efc_margin_out,
+        efc_D_out,
+        efc_vel_out,
+        efc_aref_out,
+        efc_frictionloss_out,
+      )
+
+  return kernel
+
+
+@wp.kernel
+def _contact_pyramidal_count(
+  # Model:
   body_weldid: wp.array[int],
   body_dofnum: wp.array[int],
   body_dofadr: wp.array[int],
-  body_invweight0: wp.array2d[wp.vec2],
-  dof_bodyid: wp.array[int],
   dof_parentid: wp.array[int],
   geom_bodyid: wp.array[int],
   flex_vertadr: wp.array[int],
   flex_vertbodyid: wp.array[int],
   is_sparse: bool,
   # Data in:
-  qvel_in: wp.array2d[float],
-  subtree_com_in: wp.array2d[wp.vec3],
-  cdof_in: wp.array2d[wp.spatial_vector],
-  njmax_in: int,
-  njmax_nnz_in: int,
   nacon_in: wp.array[int],
-  # In:
+  # Contact in:
   dist_in: wp.array[float],
   condim_in: wp.array[int],
   includemargin_in: wp.array[float],
-  worldid_in: wp.array[int],
   geom_in: wp.array[wp.vec2i],
   flex_in: wp.array[wp.vec2i],
   vert_in: wp.array[wp.vec2i],
-  pos_in: wp.array[wp.vec3],
-  frame_in: wp.array[wp.mat33],
-  friction_in: wp.array[vec5],
-  solref_in: wp.array[wp.vec2],
-  solimp_in: wp.array[vec5],
   type_in: wp.array[int],
-  # Data out:
-  nefc_out: wp.array[int],
-  contact_efc_address_out: wp.array2d[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
   # Out:
-  efc_nnz_out: wp.array[int],
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
 ):
   conid, dimid = wp.tid()
 
   if conid >= nacon_in[0]:
+    efcid_count_out[conid, dimid] = 0
+    nnz_count_out[conid, dimid] = 0
     return
 
   if not type_in[conid] & ContactType.CONSTRAINT:
+    efcid_count_out[conid, dimid] = 0
+    nnz_count_out[conid, dimid] = 0
     return
 
   condim = condim_in[conid]
 
   if condim == 1 and dimid > 0:
+    efcid_count_out[conid, dimid] = 0
+    nnz_count_out[conid, dimid] = 0
     return
   elif condim > 1 and dimid >= 2 * (condim - 1):
+    efcid_count_out[conid, dimid] = 0
+    nnz_count_out[conid, dimid] = 0
     return
 
   includemargin = includemargin_in[conid]
   pos = dist_in[conid] - includemargin
   active = pos < 0
 
-  if active:
-    worldid = worldid_in[conid]
+  if not active:
+    efcid_count_out[conid, dimid] = 0
+    nnz_count_out[conid, dimid] = 0
+    return
 
-    efcid = wp.atomic_add(nefc_out, worldid, 1)
-    if efcid >= njmax_in:
-      contact_efc_address_out[conid, dimid] = -1
-      return
+  efcid_count_out[conid, dimid] = 1
 
-    timestep = opt_timestep[worldid % opt_timestep.shape[0]]
-    impratio_invsqrt = opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
-    contact_efc_address_out[conid, dimid] = efcid
-
+  if is_sparse:
     geom = geom_in[conid]
 
     if geom[0] >= 0:
@@ -1768,260 +2409,357 @@ def _contact_pyramidal(
       vert = vert_in[conid]
       body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
 
-    con_pos = pos_in[conid]
-    frame = frame_in[conid]
+    rownnz = _contact_dof_tree_rownnz(
+      body_weldid, body_dofadr, body_dofnum, dof_parentid, body1, body2
+    )
+    nnz_count_out[conid, dimid] = rownnz
+  else:
+    nnz_count_out[conid, dimid] = 0
 
-    # pyramidal has common invweight across all edges
-    body_invweight0_id = worldid % body_invweight0.shape[0]
-    invweight = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
 
-    if condim > 1:
-      dimid2 = dimid / 2 + 1
+def _contact_pyramidal(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    opt_impratio_invsqrt: wp.array[float],
+    body_parentid: wp.array[int],
+    body_rootid: wp.array[int],
+    body_weldid: wp.array[int],
+    body_dofnum: wp.array[int],
+    body_dofadr: wp.array[int],
+    body_invweight0: wp.array2d[wp.vec2],
+    dof_bodyid: wp.array[int],
+    dof_parentid: wp.array[int],
+    geom_bodyid: wp.array[int],
+    flex_vertadr: wp.array[int],
+    flex_vertbodyid: wp.array[int],
+    # Deterministic-mode inputs:
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data in:
+    qvel_in: wp.array2d[float],
+    subtree_com_in: wp.array2d[wp.vec3],
+    cdof_in: wp.array2d[wp.spatial_vector],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nacon_in: wp.array[int],
+    # In:
+    dist_in: wp.array[float],
+    condim_in: wp.array[int],
+    includemargin_in: wp.array[float],
+    worldid_in: wp.array[int],
+    geom_in: wp.array[wp.vec2i],
+    flex_in: wp.array[wp.vec2i],
+    vert_in: wp.array[wp.vec2i],
+    pos_in: wp.array[wp.vec3],
+    frame_in: wp.array[wp.mat33],
+    friction_in: wp.array[vec5],
+    solref_in: wp.array[wp.vec2],
+    solimp_in: wp.array[vec5],
+    type_in: wp.array[int],
+    # Data out:
+    nefc_out: wp.array[int],
+    contact_efc_address_out: wp.array2d[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    conid, dimid = wp.tid()
 
-      friction = friction_in[conid]
-      fri0 = friction[0]
-      frii = friction[dimid2 - 1]
-      invweight = invweight + fri0 * fri0 * invweight
-      invweight = invweight * 2.0 * fri0 * fri0 * impratio_invsqrt * impratio_invsqrt
+    if conid >= nacon_in[0]:
+      return
 
-    Jqvel = float(0.0)
+    if not type_in[conid] & ContactType.CONSTRAINT:
+      return
 
-    # skip fixed bodies
-    body1 = body_weldid[body1]
-    body2 = body_weldid[body2]
+    condim = condim_in[conid]
 
-    da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
-    da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
+    if condim == 1 and dimid > 0:
+      return
+    elif condim > 1 and dimid >= 2 * (condim - 1):
+      return
 
-    if is_sparse:
-      pda1 = da1
-      pda2 = da2
-      rownnz = int(0)
-      while pda1 >= 0 or pda2 >= 0:
-        da = wp.max(pda1, pda2)
-        # skip common dofs
-        if pda1 == da and pda2 == da:
-          break
-        if pda1 == da:
-          pda1 = dof_parentid[pda1]
-        if pda2 == da:
-          pda2 = dof_parentid[pda2]
-        rownnz += 1
+    includemargin = includemargin_in[conid]
+    pos = dist_in[conid] - includemargin
+    active = pos < 0
 
-      # get rowadr
-      rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz)
-      if rowadr + rownnz > njmax_nnz_in:
-        return
-      efc_J_rowadr_out[worldid, efcid] = rowadr
-      efc_J_rownnz_out[worldid, efcid] = rownnz
+    if active:
+      worldid = worldid_in[conid]
 
-    da = wp.max(da1, da2)
-
-    if is_sparse:
-      nnz = int(0)
-      dofid = int(da)
-    else:
-      dofid = int(nv - 1)
-
-    while True:
-      if is_sparse:
-        if nnz >= rownnz:
-          break
+      if wp.static(deterministic):
+        efcid = nefc_base_in[worldid] + efcid_offsets_in[conid, dimid]
       else:
-        if dofid < 0:
-          break
+        efcid = wp.atomic_add(nefc_out, worldid, 1)
 
-      if dofid == da:
-        # TODO(team): contact_jacobian
-        jac1p, jac1r = support.jac_dof(
-          body_parentid,
-          body_rootid,
-          dof_bodyid,
-          subtree_com_in,
-          cdof_in,
-          con_pos,
-          body1,
-          dofid,
-          worldid,
-        )
-        jac2p, jac2r = support.jac_dof(
-          body_parentid,
-          body_rootid,
-          dof_bodyid,
-          subtree_com_in,
-          cdof_in,
-          con_pos,
-          body2,
-          dofid,
-          worldid,
-        )
+      if efcid >= njmax_in:
+        contact_efc_address_out[conid, dimid] = -1
+        return
 
-        J = float(0.0)
-        Ji = float(0.0)
-        if condim > 1:
-          dimid2 = dimid / 2 + 1
+      timestep = opt_timestep[worldid % opt_timestep.shape[0]]
+      impratio_invsqrt = opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
+      contact_efc_address_out[conid, dimid] = efcid
 
-        for xyz in range(3):
-          jacp_dif = jac2p[xyz] - jac1p[xyz]
-          J += frame[0, xyz] * jacp_dif
+      geom = geom_in[conid]
+
+      if geom[0] >= 0:
+        body1 = geom_bodyid[geom[0]]
+      else:
+        flex = flex_in[conid]
+        vert = vert_in[conid]
+        body1 = flex_vertbodyid[flex_vertadr[flex[0]] + vert[0]]
+
+      if geom[1] >= 0:
+        body2 = geom_bodyid[geom[1]]
+      else:
+        flex = flex_in[conid]
+        vert = vert_in[conid]
+        body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
+
+      con_pos = pos_in[conid]
+      frame = frame_in[conid]
+
+      # pyramidal has common invweight across all edges
+      body_invweight0_id = worldid % body_invweight0.shape[0]
+      invweight = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
+
+      if condim > 1:
+        dimid2 = dimid / 2 + 1
+
+        friction = friction_in[conid]
+        fri0 = friction[0]
+        frii = friction[dimid2 - 1]
+        invweight = invweight + fri0 * fri0 * invweight
+        invweight = invweight * 2.0 * fri0 * fri0 * impratio_invsqrt * impratio_invsqrt
+
+      Jqvel = float(0.0)
+
+      # skip fixed bodies
+      body1 = body_weldid[body1]
+      body2 = body_weldid[body2]
+
+      da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
+      da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
+
+      if wp.static(is_sparse):
+        pda1 = da1
+        pda2 = da2
+        rownnz = int(0)
+        while pda1 >= 0 or pda2 >= 0:
+          da = wp.max(pda1, pda2)
+          # skip common dofs
+          if pda1 == da and pda2 == da:
+            break
+          if pda1 == da:
+            pda1 = dof_parentid[pda1]
+          if pda2 == da:
+            pda2 = dof_parentid[pda2]
+          rownnz += 1
+
+        # get rowadr
+        if wp.static(deterministic):
+          rowadr = nnz_base_in[worldid] + nnz_offsets_in[conid, dimid]
+        else:
+          rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz)
+
+        if rowadr + rownnz > njmax_nnz_in:
+          return
+        efc_J_rowadr_out[worldid, efcid] = rowadr
+        efc_J_rownnz_out[worldid, efcid] = rownnz
+
+      da = wp.max(da1, da2)
+
+      if wp.static(is_sparse):
+        nnz = int(0)
+        dofid = int(da)
+      else:
+        dofid = int(nv - 1)
+
+      while True:
+        if wp.static(is_sparse):
+          if nnz >= rownnz:
+            break
+        else:
+          if dofid < 0:
+            break
+
+        if dofid == da:
+          # TODO(team): contact_jacobian
+          jac1p, jac1r = support.jac_dof(
+            body_parentid,
+            body_rootid,
+            dof_bodyid,
+            subtree_com_in,
+            cdof_in,
+            con_pos,
+            body1,
+            dofid,
+            worldid,
+          )
+          jac2p, jac2r = support.jac_dof(
+            body_parentid,
+            body_rootid,
+            dof_bodyid,
+            subtree_com_in,
+            cdof_in,
+            con_pos,
+            body2,
+            dofid,
+            worldid,
+          )
+
+          J = float(0.0)
+          Ji = float(0.0)
+          if condim > 1:
+            dimid2 = dimid / 2 + 1
+
+          for xyz in range(3):
+            jacp_dif = jac2p[xyz] - jac1p[xyz]
+            J += frame[0, xyz] * jacp_dif
+
+            if condim > 1:
+              if dimid2 < 3:
+                Ji += frame[dimid2, xyz] * jacp_dif
+              else:
+                Ji += frame[dimid2 - 3, xyz] * (jac2r[xyz] - jac1r[xyz])
 
           if condim > 1:
-            if dimid2 < 3:
-              Ji += frame[dimid2, xyz] * jacp_dif
+            if dimid % 2 == 0:
+              J += Ji * frii
             else:
-              Ji += frame[dimid2 - 3, xyz] * (jac2r[xyz] - jac1r[xyz])
+              J -= Ji * frii
 
-        if condim > 1:
-          if dimid % 2 == 0:
-            J += Ji * frii
+          if wp.static(is_sparse):
+            sparseid = rowadr + nnz
+            efc_J_colind_out[worldid, 0, sparseid] = dofid
+            efc_J_out[worldid, 0, sparseid] = J
+            nnz += 1
           else:
-            J -= Ji * frii
+            efc_J_out[worldid, efcid, dofid] = J
+          Jqvel += J * qvel_in[worldid, dofid]
+          if wp.static(is_sparse):
+            if nnz >= rownnz:
+              break
 
-        if is_sparse:
-          sparseid = rowadr + nnz
-          efc_J_colind_out[worldid, 0, sparseid] = dofid
-          efc_J_out[worldid, 0, sparseid] = J
-          nnz += 1
+          # Advance tree pointers and recompute da for next iteration
+          if da1 == da:
+            da1 = dof_parentid[da1]
+          if da2 == da:
+            da2 = dof_parentid[da2]
+          da = wp.max(da1, da2)
+          if wp.static(is_sparse):
+            dofid = da
+          else:
+            dofid -= 1
         else:
-          efc_J_out[worldid, efcid, dofid] = J
-        Jqvel += J * qvel_in[worldid, dofid]
-        if is_sparse and nnz >= rownnz:
-          break
+          if not wp.static(is_sparse):
+            efc_J_out[worldid, efcid, dofid] = 0.0
+            dofid -= 1
 
-        # Advance tree pointers and recompute da for next iteration
-        if da1 == da:
-          da1 = dof_parentid[da1]
-        if da2 == da:
-          da2 = dof_parentid[da2]
-        da = wp.max(da1, da2)
-        if is_sparse:
-          dofid = da
-        else:
-          dofid -= 1
+      if condim == 1:
+        efc_type = ConstraintType.CONTACT_FRICTIONLESS
       else:
-        if not is_sparse:
-          efc_J_out[worldid, efcid, dofid] = 0.0
-          dofid -= 1
+        efc_type = ConstraintType.CONTACT_PYRAMIDAL
 
-    if condim == 1:
-      efc_type = ConstraintType.CONTACT_FRICTIONLESS
-    else:
-      efc_type = ConstraintType.CONTACT_PYRAMIDAL
+      _efc_row(
+        opt_disableflags,
+        worldid,
+        timestep,
+        efcid,
+        pos,
+        pos,
+        invweight,
+        solref_in[conid],
+        solimp_in[conid],
+        includemargin,
+        Jqvel,
+        0.0,
+        efc_type,
+        conid,
+        efc_type_out,
+        efc_id_out,
+        efc_pos_out,
+        efc_margin_out,
+        efc_D_out,
+        efc_vel_out,
+        efc_aref_out,
+        efc_frictionloss_out,
+      )
 
-    _efc_row(
-      opt_disableflags,
-      worldid,
-      timestep,
-      efcid,
-      pos,
-      pos,
-      invweight,
-      solref_in[conid],
-      solimp_in[conid],
-      includemargin,
-      Jqvel,
-      0.0,
-      efc_type,
-      conid,
-      efc_type_out,
-      efc_id_out,
-      efc_pos_out,
-      efc_margin_out,
-      efc_D_out,
-      efc_vel_out,
-      efc_aref_out,
-      efc_frictionloss_out,
-    )
+  return kernel
 
 
 @wp.kernel
-def _contact_elliptic(
+def _contact_elliptic_count(
   # Model:
-  nv: int,
-  opt_timestep: wp.array[float],
-  opt_disableflags: int,
-  opt_impratio_invsqrt: wp.array[float],
-  body_parentid: wp.array[int],
-  body_rootid: wp.array[int],
   body_weldid: wp.array[int],
   body_dofnum: wp.array[int],
   body_dofadr: wp.array[int],
-  body_invweight0: wp.array2d[wp.vec2],
-  dof_bodyid: wp.array[int],
   dof_parentid: wp.array[int],
   geom_bodyid: wp.array[int],
   flex_vertadr: wp.array[int],
   flex_vertbodyid: wp.array[int],
   is_sparse: bool,
   # Data in:
-  qvel_in: wp.array2d[float],
-  subtree_com_in: wp.array2d[wp.vec3],
-  cdof_in: wp.array2d[wp.spatial_vector],
-  njmax_in: int,
-  njmax_nnz_in: int,
   nacon_in: wp.array[int],
-  # In:
+  # Contact in:
   dist_in: wp.array[float],
   condim_in: wp.array[int],
   includemargin_in: wp.array[float],
-  worldid_in: wp.array[int],
   geom_in: wp.array[wp.vec2i],
   flex_in: wp.array[wp.vec2i],
   vert_in: wp.array[wp.vec2i],
-  pos_in: wp.array[wp.vec3],
-  frame_in: wp.array[wp.mat33],
-  friction_in: wp.array[vec5],
-  solref_in: wp.array[wp.vec2],
-  solreffriction_in: wp.array[wp.vec2],
-  solimp_in: wp.array[vec5],
   type_in: wp.array[int],
-  # Data out:
-  nefc_out: wp.array[int],
-  contact_efc_address_out: wp.array2d[int],
-  efc_type_out: wp.array2d[int],
-  efc_id_out: wp.array2d[int],
-  efc_J_rownnz_out: wp.array2d[int],
-  efc_J_rowadr_out: wp.array2d[int],
-  efc_J_colind_out: wp.array3d[int],
-  efc_J_out: wp.array3d[float],
-  efc_pos_out: wp.array2d[float],
-  efc_margin_out: wp.array2d[float],
-  efc_D_out: wp.array2d[float],
-  efc_vel_out: wp.array2d[float],
-  efc_aref_out: wp.array2d[float],
-  efc_frictionloss_out: wp.array2d[float],
   # Out:
-  efc_nnz_out: wp.array[int],
+  efcid_count_out: wp.array2d[int],
+  nnz_count_out: wp.array2d[int],
 ):
   conid, dimid = wp.tid()
 
   if conid >= nacon_in[0]:
+    efcid_count_out[conid, dimid] = 0
+    nnz_count_out[conid, dimid] = 0
     return
 
   if not type_in[conid] & ContactType.CONSTRAINT:
+    efcid_count_out[conid, dimid] = 0
+    nnz_count_out[conid, dimid] = 0
     return
 
   condim = condim_in[conid]
 
   if dimid > condim - 1:
+    efcid_count_out[conid, dimid] = 0
+    nnz_count_out[conid, dimid] = 0
     return
 
   includemargin = includemargin_in[conid]
   pos = dist_in[conid] - includemargin
   active = pos < 0.0
 
-  if active:
-    worldid = worldid_in[conid]
+  if not active:
+    efcid_count_out[conid, dimid] = 0
+    nnz_count_out[conid, dimid] = 0
+    return
 
-    efcid = wp.atomic_add(nefc_out, worldid, 1)
-    if efcid >= njmax_in:
-      contact_efc_address_out[conid, dimid] = -1
-      return
+  efcid_count_out[conid, dimid] = 1
 
-    timestep = opt_timestep[worldid % opt_timestep.shape[0]]
-    impratio_invsqrt = opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
-    contact_efc_address_out[conid, dimid] = efcid
-
+  if is_sparse:
     geom = geom_in[conid]
 
     if geom[0] >= 0:
@@ -2038,170 +2776,298 @@ def _contact_elliptic(
       vert = vert_in[conid]
       body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
 
-    con_pos = pos_in[conid]
-    frame = frame_in[conid]
-
-    Jqvel = float(0.0)
-
-    # skip fixed bodies
-    body1 = body_weldid[body1]
-    body2 = body_weldid[body2]
-
-    da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
-    da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
-
-    if is_sparse:
-      # count non-zeros
-      pda1 = da1
-      pda2 = da2
-      rownnz = int(0)
-      while pda1 >= 0 or pda2 >= 0:
-        da = wp.max(pda1, pda2)
-        # skip common dofs
-        if pda1 == da and pda2 == da:
-          break
-        if pda1 == da:
-          pda1 = dof_parentid[pda1]
-        if pda2 == da:
-          pda2 = dof_parentid[pda2]
-        rownnz += 1
-
-      # get rowadr
-      rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz)
-      if rowadr + rownnz > njmax_nnz_in:
-        return
-      efc_J_rowadr_out[worldid, efcid] = rowadr
-      efc_J_rownnz_out[worldid, efcid] = rownnz
-
-    da = wp.max(da1, da2)
-
-    if is_sparse:
-      nnz = int(0)
-      dofid = int(da)
-    else:
-      dofid = int(nv - 1)
-
-    while True:
-      if is_sparse:
-        if nnz >= rownnz:
-          break
-      else:
-        if dofid < 0:
-          break
-
-      if dofid == da:
-        # TODO(team): contact jacobian
-        jac1p, jac1r = support.jac_dof(
-          body_parentid,
-          body_rootid,
-          dof_bodyid,
-          subtree_com_in,
-          cdof_in,
-          con_pos,
-          body1,
-          dofid,
-          worldid,
-        )
-        jac2p, jac2r = support.jac_dof(
-          body_parentid,
-          body_rootid,
-          dof_bodyid,
-          subtree_com_in,
-          cdof_in,
-          con_pos,
-          body2,
-          dofid,
-          worldid,
-        )
-
-        J = float(0.0)
-        for xyz in range(3):
-          if dimid < 3:
-            jac_dif = jac2p[xyz] - jac1p[xyz]
-            J += frame[dimid, xyz] * jac_dif
-          else:
-            jac_dif = jac2r[xyz] - jac1r[xyz]
-            J += frame[dimid - 3, xyz] * jac_dif
-
-        if is_sparse:
-          sparseid = rowadr + nnz
-          efc_J_colind_out[worldid, 0, sparseid] = dofid
-          efc_J_out[worldid, 0, sparseid] = J
-          nnz += 1
-        else:
-          efc_J_out[worldid, efcid, dofid] = J
-        Jqvel += J * qvel_in[worldid, dofid]
-        if is_sparse and nnz >= rownnz:
-          break
-
-        # Advance tree pointers and recompute da for next iteration
-        if da1 == da:
-          da1 = dof_parentid[da1]
-        if da2 == da:
-          da2 = dof_parentid[da2]
-        da = wp.max(da1, da2)
-        if is_sparse:
-          dofid = da
-        else:
-          dofid -= 1
-      else:
-        if not is_sparse:
-          efc_J_out[worldid, efcid, dofid] = 0.0
-          dofid -= 1
-
-    body_invweight0_id = worldid % body_invweight0.shape[0]
-    invweight = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
-
-    ref = solref_in[conid]
-    pos_aref = pos
-
-    if dimid > 0:
-      solreffriction = solreffriction_in[conid]
-
-      # non-normal directions use solreffriction (if non-zero)
-      if solreffriction[0] or solreffriction[1]:
-        ref = solreffriction
-
-      invweight = invweight * impratio_invsqrt * impratio_invsqrt
-      friction = friction_in[conid]
-
-      if dimid > 1:
-        fri0 = friction[0]
-        frii = friction[dimid - 1]
-        fri = fri0 * fri0 / (frii * frii)
-        invweight *= fri
-
-      pos_aref = 0.0
-
-    if condim == 1:
-      efc_type = ConstraintType.CONTACT_FRICTIONLESS
-    else:
-      efc_type = ConstraintType.CONTACT_ELLIPTIC
-
-    _efc_row(
-      opt_disableflags,
-      worldid,
-      timestep,
-      efcid,
-      pos_aref,
-      pos,
-      invweight,
-      ref,
-      solimp_in[conid],
-      includemargin,
-      Jqvel,
-      0.0,
-      efc_type,
-      conid,
-      efc_type_out,
-      efc_id_out,
-      efc_pos_out,
-      efc_margin_out,
-      efc_D_out,
-      efc_vel_out,
-      efc_aref_out,
-      efc_frictionloss_out,
+    rownnz = _contact_dof_tree_rownnz(
+      body_weldid, body_dofadr, body_dofnum, dof_parentid, body1, body2
     )
+    nnz_count_out[conid, dimid] = rownnz
+  else:
+    nnz_count_out[conid, dimid] = 0
+
+
+def _contact_elliptic(is_sparse: bool, deterministic: bool):
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    nv: int,
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    opt_impratio_invsqrt: wp.array[float],
+    body_parentid: wp.array[int],
+    body_rootid: wp.array[int],
+    body_weldid: wp.array[int],
+    body_dofnum: wp.array[int],
+    body_dofadr: wp.array[int],
+    body_invweight0: wp.array2d[wp.vec2],
+    dof_bodyid: wp.array[int],
+    dof_parentid: wp.array[int],
+    geom_bodyid: wp.array[int],
+    flex_vertadr: wp.array[int],
+    flex_vertbodyid: wp.array[int],
+    # Deterministic-mode inputs:
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
+    # Data in:
+    qvel_in: wp.array2d[float],
+    subtree_com_in: wp.array2d[wp.vec3],
+    cdof_in: wp.array2d[wp.spatial_vector],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nacon_in: wp.array[int],
+    # In:
+    dist_in: wp.array[float],
+    condim_in: wp.array[int],
+    includemargin_in: wp.array[float],
+    worldid_in: wp.array[int],
+    geom_in: wp.array[wp.vec2i],
+    flex_in: wp.array[wp.vec2i],
+    vert_in: wp.array[wp.vec2i],
+    pos_in: wp.array[wp.vec3],
+    frame_in: wp.array[wp.mat33],
+    friction_in: wp.array[vec5],
+    solref_in: wp.array[wp.vec2],
+    solreffriction_in: wp.array[wp.vec2],
+    solimp_in: wp.array[vec5],
+    type_in: wp.array[int],
+    # Data out:
+    nefc_out: wp.array[int],
+    contact_efc_address_out: wp.array2d[int],
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    conid, dimid = wp.tid()
+
+    if conid >= nacon_in[0]:
+      return
+
+    if not type_in[conid] & ContactType.CONSTRAINT:
+      return
+
+    condim = condim_in[conid]
+
+    if dimid > condim - 1:
+      return
+
+    includemargin = includemargin_in[conid]
+    pos = dist_in[conid] - includemargin
+    active = pos < 0.0
+
+    if active:
+      worldid = worldid_in[conid]
+
+      if wp.static(deterministic):
+        efcid = nefc_base_in[worldid] + efcid_offsets_in[conid, dimid]
+      else:
+        efcid = wp.atomic_add(nefc_out, worldid, 1)
+
+      if efcid >= njmax_in:
+        contact_efc_address_out[conid, dimid] = -1
+        return
+
+      timestep = opt_timestep[worldid % opt_timestep.shape[0]]
+      impratio_invsqrt = opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
+      contact_efc_address_out[conid, dimid] = efcid
+
+      geom = geom_in[conid]
+
+      if geom[0] >= 0:
+        body1 = geom_bodyid[geom[0]]
+      else:
+        flex = flex_in[conid]
+        vert = vert_in[conid]
+        body1 = flex_vertbodyid[flex_vertadr[flex[0]] + vert[0]]
+
+      if geom[1] >= 0:
+        body2 = geom_bodyid[geom[1]]
+      else:
+        flex = flex_in[conid]
+        vert = vert_in[conid]
+        body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
+
+      con_pos = pos_in[conid]
+      frame = frame_in[conid]
+
+      Jqvel = float(0.0)
+
+      # skip fixed bodies
+      body1 = body_weldid[body1]
+      body2 = body_weldid[body2]
+
+      da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
+      da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
+
+      if wp.static(is_sparse):
+        # count non-zeros
+        pda1 = da1
+        pda2 = da2
+        rownnz = int(0)
+        while pda1 >= 0 or pda2 >= 0:
+          da = wp.max(pda1, pda2)
+          # skip common dofs
+          if pda1 == da and pda2 == da:
+            break
+          if pda1 == da:
+            pda1 = dof_parentid[pda1]
+          if pda2 == da:
+            pda2 = dof_parentid[pda2]
+          rownnz += 1
+
+        # get rowadr
+        if wp.static(deterministic):
+          rowadr = nnz_base_in[worldid] + nnz_offsets_in[conid, dimid]
+        else:
+          rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz)
+
+        if rowadr + rownnz > njmax_nnz_in:
+          return
+        efc_J_rowadr_out[worldid, efcid] = rowadr
+        efc_J_rownnz_out[worldid, efcid] = rownnz
+
+      da = wp.max(da1, da2)
+
+      if wp.static(is_sparse):
+        nnz = int(0)
+        dofid = int(da)
+      else:
+        dofid = int(nv - 1)
+
+      while True:
+        if wp.static(is_sparse):
+          if nnz >= rownnz:
+            break
+        else:
+          if dofid < 0:
+            break
+
+        if dofid == da:
+          # TODO(team): contact jacobian
+          jac1p, jac1r = support.jac_dof(
+            body_parentid,
+            body_rootid,
+            dof_bodyid,
+            subtree_com_in,
+            cdof_in,
+            con_pos,
+            body1,
+            dofid,
+            worldid,
+          )
+          jac2p, jac2r = support.jac_dof(
+            body_parentid,
+            body_rootid,
+            dof_bodyid,
+            subtree_com_in,
+            cdof_in,
+            con_pos,
+            body2,
+            dofid,
+            worldid,
+          )
+
+          J = float(0.0)
+          for xyz in range(3):
+            if dimid < 3:
+              jac_dif = jac2p[xyz] - jac1p[xyz]
+              J += frame[dimid, xyz] * jac_dif
+            else:
+              jac_dif = jac2r[xyz] - jac1r[xyz]
+              J += frame[dimid - 3, xyz] * jac_dif
+
+          if wp.static(is_sparse):
+            sparseid = rowadr + nnz
+            efc_J_colind_out[worldid, 0, sparseid] = dofid
+            efc_J_out[worldid, 0, sparseid] = J
+            nnz += 1
+          else:
+            efc_J_out[worldid, efcid, dofid] = J
+          Jqvel += J * qvel_in[worldid, dofid]
+          if wp.static(is_sparse):
+            if nnz >= rownnz:
+              break
+
+          # Advance tree pointers and recompute da for next iteration
+          if da1 == da:
+            da1 = dof_parentid[da1]
+          if da2 == da:
+            da2 = dof_parentid[da2]
+          da = wp.max(da1, da2)
+          if wp.static(is_sparse):
+            dofid = da
+          else:
+            dofid -= 1
+        else:
+          if not wp.static(is_sparse):
+            efc_J_out[worldid, efcid, dofid] = 0.0
+            dofid -= 1
+
+      body_invweight0_id = worldid % body_invweight0.shape[0]
+      invweight = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
+
+      ref = solref_in[conid]
+      pos_aref = pos
+
+      if dimid > 0:
+        solreffriction = solreffriction_in[conid]
+
+        # non-normal directions use solreffriction (if non-zero)
+        if solreffriction[0] or solreffriction[1]:
+          ref = solreffriction
+
+        invweight = invweight * impratio_invsqrt * impratio_invsqrt
+        friction = friction_in[conid]
+
+        if dimid > 1:
+          fri0 = friction[0]
+          frii = friction[dimid - 1]
+          fri = fri0 * fri0 / (frii * frii)
+          invweight *= fri
+
+        pos_aref = 0.0
+
+      if condim == 1:
+        efc_type = ConstraintType.CONTACT_FRICTIONLESS
+      else:
+        efc_type = ConstraintType.CONTACT_ELLIPTIC
+
+      _efc_row(
+        opt_disableflags,
+        worldid,
+        timestep,
+        efcid,
+        pos_aref,
+        pos,
+        invweight,
+        ref,
+        solimp_in[conid],
+        includemargin,
+        Jqvel,
+        0.0,
+        efc_type,
+        conid,
+        efc_type_out,
+        efc_id_out,
+        efc_pos_out,
+        efc_margin_out,
+        efc_D_out,
+        efc_vel_out,
+        efc_aref_out,
+        efc_frictionloss_out,
+      )
+
+  return kernel
 
 
 @event_scope
@@ -2215,11 +3081,84 @@ def make_constraint(m: types.Model, d: types.Data):
     inputs=[d.ne, d.nf, d.nl, d.nefc, efc_nnz],
   )
 
+  det = m.opt.deterministic
+
+  # Dummy arrays for deterministic-only kernel params in non-det mode.
+  _d1 = wp.zeros(1, dtype=int)
+  _d2 = wp.zeros((1, 1), dtype=int)
+
+  # Shared efc output list (reused by equality / friction / limit kernels).
+  def _efc_outputs(count_out):
+    return [
+      count_out,
+      d.nefc,
+      d.efc.type,
+      d.efc.id,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      d.efc.J,
+      d.efc.pos,
+      d.efc.margin,
+      d.efc.D,
+      d.efc.vel,
+      d.efc.aref,
+      d.efc.frictionloss,
+      efc_nnz,
+    ]
+
+  def _scan_launch(dim, counts, nnz_counts, offsets, nnz_offsets,
+                   nefc_base, nnz_base):
+    wp.launch(
+      _per_world_exclusive_scan_2d,
+      dim=d.nworld,
+      inputs=[counts, nnz_counts],
+      outputs=[offsets, nnz_offsets, nefc_base, nnz_base, d.nefc, efc_nnz],
+    )
+
+  def _alloc_scan_bufs(dim):
+    counts = wp.empty(dim, dtype=int)
+    nnz_counts = wp.empty(dim, dtype=int)
+    offsets = wp.empty(dim, dtype=int)
+    nnz_offsets = wp.empty(dim, dtype=int)
+    nefc_base = wp.empty(d.nworld, dtype=int)
+    nnz_base = wp.empty(d.nworld, dtype=int)
+    return counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base
+
   if not (m.opt.disableflags & types.DisableBit.CONSTRAINT):
     if not (m.opt.disableflags & types.DisableBit.EQUALITY):
+      # --- equality_connect ---
+      _dim = (d.nworld, m.eq_connect_adr.size)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim)
+        )
+        wp.launch(
+          _equality_connect_count,
+          dim=_dim,
+          inputs=[
+            m.nsite,
+            m.body_weldid,
+            m.body_dofnum,
+            m.body_dofadr,
+            m.dof_parentid,
+            m.site_bodyid,
+            m.eq_obj1id,
+            m.eq_obj2id,
+            m.eq_objtype,
+            m.is_sparse,
+            m.eq_connect_adr,
+            d.eq_active,
+          ],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _equality_connect,
-        dim=(d.nworld, m.eq_connect_adr.size),
+        _equality_connect(m.is_sparse, det),
+        dim=_dim,
         inputs=[
           m.nv,
           m.nsite,
@@ -2240,7 +3179,6 @@ def make_constraint(m: types.Model, d: types.Data):
           m.eq_solref,
           m.eq_solimp,
           m.eq_data,
-          m.is_sparse,
           m.eq_connect_adr,
           d.qvel,
           d.eq_active,
@@ -2251,28 +3189,46 @@ def make_constraint(m: types.Model, d: types.Data):
           d.cdof,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
-        outputs=[
-          d.ne,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.ne),
       )
+
+      # --- equality_weld ---
+      _dim = (d.nworld, m.eq_wld_adr.size)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim)
+        )
+        wp.launch(
+          _equality_weld_count,
+          dim=_dim,
+          inputs=[
+            m.nsite,
+            m.body_weldid,
+            m.body_dofnum,
+            m.body_dofadr,
+            m.dof_parentid,
+            m.site_bodyid,
+            m.eq_obj1id,
+            m.eq_obj2id,
+            m.eq_objtype,
+            m.is_sparse,
+            m.eq_wld_adr,
+            d.eq_active,
+          ],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _equality_weld,
-        dim=(d.nworld, m.eq_wld_adr.size),
+        _equality_weld(m.is_sparse, det),
+        dim=_dim,
         inputs=[
           m.nv,
           m.nsite,
@@ -2294,7 +3250,6 @@ def make_constraint(m: types.Model, d: types.Data):
           m.eq_solref,
           m.eq_solimp,
           m.eq_data,
-          m.is_sparse,
           m.eq_wld_adr,
           d.qvel,
           d.eq_active,
@@ -2306,28 +3261,38 @@ def make_constraint(m: types.Model, d: types.Data):
           d.cdof,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
-        outputs=[
-          d.ne,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.ne),
       )
+
+      # --- equality_joint ---
+      _dim = (d.nworld, m.eq_jnt_adr.size)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim)
+        )
+        wp.launch(
+          _equality_joint_count,
+          dim=_dim,
+          inputs=[
+            m.eq_obj2id,
+            m.is_sparse,
+            m.eq_jnt_adr,
+            d.eq_active,
+          ],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _equality_joint,
-        dim=(d.nworld, m.eq_jnt_adr.size),
+        _equality_joint(m.is_sparse, det),
+        dim=_dim,
         inputs=[
           m.nv,
           m.opt.timestep,
@@ -2341,35 +3306,49 @@ def make_constraint(m: types.Model, d: types.Data):
           m.eq_solref,
           m.eq_solimp,
           m.eq_data,
-          m.is_sparse,
           m.eq_jnt_adr,
           d.qpos,
           d.qvel,
           d.eq_active,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
-        outputs=[
-          d.ne,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.ne),
       )
+
+      # --- equality_tendon ---
+      _dim = (d.nworld, m.eq_ten_adr.size)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim)
+        )
+        wp.launch(
+          _equality_tendon_count,
+          dim=_dim,
+          inputs=[
+            m.nv,
+            m.eq_obj1id,
+            m.eq_obj2id,
+            m.ten_J_rownnz,
+            m.ten_J_rowadr,
+            m.ten_J_colind,
+            m.is_sparse,
+            m.eq_ten_adr,
+            d.eq_active,
+          ],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _equality_tendon,
-        dim=(d.nworld, m.eq_ten_adr.size),
+        _equality_tendon(m.is_sparse, det),
+        dim=_dim,
         inputs=[
           m.nv,
           m.opt.timestep,
@@ -2384,7 +3363,6 @@ def make_constraint(m: types.Model, d: types.Data):
           m.ten_J_colind,
           m.tendon_length0,
           m.tendon_invweight0,
-          m.is_sparse,
           m.eq_ten_adr,
           d.qvel,
           d.eq_active,
@@ -2392,28 +3370,40 @@ def make_constraint(m: types.Model, d: types.Data):
           d.ten_length,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
-        outputs=[
-          d.ne,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.ne),
       )
 
+      # --- equality_flex ---
+      _nflex = m.eq_flex_adr.size * m.nflexedge
+      _dim_flat = (d.nworld, _nflex)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim_flat)
+        )
+        wp.launch(
+          _equality_flex_count,
+          dim=(d.nworld, m.eq_flex_adr.size, m.nflexedge),
+          inputs=[
+            m.flex_edgeadr,
+            m.flex_edgenum,
+            m.flexedge_J_rownnz,
+            m.eq_obj1id,
+            m.is_sparse,
+            m.eq_flex_adr,
+          ],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim_flat, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _equality_flex(m.is_sparse),
+        _equality_flex(m.is_sparse, det),
         dim=(d.nworld, m.eq_flex_adr.size, m.nflexedge),
         inputs=[
           m.nv,
@@ -2435,30 +3425,34 @@ def make_constraint(m: types.Model, d: types.Data):
           d.flexedge_length,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
-        outputs=[
-          d.ne,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.ne),
       )
 
     if not (m.opt.disableflags & types.DisableBit.FRICTIONLOSS):
+      # --- friction_dof ---
+      _dim = (d.nworld, m.nv)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim)
+        )
+        wp.launch(
+          _friction_dof_count,
+          dim=_dim,
+          inputs=[m.dof_frictionloss, m.is_sparse],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _friction_dof,
-        dim=(d.nworld, m.nv),
+        _friction_dof(m.is_sparse, det),
+        dim=_dim,
         inputs=[
           m.nv,
           m.opt.timestep,
@@ -2467,33 +3461,36 @@ def make_constraint(m: types.Model, d: types.Data):
           m.dof_solimp,
           m.dof_frictionloss,
           m.dof_invweight0,
-          m.is_sparse,
           d.qvel,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
-        outputs=[
-          d.nf,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.nf),
       )
 
+      # --- friction_tendon ---
+      _dim = (d.nworld, m.ntendon)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim)
+        )
+        wp.launch(
+          _friction_tendon_count,
+          dim=_dim,
+          inputs=[m.ten_J_rownnz, m.tendon_frictionloss, m.is_sparse],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _friction_tendon,
-        dim=(d.nworld, m.ntendon),
+        _friction_tendon(m.is_sparse, det),
+        dim=_dim,
         inputs=[
           m.nv,
           m.opt.timestep,
@@ -2505,36 +3502,46 @@ def make_constraint(m: types.Model, d: types.Data):
           m.tendon_solimp_fri,
           m.tendon_frictionloss,
           m.tendon_invweight0,
-          m.is_sparse,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
           d.qvel,
           d.ten_J,
           d.njmax,
           d.njmax_nnz,
         ],
-        outputs=[
-          d.nf,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.nf),
       )
 
     # limit
     if not (m.opt.disableflags & types.DisableBit.LIMIT):
+      # --- limit_ball ---
+      _dim = (d.nworld, m.jnt_limited_ball_adr.size)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim)
+        )
+        wp.launch(
+          _limit_ball_count,
+          dim=_dim,
+          inputs=[
+            m.jnt_qposadr,
+            m.jnt_range,
+            m.jnt_margin,
+            m.is_sparse,
+            m.jnt_limited_ball_adr,
+            d.qpos,
+          ],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _limit_ball,
-        dim=(d.nworld, m.jnt_limited_ball_adr.size),
+        _limit_ball(m.is_sparse, det),
+        dim=_dim,
         inputs=[
           m.nv,
           m.opt.timestep,
@@ -2546,35 +3553,45 @@ def make_constraint(m: types.Model, d: types.Data):
           m.jnt_range,
           m.jnt_margin,
           m.dof_invweight0,
-          m.is_sparse,
           m.jnt_limited_ball_adr,
           d.qpos,
           d.qvel,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
-        outputs=[
-          d.nl,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.nl),
       )
 
+      # --- limit_slide_hinge ---
+      _dim = (d.nworld, m.jnt_limited_slide_hinge_adr.size)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim)
+        )
+        wp.launch(
+          _limit_slide_hinge_count,
+          dim=_dim,
+          inputs=[
+            m.jnt_qposadr,
+            m.jnt_range,
+            m.jnt_margin,
+            m.is_sparse,
+            m.jnt_limited_slide_hinge_adr,
+            d.qpos,
+          ],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _limit_slide_hinge,
-        dim=(d.nworld, m.jnt_limited_slide_hinge_adr.size),
+        _limit_slide_hinge(m.is_sparse, det),
+        dim=_dim,
         inputs=[
           m.nv,
           m.opt.timestep,
@@ -2586,35 +3603,45 @@ def make_constraint(m: types.Model, d: types.Data):
           m.jnt_range,
           m.jnt_margin,
           m.dof_invweight0,
-          m.is_sparse,
           m.jnt_limited_slide_hinge_adr,
           d.qpos,
           d.qvel,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
-        outputs=[
-          d.nl,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.nl),
       )
 
+      # --- limit_tendon ---
+      _dim = (d.nworld, m.tendon_limited_adr.size)
+      if det:
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
+          _alloc_scan_bufs(_dim)
+        )
+        wp.launch(
+          _limit_tendon_count,
+          dim=_dim,
+          inputs=[
+            m.ten_J_rownnz,
+            m.tendon_range,
+            m.tendon_margin,
+            m.is_sparse,
+            m.tendon_limited_adr,
+            d.ten_length,
+          ],
+          outputs=[counts, nnz_counts],
+        )
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
+                     nefc_base, nnz_base)
+      else:
+        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
-        _limit_tendon,
-        dim=(d.nworld, m.tendon_limited_adr.size),
+        _limit_tendon(m.is_sparse, det),
+        dim=_dim,
         inputs=[
           m.nv,
           m.opt.timestep,
@@ -2627,39 +3654,74 @@ def make_constraint(m: types.Model, d: types.Data):
           m.tendon_range,
           m.tendon_margin,
           m.tendon_invweight0,
-          m.is_sparse,
           m.tendon_limited_adr,
           d.qvel,
           d.ten_J,
           d.ten_length,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
-        outputs=[
-          d.nl,
-          d.nefc,
-          d.efc.type,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          d.efc.J_colind,
-          d.efc.J,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-          efc_nnz,
-        ],
+        outputs=_efc_outputs(d.nl),
       )
 
     # contact
     if not (m.opt.disableflags & types.DisableBit.CONTACT):
       if m.opt.cone == types.ConeType.PYRAMIDAL:
+        _dim = (d.naconmax, m.nmaxpyramid)
+        if det:
+          counts = wp.empty(_dim, dtype=int)
+          nnz_counts = wp.empty(_dim, dtype=int)
+          offsets = wp.empty(_dim, dtype=int)
+          nnz_offsets = wp.empty(_dim, dtype=int)
+          nefc_base = wp.empty(d.nworld, dtype=int)
+          nnz_base = wp.empty(d.nworld, dtype=int)
+          world_start = wp.empty(d.nworld, dtype=int)
+          world_end = wp.empty(d.nworld, dtype=int)
+          wp.launch(
+            _contact_pyramidal_count,
+            dim=_dim,
+            inputs=[
+              m.body_weldid,
+              m.body_dofnum,
+              m.body_dofadr,
+              m.dof_parentid,
+              m.geom_bodyid,
+              m.flex_vertadr,
+              m.flex_vertbodyid,
+              m.is_sparse,
+              d.nacon,
+              d.contact.dist,
+              d.contact.dim,
+              d.contact.includemargin,
+              d.contact.geom,
+              d.contact.flex,
+              d.contact.vert,
+              d.contact.type,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          wp.launch(
+            _contact_world_boundaries,
+            dim=d.nworld,
+            inputs=[d.contact.worldid, d.nacon],
+            outputs=[world_start, world_end],
+          )
+          wp.launch(
+            _contact_per_world_scan,
+            dim=d.nworld,
+            inputs=[counts, nnz_counts, world_start, world_end],
+            outputs=[offsets, nnz_offsets, nefc_base, nnz_base,
+                     d.nefc, efc_nnz],
+          )
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
         wp.launch(
-          _contact_pyramidal,
-          dim=(d.naconmax, m.nmaxpyramid),
+          _contact_pyramidal(m.is_sparse, det),
+          dim=_dim,
           inputs=[
             m.nv,
             m.opt.timestep,
@@ -2676,7 +3738,10 @@ def make_constraint(m: types.Model, d: types.Data):
             m.geom_bodyid,
             m.flex_vertadr,
             m.flex_vertbodyid,
-            m.is_sparse,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
             d.qvel,
             d.subtree_com,
             d.cdof,
@@ -2716,9 +3781,57 @@ def make_constraint(m: types.Model, d: types.Data):
           ],
         )
       elif m.opt.cone == types.ConeType.ELLIPTIC:
+        _dim = (d.naconmax, m.nmaxcondim)
+        if det:
+          counts = wp.empty(_dim, dtype=int)
+          nnz_counts = wp.empty(_dim, dtype=int)
+          offsets = wp.empty(_dim, dtype=int)
+          nnz_offsets = wp.empty(_dim, dtype=int)
+          nefc_base = wp.empty(d.nworld, dtype=int)
+          nnz_base = wp.empty(d.nworld, dtype=int)
+          world_start = wp.empty(d.nworld, dtype=int)
+          world_end = wp.empty(d.nworld, dtype=int)
+          wp.launch(
+            _contact_elliptic_count,
+            dim=_dim,
+            inputs=[
+              m.body_weldid,
+              m.body_dofnum,
+              m.body_dofadr,
+              m.dof_parentid,
+              m.geom_bodyid,
+              m.flex_vertadr,
+              m.flex_vertbodyid,
+              m.is_sparse,
+              d.nacon,
+              d.contact.dist,
+              d.contact.dim,
+              d.contact.includemargin,
+              d.contact.geom,
+              d.contact.flex,
+              d.contact.vert,
+              d.contact.type,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          wp.launch(
+            _contact_world_boundaries,
+            dim=d.nworld,
+            inputs=[d.contact.worldid, d.nacon],
+            outputs=[world_start, world_end],
+          )
+          wp.launch(
+            _contact_per_world_scan,
+            dim=d.nworld,
+            inputs=[counts, nnz_counts, world_start, world_end],
+            outputs=[offsets, nnz_offsets, nefc_base, nnz_base,
+                     d.nefc, efc_nnz],
+          )
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
         wp.launch(
-          _contact_elliptic,
-          dim=(d.naconmax, m.nmaxcondim),
+          _contact_elliptic(m.is_sparse, det),
+          dim=_dim,
           inputs=[
             m.nv,
             m.opt.timestep,
@@ -2735,7 +3848,10 @@ def make_constraint(m: types.Model, d: types.Data):
             m.geom_bodyid,
             m.flex_vertadr,
             m.flex_vertbodyid,
-            m.is_sparse,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
             d.qvel,
             d.subtree_com,
             d.cdof,
@@ -2774,4 +3890,21 @@ def make_constraint(m: types.Model, d: types.Data):
             d.efc.frictionloss,
             efc_nnz,
           ],
+        )
+
+  # Overflow check for deterministic mode.
+  if det:
+    nefc_host = d.nefc.numpy()
+    if nefc_host.max() > d.njmax:
+      raise RuntimeError(
+        f"opt.deterministic: nefc overflow (max={nefc_host.max()}, "
+        f"njmax={d.njmax}). Increase njmax when calling put_data / make_data."
+      )
+    if m.is_sparse:
+      efc_nnz_host = efc_nnz.numpy()
+      if efc_nnz_host.max() > d.njmax_nnz:
+        raise RuntimeError(
+          f"opt.deterministic: efc_nnz overflow "
+          f"(max={efc_nnz_host.max()}, njmax_nnz={d.njmax_nnz}). "
+          f"Increase njmax_nnz."
         )

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -67,20 +67,20 @@ def _per_world_exclusive_scan_2d(
   # In:
   counts_in: wp.array2d[int],  # (nworld, N)
   nnz_counts_in: wp.array2d[int],  # (nworld, N)
+  # Data out:
+  nefc_out: wp.array[int],
   # Out:
+  efc_nnz_out: wp.array[int],
   offsets_out: wp.array2d[int],  # (nworld, N)
   nnz_offsets_out: wp.array2d[int],  # (nworld, N)
-  base_out: wp.array[int],  # (nworld,) snapshot of nefc_inout before bump
-  nnz_base_out: wp.array[int],  # (nworld,) snapshot of efc_nnz_inout before bump
-  # InOut:
-  nefc_inout: wp.array[int],
-  efc_nnz_inout: wp.array[int],
+  base_out: wp.array[int],  # (nworld,) snapshot of nefc_out before bump
+  nnz_base_out: wp.array[int],  # (nworld,) snapshot of efc_nnz_out before bump
 ):
   worldid = wp.tid()
 
   # snapshot the pre-bump totals so downstream emit kernels can read a stable base
-  base_out[worldid] = nefc_inout[worldid]
-  nnz_base_out[worldid] = efc_nnz_inout[worldid]
+  base_out[worldid] = nefc_out[worldid]
+  nnz_base_out[worldid] = efc_nnz_out[worldid]
 
   acc = int(0)
   acc_nnz = int(0)
@@ -91,13 +91,13 @@ def _per_world_exclusive_scan_2d(
     acc += counts_in[worldid, i]
     acc_nnz += nnz_counts_in[worldid, i]
 
-  nefc_inout[worldid] += acc
-  efc_nnz_inout[worldid] += acc_nnz
+  nefc_out[worldid] += acc
+  efc_nnz_out[worldid] += acc_nnz
 
 
 @wp.kernel
 def _contact_world_boundaries(
-  # In:
+  # Data in:
   contact_worldid_in: wp.array[int],
   nacon_in: wp.array[int],
   # Out:
@@ -128,19 +128,19 @@ def _contact_per_world_scan(
   nnz_counts_in: wp.array2d[int],  # (naconmax, nsubdim)
   world_start_in: wp.array[int],  # (nworld,)
   world_end_in: wp.array[int],  # (nworld,)
+  # Data out:
+  nefc_out: wp.array[int],
   # Out:
+  efc_nnz_out: wp.array[int],
   offsets_out: wp.array2d[int],  # (naconmax, nsubdim)
   nnz_offsets_out: wp.array2d[int],  # (naconmax, nsubdim)
   base_out: wp.array[int],  # (nworld,)
   nnz_base_out: wp.array[int],  # (nworld,)
-  # InOut:
-  nefc_inout: wp.array[int],
-  efc_nnz_inout: wp.array[int],
 ):
   worldid = wp.tid()
 
-  base_out[worldid] = nefc_inout[worldid]
-  nnz_base_out[worldid] = efc_nnz_inout[worldid]
+  base_out[worldid] = nefc_out[worldid]
+  nnz_base_out[worldid] = efc_nnz_out[worldid]
 
   acc = int(0)
   acc_nnz = int(0)
@@ -154,22 +154,25 @@ def _contact_per_world_scan(
       acc += counts_in[cid, sub]
       acc_nnz += nnz_counts_in[cid, sub]
 
-  nefc_inout[worldid] += acc
-  efc_nnz_inout[worldid] += acc_nnz
+  nefc_out[worldid] += acc
+  efc_nnz_out[worldid] += acc_nnz
 
 
 @wp.func
 def _dof_tree_rownnz(
+  # Model:
   body_weldid: wp.array[int],
-  body_dofadr: wp.array[int],
   body_dofnum: wp.array[int],
+  body_dofadr: wp.array[int],
   dof_parentid: wp.array[int],
+  # In:
   body1: int,
   body2: int,
 ) -> int:
-  """Counts non-zeros in a 2-body (body1, body2) Jacobian row by walking the
-  dof parent tree. Matches the rownnz walk used in _equality_connect and
-  _equality_weld (continues through common dofs)."""
+  """Counts non-zeros in a 2-body Jacobian row.
+
+  Matches the rownnz walk used in `_equality_connect` and `_equality_weld`.
+  """
   b1 = body_weldid[body1]
   b2 = body_weldid[body2]
   pda1 = int(body_dofadr[b1] + body_dofnum[b1] - 1)
@@ -187,16 +190,19 @@ def _dof_tree_rownnz(
 
 @wp.func
 def _contact_dof_tree_rownnz(
+  # Model:
   body_weldid: wp.array[int],
-  body_dofadr: wp.array[int],
   body_dofnum: wp.array[int],
+  body_dofadr: wp.array[int],
   dof_parentid: wp.array[int],
+  # In:
   body1: int,
   body2: int,
 ) -> int:
-  """Counts non-zeros in a 2-body contact Jacobian row by walking the dof
-  parent tree. Breaks on common dofs — matches the rownnz walk used in
-  _contact_pyramidal and _contact_elliptic."""
+  """Counts non-zeros in a 2-body contact Jacobian row.
+
+  Matches the rownnz walk used in `_contact_pyramidal` and `_contact_elliptic`.
+  """
   b1 = body_weldid[body1]
   b2 = body_weldid[body2]
   pda1 = int(body_dofadr[b1] + body_dofnum[b1] - 1)
@@ -217,16 +223,20 @@ def _contact_dof_tree_rownnz(
 
 @wp.func
 def _tendon_merge_rownnz(
+  # Model:
   nv: int,
   ten_J_rownnz: wp.array[int],
   ten_J_rowadr: wp.array[int],
   ten_J_colind: wp.array[int],
+  # In:
   obj1id: int,
   obj2id: int,
   has_obj2: bool,
 ) -> int:
-  """Counts unique dofs across two tendon Jacobians — matches the rownnz
-  walk in _equality_tendon (upper bound for slot reservation)."""
+  """Counts unique dofs across two tendon Jacobians.
+
+  Matches the rownnz walk in `_equality_tendon`.
+  """
   rownnz1 = ten_J_rownnz[obj1id]
   rowadr1 = ten_J_rowadr[obj1id]
   rownnz2 = int(0)
@@ -361,9 +371,7 @@ def _equality_connect_count(
     else:
       body1 = obj1id
       body2 = obj2id
-    rownnz = _dof_tree_rownnz(
-      body_weldid, body_dofadr, body_dofnum, dof_parentid, body1, body2
-    )
+    rownnz = _dof_tree_rownnz(body_weldid, body_dofnum, body_dofadr, dof_parentid, body1, body2)
     nnz_count_out[worldid, eqconnectid] = 3 * rownnz
   else:
     nnz_count_out[worldid, eqconnectid] = 0
@@ -403,6 +411,7 @@ def _equality_connect(is_sparse: bool, deterministic: bool):
     cdof_in: wp.array2d[wp.spatial_vector],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
     nefc_base_in: wp.array[int],
     efcid_offsets_in: wp.array2d[int],
     nnz_base_in: wp.array[int],
@@ -675,6 +684,7 @@ def _equality_joint(is_sparse: bool, deterministic: bool):
     eq_active_in: wp.array2d[bool],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
     nefc_base_in: wp.array[int],
     efcid_offsets_in: wp.array2d[int],
     nnz_base_in: wp.array[int],
@@ -856,6 +866,7 @@ def _equality_tendon(is_sparse: bool, deterministic: bool):
     ten_length_in: wp.array2d[float],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
     nefc_base_in: wp.array[int],
     efcid_offsets_in: wp.array2d[int],
     nnz_base_in: wp.array[int],
@@ -1075,6 +1086,7 @@ def _equality_flex(is_sparse: bool, deterministic: bool):
     flexedge_length_in: wp.array2d[float],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
     nefc_base_in: wp.array[int],
     efcid_offsets_in: wp.array2d[int],
     nnz_base_in: wp.array[int],
@@ -1217,9 +1229,7 @@ def _equality_weld_count(
     else:
       body1 = obj1id
       body2 = obj2id
-    rownnz = _dof_tree_rownnz(
-      body_weldid, body_dofadr, body_dofnum, dof_parentid, body1, body2
-    )
+    rownnz = _dof_tree_rownnz(body_weldid, body_dofnum, body_dofadr, dof_parentid, body1, body2)
     nnz_count_out[worldid, eqweldid] = 6 * rownnz
   else:
     nnz_count_out[worldid, eqweldid] = 0
@@ -1261,6 +1271,7 @@ def _equality_weld(is_sparse: bool, deterministic: bool):
     cdof_in: wp.array2d[wp.spatial_vector],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
     nefc_base_in: wp.array[int],
     efcid_offsets_in: wp.array2d[int],
     nnz_base_in: wp.array[int],
@@ -1595,6 +1606,7 @@ def _friction_dof(is_sparse: bool, deterministic: bool):
     qvel_in: wp.array2d[float],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
     nefc_base_in: wp.array[int],
     efcid_offsets_in: wp.array2d[int],
     nnz_base_in: wp.array[int],
@@ -1721,16 +1733,16 @@ def _friction_tendon(is_sparse: bool, deterministic: bool):
     tendon_solimp_fri: wp.array2d[vec5],
     tendon_frictionloss: wp.array2d[float],
     tendon_invweight0: wp.array2d[float],
-    # Deterministic-mode inputs:
-    nefc_base_in: wp.array[int],
-    efcid_offsets_in: wp.array2d[int],
-    nnz_base_in: wp.array[int],
-    nnz_offsets_in: wp.array2d[int],
     # Data in:
     qvel_in: wp.array2d[float],
     ten_J_in: wp.array2d[float],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
     # Data out:
     nf_out: wp.array[int],
     nefc_out: wp.array[int],
@@ -1890,6 +1902,7 @@ def _limit_slide_hinge(is_sparse: bool, deterministic: bool):
     qvel_in: wp.array2d[float],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
     nefc_base_in: wp.array[int],
     efcid_offsets_in: wp.array2d[int],
     nnz_base_in: wp.array[int],
@@ -2046,6 +2059,7 @@ def _limit_ball(is_sparse: bool, deterministic: bool):
     qvel_in: wp.array2d[float],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
     nefc_base_in: wp.array[int],
     efcid_offsets_in: wp.array2d[int],
     nnz_base_in: wp.array[int],
@@ -2220,6 +2234,7 @@ def _limit_tendon(is_sparse: bool, deterministic: bool):
     ten_length_in: wp.array2d[float],
     njmax_in: int,
     njmax_nnz_in: int,
+    # In:
     nefc_base_in: wp.array[int],
     efcid_offsets_in: wp.array2d[int],
     nnz_base_in: wp.array[int],
@@ -2346,7 +2361,7 @@ def _contact_pyramidal_count(
   is_sparse: bool,
   # Data in:
   nacon_in: wp.array[int],
-  # Contact in:
+  # In:
   dist_in: wp.array[float],
   condim_in: wp.array[int],
   includemargin_in: wp.array[float],
@@ -2409,9 +2424,7 @@ def _contact_pyramidal_count(
       vert = vert_in[conid]
       body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
 
-    rownnz = _contact_dof_tree_rownnz(
-      body_weldid, body_dofadr, body_dofnum, dof_parentid, body1, body2
-    )
+    rownnz = _contact_dof_tree_rownnz(body_weldid, body_dofnum, body_dofadr, dof_parentid, body1, body2)
     nnz_count_out[conid, dimid] = rownnz
   else:
     nnz_count_out[conid, dimid] = 0
@@ -2436,11 +2449,6 @@ def _contact_pyramidal(is_sparse: bool, deterministic: bool):
     geom_bodyid: wp.array[int],
     flex_vertadr: wp.array[int],
     flex_vertbodyid: wp.array[int],
-    # Deterministic-mode inputs:
-    nefc_base_in: wp.array[int],
-    efcid_offsets_in: wp.array2d[int],
-    nnz_base_in: wp.array[int],
-    nnz_offsets_in: wp.array2d[int],
     # Data in:
     qvel_in: wp.array2d[float],
     subtree_com_in: wp.array2d[wp.vec3],
@@ -2449,6 +2457,10 @@ def _contact_pyramidal(is_sparse: bool, deterministic: bool):
     njmax_nnz_in: int,
     nacon_in: wp.array[int],
     # In:
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
     dist_in: wp.array[float],
     condim_in: wp.array[int],
     includemargin_in: wp.array[float],
@@ -2717,7 +2729,7 @@ def _contact_elliptic_count(
   is_sparse: bool,
   # Data in:
   nacon_in: wp.array[int],
-  # Contact in:
+  # In:
   dist_in: wp.array[float],
   condim_in: wp.array[int],
   includemargin_in: wp.array[float],
@@ -2776,9 +2788,7 @@ def _contact_elliptic_count(
       vert = vert_in[conid]
       body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
 
-    rownnz = _contact_dof_tree_rownnz(
-      body_weldid, body_dofadr, body_dofnum, dof_parentid, body1, body2
-    )
+    rownnz = _contact_dof_tree_rownnz(body_weldid, body_dofnum, body_dofadr, dof_parentid, body1, body2)
     nnz_count_out[conid, dimid] = rownnz
   else:
     nnz_count_out[conid, dimid] = 0
@@ -2803,11 +2813,6 @@ def _contact_elliptic(is_sparse: bool, deterministic: bool):
     geom_bodyid: wp.array[int],
     flex_vertadr: wp.array[int],
     flex_vertbodyid: wp.array[int],
-    # Deterministic-mode inputs:
-    nefc_base_in: wp.array[int],
-    efcid_offsets_in: wp.array2d[int],
-    nnz_base_in: wp.array[int],
-    nnz_offsets_in: wp.array2d[int],
     # Data in:
     qvel_in: wp.array2d[float],
     subtree_com_in: wp.array2d[wp.vec3],
@@ -2816,6 +2821,10 @@ def _contact_elliptic(is_sparse: bool, deterministic: bool):
     njmax_nnz_in: int,
     nacon_in: wp.array[int],
     # In:
+    nefc_base_in: wp.array[int],
+    efcid_offsets_in: wp.array2d[int],
+    nnz_base_in: wp.array[int],
+    nnz_offsets_in: wp.array2d[int],
     dist_in: wp.array[float],
     condim_in: wp.array[int],
     includemargin_in: wp.array[float],
@@ -3107,13 +3116,12 @@ def make_constraint(m: types.Model, d: types.Data):
       efc_nnz,
     ]
 
-  def _scan_launch(dim, counts, nnz_counts, offsets, nnz_offsets,
-                   nefc_base, nnz_base):
+  def _scan_launch(dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base):
     wp.launch(
       _per_world_exclusive_scan_2d,
       dim=d.nworld,
       inputs=[counts, nnz_counts],
-      outputs=[offsets, nnz_offsets, nefc_base, nnz_base, d.nefc, efc_nnz],
+      outputs=[d.nefc, efc_nnz, offsets, nnz_offsets, nefc_base, nnz_base],
     )
 
   def _alloc_scan_bufs(dim):
@@ -3130,9 +3138,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- equality_connect ---
       _dim = (d.nworld, m.eq_connect_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
         wp.launch(
           _equality_connect_count,
           dim=_dim,
@@ -3152,8 +3158,7 @@ def make_constraint(m: types.Model, d: types.Data):
           ],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3200,9 +3205,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- equality_weld ---
       _dim = (d.nworld, m.eq_wld_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
         wp.launch(
           _equality_weld_count,
           dim=_dim,
@@ -3222,8 +3225,7 @@ def make_constraint(m: types.Model, d: types.Data):
           ],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3272,9 +3274,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- equality_joint ---
       _dim = (d.nworld, m.eq_jnt_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
         wp.launch(
           _equality_joint_count,
           dim=_dim,
@@ -3286,8 +3286,7 @@ def make_constraint(m: types.Model, d: types.Data):
           ],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3323,9 +3322,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- equality_tendon ---
       _dim = (d.nworld, m.eq_ten_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
         wp.launch(
           _equality_tendon_count,
           dim=_dim,
@@ -3342,8 +3339,7 @@ def make_constraint(m: types.Model, d: types.Data):
           ],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3382,9 +3378,7 @@ def make_constraint(m: types.Model, d: types.Data):
       _nflex = m.eq_flex_adr.size * m.nflexedge
       _dim_flat = (d.nworld, _nflex)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim_flat)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim_flat)
         wp.launch(
           _equality_flex_count,
           dim=(d.nworld, m.eq_flex_adr.size, m.nflexedge),
@@ -3398,8 +3392,7 @@ def make_constraint(m: types.Model, d: types.Data):
           ],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim_flat, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim_flat, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3437,17 +3430,14 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- friction_dof ---
       _dim = (d.nworld, m.nv)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
         wp.launch(
           _friction_dof_count,
           dim=_dim,
           inputs=[m.dof_frictionloss, m.is_sparse],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3475,17 +3465,14 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- friction_tendon ---
       _dim = (d.nworld, m.ntendon)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
         wp.launch(
           _friction_tendon_count,
           dim=_dim,
           inputs=[m.ten_J_rownnz, m.tendon_frictionloss, m.is_sparse],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3502,14 +3489,14 @@ def make_constraint(m: types.Model, d: types.Data):
           m.tendon_solimp_fri,
           m.tendon_frictionloss,
           m.tendon_invweight0,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
           d.qvel,
           d.ten_J,
           d.njmax,
           d.njmax_nnz,
+          nefc_base,
+          offsets,
+          nnz_base,
+          nnz_offsets,
         ],
         outputs=_efc_outputs(d.nf),
       )
@@ -3519,9 +3506,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- limit_ball ---
       _dim = (d.nworld, m.jnt_limited_ball_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
         wp.launch(
           _limit_ball_count,
           dim=_dim,
@@ -3535,8 +3520,7 @@ def make_constraint(m: types.Model, d: types.Data):
           ],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3569,9 +3553,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- limit_slide_hinge ---
       _dim = (d.nworld, m.jnt_limited_slide_hinge_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
         wp.launch(
           _limit_slide_hinge_count,
           dim=_dim,
@@ -3585,8 +3567,7 @@ def make_constraint(m: types.Model, d: types.Data):
           ],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3619,9 +3600,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- limit_tendon ---
       _dim = (d.nworld, m.tendon_limited_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = (
-          _alloc_scan_bufs(_dim)
-        )
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
         wp.launch(
           _limit_tendon_count,
           dim=_dim,
@@ -3635,8 +3614,7 @@ def make_constraint(m: types.Model, d: types.Data):
           ],
           outputs=[counts, nnz_counts],
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets,
-                     nefc_base, nnz_base)
+        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
       else:
         nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
       wp.launch(
@@ -3714,8 +3692,7 @@ def make_constraint(m: types.Model, d: types.Data):
             _contact_per_world_scan,
             dim=d.nworld,
             inputs=[counts, nnz_counts, world_start, world_end],
-            outputs=[offsets, nnz_offsets, nefc_base, nnz_base,
-                     d.nefc, efc_nnz],
+            outputs=[d.nefc, efc_nnz, offsets, nnz_offsets, nefc_base, nnz_base],
           )
         else:
           nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
@@ -3738,16 +3715,16 @@ def make_constraint(m: types.Model, d: types.Data):
             m.geom_bodyid,
             m.flex_vertadr,
             m.flex_vertbodyid,
-            nefc_base,
-            offsets,
-            nnz_base,
-            nnz_offsets,
             d.qvel,
             d.subtree_com,
             d.cdof,
             d.njmax,
             d.njmax_nnz,
             d.nacon,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
             d.contact.dist,
             d.contact.dim,
             d.contact.includemargin,
@@ -3824,8 +3801,7 @@ def make_constraint(m: types.Model, d: types.Data):
             _contact_per_world_scan,
             dim=d.nworld,
             inputs=[counts, nnz_counts, world_start, world_end],
-            outputs=[offsets, nnz_offsets, nefc_base, nnz_base,
-                     d.nefc, efc_nnz],
+            outputs=[d.nefc, efc_nnz, offsets, nnz_offsets, nefc_base, nnz_base],
           )
         else:
           nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
@@ -3848,16 +3824,16 @@ def make_constraint(m: types.Model, d: types.Data):
             m.geom_bodyid,
             m.flex_vertadr,
             m.flex_vertbodyid,
-            nefc_base,
-            offsets,
-            nnz_base,
-            nnz_offsets,
             d.qvel,
             d.subtree_com,
             d.cdof,
             d.njmax,
             d.njmax_nnz,
             d.nacon,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
             d.contact.dist,
             d.contact.dim,
             d.contact.includemargin,
@@ -3904,7 +3880,5 @@ def make_constraint(m: types.Model, d: types.Data):
       efc_nnz_host = efc_nnz.numpy()
       if efc_nnz_host.max() > d.njmax_nnz:
         raise RuntimeError(
-          f"opt.deterministic: efc_nnz overflow "
-          f"(max={efc_nnz_host.max()}, njmax_nnz={d.njmax_nnz}). "
-          f"Increase njmax_nnz."
+          f"opt.deterministic: efc_nnz overflow (max={efc_nnz_host.max()}, njmax_nnz={d.njmax_nnz}). Increase njmax_nnz."
         )

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -3079,18 +3079,68 @@ def _contact_elliptic(is_sparse: bool, deterministic: bool):
   return kernel
 
 
+def _ensure_det_scratch(m: types.Model, d: types.Data) -> dict:
+  """Lazily allocate persisted scratch for the deterministic constraint pipeline.
+
+  Every deterministic family needs 6 scratch arrays (counts, nnz_counts,
+  offsets, nnz_offsets, nefc_base, nnz_base). Before FP1 these were allocated
+  with wp.empty(...) on every make_constraint() call; this helper allocates
+  once per (m, d) instance and reuses thereafter.
+  """
+  scratch = getattr(d, "_det_scratch", None)
+  if scratch is not None:
+    return scratch
+
+  scratch = {"efc_nnz": wp.empty((d.nworld,), dtype=int)}
+
+  def _alloc(name: str, dim):
+    scratch[f"{name}_counts"] = wp.empty(dim, dtype=int)
+    scratch[f"{name}_nnz_counts"] = wp.empty(dim, dtype=int)
+    scratch[f"{name}_offsets"] = wp.empty(dim, dtype=int)
+    scratch[f"{name}_nnz_offsets"] = wp.empty(dim, dtype=int)
+    scratch[f"{name}_nefc_base"] = wp.empty((d.nworld,), dtype=int)
+    scratch[f"{name}_nnz_base"] = wp.empty((d.nworld,), dtype=int)
+
+  _alloc("eq_connect", (d.nworld, m.eq_connect_adr.size))
+  _alloc("eq_weld", (d.nworld, m.eq_wld_adr.size))
+  _alloc("eq_joint", (d.nworld, m.eq_jnt_adr.size))
+  _alloc("eq_tendon", (d.nworld, m.eq_ten_adr.size))
+  _alloc("eq_flex", (d.nworld, m.eq_flex_adr.size * m.nflexedge))
+  _alloc("friction_dof", (d.nworld, m.nv))
+  _alloc("friction_tendon", (d.nworld, m.ntendon))
+  _alloc("limit_ball", (d.nworld, m.jnt_limited_ball_adr.size))
+  _alloc("limit_slide_hinge", (d.nworld, m.jnt_limited_slide_hinge_adr.size))
+  _alloc("limit_tendon", (d.nworld, m.tendon_limited_adr.size))
+
+  if m.opt.cone == types.ConeType.PYRAMIDAL:
+    contact_nsub = m.nmaxpyramid
+  else:
+    contact_nsub = m.nmaxcondim
+  _alloc("contact", (d.naconmax, contact_nsub))
+  scratch["contact_world_start"] = wp.empty((d.nworld,), dtype=int)
+  scratch["contact_world_end"] = wp.empty((d.nworld,), dtype=int)
+
+  d._det_scratch = scratch
+  return scratch
+
+
 @event_scope
 def make_constraint(m: types.Model, d: types.Data):
   """Creates constraint jacobians and other supporting data."""
-  efc_nnz = wp.empty((d.nworld,), dtype=int)
+  det = m.opt.deterministic
+
+  if det:
+    s = _ensure_det_scratch(m, d)
+    efc_nnz = s["efc_nnz"]
+  else:
+    s = None
+    efc_nnz = wp.empty((d.nworld,), dtype=int)
 
   wp.launch(
     _zero_constraint_counts,
     dim=d.nworld,
     inputs=[d.ne, d.nf, d.nl, d.nefc, efc_nnz],
   )
-
-  det = m.opt.deterministic
 
   # Dummy arrays for deterministic-only kernel params in non-det mode.
   _d1 = wp.zeros(1, dtype=int)
@@ -3124,21 +3174,22 @@ def make_constraint(m: types.Model, d: types.Data):
       outputs=[d.nefc, efc_nnz, offsets, nnz_offsets, nefc_base, nnz_base],
     )
 
-  def _alloc_scan_bufs(dim):
-    counts = wp.empty(dim, dtype=int)
-    nnz_counts = wp.empty(dim, dtype=int)
-    offsets = wp.empty(dim, dtype=int)
-    nnz_offsets = wp.empty(dim, dtype=int)
-    nefc_base = wp.empty(d.nworld, dtype=int)
-    nnz_base = wp.empty(d.nworld, dtype=int)
-    return counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base
+  def _alloc_scan_bufs(name: str):
+    return (
+      s[f"{name}_counts"],
+      s[f"{name}_nnz_counts"],
+      s[f"{name}_offsets"],
+      s[f"{name}_nnz_offsets"],
+      s[f"{name}_nefc_base"],
+      s[f"{name}_nnz_base"],
+    )
 
   if not (m.opt.disableflags & types.DisableBit.CONSTRAINT):
     if not (m.opt.disableflags & types.DisableBit.EQUALITY):
       # --- equality_connect ---
       _dim = (d.nworld, m.eq_connect_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_connect")
         wp.launch(
           _equality_connect_count,
           dim=_dim,
@@ -3205,7 +3256,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- equality_weld ---
       _dim = (d.nworld, m.eq_wld_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_weld")
         wp.launch(
           _equality_weld_count,
           dim=_dim,
@@ -3274,7 +3325,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- equality_joint ---
       _dim = (d.nworld, m.eq_jnt_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_joint")
         wp.launch(
           _equality_joint_count,
           dim=_dim,
@@ -3322,7 +3373,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- equality_tendon ---
       _dim = (d.nworld, m.eq_ten_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_tendon")
         wp.launch(
           _equality_tendon_count,
           dim=_dim,
@@ -3378,7 +3429,7 @@ def make_constraint(m: types.Model, d: types.Data):
       _nflex = m.eq_flex_adr.size * m.nflexedge
       _dim_flat = (d.nworld, _nflex)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim_flat)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_flex")
         wp.launch(
           _equality_flex_count,
           dim=(d.nworld, m.eq_flex_adr.size, m.nflexedge),
@@ -3430,7 +3481,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- friction_dof ---
       _dim = (d.nworld, m.nv)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("friction_dof")
         wp.launch(
           _friction_dof_count,
           dim=_dim,
@@ -3465,7 +3516,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- friction_tendon ---
       _dim = (d.nworld, m.ntendon)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("friction_tendon")
         wp.launch(
           _friction_tendon_count,
           dim=_dim,
@@ -3506,7 +3557,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- limit_ball ---
       _dim = (d.nworld, m.jnt_limited_ball_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("limit_ball")
         wp.launch(
           _limit_ball_count,
           dim=_dim,
@@ -3553,7 +3604,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- limit_slide_hinge ---
       _dim = (d.nworld, m.jnt_limited_slide_hinge_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("limit_slide_hinge")
         wp.launch(
           _limit_slide_hinge_count,
           dim=_dim,
@@ -3600,7 +3651,7 @@ def make_constraint(m: types.Model, d: types.Data):
       # --- limit_tendon ---
       _dim = (d.nworld, m.tendon_limited_adr.size)
       if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs(_dim)
+        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("limit_tendon")
         wp.launch(
           _limit_tendon_count,
           dim=_dim,
@@ -3651,14 +3702,9 @@ def make_constraint(m: types.Model, d: types.Data):
       if m.opt.cone == types.ConeType.PYRAMIDAL:
         _dim = (d.naconmax, m.nmaxpyramid)
         if det:
-          counts = wp.empty(_dim, dtype=int)
-          nnz_counts = wp.empty(_dim, dtype=int)
-          offsets = wp.empty(_dim, dtype=int)
-          nnz_offsets = wp.empty(_dim, dtype=int)
-          nefc_base = wp.empty(d.nworld, dtype=int)
-          nnz_base = wp.empty(d.nworld, dtype=int)
-          world_start = wp.empty(d.nworld, dtype=int)
-          world_end = wp.empty(d.nworld, dtype=int)
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("contact")
+          world_start = s["contact_world_start"]
+          world_end = s["contact_world_end"]
           wp.launch(
             _contact_pyramidal_count,
             dim=_dim,
@@ -3760,14 +3806,9 @@ def make_constraint(m: types.Model, d: types.Data):
       elif m.opt.cone == types.ConeType.ELLIPTIC:
         _dim = (d.naconmax, m.nmaxcondim)
         if det:
-          counts = wp.empty(_dim, dtype=int)
-          nnz_counts = wp.empty(_dim, dtype=int)
-          offsets = wp.empty(_dim, dtype=int)
-          nnz_offsets = wp.empty(_dim, dtype=int)
-          nefc_base = wp.empty(d.nworld, dtype=int)
-          nnz_base = wp.empty(d.nworld, dtype=int)
-          world_start = wp.empty(d.nworld, dtype=int)
-          world_end = wp.empty(d.nworld, dtype=int)
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("contact")
+          world_start = s["contact_world_start"]
+          world_end = s["contact_world_end"]
           wp.launch(
             _contact_elliptic_count,
             dim=_dim,

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -3187,727 +3187,739 @@ def make_constraint(m: types.Model, d: types.Data):
   if not (m.opt.disableflags & types.DisableBit.CONSTRAINT):
     if not (m.opt.disableflags & types.DisableBit.EQUALITY):
       # --- equality_connect ---
-      _dim = (d.nworld, m.eq_connect_adr.size)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_connect")
+      if m.eq_connect_adr.size > 0:
+        _dim = (d.nworld, m.eq_connect_adr.size)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_connect")
+          wp.launch(
+            _equality_connect_count,
+            dim=_dim,
+            inputs=[
+              m.nsite,
+              m.body_weldid,
+              m.body_dofnum,
+              m.body_dofadr,
+              m.dof_parentid,
+              m.site_bodyid,
+              m.eq_obj1id,
+              m.eq_obj2id,
+              m.eq_objtype,
+              m.is_sparse,
+              m.eq_connect_adr,
+              d.eq_active,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
         wp.launch(
-          _equality_connect_count,
-          dim=_dim,
-          inputs=[
-            m.nsite,
-            m.body_weldid,
-            m.body_dofnum,
-            m.body_dofadr,
-            m.dof_parentid,
-            m.site_bodyid,
-            m.eq_obj1id,
-            m.eq_obj2id,
-            m.eq_objtype,
-            m.is_sparse,
-            m.eq_connect_adr,
-            d.eq_active,
-          ],
-          outputs=[counts, nnz_counts],
-        )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _equality_connect(m.is_sparse, det),
-        dim=_dim,
-        inputs=[
-          m.nv,
-          m.nsite,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.body_parentid,
-          m.body_rootid,
-          m.body_weldid,
-          m.body_dofnum,
-          m.body_dofadr,
-          m.body_invweight0,
-          m.dof_bodyid,
-          m.dof_parentid,
-          m.site_bodyid,
-          m.eq_obj1id,
-          m.eq_obj2id,
-          m.eq_objtype,
-          m.eq_solref,
-          m.eq_solimp,
-          m.eq_data,
-          m.eq_connect_adr,
-          d.qvel,
-          d.eq_active,
-          d.xpos,
-          d.xmat,
-          d.site_xpos,
-          d.subtree_com,
-          d.cdof,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.ne),
-      )
-
-      # --- equality_weld ---
-      _dim = (d.nworld, m.eq_wld_adr.size)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_weld")
-        wp.launch(
-          _equality_weld_count,
-          dim=_dim,
-          inputs=[
-            m.nsite,
-            m.body_weldid,
-            m.body_dofnum,
-            m.body_dofadr,
-            m.dof_parentid,
-            m.site_bodyid,
-            m.eq_obj1id,
-            m.eq_obj2id,
-            m.eq_objtype,
-            m.is_sparse,
-            m.eq_wld_adr,
-            d.eq_active,
-          ],
-          outputs=[counts, nnz_counts],
-        )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _equality_weld(m.is_sparse, det),
-        dim=_dim,
-        inputs=[
-          m.nv,
-          m.nsite,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.body_parentid,
-          m.body_rootid,
-          m.body_weldid,
-          m.body_dofnum,
-          m.body_dofadr,
-          m.body_invweight0,
-          m.dof_bodyid,
-          m.dof_parentid,
-          m.site_bodyid,
-          m.site_quat,
-          m.eq_obj1id,
-          m.eq_obj2id,
-          m.eq_objtype,
-          m.eq_solref,
-          m.eq_solimp,
-          m.eq_data,
-          m.eq_wld_adr,
-          d.qvel,
-          d.eq_active,
-          d.xpos,
-          d.xquat,
-          d.xmat,
-          d.site_xpos,
-          d.subtree_com,
-          d.cdof,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.ne),
-      )
-
-      # --- equality_joint ---
-      _dim = (d.nworld, m.eq_jnt_adr.size)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_joint")
-        wp.launch(
-          _equality_joint_count,
-          dim=_dim,
-          inputs=[
-            m.eq_obj2id,
-            m.is_sparse,
-            m.eq_jnt_adr,
-            d.eq_active,
-          ],
-          outputs=[counts, nnz_counts],
-        )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _equality_joint(m.is_sparse, det),
-        dim=_dim,
-        inputs=[
-          m.nv,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.qpos0,
-          m.jnt_qposadr,
-          m.jnt_dofadr,
-          m.dof_invweight0,
-          m.eq_obj1id,
-          m.eq_obj2id,
-          m.eq_solref,
-          m.eq_solimp,
-          m.eq_data,
-          m.eq_jnt_adr,
-          d.qpos,
-          d.qvel,
-          d.eq_active,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.ne),
-      )
-
-      # --- equality_tendon ---
-      _dim = (d.nworld, m.eq_ten_adr.size)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_tendon")
-        wp.launch(
-          _equality_tendon_count,
+          _equality_connect(m.is_sparse, det),
           dim=_dim,
           inputs=[
             m.nv,
+            m.nsite,
+            m.opt.timestep,
+            m.opt.disableflags,
+            m.body_parentid,
+            m.body_rootid,
+            m.body_weldid,
+            m.body_dofnum,
+            m.body_dofadr,
+            m.body_invweight0,
+            m.dof_bodyid,
+            m.dof_parentid,
+            m.site_bodyid,
             m.eq_obj1id,
             m.eq_obj2id,
+            m.eq_objtype,
+            m.eq_solref,
+            m.eq_solimp,
+            m.eq_data,
+            m.eq_connect_adr,
+            d.qvel,
+            d.eq_active,
+            d.xpos,
+            d.xmat,
+            d.site_xpos,
+            d.subtree_com,
+            d.cdof,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
+          ],
+          outputs=_efc_outputs(d.ne),
+        )
+
+      # --- equality_weld ---
+      if m.eq_wld_adr.size > 0:
+        _dim = (d.nworld, m.eq_wld_adr.size)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_weld")
+          wp.launch(
+            _equality_weld_count,
+            dim=_dim,
+            inputs=[
+              m.nsite,
+              m.body_weldid,
+              m.body_dofnum,
+              m.body_dofadr,
+              m.dof_parentid,
+              m.site_bodyid,
+              m.eq_obj1id,
+              m.eq_obj2id,
+              m.eq_objtype,
+              m.is_sparse,
+              m.eq_wld_adr,
+              d.eq_active,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
+        wp.launch(
+          _equality_weld(m.is_sparse, det),
+          dim=_dim,
+          inputs=[
+            m.nv,
+            m.nsite,
+            m.opt.timestep,
+            m.opt.disableflags,
+            m.body_parentid,
+            m.body_rootid,
+            m.body_weldid,
+            m.body_dofnum,
+            m.body_dofadr,
+            m.body_invweight0,
+            m.dof_bodyid,
+            m.dof_parentid,
+            m.site_bodyid,
+            m.site_quat,
+            m.eq_obj1id,
+            m.eq_obj2id,
+            m.eq_objtype,
+            m.eq_solref,
+            m.eq_solimp,
+            m.eq_data,
+            m.eq_wld_adr,
+            d.qvel,
+            d.eq_active,
+            d.xpos,
+            d.xquat,
+            d.xmat,
+            d.site_xpos,
+            d.subtree_com,
+            d.cdof,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
+          ],
+          outputs=_efc_outputs(d.ne),
+        )
+
+      # --- equality_joint ---
+      if m.eq_jnt_adr.size > 0:
+        _dim = (d.nworld, m.eq_jnt_adr.size)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_joint")
+          wp.launch(
+            _equality_joint_count,
+            dim=_dim,
+            inputs=[
+              m.eq_obj2id,
+              m.is_sparse,
+              m.eq_jnt_adr,
+              d.eq_active,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
+        wp.launch(
+          _equality_joint(m.is_sparse, det),
+          dim=_dim,
+          inputs=[
+            m.nv,
+            m.opt.timestep,
+            m.opt.disableflags,
+            m.qpos0,
+            m.jnt_qposadr,
+            m.jnt_dofadr,
+            m.dof_invweight0,
+            m.eq_obj1id,
+            m.eq_obj2id,
+            m.eq_solref,
+            m.eq_solimp,
+            m.eq_data,
+            m.eq_jnt_adr,
+            d.qpos,
+            d.qvel,
+            d.eq_active,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
+          ],
+          outputs=_efc_outputs(d.ne),
+        )
+
+      # --- equality_tendon ---
+      if m.eq_ten_adr.size > 0:
+        _dim = (d.nworld, m.eq_ten_adr.size)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_tendon")
+          wp.launch(
+            _equality_tendon_count,
+            dim=_dim,
+            inputs=[
+              m.nv,
+              m.eq_obj1id,
+              m.eq_obj2id,
+              m.ten_J_rownnz,
+              m.ten_J_rowadr,
+              m.ten_J_colind,
+              m.is_sparse,
+              m.eq_ten_adr,
+              d.eq_active,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
+        wp.launch(
+          _equality_tendon(m.is_sparse, det),
+          dim=_dim,
+          inputs=[
+            m.nv,
+            m.opt.timestep,
+            m.opt.disableflags,
+            m.eq_obj1id,
+            m.eq_obj2id,
+            m.eq_solref,
+            m.eq_solimp,
+            m.eq_data,
             m.ten_J_rownnz,
             m.ten_J_rowadr,
             m.ten_J_colind,
-            m.is_sparse,
+            m.tendon_length0,
+            m.tendon_invweight0,
             m.eq_ten_adr,
+            d.qvel,
             d.eq_active,
+            d.ten_J,
+            d.ten_length,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
           ],
-          outputs=[counts, nnz_counts],
+          outputs=_efc_outputs(d.ne),
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _equality_tendon(m.is_sparse, det),
-        dim=_dim,
-        inputs=[
-          m.nv,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.eq_obj1id,
-          m.eq_obj2id,
-          m.eq_solref,
-          m.eq_solimp,
-          m.eq_data,
-          m.ten_J_rownnz,
-          m.ten_J_rowadr,
-          m.ten_J_colind,
-          m.tendon_length0,
-          m.tendon_invweight0,
-          m.eq_ten_adr,
-          d.qvel,
-          d.eq_active,
-          d.ten_J,
-          d.ten_length,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.ne),
-      )
 
       # --- equality_flex ---
       _nflex = m.eq_flex_adr.size * m.nflexedge
-      _dim_flat = (d.nworld, _nflex)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_flex")
+      if _nflex > 0:
+        _dim_flat = (d.nworld, _nflex)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("eq_flex")
+          wp.launch(
+            _equality_flex_count,
+            dim=(d.nworld, m.eq_flex_adr.size, m.nflexedge),
+            inputs=[
+              m.flex_edgeadr,
+              m.flex_edgenum,
+              m.flexedge_J_rownnz,
+              m.eq_obj1id,
+              m.is_sparse,
+              m.eq_flex_adr,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim_flat, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
         wp.launch(
-          _equality_flex_count,
+          _equality_flex(m.is_sparse, det),
           dim=(d.nworld, m.eq_flex_adr.size, m.nflexedge),
           inputs=[
+            m.nv,
+            m.opt.timestep,
+            m.opt.disableflags,
             m.flex_edgeadr,
             m.flex_edgenum,
+            m.flexedge_length0,
+            m.flexedge_invweight0,
             m.flexedge_J_rownnz,
+            m.flexedge_J_rowadr,
+            m.flexedge_J_colind,
             m.eq_obj1id,
-            m.is_sparse,
+            m.eq_solref,
+            m.eq_solimp,
             m.eq_flex_adr,
+            d.qvel,
+            d.flexedge_J,
+            d.flexedge_length,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
           ],
-          outputs=[counts, nnz_counts],
+          outputs=_efc_outputs(d.ne),
         )
-        _scan_launch(_dim_flat, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _equality_flex(m.is_sparse, det),
-        dim=(d.nworld, m.eq_flex_adr.size, m.nflexedge),
-        inputs=[
-          m.nv,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.flex_edgeadr,
-          m.flex_edgenum,
-          m.flexedge_length0,
-          m.flexedge_invweight0,
-          m.flexedge_J_rownnz,
-          m.flexedge_J_rowadr,
-          m.flexedge_J_colind,
-          m.eq_obj1id,
-          m.eq_solref,
-          m.eq_solimp,
-          m.eq_flex_adr,
-          d.qvel,
-          d.flexedge_J,
-          d.flexedge_length,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.ne),
-      )
 
     if not (m.opt.disableflags & types.DisableBit.FRICTIONLOSS):
       # --- friction_dof ---
-      _dim = (d.nworld, m.nv)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("friction_dof")
+      if m.nv > 0:
+        _dim = (d.nworld, m.nv)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("friction_dof")
+          wp.launch(
+            _friction_dof_count,
+            dim=_dim,
+            inputs=[m.dof_frictionloss, m.is_sparse],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
         wp.launch(
-          _friction_dof_count,
+          _friction_dof(m.is_sparse, det),
           dim=_dim,
-          inputs=[m.dof_frictionloss, m.is_sparse],
-          outputs=[counts, nnz_counts],
+          inputs=[
+            m.nv,
+            m.opt.timestep,
+            m.opt.disableflags,
+            m.dof_solref,
+            m.dof_solimp,
+            m.dof_frictionloss,
+            m.dof_invweight0,
+            d.qvel,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
+          ],
+          outputs=_efc_outputs(d.nf),
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _friction_dof(m.is_sparse, det),
-        dim=_dim,
-        inputs=[
-          m.nv,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.dof_solref,
-          m.dof_solimp,
-          m.dof_frictionloss,
-          m.dof_invweight0,
-          d.qvel,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.nf),
-      )
 
       # --- friction_tendon ---
-      _dim = (d.nworld, m.ntendon)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("friction_tendon")
+      if m.ntendon > 0:
+        _dim = (d.nworld, m.ntendon)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("friction_tendon")
+          wp.launch(
+            _friction_tendon_count,
+            dim=_dim,
+            inputs=[m.ten_J_rownnz, m.tendon_frictionloss, m.is_sparse],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
         wp.launch(
-          _friction_tendon_count,
+          _friction_tendon(m.is_sparse, det),
           dim=_dim,
-          inputs=[m.ten_J_rownnz, m.tendon_frictionloss, m.is_sparse],
-          outputs=[counts, nnz_counts],
+          inputs=[
+            m.nv,
+            m.opt.timestep,
+            m.opt.disableflags,
+            m.ten_J_rownnz,
+            m.ten_J_rowadr,
+            m.ten_J_colind,
+            m.tendon_solref_fri,
+            m.tendon_solimp_fri,
+            m.tendon_frictionloss,
+            m.tendon_invweight0,
+            d.qvel,
+            d.ten_J,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
+          ],
+          outputs=_efc_outputs(d.nf),
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _friction_tendon(m.is_sparse, det),
-        dim=_dim,
-        inputs=[
-          m.nv,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.ten_J_rownnz,
-          m.ten_J_rowadr,
-          m.ten_J_colind,
-          m.tendon_solref_fri,
-          m.tendon_solimp_fri,
-          m.tendon_frictionloss,
-          m.tendon_invweight0,
-          d.qvel,
-          d.ten_J,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.nf),
-      )
 
     # limit
     if not (m.opt.disableflags & types.DisableBit.LIMIT):
       # --- limit_ball ---
-      _dim = (d.nworld, m.jnt_limited_ball_adr.size)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("limit_ball")
+      if m.jnt_limited_ball_adr.size > 0:
+        _dim = (d.nworld, m.jnt_limited_ball_adr.size)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("limit_ball")
+          wp.launch(
+            _limit_ball_count,
+            dim=_dim,
+            inputs=[
+              m.jnt_qposadr,
+              m.jnt_range,
+              m.jnt_margin,
+              m.is_sparse,
+              m.jnt_limited_ball_adr,
+              d.qpos,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
         wp.launch(
-          _limit_ball_count,
+          _limit_ball(m.is_sparse, det),
           dim=_dim,
           inputs=[
+            m.nv,
+            m.opt.timestep,
+            m.opt.disableflags,
             m.jnt_qposadr,
+            m.jnt_dofadr,
+            m.jnt_solref,
+            m.jnt_solimp,
             m.jnt_range,
             m.jnt_margin,
-            m.is_sparse,
+            m.dof_invweight0,
             m.jnt_limited_ball_adr,
             d.qpos,
+            d.qvel,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
           ],
-          outputs=[counts, nnz_counts],
+          outputs=_efc_outputs(d.nl),
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _limit_ball(m.is_sparse, det),
-        dim=_dim,
-        inputs=[
-          m.nv,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.jnt_qposadr,
-          m.jnt_dofadr,
-          m.jnt_solref,
-          m.jnt_solimp,
-          m.jnt_range,
-          m.jnt_margin,
-          m.dof_invweight0,
-          m.jnt_limited_ball_adr,
-          d.qpos,
-          d.qvel,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.nl),
-      )
 
       # --- limit_slide_hinge ---
-      _dim = (d.nworld, m.jnt_limited_slide_hinge_adr.size)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("limit_slide_hinge")
+      if m.jnt_limited_slide_hinge_adr.size > 0:
+        _dim = (d.nworld, m.jnt_limited_slide_hinge_adr.size)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("limit_slide_hinge")
+          wp.launch(
+            _limit_slide_hinge_count,
+            dim=_dim,
+            inputs=[
+              m.jnt_qposadr,
+              m.jnt_range,
+              m.jnt_margin,
+              m.is_sparse,
+              m.jnt_limited_slide_hinge_adr,
+              d.qpos,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
         wp.launch(
-          _limit_slide_hinge_count,
+          _limit_slide_hinge(m.is_sparse, det),
           dim=_dim,
           inputs=[
+            m.nv,
+            m.opt.timestep,
+            m.opt.disableflags,
             m.jnt_qposadr,
+            m.jnt_dofadr,
+            m.jnt_solref,
+            m.jnt_solimp,
             m.jnt_range,
             m.jnt_margin,
-            m.is_sparse,
+            m.dof_invweight0,
             m.jnt_limited_slide_hinge_adr,
             d.qpos,
+            d.qvel,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
           ],
-          outputs=[counts, nnz_counts],
+          outputs=_efc_outputs(d.nl),
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _limit_slide_hinge(m.is_sparse, det),
-        dim=_dim,
-        inputs=[
-          m.nv,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.jnt_qposadr,
-          m.jnt_dofadr,
-          m.jnt_solref,
-          m.jnt_solimp,
-          m.jnt_range,
-          m.jnt_margin,
-          m.dof_invweight0,
-          m.jnt_limited_slide_hinge_adr,
-          d.qpos,
-          d.qvel,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.nl),
-      )
 
       # --- limit_tendon ---
-      _dim = (d.nworld, m.tendon_limited_adr.size)
-      if det:
-        counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("limit_tendon")
+      if m.tendon_limited_adr.size > 0:
+        _dim = (d.nworld, m.tendon_limited_adr.size)
+        if det:
+          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("limit_tendon")
+          wp.launch(
+            _limit_tendon_count,
+            dim=_dim,
+            inputs=[
+              m.ten_J_rownnz,
+              m.tendon_range,
+              m.tendon_margin,
+              m.is_sparse,
+              m.tendon_limited_adr,
+              d.ten_length,
+            ],
+            outputs=[counts, nnz_counts],
+          )
+          _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
+        else:
+          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
         wp.launch(
-          _limit_tendon_count,
+          _limit_tendon(m.is_sparse, det),
           dim=_dim,
           inputs=[
+            m.nv,
+            m.opt.timestep,
+            m.opt.disableflags,
             m.ten_J_rownnz,
+            m.ten_J_rowadr,
+            m.ten_J_colind,
+            m.tendon_solref_lim,
+            m.tendon_solimp_lim,
             m.tendon_range,
             m.tendon_margin,
-            m.is_sparse,
+            m.tendon_invweight0,
             m.tendon_limited_adr,
+            d.qvel,
+            d.ten_J,
             d.ten_length,
+            d.njmax,
+            d.njmax_nnz,
+            nefc_base,
+            offsets,
+            nnz_base,
+            nnz_offsets,
           ],
-          outputs=[counts, nnz_counts],
+          outputs=_efc_outputs(d.nl),
         )
-        _scan_launch(_dim, counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base)
-      else:
-        nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-      wp.launch(
-        _limit_tendon(m.is_sparse, det),
-        dim=_dim,
-        inputs=[
-          m.nv,
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.ten_J_rownnz,
-          m.ten_J_rowadr,
-          m.ten_J_colind,
-          m.tendon_solref_lim,
-          m.tendon_solimp_lim,
-          m.tendon_range,
-          m.tendon_margin,
-          m.tendon_invweight0,
-          m.tendon_limited_adr,
-          d.qvel,
-          d.ten_J,
-          d.ten_length,
-          d.njmax,
-          d.njmax_nnz,
-          nefc_base,
-          offsets,
-          nnz_base,
-          nnz_offsets,
-        ],
-        outputs=_efc_outputs(d.nl),
-      )
 
     # contact
     if not (m.opt.disableflags & types.DisableBit.CONTACT):
       if m.opt.cone == types.ConeType.PYRAMIDAL:
-        _dim = (d.naconmax, m.nmaxpyramid)
-        if det:
-          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("contact")
-          world_start = s["contact_world_start"]
-          world_end = s["contact_world_end"]
+        if d.naconmax > 0 and m.nmaxpyramid > 0:
+          _dim = (d.naconmax, m.nmaxpyramid)
+          if det:
+            counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("contact")
+            world_start = s["contact_world_start"]
+            world_end = s["contact_world_end"]
+            wp.launch(
+              _contact_pyramidal_count,
+              dim=_dim,
+              inputs=[
+                m.body_weldid,
+                m.body_dofnum,
+                m.body_dofadr,
+                m.dof_parentid,
+                m.geom_bodyid,
+                m.flex_vertadr,
+                m.flex_vertbodyid,
+                m.is_sparse,
+                d.nacon,
+                d.contact.dist,
+                d.contact.dim,
+                d.contact.includemargin,
+                d.contact.geom,
+                d.contact.flex,
+                d.contact.vert,
+                d.contact.type,
+              ],
+              outputs=[counts, nnz_counts],
+            )
+            wp.launch(
+              _contact_world_boundaries,
+              dim=d.nworld,
+              inputs=[d.contact.worldid, d.nacon],
+              outputs=[world_start, world_end],
+            )
+            wp.launch(
+              _contact_per_world_scan,
+              dim=d.nworld,
+              inputs=[counts, nnz_counts, world_start, world_end],
+              outputs=[d.nefc, efc_nnz, offsets, nnz_offsets, nefc_base, nnz_base],
+            )
+          else:
+            nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
           wp.launch(
-            _contact_pyramidal_count,
+            _contact_pyramidal(m.is_sparse, det),
             dim=_dim,
             inputs=[
+              m.nv,
+              m.opt.timestep,
+              m.opt.disableflags,
+              m.opt.impratio_invsqrt,
+              m.body_parentid,
+              m.body_rootid,
               m.body_weldid,
               m.body_dofnum,
               m.body_dofadr,
+              m.body_invweight0,
+              m.dof_bodyid,
               m.dof_parentid,
               m.geom_bodyid,
               m.flex_vertadr,
               m.flex_vertbodyid,
-              m.is_sparse,
+              d.qvel,
+              d.subtree_com,
+              d.cdof,
+              d.njmax,
+              d.njmax_nnz,
               d.nacon,
+              nefc_base,
+              offsets,
+              nnz_base,
+              nnz_offsets,
               d.contact.dist,
               d.contact.dim,
               d.contact.includemargin,
+              d.contact.worldid,
               d.contact.geom,
               d.contact.flex,
               d.contact.vert,
+              d.contact.pos,
+              d.contact.frame,
+              d.contact.friction,
+              d.contact.solref,
+              d.contact.solimp,
               d.contact.type,
             ],
-            outputs=[counts, nnz_counts],
+            outputs=[
+              d.nefc,
+              d.contact.efc_address,
+              d.efc.type,
+              d.efc.id,
+              d.efc.J_rownnz,
+              d.efc.J_rowadr,
+              d.efc.J_colind,
+              d.efc.J,
+              d.efc.pos,
+              d.efc.margin,
+              d.efc.D,
+              d.efc.vel,
+              d.efc.aref,
+              d.efc.frictionloss,
+              efc_nnz,
+            ],
           )
-          wp.launch(
-            _contact_world_boundaries,
-            dim=d.nworld,
-            inputs=[d.contact.worldid, d.nacon],
-            outputs=[world_start, world_end],
-          )
-          wp.launch(
-            _contact_per_world_scan,
-            dim=d.nworld,
-            inputs=[counts, nnz_counts, world_start, world_end],
-            outputs=[d.nefc, efc_nnz, offsets, nnz_offsets, nefc_base, nnz_base],
-          )
-        else:
-          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-        wp.launch(
-          _contact_pyramidal(m.is_sparse, det),
-          dim=_dim,
-          inputs=[
-            m.nv,
-            m.opt.timestep,
-            m.opt.disableflags,
-            m.opt.impratio_invsqrt,
-            m.body_parentid,
-            m.body_rootid,
-            m.body_weldid,
-            m.body_dofnum,
-            m.body_dofadr,
-            m.body_invweight0,
-            m.dof_bodyid,
-            m.dof_parentid,
-            m.geom_bodyid,
-            m.flex_vertadr,
-            m.flex_vertbodyid,
-            d.qvel,
-            d.subtree_com,
-            d.cdof,
-            d.njmax,
-            d.njmax_nnz,
-            d.nacon,
-            nefc_base,
-            offsets,
-            nnz_base,
-            nnz_offsets,
-            d.contact.dist,
-            d.contact.dim,
-            d.contact.includemargin,
-            d.contact.worldid,
-            d.contact.geom,
-            d.contact.flex,
-            d.contact.vert,
-            d.contact.pos,
-            d.contact.frame,
-            d.contact.friction,
-            d.contact.solref,
-            d.contact.solimp,
-            d.contact.type,
-          ],
-          outputs=[
-            d.nefc,
-            d.contact.efc_address,
-            d.efc.type,
-            d.efc.id,
-            d.efc.J_rownnz,
-            d.efc.J_rowadr,
-            d.efc.J_colind,
-            d.efc.J,
-            d.efc.pos,
-            d.efc.margin,
-            d.efc.D,
-            d.efc.vel,
-            d.efc.aref,
-            d.efc.frictionloss,
-            efc_nnz,
-          ],
-        )
       elif m.opt.cone == types.ConeType.ELLIPTIC:
-        _dim = (d.naconmax, m.nmaxcondim)
-        if det:
-          counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("contact")
-          world_start = s["contact_world_start"]
-          world_end = s["contact_world_end"]
+        if d.naconmax > 0 and m.nmaxcondim > 0:
+          _dim = (d.naconmax, m.nmaxcondim)
+          if det:
+            counts, nnz_counts, offsets, nnz_offsets, nefc_base, nnz_base = _alloc_scan_bufs("contact")
+            world_start = s["contact_world_start"]
+            world_end = s["contact_world_end"]
+            wp.launch(
+              _contact_elliptic_count,
+              dim=_dim,
+              inputs=[
+                m.body_weldid,
+                m.body_dofnum,
+                m.body_dofadr,
+                m.dof_parentid,
+                m.geom_bodyid,
+                m.flex_vertadr,
+                m.flex_vertbodyid,
+                m.is_sparse,
+                d.nacon,
+                d.contact.dist,
+                d.contact.dim,
+                d.contact.includemargin,
+                d.contact.geom,
+                d.contact.flex,
+                d.contact.vert,
+                d.contact.type,
+              ],
+              outputs=[counts, nnz_counts],
+            )
+            wp.launch(
+              _contact_world_boundaries,
+              dim=d.nworld,
+              inputs=[d.contact.worldid, d.nacon],
+              outputs=[world_start, world_end],
+            )
+            wp.launch(
+              _contact_per_world_scan,
+              dim=d.nworld,
+              inputs=[counts, nnz_counts, world_start, world_end],
+              outputs=[d.nefc, efc_nnz, offsets, nnz_offsets, nefc_base, nnz_base],
+            )
+          else:
+            nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
           wp.launch(
-            _contact_elliptic_count,
+            _contact_elliptic(m.is_sparse, det),
             dim=_dim,
             inputs=[
+              m.nv,
+              m.opt.timestep,
+              m.opt.disableflags,
+              m.opt.impratio_invsqrt,
+              m.body_parentid,
+              m.body_rootid,
               m.body_weldid,
               m.body_dofnum,
               m.body_dofadr,
+              m.body_invweight0,
+              m.dof_bodyid,
               m.dof_parentid,
               m.geom_bodyid,
               m.flex_vertadr,
               m.flex_vertbodyid,
-              m.is_sparse,
+              d.qvel,
+              d.subtree_com,
+              d.cdof,
+              d.njmax,
+              d.njmax_nnz,
               d.nacon,
+              nefc_base,
+              offsets,
+              nnz_base,
+              nnz_offsets,
               d.contact.dist,
               d.contact.dim,
               d.contact.includemargin,
+              d.contact.worldid,
               d.contact.geom,
               d.contact.flex,
               d.contact.vert,
+              d.contact.pos,
+              d.contact.frame,
+              d.contact.friction,
+              d.contact.solref,
+              d.contact.solreffriction,
+              d.contact.solimp,
               d.contact.type,
             ],
-            outputs=[counts, nnz_counts],
+            outputs=[
+              d.nefc,
+              d.contact.efc_address,
+              d.efc.type,
+              d.efc.id,
+              d.efc.J_rownnz,
+              d.efc.J_rowadr,
+              d.efc.J_colind,
+              d.efc.J,
+              d.efc.pos,
+              d.efc.margin,
+              d.efc.D,
+              d.efc.vel,
+              d.efc.aref,
+              d.efc.frictionloss,
+              efc_nnz,
+            ],
           )
-          wp.launch(
-            _contact_world_boundaries,
-            dim=d.nworld,
-            inputs=[d.contact.worldid, d.nacon],
-            outputs=[world_start, world_end],
-          )
-          wp.launch(
-            _contact_per_world_scan,
-            dim=d.nworld,
-            inputs=[counts, nnz_counts, world_start, world_end],
-            outputs=[d.nefc, efc_nnz, offsets, nnz_offsets, nefc_base, nnz_base],
-          )
-        else:
-          nefc_base, offsets, nnz_base, nnz_offsets = _d1, _d2, _d1, _d2
-        wp.launch(
-          _contact_elliptic(m.is_sparse, det),
-          dim=_dim,
-          inputs=[
-            m.nv,
-            m.opt.timestep,
-            m.opt.disableflags,
-            m.opt.impratio_invsqrt,
-            m.body_parentid,
-            m.body_rootid,
-            m.body_weldid,
-            m.body_dofnum,
-            m.body_dofadr,
-            m.body_invweight0,
-            m.dof_bodyid,
-            m.dof_parentid,
-            m.geom_bodyid,
-            m.flex_vertadr,
-            m.flex_vertbodyid,
-            d.qvel,
-            d.subtree_com,
-            d.cdof,
-            d.njmax,
-            d.njmax_nnz,
-            d.nacon,
-            nefc_base,
-            offsets,
-            nnz_base,
-            nnz_offsets,
-            d.contact.dist,
-            d.contact.dim,
-            d.contact.includemargin,
-            d.contact.worldid,
-            d.contact.geom,
-            d.contact.flex,
-            d.contact.vert,
-            d.contact.pos,
-            d.contact.frame,
-            d.contact.friction,
-            d.contact.solref,
-            d.contact.solreffriction,
-            d.contact.solimp,
-            d.contact.type,
-          ],
-          outputs=[
-            d.nefc,
-            d.contact.efc_address,
-            d.efc.type,
-            d.efc.id,
-            d.efc.J_rownnz,
-            d.efc.J_rowadr,
-            d.efc.J_colind,
-            d.efc.J,
-            d.efc.pos,
-            d.efc.margin,
-            d.efc.D,
-            d.efc.vel,
-            d.efc.aref,
-            d.efc.frictionloss,
-            efc_nnz,
-          ],
-        )
 
   # Overflow check for deterministic mode.
   if det:

--- a/mujoco_warp/_src/determinism_test.py
+++ b/mujoco_warp/_src/determinism_test.py
@@ -1,0 +1,354 @@
+# Copyright 2026 The Newton Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for GPU determinism (contact sorting + constraint row allocation)."""
+
+import numpy as np
+import warp as wp
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import mujoco_warp as mjw
+from mujoco_warp import test_data
+from mujoco_warp._src import collision_driver
+
+_NSTEPS = 10
+_CONTACT_FIELDS = (
+  "dist",
+  "pos",
+  "frame",
+  "includemargin",
+  "friction",
+  "solref",
+  "solreffriction",
+  "solimp",
+  "dim",
+  "geom",
+  "flex",
+  "vert",
+  "efc_address",
+  "worldid",
+  "type",
+  "geomcollisionid",
+)
+
+
+# Per-row efc fields to compare across runs (excluding J which has solver-path-
+# dependent shape handled separately).
+_EFC_ROW_FIELDS = ("type", "id", "pos", "margin", "D", "vel", "aref", "frictionloss")
+
+
+def _run_and_collect_contacts(path, nworld, nsteps, deterministic):
+  """Run simulation and return contact geom arrays from last step."""
+  _, _, m, d = test_data.fixture(path=path, nworld=nworld)
+  m.opt.deterministic = deterministic
+  for _ in range(nsteps):
+    mjw.step(m, d)
+  nacon = d.nacon.numpy()[0]
+  return {
+    "nacon": nacon,
+    "geom": d.contact.geom.numpy()[:nacon].copy(),
+    "dist": d.contact.dist.numpy()[:nacon].copy(),
+    "pos": d.contact.pos.numpy()[:nacon].copy(),
+    "frame": d.contact.frame.numpy()[:nacon].copy(),
+    "dim": d.contact.dim.numpy()[:nacon].copy(),
+    "worldid": d.contact.worldid.numpy()[:nacon].copy(),
+    "geomcollisionid": d.contact.geomcollisionid.numpy()[:nacon].copy(),
+  }
+
+
+def _copy_contact_fields(d):
+  """Return copies of every contact array."""
+  return {field: getattr(d.contact, field).numpy().copy() for field in _CONTACT_FIELDS}
+
+
+def _write_contact_fields(d, contact_fields):
+  """Write full contact arrays back to device memory."""
+  for field, values in contact_fields.items():
+    arr = getattr(d.contact, field)
+    wp.copy(arr, wp.array(values, dtype=arr.dtype, device=arr.device))
+
+
+def _permute_active_contacts(contact_fields, nacon, perm):
+  """Return a copy with the active contacts permuted by `perm`."""
+  permuted = {field: values.copy() for field, values in contact_fields.items()}
+  for field, values in permuted.items():
+    values[:nacon] = values[perm]
+  return permuted
+
+
+def _sorted_contact_order(contact_fields, nacon):
+  """Return stable sorted indices for the active contacts."""
+  geom = contact_fields["geom"]
+  worldid = contact_fields["worldid"]
+  geomcollisionid = contact_fields["geomcollisionid"]
+  return sorted(
+    range(nacon),
+    key=lambda idx: (
+      int(worldid[idx]),
+      int(geom[idx, 0]),
+      int(geom[idx, 1]),
+      int(geomcollisionid[idx]),
+    ),
+  )
+
+
+class ContactSortDeterminismTest(parameterized.TestCase):
+  """Tests that contact sorting produces deterministic contact ordering."""
+
+  @parameterized.parameters(
+    ("collision.xml", 1),
+    ("collision.xml", 4),
+    ("humanoid/humanoid.xml", 1),
+    ("humanoid/humanoid.xml", 4),
+  )
+  def test_contact_ordering_deterministic(self, path, nworld):
+    """Contacts are bitwise identical across multiple runs."""
+    nruns = 3
+    results = [_run_and_collect_contacts(path, nworld, _NSTEPS, True) for _ in range(nruns)]
+
+    # Verify contacts were generated.
+    self.assertGreater(results[0]["nacon"], 0, f"No contacts for {path}")
+
+    for run in range(1, nruns):
+      self.assertEqual(results[0]["nacon"], results[run]["nacon"])
+      np.testing.assert_array_equal(
+        results[0]["geom"],
+        results[run]["geom"],
+        err_msg=f"Contact geom ordering differs: run 0 vs run {run}",
+      )
+
+  @parameterized.parameters(
+    ("collision.xml", 1),
+    ("humanoid/humanoid.xml", 1),
+  )
+  def test_contact_fields_deterministic(self, path, nworld):
+    """All contact fields are bitwise identical across runs."""
+    nruns = 3
+    results = [_run_and_collect_contacts(path, nworld, _NSTEPS, True) for _ in range(nruns)]
+
+    self.assertGreater(results[0]["nacon"], 0)
+
+    for run in range(1, nruns):
+      self.assertEqual(results[0]["nacon"], results[run]["nacon"])
+      for field in ("dist", "pos", "frame", "geom", "dim", "worldid", "geomcollisionid"):
+        np.testing.assert_array_equal(
+          results[0][field],
+          results[run][field],
+          err_msg=f"{field} differs: run 0 vs run {run}",
+        )
+
+  def test_contacts_sorted_by_geom(self):
+    """Contacts are sorted by (worldid, geom0, geom1) after deterministic step."""
+    result = _run_and_collect_contacts("collision.xml", 1, _NSTEPS, True)
+
+    nacon = result["nacon"]
+    self.assertGreater(nacon, 1)
+
+    geom = result["geom"]
+    worldid = result["worldid"]
+
+    # Verify sorted: (worldid, geom0, geom1) is non-decreasing.
+    for i in range(1, nacon):
+      key_prev = (worldid[i - 1], geom[i - 1, 0], geom[i - 1, 1])
+      key_curr = (worldid[i], geom[i, 0], geom[i, 1])
+      self.assertLessEqual(
+        key_prev,
+        key_curr,
+        f"Contacts not sorted at index {i}: {key_prev} > {key_curr}",
+      )
+
+  def test_sort_contacts_reorders_mixed_contacts(self):
+    """Sorting restores deterministic contact order after contacts are mixed."""
+    _, _, m, d = test_data.fixture(path="collision.xml", nworld=4)
+    m.opt.deterministic = False
+
+    mjw.forward(m, d)
+
+    nacon = d.nacon.numpy()[0]
+    self.assertGreaterEqual(nacon, 5)
+
+    original = _copy_contact_fields(d)
+    perm = np.concatenate((np.arange(1, nacon, 2), np.arange(0, nacon, 2)))
+    self.assertFalse(np.array_equal(perm, np.arange(nacon)))
+
+    mixed = _permute_active_contacts(original, nacon, perm)
+    _write_contact_fields(d, mixed)
+
+    expected_order = _sorted_contact_order(mixed, nacon)
+    expected = _permute_active_contacts(mixed, nacon, expected_order)
+
+    collision_driver._sort_contacts(m, d)
+
+    actual = _copy_contact_fields(d)
+    self.assertEqual(d.nacon.numpy()[0], nacon)
+
+    for field in _CONTACT_FIELDS:
+      np.testing.assert_array_equal(
+        actual[field][:nacon],
+        expected[field][:nacon],
+        err_msg=f"{field} was not permuted into deterministic order",
+      )
+
+  def test_deterministic_flag_default_false(self):
+    """The deterministic flag defaults to False."""
+    _, _, m, _ = test_data.fixture(path="collision.xml")
+    self.assertFalse(m.opt.deterministic)
+
+
+def _run_and_collect_efc(path, nworld, nsteps, deterministic, jacobian):
+  """Run simulation and return nefc + all per-row efc fields + J from last step."""
+  overrides = {"opt.jacobian": jacobian}
+  _, _, m, d = test_data.fixture(path=path, nworld=nworld, overrides=overrides)
+  m.opt.deterministic = deterministic
+  for _ in range(nsteps):
+    mjw.step(m, d)
+
+  nefc = d.nefc.numpy().copy()
+  result = {"nefc": nefc, "is_sparse": m.is_sparse}
+  # Per-row fields: (nworld, njmax). Slice per world to its nefc entries.
+  # Tests concatenate across worlds so shape is (sum(nefc),) — ordering within
+  # each world is the quantity that must be stable.
+  for field in _EFC_ROW_FIELDS:
+    arr = getattr(d.efc, field).numpy()
+    result[field] = np.concatenate([arr[w, : nefc[w]].copy() for w in range(nworld)])
+
+  # J and sparse metadata.
+  if m.is_sparse:
+    j_rownnz = d.efc.J_rownnz.numpy()
+    j_rowadr = d.efc.J_rowadr.numpy()
+    # J_colind in sparse is (nworld, 1, njmax*nv); flat per world slice.
+    j_colind_flat = d.efc.J_colind.numpy()[:, 0, :]
+    j_flat = d.efc.J.numpy()[:, 0, :]  # (nworld, njmax * nv)
+    result["J_rownnz"] = np.concatenate([j_rownnz[w, : nefc[w]].copy() for w in range(nworld)])
+    result["J_rowadr"] = np.concatenate([j_rowadr[w, : nefc[w]].copy() for w in range(nworld)])
+    # For colind/J values, collect only entries that correspond to active
+    # rows; per-row length is rownnz[i] starting at rowadr[i].
+    colind_parts = []
+    j_parts = []
+    for w in range(nworld):
+      for i in range(nefc[w]):
+        nnz = j_rownnz[w, i]
+        adr = j_rowadr[w, i]
+        colind_parts.append(j_colind_flat[w, adr : adr + nnz].copy())
+        j_parts.append(j_flat[w, adr : adr + nnz].copy())
+    result["J_colind"] = np.concatenate(colind_parts) if colind_parts else np.empty(0, dtype=np.int32)
+    result["J"] = np.concatenate(j_parts) if j_parts else np.empty(0)
+  else:
+    # Dense J is (nworld, njmax_pad, nv_pad). Slice to nefc rows per world.
+    j_dense = d.efc.J.numpy()
+    result["J"] = np.concatenate([j_dense[w, : nefc[w], :].reshape(-1).copy() for w in range(nworld)])
+
+  return result
+
+
+class ConstraintAllocationDeterminismTest(parameterized.TestCase):
+  """Phase 2: tests that constraint row allocation produces deterministic efc rows."""
+
+  @parameterized.parameters(
+    ("humanoid/humanoid.xml", 1, "DENSE"),
+    ("humanoid/humanoid.xml", 4, "DENSE"),
+    ("humanoid/humanoid.xml", 1, "SPARSE"),
+    ("humanoid/humanoid.xml", 4, "SPARSE"),
+    ("collision.xml", 1, "DENSE"),
+    ("collision.xml", 4, "DENSE"),
+    ("collision.xml", 1, "SPARSE"),
+    ("collision.xml", 4, "SPARSE"),
+  )
+  def test_nefc_deterministic(self, path, nworld, jacobian):
+    """d.nefc is bitwise identical across repeat runs in deterministic mode."""
+    nruns = 3
+    results = [_run_and_collect_efc(path, nworld, _NSTEPS, True, jacobian) for _ in range(nruns)]
+    self.assertGreater(results[0]["nefc"].sum(), 0, f"No constraints for {path}")
+    for run in range(1, nruns):
+      np.testing.assert_array_equal(
+        results[0]["nefc"],
+        results[run]["nefc"],
+        err_msg=f"nefc differs: run 0 vs run {run} ({path}, nworld={nworld}, {jacobian})",
+      )
+
+  @parameterized.parameters(
+    ("humanoid/humanoid.xml", 1, "DENSE"),
+    ("humanoid/humanoid.xml", 4, "DENSE"),
+    ("humanoid/humanoid.xml", 1, "SPARSE"),
+    ("humanoid/humanoid.xml", 4, "SPARSE"),
+    ("collision.xml", 1, "DENSE"),
+    ("collision.xml", 4, "DENSE"),
+    ("collision.xml", 1, "SPARSE"),
+    ("collision.xml", 4, "SPARSE"),
+  )
+  def test_efc_rows_deterministic(self, path, nworld, jacobian):
+    """Per-row efc fields are bitwise identical across runs in deterministic mode."""
+    nruns = 3
+    results = [_run_and_collect_efc(path, nworld, _NSTEPS, True, jacobian) for _ in range(nruns)]
+    self.assertGreater(results[0]["nefc"].sum(), 0)
+
+    for run in range(1, nruns):
+      for field in _EFC_ROW_FIELDS:
+        np.testing.assert_array_equal(
+          results[0][field],
+          results[run][field],
+          err_msg=f"efc.{field} differs: run 0 vs run {run} ({path}, nworld={nworld}, {jacobian})",
+        )
+
+  @parameterized.parameters(
+    ("humanoid/humanoid.xml", 1, "DENSE"),
+    ("humanoid/humanoid.xml", 4, "DENSE"),
+    ("humanoid/humanoid.xml", 1, "SPARSE"),
+    ("humanoid/humanoid.xml", 4, "SPARSE"),
+  )
+  def test_efc_J_deterministic(self, path, nworld, jacobian):
+    """Jacobian values (and sparse metadata) are bitwise identical across runs."""
+    nruns = 3
+    results = [_run_and_collect_efc(path, nworld, _NSTEPS, True, jacobian) for _ in range(nruns)]
+    self.assertGreater(results[0]["nefc"].sum(), 0)
+
+    for run in range(1, nruns):
+      np.testing.assert_array_equal(
+        results[0]["J"],
+        results[run]["J"],
+        err_msg=f"efc.J differs: run 0 vs run {run} ({path}, nworld={nworld}, {jacobian})",
+      )
+      if results[0]["is_sparse"]:
+        for field in ("J_rownnz", "J_rowadr", "J_colind"):
+          np.testing.assert_array_equal(
+            results[0][field],
+            results[run][field],
+            err_msg=f"efc.{field} differs: run 0 vs run {run} ({path}, nworld={nworld}, {jacobian})",
+          )
+
+  def test_overflow_raises_in_deterministic_mode(self):
+    """Artificially small njmax triggers RuntimeError in deterministic mode."""
+    _, _, m, d = test_data.fixture(path="humanoid/humanoid.xml", nworld=1)
+    m.opt.deterministic = True
+    # njmax normally tracks the required storage. Force overflow by lowering
+    # it below the real constraint count. One step should populate more than
+    # 1 row, so 1 is guaranteed to overflow.
+    d.njmax = 1
+    with self.assertRaisesRegex(RuntimeError, "nefc overflow"):
+      mjw.step(m, d)
+
+  def test_nondet_path_unaffected_by_njmax(self):
+    """Non-deterministic mode must not trigger overflow check (silent-truncate preserved)."""
+    _, _, m, d = test_data.fixture(path="humanoid/humanoid.xml", nworld=1)
+    m.opt.deterministic = False
+    # With det=False the overflow check should not run even if we set njmax
+    # artificially. The existing silent-return-on-overflow behavior is
+    # preserved — we just need it to not crash.
+    # Step once with normal njmax to confirm baseline.
+    mjw.step(m, d)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/mujoco_warp/_src/determinism_test.py
+++ b/mujoco_warp/_src/determinism_test.py
@@ -22,6 +22,7 @@ from absl.testing import parameterized
 import mujoco_warp as mjw
 from mujoco_warp import test_data
 from mujoco_warp._src import collision_driver
+from mujoco_warp._src.benchmark import benchmark
 
 _NSTEPS = 10
 _CONTACT_FIELDS = (
@@ -328,6 +329,40 @@ class ConstraintAllocationDeterminismTest(parameterized.TestCase):
             err_msg=f"efc.{field} differs: run 0 vs run {run} ({path}, nworld={nworld}, {jacobian})",
           )
 
+  @parameterized.parameters(
+    ("humanoid/humanoid.xml", 16, "DENSE"),
+    ("collision.xml", 16, "SPARSE"),
+  )
+  def test_large_nworld_efc_deterministic(self, path, nworld, jacobian):
+    """Larger nworld cases stay bitwise stable in deterministic mode."""
+    nruns = 2
+    results = [_run_and_collect_efc(path, nworld, _NSTEPS, True, jacobian) for _ in range(nruns)]
+    self.assertGreater(results[0]["nefc"].sum(), 0)
+
+    np.testing.assert_array_equal(
+      results[0]["nefc"],
+      results[1]["nefc"],
+      err_msg=f"nefc differs ({path}, nworld={nworld}, {jacobian})",
+    )
+    for field in _EFC_ROW_FIELDS:
+      np.testing.assert_array_equal(
+        results[0][field],
+        results[1][field],
+        err_msg=f"efc.{field} differs ({path}, nworld={nworld}, {jacobian})",
+      )
+    np.testing.assert_array_equal(
+      results[0]["J"],
+      results[1]["J"],
+      err_msg=f"efc.J differs ({path}, nworld={nworld}, {jacobian})",
+    )
+    if results[0]["is_sparse"]:
+      for field in ("J_rownnz", "J_rowadr", "J_colind"):
+        np.testing.assert_array_equal(
+          results[0][field],
+          results[1][field],
+          err_msg=f"efc.{field} differs ({path}, nworld={nworld}, {jacobian})",
+        )
+
   def test_overflow_raises_in_deterministic_mode(self):
     """Artificially small njmax triggers RuntimeError in deterministic mode."""
     _, _, m, d = test_data.fixture(path="humanoid/humanoid.xml", nworld=1)
@@ -348,6 +383,50 @@ class ConstraintAllocationDeterminismTest(parameterized.TestCase):
     # preserved — we just need it to not crash.
     # Step once with normal njmax to confirm baseline.
     mjw.step(m, d)
+
+
+class DeterminismBenchmarkCollectionTest(absltest.TestCase):
+  """Tests for deterministic benchmark data collection."""
+
+  def test_benchmark_graph_capture_nondeterministic(self):
+    """The existing CUDA-graph benchmark path still works for det=False."""
+    _, _, m, d = test_data.fixture(path="collision.xml", nworld=1)
+    m.opt.deterministic = False
+
+    jit_duration, run_duration, _, nacon, nefc, _, nsuccess = benchmark(
+      mjw.step,
+      m,
+      d,
+      nstep=2,
+      measure_alloc=True,
+      use_cuda_graph=True,
+    )
+
+    self.assertGreater(jit_duration, 0.0)
+    self.assertGreater(run_duration, 0.0)
+    self.assertLen(nacon, 2)
+    self.assertLen(nefc, 2)
+    self.assertEqual(nsuccess, d.nworld)
+
+  def test_benchmark_deterministic_without_cuda_graph(self):
+    """Deterministic benchmark collection works with CUDA graphs disabled."""
+    _, _, m, d = test_data.fixture(path="collision.xml", nworld=1)
+    m.opt.deterministic = True
+
+    jit_duration, run_duration, _, nacon, nefc, _, nsuccess = benchmark(
+      mjw.step,
+      m,
+      d,
+      nstep=2,
+      measure_alloc=True,
+      use_cuda_graph=False,
+    )
+
+    self.assertGreater(jit_duration, 0.0)
+    self.assertGreater(run_duration, 0.0)
+    self.assertLen(nacon, 2)
+    self.assertLen(nefc, 2)
+    self.assertEqual(nsuccess, d.nworld)
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/determinism_test.py
+++ b/mujoco_warp/_src/determinism_test.py
@@ -417,6 +417,27 @@ class ConstraintAllocationDeterminismTest(parameterized.TestCase):
           err_msg=f"efc.{field} differs ({path}, nworld={nworld}, {jacobian})",
         )
 
+  @parameterized.parameters("DENSE", "SPARSE")
+  def test_zero_size_families_skip_cleanly(self, jacobian):
+    """Contact-only models still work when many deterministic families are size 0."""
+    overrides = {"opt.jacobian": jacobian}
+    _, _, m, d = test_data.fixture(path="collision.xml", nworld=4, overrides=overrides)
+    m.opt.deterministic = True
+
+    self.assertEqual(m.eq_connect_adr.size, 0)
+    self.assertEqual(m.eq_wld_adr.size, 0)
+    self.assertEqual(m.eq_jnt_adr.size, 0)
+    self.assertEqual(m.eq_ten_adr.size, 0)
+    self.assertEqual(m.eq_flex_adr.size, 0)
+    self.assertEqual(m.ntendon, 0)
+    self.assertEqual(m.jnt_limited_ball_adr.size, 0)
+    self.assertEqual(m.jnt_limited_slide_hinge_adr.size, 0)
+    self.assertEqual(m.tendon_limited_adr.size, 0)
+
+    mjw.step(m, d)
+
+    self.assertGreater(d.nefc.numpy().sum(), 0)
+
   def test_overflow_raises_in_deterministic_mode(self):
     """Artificially small njmax triggers RuntimeError in deterministic mode."""
     _, _, m, d = test_data.fixture(path="humanoid/humanoid.xml", nworld=1)

--- a/mujoco_warp/_src/determinism_test.py
+++ b/mujoco_warp/_src/determinism_test.py
@@ -219,7 +219,7 @@ def _run_and_collect_efc(path, nworld, nsteps, deterministic, jacobian):
   nefc = d.nefc.numpy().copy()
   result = {"nefc": nefc, "is_sparse": m.is_sparse}
   # Per-row fields: (nworld, njmax). Slice per world to its nefc entries.
-  # Tests concatenate across worlds so shape is (sum(nefc),) — ordering within
+  # Tests concatenate across worlds so shape is (sum(nefc),) - ordering within
   # each world is the quantity that must be stable.
   for field in _EFC_ROW_FIELDS:
     arr = getattr(d.efc, field).numpy()
@@ -249,9 +249,39 @@ def _run_and_collect_efc(path, nworld, nsteps, deterministic, jacobian):
   else:
     # Dense J is (nworld, njmax_pad, nv_pad). Slice to nefc rows per world.
     j_dense = d.efc.J.numpy()
+    result["J_row_width"] = j_dense.shape[2]
     result["J"] = np.concatenate([j_dense[w, : nefc[w], :].reshape(-1).copy() for w in range(nworld)])
 
   return result
+
+
+def _sorted_efc_row_records(result):
+  """Returns a canonical multiset representation of efc rows for comparison."""
+  records = []
+  total_rows = int(np.sum(result["nefc"]))
+  j_offset = 0
+
+  for row in range(total_rows):
+    record = [int(result["type"][row])]
+    for field in ("pos", "margin", "D", "vel", "aref", "frictionloss"):
+      record.append(np.asarray(result[field][row]).tobytes())
+
+    if result["is_sparse"]:
+      nnz = int(result["J_rownnz"][row])
+      colind = result["J_colind"][j_offset : j_offset + nnz]
+      j_values = result["J"][j_offset : j_offset + nnz]
+      j_offset += nnz
+      record.append(colind.tobytes())
+      record.append(j_values.tobytes())
+    else:
+      row_width = int(result["J_row_width"])
+      j_values = result["J"][j_offset : j_offset + row_width]
+      j_offset += row_width
+      record.append(j_values.tobytes())
+
+    records.append(tuple(record))
+
+  return sorted(records)
 
 
 class ConstraintAllocationDeterminismTest(parameterized.TestCase):
@@ -308,6 +338,10 @@ class ConstraintAllocationDeterminismTest(parameterized.TestCase):
     ("humanoid/humanoid.xml", 4, "DENSE"),
     ("humanoid/humanoid.xml", 1, "SPARSE"),
     ("humanoid/humanoid.xml", 4, "SPARSE"),
+    ("collision.xml", 1, "DENSE"),
+    ("collision.xml", 4, "DENSE"),
+    ("collision.xml", 1, "SPARSE"),
+    ("collision.xml", 4, "SPARSE"),
   )
   def test_efc_J_deterministic(self, path, nworld, jacobian):
     """Jacobian values (and sparse metadata) are bitwise identical across runs."""
@@ -328,6 +362,26 @@ class ConstraintAllocationDeterminismTest(parameterized.TestCase):
             results[run][field],
             err_msg=f"efc.{field} differs: run 0 vs run {run} ({path}, nworld={nworld}, {jacobian})",
           )
+
+  @parameterized.parameters(
+    ("collision.xml", 1, "DENSE"),
+    ("collision.xml", 1, "SPARSE"),
+  )
+  def test_deterministic_matches_nondeterministic_row_multiset(self, path, nworld, jacobian):
+    """Deterministic allocation preserves the same efc row contents as the legacy path."""
+    deterministic = _run_and_collect_efc(path, nworld, _NSTEPS, True, jacobian)
+    nondeterministic = _run_and_collect_efc(path, nworld, _NSTEPS, False, jacobian)
+
+    self.assertGreater(deterministic["nefc"].sum(), 0)
+    np.testing.assert_array_equal(
+      deterministic["nefc"],
+      nondeterministic["nefc"],
+      err_msg=f"nefc differs between det off/on ({path}, nworld={nworld}, {jacobian})",
+    )
+    self.assertListEqual(
+      _sorted_efc_row_records(deterministic),
+      _sorted_efc_row_records(nondeterministic),
+    )
 
   @parameterized.parameters(
     ("humanoid/humanoid.xml", 16, "DENSE"),
@@ -380,17 +434,22 @@ class ConstraintAllocationDeterminismTest(parameterized.TestCase):
     m.opt.deterministic = False
     # With det=False the overflow check should not run even if we set njmax
     # artificially. The existing silent-return-on-overflow behavior is
-    # preserved — we just need it to not crash.
+    # preserved - we just need it to not crash.
     # Step once with normal njmax to confirm baseline.
     mjw.step(m, d)
 
 
-class DeterminismBenchmarkCollectionTest(absltest.TestCase):
+class DeterminismBenchmarkCollectionTest(parameterized.TestCase):
   """Tests for deterministic benchmark data collection."""
 
-  def test_benchmark_graph_capture_nondeterministic(self):
+  @parameterized.parameters(
+    ("NEWTON", "DENSE"),
+    ("CG", "SPARSE"),
+  )
+  def test_benchmark_graph_capture_nondeterministic(self, solver, jacobian):
     """The existing CUDA-graph benchmark path still works for det=False."""
-    _, _, m, d = test_data.fixture(path="collision.xml", nworld=1)
+    overrides = {"opt.solver": solver, "opt.jacobian": jacobian}
+    _, _, m, d = test_data.fixture(path="collision.xml", nworld=1, overrides=overrides)
     m.opt.deterministic = False
 
     jit_duration, run_duration, _, nacon, nefc, _, nsuccess = benchmark(
@@ -408,9 +467,14 @@ class DeterminismBenchmarkCollectionTest(absltest.TestCase):
     self.assertLen(nefc, 2)
     self.assertEqual(nsuccess, d.nworld)
 
-  def test_benchmark_deterministic_without_cuda_graph(self):
+  @parameterized.parameters(
+    ("NEWTON", "DENSE"),
+    ("CG", "SPARSE"),
+  )
+  def test_benchmark_deterministic_without_cuda_graph(self, solver, jacobian):
     """Deterministic benchmark collection works with CUDA graphs disabled."""
-    _, _, m, d = test_data.fixture(path="collision.xml", nworld=1)
+    overrides = {"opt.solver": solver, "opt.jacobian": jacobian}
+    _, _, m, d = test_data.fixture(path="collision.xml", nworld=1, overrides=overrides)
     m.opt.deterministic = True
 
     jit_duration, run_duration, _, nacon, nefc, _, nsuccess = benchmark(

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -740,8 +740,8 @@ class Option:
       zeros out the contacts at each step)
     contact_sensor_maxmatch: max number of contacts considered by contact sensor matching criteria
                              contacts matched after this value is exceded will be ignored
-    deterministic: enable deterministic contact ordering and constraint row allocation
-      TODO: update this description as more optional deterministic pipeline stages are released
+    deterministic: enable deterministic contact ordering and constraint row allocation.
+      TODO update this description as more optional deterministic pipeline stages are released
   """
 
   timestep: array("*", float)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -740,6 +740,8 @@ class Option:
       zeros out the contacts at each step)
     contact_sensor_maxmatch: max number of contacts considered by contact sensor matching criteria
                              contacts matched after this value is exceded will be ignored
+    deterministic: enable deterministic contact ordering and constraint row allocation
+      TODO: update this description as more optional deterministic pipeline stages are released
   """
 
   timestep: array("*", float)
@@ -770,6 +772,7 @@ class Option:
   graph_conditional: bool
   run_collision_detection: bool
   contact_sensor_maxmatch: int
+  deterministic: bool
 
 
 @dataclasses.dataclass

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -68,6 +68,7 @@ _REPLAY = flags.DEFINE_string("replay", None, "keyframe sequence to replay, keyf
 _MEMORY = flags.DEFINE_bool("memory", False, "print memory report")
 _FORMAT = flags.DEFINE_enum("format", "human", ["human", "short", "json"], "output format for results")
 _INFO = flags.DEFINE_bool("info", False, "print Model and Data info")
+_USE_CUDA_GRAPH = flags.DEFINE_bool("use_cuda_graph", True, "capture the benchmarked function as a CUDA graph")
 
 # Render
 _WIDTH = flags.DEFINE_integer("width", 64, "render width (pixels)")
@@ -491,7 +492,18 @@ def _main(argv: Sequence[str]):
       print(out)
 
     fn = _FUNCS[_FUNCTION.value]
-    res = benchmark(fn, m, d, _NSTEP.value, ctrls, _EVENT_TRACE.value, _MEASURE_ALLOC.value, _MEASURE_SOLVER.value, rc)
+    res = benchmark(
+      fn,
+      m,
+      d,
+      _NSTEP.value,
+      ctrls,
+      _EVENT_TRACE.value,
+      _MEASURE_ALLOC.value,
+      _MEASURE_SOLVER.value,
+      _USE_CUDA_GRAPH.value,
+      rc,
+    )
 
     match _FORMAT.value:
       case "short":


### PR DESCRIPTION
# Determinism support 2/N: deterministic constraint row allocation

For now I am just putting this in as a draft, opening it up early against main for review. Checks won't pass because 1/N changes are omitted.

## Summary

This PR extends the opt-in `opt.deterministic` flag introduced in #1281 to make constraint row allocation reproducible across repeated runs of the same input. The `wp.atomic_add(nefc_out, worldid, N)` allocation used inside each constraint kernel is replaced with a deterministic **count -> exclusive-scan -> emit** pipeline. After 2/N, every constraint row should be at the same position on every run, so `d.nefc`, `d.efc.*`, and `d.efc.J` are bitwise stable.

### Guarantees after 2/N (on top of 1/N)

- Stable `d.contact.*` ordering (from 1/N).
- Stable `d.nefc` across runs.
- Stable per-row `d.efc.*` values.
- Stable dense and sparse `d.efc.J` (including `J_rownnz`, `J_rowadr`, `J_colind`).

### Not yet guaranteed (deliberately out of scope)

- Bitwise `qacc`, `qvel`, `qpos`. Still gated on deterministic solver reductions.
- CUDA-graph capture with `opt.deterministic=True`. Blocked by host-side overflow readback

## Changes

- `mujoco_warp/_src/constraint.py`: replaces atomic slot allocation with the deterministic count -> scan -> emit pipeline across all constraint families (equality, friction, limit, contact pyramidal, contact elliptic).
- `mujoco_warp/_src/constraint.py`: **persisted deterministic scratch buffers**, all per-family `counts`, `nnz_counts`, `offsets`, `nnz_offsets`, `nefc_base`, `nnz_base`, plus contact `world_start` / `world_end`, are allocated once per `(m, d)` and reused across steps.
- `mujoco_warp/_src/constraint.py`: **skip zero-size families**, python-side early-skip for families whose `size == 0` avoids ~10–20 no-op kernel launches per step on models like humanoid.
- `mujoco_warp/_src/types.py`: `opt.deterministic` docstring updated to reflect that the flag now also covers constraint row allocation.
- `mujoco_warp/_src/determinism_test.py`: expanded determinism regression coverage for `nefc`, per-row `efc.*`, dense and sparse `efc.J`, canonicalized det-on vs det-off row-multiset equivalence, and benchmark-path smoke coverage for both solver paths.
- `mujoco_warp/_src/benchmark.py`, `mujoco_warp/testspeed.py`: expose `--use_cuda_graph` at the CLI and pipe it through `benchmark()` so `opt.deterministic=True` can be benchmarked on the non-captured path while the host-side overflow readback remains (can remove this if unwanted, mainly for helping me test).

## Benchmarks

I used similar benchmarking, just extended, as in the last PR, thanks to claude lol.

Environment:

- GPU: `NVIDIA GeForce RTX 4060 Laptop GPU` (8 GiB, `sm_89`)
- Warp: `1.13.0.dev20260227`, CUDA Toolkit 12.9, Driver 12.5
- Methodology: 3 trials × 500 measured steps, 50 warmup steps, explicit sync around the timing window, `us/step = 1e6 * run_duration / (nworld * nstep)`.
- `use_cuda_graph=False` on both off and on runs (required for deterministic mode today, host-side overflow readback is not capture-safe).
- Capacity margin applied to both off and on: `njmax = baseline + 32`, `njmax_nnz = baseline + 32 * nv` (deterministic overflow validation would otherwise trip after warmup).
- `collision.xml` `nworld=512` used `nccdmax=8` to fit in 8 GiB, applied to both runs.

### Newton + Dense

| model                   | nworld | mean ncon | mean nefc | off (us/step) | on (us/step) | overhead |
|-------------------------|-------:|----------:|----------:|--------------:|-------------:|---------:|
| `humanoid/humanoid.xml` |      1 |      9.53 |     30.63 |       4318.30 |      6022.23 |  +39.5%  |
| `humanoid/humanoid.xml` |     64 |     11.16 |     40.05 |         86.05 |       110.70 |  +28.7%  |
| `humanoid/humanoid.xml` |    512 |     11.22 |     44.95 |         12.23 |        15.17 |  +24.1%  |
| `collision.xml`         |      1 |     10.82 |     23.47 |       4836.62 |      6363.59 |  +31.6%  |
| `collision.xml`         |     64 |     10.81 |     23.57 |         77.49 |       100.23 |  +29.3%  |
| `collision.xml`         |    512 |     10.82 |     24.19 |         11.87 |        15.02 |  +26.5%  |

### CG + Sparse

| model                   | nworld | mean ncon | mean nefc | off (us/step) | on (us/step) | overhead |
|-------------------------|-------:|----------:|----------:|--------------:|-------------:|---------:|
| `humanoid/humanoid.xml` |      1 |      9.16 |     27.82 |       8374.90 |     10129.02 |  +20.9%  |
| `humanoid/humanoid.xml` |     64 |     11.18 |     38.88 |        128.68 |       155.16 |  +20.6%  |
| `humanoid/humanoid.xml` |    512 |     11.18 |     43.58 |         16.21 |        21.31 |  +31.4%  |
| `collision.xml`         |      1 |     10.74 |     23.31 |       5421.41 |      7149.21 |  +31.9%  |
| `collision.xml`         |     64 |     10.74 |     23.31 |         93.56 |       111.70 |  +19.4%  |
| `collision.xml`         |    512 |     10.74 |     23.31 |         12.15 |        14.05 |  +15.6%  |

Overhead range across the matrix: **+15.6% .. +39.5%**.

The benchmarks are decent, not amazing not horrible. There are several performance enhancements I have in mind (aside from CUDA graph support of course) that might be able to bring the overhead down quite a bit. I already implemented two which helped a decent bit.

Luckily, I was able to test this a couple days ago, but recently I installed the new Windows updates, and I am 99.9% sure these caused CUDA latency regression because I cannot get the same performance benchmarks on either this PR nor am I able to get similar numbers for the last PR. The latency is so bad that I literally cannot test on this windows slop machine so I might struggle in getting better performance benchmarks until I can get a workaround for this security update. 

### Performance enhancements in this PR

Two small perf enhancements are included in so that 2/N is closer to the 1/N cost. Neither changes the determinism semantics; both are measured against the same matrix.

**Persisted deterministic scratch buffers.** Allocates every scratch buffer once per `(m, d)` and reuses it across steps instead of `wp.empty(...)` on every constraint family. Measured on this branch (`humanoid.xml` and `collision.xml`, 3 trials × 500 steps):

| model                    | nworld | overhead before | overhead after | pp reduction | % reduction |
|--------------------------|-------:|----------------:|---------------:|-------------:|------------:|
| `humanoid/humanoid.xml`  |      1 |         +36.6%  |       +20.3%   |     −16.3    |     −45%    |
| `humanoid/humanoid.xml`  |     64 |         +40.5%  |       +21.5%   |     −19.0    |     −47%    |
| `humanoid/humanoid.xml`  |    512 |         +42.5%  |       +36.0%   |      −6.5    |     −15%    |
| `collision.xml`          |     64 |         +29.1%  |       +12.4%   |     −16.7    |     −57%    |
| `collision.xml`          |    512 |         +23.1%  |       +13.6%   |      −9.5    |     −41%    |

Saves ~370–830 µs/step of device-side work.

**Skip zero-size families.** Python-side early-skip for constraint families whose family-size is 0 (e.g. unused equality / friction / limit). Avoids ~10–20 no-op kernel launches per step on humanoid-like models. Small but consistent saving, largest impact at small `nworld` where launch overhead dominates.