### PR TITLE
update tests with improved array initialization

### DIFF
--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -722,16 +722,17 @@ class CollisionTest(parameterized.TestCase):
     )
     self.assertTrue((m.nxn_pairid.numpy()[:][:, 0] == 0).all())
 
+    d.nacon.zero_()
+    d.contact.dim.zero_()
+
     for arr in (
-      d.nacon,
       d.contact.includemargin,
-      d.contact.dim,
       d.contact.friction,
       d.contact.solref,
       d.contact.solreffriction,
       d.contact.solimp,
     ):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.collision(m, d)
 
@@ -765,16 +766,17 @@ class CollisionTest(parameterized.TestCase):
     )
     self.assertTrue((m.nxn_pairid.numpy()[:][:, 0] == 0).all())
 
+    d.nacon.zero_()
+    d.contact.dim.zero_()
+
     for arr in (
-      d.nacon,
       d.contact.includemargin,
-      d.contact.dim,
       d.contact.friction,
       d.contact.solref,
       d.contact.solreffriction,
       d.contact.solimp,
     ):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.collision(m, d)
 
@@ -809,16 +811,17 @@ class CollisionTest(parameterized.TestCase):
     )
     self.assertTrue((m.nxn_pairid.numpy()[:][:, 0] == 0).all())
 
+    d.nacon.zero_()
+    d.contact.dim.zero_()
+
     for arr in (
-      d.nacon,
       d.contact.includemargin,
-      d.contact.dim,
       d.contact.friction,
       d.contact.solref,
       d.contact.solreffriction,
       d.contact.solimp,
     ):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.collision(m, d)
 
@@ -857,16 +860,17 @@ class CollisionTest(parameterized.TestCase):
     )
     np.testing.assert_equal(m.nxn_pairid.numpy()[:][:, 0], np.array([-2, -1, 0]))
 
+    d.nacon.zero_()
+    d.contact.dim.zero_()
+
     for arr in (
-      d.nacon,
       d.contact.includemargin,
-      d.contact.dim,
       d.contact.friction,
       d.contact.solref,
       d.contact.solreffriction,
       d.contact.solimp,
     ):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.collision(m, d)
 

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -837,6 +837,7 @@ def fwd_actuation(m: Model, d: Data):
   if not m.nu or (m.opt.disableflags & DisableBit.ACTUATION):
     d.act_dot.zero_()
     d.qfrc_actuator.zero_()
+    d.actuator_force.zero_()
     return
 
   wp.launch(

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -46,7 +46,7 @@ class ForwardTest(parameterized.TestCase):
     _, mjd, m, d = test_data.fixture(xml, qvel_noise=0.01, ctrl_noise=0.1)
 
     for arr in (d.actuator_velocity, d.qfrc_bias):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.fwd_velocity(m, d)
 
@@ -57,7 +57,7 @@ class ForwardTest(parameterized.TestCase):
   def test_fwd_velocity_tendon(self, jacobian):
     _, mjd, m, d = test_data.fixture("tendon/fixed.xml", overrides={"opt.jacobian": jacobian})
 
-    d.ten_velocity.zero_()
+    d.ten_velocity.fill_(wp.inf)
     mjw.fwd_velocity(m, d)
 
     _assert_eq(d.ten_velocity.numpy()[0], mjd.ten_velocity, "ten_velocity")
@@ -70,7 +70,7 @@ class ForwardTest(parameterized.TestCase):
     mjm, mjd, m, d = test_data.fixture(xml, keyframe=0, overrides={"opt.disableflags": disableflags})
 
     for arr in (d.qfrc_actuator, d.actuator_force, d.act_dot):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.fwd_actuation(m, d)
 
@@ -117,7 +117,7 @@ class ForwardTest(parameterized.TestCase):
     _, mjd, m, d = test_data.fixture("humanoid/humanoid.xml", qvel_noise=0.01, ctrl_noise=0.1)
 
     for arr in (d.qfrc_smooth, d.qacc_smooth):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.fwd_acceleration(m, d)
 
@@ -304,7 +304,7 @@ class ForwardTest(parameterized.TestCase):
         "actuation/tendon_force_limit.xml", keyframe=keyframe, overrides={"opt.jacobian": jacobian}
       )
 
-      d.actuator_force.zero_()
+      d.actuator_force.fill_(wp.inf)
 
       mjw.forward(m, d)
 
@@ -596,10 +596,10 @@ class ForwardTest(parameterized.TestCase):
     self.assertEqual(d.ctrl.numpy()[0, 0], 2.0)
 
     # reset ctrl, disable actuation, verify callback not called
-    d.ctrl.zero_()
+    d.ctrl.fill_(5.0)
     m.opt.disableflags |= DisableBit.ACTUATION
     mjw.forward(m, d)
-    self.assertEqual(d.ctrl.numpy()[0, 0], 0.0)
+    self.assertEqual(d.ctrl.numpy()[0, 0], 5.0)
 
   @parameterized.product(
     frequency=(1.5, 0.5),

--- a/mujoco_warp/_src/inverse_test.py
+++ b/mujoco_warp/_src/inverse_test.py
@@ -107,7 +107,7 @@ class InverseTest(parameterized.TestCase):
     qfrc_inverse = d.qfrc_applied.numpy()[0] + d.qfrc_actuator.numpy()[0] + qfrc_xfrc_applied.numpy()[0]
 
     for arr in (d.qfrc_constraint, d.qfrc_inverse):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.inverse(m, d)
 
@@ -156,7 +156,7 @@ class InverseTest(parameterized.TestCase):
     qfrc_inverse = d.qfrc_applied.numpy()[0] + d.qfrc_actuator.numpy()[0] + qfrc_xfrc_applied.numpy()[0]
 
     for arr in (d.qfrc_constraint, d.qfrc_inverse):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.inverse(m, d)
 

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -469,7 +469,7 @@ class SensorTest(parameterized.TestCase):
       xml, qvel_noise=0.01, ctrl_noise=0.1, overrides={"opt.disableflags": DisableBit.CONSTRAINT}
     )
 
-    d.energy.zero_()
+    d.energy.fill_(wp.inf)
 
     mujoco.mj_energyPos(mjm, mjd)
     mjw.energy_pos(m, d)

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -1195,7 +1195,9 @@ def _cfrc(
   cfrc_int_out: wp.array2d[wp.spatial_vector],
 ):
   worldid, bodyid = wp.tid()
-  bodyid += 1  # skip world body
+  if bodyid == 0:
+    cfrc_int_out[worldid, 0] = wp.spatial_vector(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    return
   cacc = cacc_in[worldid, bodyid]
   cinert = cinert_in[worldid, bodyid]
   cvel = cvel_in[worldid, bodyid]
@@ -1208,9 +1210,7 @@ def _cfrc(
 
 
 def _rne_cfrc(m: Model, d: Data, flg_cfrc_ext: bool = False):
-  wp.launch(
-    _cfrc, dim=[d.nworld, m.nbody - 1], inputs=[d.cinert, d.cvel, d.cacc, d.cfrc_ext, flg_cfrc_ext], outputs=[d.cfrc_int]
-  )
+  wp.launch(_cfrc, dim=[d.nworld, m.nbody], inputs=[d.cinert, d.cvel, d.cacc, d.cfrc_ext, flg_cfrc_ext], outputs=[d.cfrc_int])
 
 
 @wp.kernel
@@ -1981,6 +1981,9 @@ def _comvel_branch(
         cvel += cdof[dofid + 1] * qvel[dofid + 1]
         cvel += cdof[dofid + 2] * qvel[dofid + 2]
 
+        cdof_dot_out[worldid, dofid + 0] = wp.spatial_vector(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        cdof_dot_out[worldid, dofid + 1] = wp.spatial_vector(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        cdof_dot_out[worldid, dofid + 2] = wp.spatial_vector(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         cdof_dot_out[worldid, dofid + 3] = math.motion_cross(cvel, cdof[dofid + 3])
         cdof_dot_out[worldid, dofid + 4] = math.motion_cross(cvel, cdof[dofid + 4])
         cdof_dot_out[worldid, dofid + 5] = math.motion_cross(cvel, cdof[dofid + 5])

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -160,7 +160,7 @@ class SmoothTest(parameterized.TestCase):
     _, mjd, m, d = test_data.fixture("pendula.xml")
 
     for arr in (d.subtree_com, d.cinert, d.cdof):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.com_pos(m, d)
     _assert_eq(d.subtree_com.numpy()[0], mjd.subtree_com, "subtree_com")
@@ -171,10 +171,10 @@ class SmoothTest(parameterized.TestCase):
     """Tests camlight."""
     _, mjd, m, d = test_data.fixture("pendula.xml")
 
-    d.cam_xpos.zero_()
-    d.cam_xmat.zero_()
-    d.light_xpos.zero_()
-    d.light_xdir.zero_()
+    d.cam_xpos.fill_(wp.inf)
+    d.cam_xmat.fill_(wp.inf)
+    d.light_xpos.fill_(wp.inf)
+    d.light_xdir.fill_(wp.inf)
 
     mjw.camlight(m, d)
     _assert_eq(d.cam_xpos.numpy()[0], mjd.cam_xpos, "cam_xpos")
@@ -187,7 +187,7 @@ class SmoothTest(parameterized.TestCase):
     """Tests crb."""
     mjm, mjd, m, d = test_data.fixture("pendula.xml", overrides={"opt.jacobian": jacobian})
 
-    d.crb.zero_()
+    d.crb.fill_(wp.inf)
 
     mjw.crb(m, d)
     _assert_eq(d.crb.numpy()[0], mjd.crb, "crb")
@@ -205,8 +205,13 @@ class SmoothTest(parameterized.TestCase):
     _, mjd, m, d = test_data.fixture("pendula.xml", overrides={"opt.jacobian": jacobian})
 
     qLD = d.qLD.numpy()[0].copy()
-    for arr in (d.qLD, d.qLDiagInv):
-      arr.zero_()
+    d.qLDiagInv.fill_(wp.inf)
+    if jacobian == mujoco.mjtJacobian.mjJAC_DENSE:
+      wp_qLD = qLD.copy()
+      wp_qLD[wp_qLD != 0.0] = np.inf
+      wp.copy(d.qLD, wp.array(wp_qLD, dtype=float))
+    else:
+      d.qLD.fill_(wp.inf)
 
     mjw.factor_m(m, d)
 
@@ -225,7 +230,7 @@ class SmoothTest(parameterized.TestCase):
     qacc_smooth = np.zeros(shape=(1, mjm.nv), dtype=float)
     mujoco.mj_solveM(mjm, mjd, qacc_smooth, qfrc_smooth)
 
-    d.qacc_smooth.zero_()
+    d.qacc_smooth.fill_(wp.inf)
 
     mjw.solve_m(m, d, d.qacc_smooth, d.qfrc_smooth)
     _assert_eq(d.qacc_smooth.numpy()[0], qacc_smooth[0], "qacc_smooth")
@@ -235,7 +240,7 @@ class SmoothTest(parameterized.TestCase):
     """Tests rne."""
     _, mjd, m, d = test_data.fixture("pendula.xml", overrides={"opt.disableflags": DisableBit.CONTACT | gravity})
 
-    d.qfrc_bias.zero_()
+    d.qfrc_bias.fill_(wp.inf)
 
     mjw.rne(m, d)
     _assert_eq(d.qfrc_bias.numpy()[0], mjd.qfrc_bias, "qfrc_bias")
@@ -251,7 +256,7 @@ class SmoothTest(parameterized.TestCase):
     mujoco.mj_rnePostConstraint(mjm, mjd)
 
     for arr in (d.cacc, d.cfrc_int, d.cfrc_ext):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.rne_postconstraint(m, d)
 
@@ -320,7 +325,7 @@ class SmoothTest(parameterized.TestCase):
     _, mjd, m, d = test_data.fixture("pendula.xml")
 
     for arr in (d.cvel, d.cdof_dot):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.com_vel(m, d)
     _assert_eq(d.cvel.numpy()[0], mjd.cvel, "cvel")
@@ -392,7 +397,7 @@ class SmoothTest(parameterized.TestCase):
     mjm, mjd, m, d = test_data.fixture("pendula.xml")
 
     for arr in (d.subtree_linvel, d.subtree_angmom):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mujoco.mj_subtreeVel(mjm, mjd)
     mjw.subtree_vel(m, d)
@@ -419,7 +424,7 @@ class SmoothTest(parameterized.TestCase):
     mjm, mjd, m, d = test_data.fixture(xml, keyframe=0, overrides={"opt.jacobian": jacobian})
 
     for arr in (d.ten_length, d.ten_J, d.actuator_length, d.actuator_moment):
-      arr.zero_()
+      arr.fill_(wp.inf)
 
     mjw.tendon(m, d)
     mjw.transmission(m, d)
@@ -494,7 +499,7 @@ class SmoothTest(parameterized.TestCase):
     mjm, mjd, m, d = test_data.fixture("tendon/armature.xml", keyframe=0)
 
     # qM
-    d.qM.zero_()
+    d.qM.fill_(wp.inf)
 
     mjw._src.smooth.crb(m, d)
     mjw._src.smooth.tendon_armature(m, d)
@@ -504,7 +509,7 @@ class SmoothTest(parameterized.TestCase):
     _assert_eq(d.qM.numpy()[0, : mjm.nv, : mjm.nv], qM, "qM")
 
     # qfrc_bias
-    d.qfrc_bias.zero_()
+    d.qfrc_bias.fill_(wp.inf)
 
     mjw._src.smooth.rne(m, d)
     mjw._src.smooth.tendon_bias(m, d, d.qfrc_bias)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -63,8 +63,8 @@ class SolverTest(parameterized.TestCase):
       mjd_cost = cost(mjd.qacc)
 
       # solve with 0 iterations just initializes constraints and costs and then exits
-      d.efc.force.zero_()
-      d.qfrc_constraint.zero_()
+      d.efc.force.fill_(wp.inf)
+      d.qfrc_constraint.fill_(wp.inf)
       ctx = solver.create_solver_context(m, d)
       solver._solve(m, d, ctx)
 
@@ -167,9 +167,9 @@ class SolverTest(parameterized.TestCase):
       )
 
       # Reset and launch linesearch
-      ctx.jv.zero_()
-      ctx.quad.zero_()
-      ctx.quad_gauss.zero_()
+      ctx.jv.fill_(wp.inf)
+      ctx.quad.fill_(wp.inf)
+      ctx.quad_gauss.fill_(wp.inf)
       step_size_cost = wp.empty((d.nworld, m.opt.ls_iterations), dtype=float)
       solver._linesearch(m, d, ctx, step_size_cost)
 
@@ -297,9 +297,9 @@ class SolverTest(parameterized.TestCase):
 
       mujoco.mj_forward(mjm, mjd)
 
-      d.qacc.zero_()
-      d.qfrc_constraint.zero_()
-      d.efc.force.zero_()
+      d.qacc.fill_(wp.inf)
+      d.qfrc_constraint.fill_(wp.inf)
+      d.efc.force.fill_(wp.inf)
 
       if solver_ == mujoco.mjtSolver.mjSOL_CG:
         mjw.factor_m(m, d)
@@ -482,9 +482,9 @@ class SolverTest(parameterized.TestCase):
       qLD = np.vstack([qLD0, qLD1, qLD2])
       d.qLD = wp.from_numpy(qLD, dtype=wp.float32)
 
-    d.qacc.zero_()
-    d.qfrc_constraint.zero_()
-    d.efc.force.zero_()
+    d.qacc.fill_(wp.inf)
+    d.qfrc_constraint.fill_(wp.inf)
+    d.efc.force.fill_(wp.inf)
     solver.solve(m, d)
 
     def cost(m, d, qacc):


### PR DESCRIPTION
many tests are updated to fill arrays with `wp.inf` in order to improve testing. additionally, 2 kernels are updated.