### PR TITLE
island solver

### DIFF
--- a/mujoco_warp/_src/cli.py
+++ b/mujoco_warp/_src/cli.py
@@ -25,6 +25,7 @@ from absl import flags
 from etils import epath
 
 import mujoco_warp as mjw
+from mujoco_warp._src import io
 from mujoco_warp._src import warp_util
 from mujoco_warp._src.io import load_trajectory
 from mujoco_warp._src.io import override_model
@@ -42,6 +43,12 @@ KEYFRAME = flags.DEFINE_integer("keyframe", 0, "keyframe to initialize simulatio
 EVENT_TRACE = flags.DEFINE_bool("event_trace", False, "print an event trace report")
 NOISE_STD = flags.DEFINE_float("noise_std", 0.01, "add noise to ctrl signal (standard deviation)")
 NOISE_RATE = flags.DEFINE_float("noise_rate", 0.1, "add noise to ctrl signal (noise rate)")
+ENABLE_ISLANDS = flags.DEFINE_bool(
+  "enable_islands",
+  False,
+  "Enable constraint islands solver",
+)
+
 
 DEVICE = flags.DEFINE_string("device", None, "override the default Warp device")
 REPLAY = flags.DEFINE_string("replay", None, "NPZ file with ctrl sequence to replay")
@@ -134,6 +141,8 @@ def init_structs(
   fn: Callable[..., None], mjm: mujoco.MjModel
 ) -> Tuple[mjw.Model, mjw.Data, mjw.RenderContext | None, list[np.ndarray] | None]:
   """Initialize device structs."""
+  io.ENABLE_ISLANDS = ENABLE_ISLANDS.value
+
   mjd = mujoco.MjData(mjm)
   ctrls = None
   if REPLAY.value:

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -26,6 +26,7 @@ from mujoco_warp._src import passive
 from mujoco_warp._src import sensor
 from mujoco_warp._src import smooth
 from mujoco_warp._src import solver
+from mujoco_warp._src import types
 from mujoco_warp._src import util_misc
 from mujoco_warp._src.support import next_act
 from mujoco_warp._src.support import xfrc_accumulate
@@ -614,8 +615,7 @@ def fwd_position(m: Model, d: Data, factorize: bool = True):
   if m.opt.run_collision_detection:
     collision_driver.collision(m, d)
   constraint.make_constraint(m, d)
-  # TODO(team): remove False after island features are more complete
-  if False and not (m.opt.disableflags & DisableBit.ISLAND):
+  if m.ntree > 1 and not (m.opt.disableflags & types.DisableBit.ISLAND):
     island.island(m, d)
   smooth.transmission(m, d)
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -33,6 +33,9 @@ from mujoco_warp._src.types import TrnType
 from mujoco_warp._src.types import vec10
 from mujoco_warp._src.util_pkg import check_version
 
+# TODO(team): remove after improving island solver performance
+ENABLE_ISLANDS = False
+
 
 def _is_array_spec(typ) -> bool:
   """Check if a type annotation is an array spec (wp.array instance or bracket annotation)."""
@@ -62,6 +65,61 @@ def _create_array(data: Any, spec, sizes: dict[str, int]) -> wp.array | None:
     # also set stride 0 to 0 which is expected legacy behavior (but is deprecated)
     array.strides = (0,) + array.strides[1:]
   return array
+
+
+def _create_constraint(
+  mjm,
+  nworld: int,
+  njmax: int,
+  njmax_nnz: int,
+  sizes: dict,
+  island_enabled: bool,
+  mjd=None,
+) -> types.Constraint:
+  """Construct a types.Constraint with standard and island local fields allocated properly."""
+  efc_kwargs = {"J_rownnz": None, "J_rowadr": None, "J_colind": None, "J": None}
+  sparse = is_sparse(mjm)
+
+  for f in dataclasses.fields(types.Constraint):
+    if f.name == "itype":
+      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=int)
+    elif f.name == "iid":
+      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=int)
+    elif f.name == "iJ_rownnz":
+      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0) if sparse else (nworld, 0), dtype=int)
+    elif f.name == "iJ_rowadr":
+      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0) if sparse else (nworld, 0), dtype=int)
+    elif f.name == "iJ_colind":
+      efc_kwargs[f.name] = wp.empty((nworld, 1, njmax_nnz if island_enabled else 0) if sparse else (nworld, 0, 0), dtype=int)
+    elif f.name == "iJ":
+      efc_kwargs[f.name] = wp.empty(
+        (nworld, 1, njmax_nnz if island_enabled else 0) if sparse else (nworld, njmax if island_enabled else 0, mjm.nv),
+        dtype=float,
+      )
+    elif f.name == "iD":
+      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=float)
+    elif f.name == "iaref":
+      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=float)
+    elif f.name == "ifrictionloss":
+      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=float)
+    elif f.name == "iforce":
+      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=float)
+    elif f.name == "istate":
+      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=int)
+    else:
+      if f.name in efc_kwargs:
+        continue
+
+      if mjd is not None:
+        shape = tuple(sizes[dim] if isinstance(dim, str) else dim for dim in f.type.shape)
+        val = np.zeros(shape, dtype=f.type.dtype)
+        if f.name in ("type", "id", "pos", "margin", "D", "vel", "aref", "frictionloss", "force"):
+          val[:, : mjd.nefc] = np.tile(getattr(mjd, "efc_" + f.name), (nworld, 1))
+        efc_kwargs[f.name] = wp.array(val, dtype=f.type.dtype)
+      else:
+        efc_kwargs[f.name] = _create_array(None, f.type, sizes)
+
+  return types.Constraint(**efc_kwargs)
 
 
 def is_sparse(mjm: mujoco.MjModel) -> bool:
@@ -182,6 +240,12 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   if hasattr(mjm.opt, "impratio"):
     opt_kwargs["impratio_invsqrt"] = 1.0 / np.sqrt(np.maximum(mjm.opt.impratio, mujoco.mjMINVAL))
   opt = types.Option(**opt_kwargs)
+
+  # islands are disabled by default while performance is being improved
+  # override by setting io.ENABLE_ISLANDS = True
+  # TODO(team): remove after improving island solver performance
+  if not ENABLE_ISLANDS:
+    opt.disableflags |= types.DisableBit.ISLAND
 
   # C MuJoCo tolerance was chosen for float64 architecture, but we default to float32 on GPU
   # adjust the tolerance for lower precision, to avoid the solver spending iterations needlessly
@@ -914,6 +978,42 @@ def _resolve_batch_size(na: int | None, n: int | None, nworld: int, default: int
   return default
 
 
+def _allocate_island_arrays(
+  mjm: mujoco.MjModel,
+  d: types.Data,
+  nworld: int,
+  njmax: int,
+  island_enabled: bool,
+  mjd: mujoco.MjData,
+):
+  ntree_size = mjm.ntree if island_enabled else 0
+  nv_size = mjm.nv if island_enabled else 0
+  njmax_size = njmax if island_enabled else 0
+
+  d.nisland = wp.array(np.full(nworld, mjd.nisland), dtype=int)
+  d.tree_island = wp.array(np.tile(mjd.tree_island, (nworld, 1 if island_enabled else 0)), dtype=int)
+  d.dof_island = wp.array(np.tile(mjd.dof_island, (nworld, 1 if island_enabled else 0)), dtype=int)
+
+  d.island_dofadr = wp.empty((nworld, ntree_size), dtype=int)
+  d.island_nv = wp.empty((nworld, ntree_size), dtype=int)
+  d.island_nefc = wp.empty((nworld, ntree_size), dtype=int)
+  d.island_ne = wp.empty((nworld, ntree_size), dtype=int)
+  d.island_nf = wp.empty((nworld, ntree_size), dtype=int)
+  d.island_efcadr = wp.empty((nworld, ntree_size), dtype=int)
+  d.nidof = wp.empty((nworld if island_enabled else 0,), dtype=int)
+  d.map_dof2idof = wp.empty((nworld, nv_size), dtype=int)
+  d.map_idof2dof = wp.empty((nworld, nv_size), dtype=int)
+  d.map_efc2iefc = wp.empty((nworld, njmax_size), dtype=int)
+  d.map_iefc2efc = wp.empty((nworld, njmax_size), dtype=int)
+
+  d.dof_islandid = wp.empty((nworld, nv_size), dtype=int)
+  d.efc_islandid = wp.empty((nworld, njmax_size), dtype=int)
+  d.iqacc = wp.empty((nworld, nv_size), dtype=float)
+  d.iqacc_smooth = wp.empty((nworld, nv_size), dtype=float)
+  d.iqfrc_smooth = wp.empty((nworld, nv_size), dtype=float)
+  d.iqfrc_constraint = wp.empty((nworld, nv_size), dtype=float)
+
+
 def make_data(
   mjm: mujoco.MjModel,
   nworld: int = 1,
@@ -995,7 +1095,8 @@ def make_data(
 
   contact = types.Contact(**{f.name: _create_array(None, f.type, sizes) for f in dataclasses.fields(types.Contact)})
   contact.efc_address = wp.array(np.full((naconmax, sizes["nmaxpyramid"]), -1, dtype=int), dtype=int)
-  efc = types.Constraint(**{f.name: _create_array(None, f.type, sizes) for f in dataclasses.fields(types.Constraint)})
+
+  efc = _create_constraint(mjm, nworld, njmax, njmax_nnz, sizes, ENABLE_ISLANDS)
 
   if is_sparse(mjm):
     efc.J_rownnz = wp.zeros((nworld, njmax), dtype=int)
@@ -1052,6 +1153,24 @@ def make_data(
     # island arrays
     "nisland": None,
     "tree_island": None,
+    "dof_island": None,
+    "island_dofadr": None,
+    "island_nv": None,
+    "island_nefc": None,
+    "island_ne": None,
+    "island_nf": None,
+    "island_efcadr": None,
+    "nidof": None,
+    "map_dof2idof": None,
+    "map_idof2dof": None,
+    "map_efc2iefc": None,
+    "map_iefc2efc": None,
+    "dof_islandid": None,
+    "efc_islandid": None,
+    "iqacc": None,
+    "iqacc_smooth": None,
+    "iqfrc_smooth": None,
+    "iqfrc_constraint": None,
   }
   for f in dataclasses.fields(types.Data):
     if f.name in d_kwargs:
@@ -1067,9 +1186,7 @@ def make_data(
     d.M = wp.zeros((nworld, sizes["nv_pad"], sizes["nv_pad"]), dtype=float)
     d.qLD = wp.zeros((nworld, mjm.nv, mjm.nv), dtype=float)
 
-  # island discovery arrays
-  d.nisland = wp.zeros((nworld,), dtype=int)
-  d.tree_island = wp.zeros((nworld, mjm.ntree), dtype=int)
+  _allocate_island_arrays(mjm, d, nworld, njmax, ENABLE_ISLANDS, mjd)
 
   return d
 
@@ -1204,16 +1321,7 @@ def put_data(
   # create efc
   efc_kwargs = {"J_rownnz": None, "J_rowadr": None, "J_colind": None, "J": None}
 
-  for f in dataclasses.fields(types.Constraint):
-    if f.name in efc_kwargs:
-      continue
-    shape = tuple(sizes[dim] if isinstance(dim, str) else dim for dim in f.type.shape)
-    val = np.zeros(shape, dtype=f.type.dtype)
-    if f.name in ("type", "id", "pos", "margin", "D", "vel", "aref", "frictionloss", "force"):
-      val[:, : mjd.nefc] = np.tile(getattr(mjd, "efc_" + f.name), (nworld, 1))
-    efc_kwargs[f.name] = wp.array(val, dtype=f.type.dtype)
-
-  efc = types.Constraint(**efc_kwargs)
+  efc = _create_constraint(mjm, nworld, njmax, njmax_nnz, sizes, ENABLE_ISLANDS, mjd)
 
   if is_sparse(mjm):
     J_rownnz = np.zeros(njmax, dtype=np.int32)
@@ -1270,6 +1378,24 @@ def put_data(
     # island arrays
     "nisland": None,
     "tree_island": None,
+    "dof_island": None,
+    "island_dofadr": None,
+    "island_nv": None,
+    "island_nefc": None,
+    "island_ne": None,
+    "island_nf": None,
+    "island_efcadr": None,
+    "nidof": None,
+    "map_dof2idof": None,
+    "map_idof2dof": None,
+    "map_efc2iefc": None,
+    "map_iefc2efc": None,
+    "dof_islandid": None,
+    "efc_islandid": None,
+    "iqacc": None,
+    "iqacc_smooth": None,
+    "iqfrc_smooth": None,
+    "iqfrc_constraint": None,
   }
   for f in dataclasses.fields(types.Data):
     if f.name in d_kwargs:
@@ -1302,9 +1428,7 @@ def put_data(
     d.M = wp.array(np.full((nworld, sizes["nv_pad"], sizes["nv_pad"]), M_padded), dtype=float)
     d.qLD = wp.array(np.full((nworld, mjm.nv, mjm.nv), qLD), dtype=float)
 
-  # island arrays
-  d.nisland = wp.array(np.full(nworld, mjd.nisland), dtype=int)
-  d.tree_island = wp.array(np.tile(mjd.tree_island, (nworld, 1)), dtype=int)
+  _allocate_island_arrays(mjm, d, nworld, njmax, ENABLE_ISLANDS, mjd)
 
   d.nacon = wp.array([mjd.ncon * nworld], dtype=int)
 
@@ -1511,6 +1635,7 @@ def get_data_into(
   result.efc_frictionloss[:] = d.efc.frictionloss.numpy()[world_id, efc_idx]
   result.efc_state[:] = d.efc.state.numpy()[world_id, efc_idx]
   result.efc_force[:] = d.efc.force.numpy()[world_id, efc_idx]
+  result.efc_island[:] = d.efc.island.numpy()[world_id, efc_idx]
 
   # rne_postconstraint
   result.cacc[:] = d.cacc.numpy()[world_id]
@@ -1532,8 +1657,51 @@ def get_data_into(
   # islands
   nisland = d.nisland.numpy()[world_id]
   result.nisland = nisland
-  if nisland:
+  if d.tree_island.shape[1] > 0 and nisland:
     result.tree_island[:] = d.tree_island.numpy()[world_id]
+    result.dof_island[:] = d.dof_island.numpy()[world_id]
+    result.island_dofadr[:nisland] = d.island_dofadr.numpy()[world_id, :nisland]
+    result.island_nv[:nisland] = d.island_nv.numpy()[world_id, :nisland]
+    result.island_nefc[:nisland] = d.island_nefc.numpy()[world_id, :nisland]
+    result.island_ne[:nisland] = d.island_ne.numpy()[world_id, :nisland]
+    result.island_nf[:nisland] = d.island_nf.numpy()[world_id, :nisland]
+    result.island_iefcadr[:nisland] = d.island_efcadr.numpy()[world_id, :nisland]
+    nv = mjm.nv
+    result.map_dof2idof[:nv] = d.map_dof2idof.numpy()[world_id, :nv]
+    result.map_idof2dof[:nv] = d.map_idof2dof.numpy()[world_id, :nv]
+    result.map_efc2iefc[:nefc] = d.map_efc2iefc.numpy()[world_id, :nefc]
+    result.map_iefc2efc[:nefc] = d.map_iefc2efc.numpy()[world_id, :nefc]
+
+    result.iefc_type[:nefc] = d.efc.itype.numpy()[world_id, :nefc]
+    result.iefc_id[:nefc] = d.efc.iid.numpy()[world_id, :nefc]
+    result.iefc_D[:nefc] = d.efc.iD.numpy()[world_id, :nefc]
+    result.iefc_aref[:nefc] = d.efc.iaref.numpy()[world_id, :nefc]
+    result.iefc_frictionloss[:nefc] = d.efc.ifrictionloss.numpy()[world_id, :nefc]
+    result.iefc_state[:nefc] = d.efc.istate.numpy()[world_id, :nefc]
+    result.iefc_force[:nefc] = d.efc.iforce.numpy()[world_id, :nefc]
+
+    if is_sparse(mjm):
+      iefc_J = np.zeros((nefc, mjm.nv))
+      mujoco.mju_sparse2dense(
+        iefc_J,
+        d.efc.iJ.numpy()[world_id, 0],
+        d.efc.iJ_rownnz.numpy()[world_id, :nefc],
+        d.efc.iJ_rowadr.numpy()[world_id, :nefc],
+        d.efc.iJ_colind.numpy()[world_id, 0],
+      )
+    else:
+      iefc_J = d.efc.iJ.numpy()[world_id, :nefc, : mjm.nv]
+
+    if mujoco.mj_isSparse(mjm):
+      mujoco.mju_dense2sparse(
+        result.iefc_J,
+        iefc_J,
+        result.iefc_J_rownnz,
+        result.iefc_J_rowadr,
+        result.iefc_J_colind,
+      )
+    else:
+      result.iefc_J[: nefc * mjm.nv] = iefc_J.flatten()
 
 
 def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
@@ -2670,6 +2838,9 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
         val = np.array([float(p) for p in val.strip("[]").split()], dtype=arr.dtype)
       else:
         val = typ(val)
+
+      if attr == "disableflags" and isinstance(obj, types.Option) and not ENABLE_ISLANDS:
+        val = int(val) | types.DisableBit.ISLAND
 
       setattr(obj, attr, val)
 

--- a/mujoco_warp/_src/island.py
+++ b/mujoco_warp/_src/island.py
@@ -18,6 +18,7 @@ import warp as wp
 from mujoco_warp._src import types
 from mujoco_warp._src.types import ConstraintType
 from mujoco_warp._src.types import EqType
+from mujoco_warp._src.types import IslandSolverContext
 from mujoco_warp._src.types import ObjType
 from mujoco_warp._src.warp_util import event_scope
 
@@ -35,11 +36,15 @@ def _tree_edges(
   eq_obj1id: wp.array[int],
   eq_obj2id: wp.array[int],
   eq_objtype: wp.array[int],
+  is_sparse: bool,
   # Data in:
   nefc_in: wp.array[int],
   contact_geom_in: wp.array[wp.vec2i],
   efc_type_in: wp.array2d[int],
   efc_id_in: wp.array2d[int],
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
   efc_J_in: wp.array3d[float],
   njmax_in: int,
   # Out:
@@ -131,26 +136,39 @@ def _tree_edges(
   first_tree = int(-1)
   has_cross_edge = int(0)
 
-  for dof in range(nv):
-    # TODO(team): sparse efc_J
-    # TODO(team): tree dof skip
-    J_val = efc_J_in[worldid, efcid, dof]
-    if J_val != 0.0:
-      tree = dof_treeid[dof]
-      if tree < 0:
+  count = nv
+  rowadr = 0
+  if is_sparse:
+    count = efc_J_rownnz_in[worldid, efcid]
+    rowadr = efc_J_rowadr_in[worldid, efcid]
+
+  for i in range(count):
+    dof = i
+    if is_sparse:
+      sparseid = rowadr + i
+      dof = efc_J_colind_in[worldid, 0, sparseid]
+    else:
+      J_val = efc_J_in[worldid, efcid, dof]
+      if J_val == 0.0:
         continue
-      if first_tree == -1:
-        first_tree = tree
-      elif tree != first_tree:
-        t1 = wp.min(first_tree, tree)
-        t2 = wp.max(first_tree, tree)
-        wp.atomic_max(tree_tree, worldid, t1, t2, 1)
-        has_cross_edge = 1
+
+    tree = dof_treeid[dof]
+    if tree < 0:
+      continue
+    if first_tree == -1:
+      first_tree = tree
+    elif tree != first_tree:
+      t1 = wp.min(first_tree, tree)
+      t2 = wp.max(first_tree, tree)
+      wp.atomic_max(tree_tree, worldid, t1, t2, 1)
+      wp.atomic_max(tree_tree, worldid, t2, t1, 1)
+      has_cross_edge = 1
 
   if first_tree >= 0 and has_cross_edge == 0:
     wp.atomic_max(tree_tree, worldid, first_tree, first_tree, 1)
 
 
+@event_scope
 def tree_edges(m: types.Model, d: types.Data, tree_tree: wp.array3d[int]):
   """Compute tree-tree adjacency matrix."""
   tree_tree.zero_()
@@ -168,10 +186,14 @@ def tree_edges(m: types.Model, d: types.Data, tree_tree: wp.array3d[int]):
       m.eq_obj1id,
       m.eq_obj2id,
       m.eq_objtype,
+      m.is_sparse,
       d.nefc,
       d.contact.geom,
       d.efc.type,
       d.efc.id,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
       d.efc.J,
       d.njmax,
     ],
@@ -243,6 +265,19 @@ def _flood_fill(
 
 
 @event_scope
+def flood_fill(m: types.Model, d: types.Data, tree_tree: wp.array3d[int]):
+  d.tree_island.fill_(-1)
+  stack_scratch = wp.empty((d.nworld, m.ntree * m.ntree), dtype=int)
+
+  wp.launch(
+    _flood_fill,
+    dim=d.nworld,
+    inputs=[m.ntree, tree_tree, d.tree_island, stack_scratch],
+    outputs=[d.nisland, d.tree_island, stack_scratch],
+  )
+
+
+@event_scope
 def island(m: types.Model, d: types.Data):
   """Discover constraint islands."""
   if m.ntree == 0:
@@ -254,12 +289,778 @@ def island(m: types.Model, d: types.Data):
   tree_edges(m, d, tree_tree)
 
   # Step 2: DFS flood fill
-  d.tree_island.fill_(-1)
-  stack_scratch = wp.empty((d.nworld, m.ntree * m.ntree), dtype=int)
+  flood_fill(m, d, tree_tree)
+
+
+@wp.kernel
+def _island_count_dofs(
+  dof_treeid: wp.array[int],
+  tree_island_in: wp.array2d[int],
+  dof_island_out: wp.array2d[int],
+  island_nv_out: wp.array2d[int],
+):
+  worldid, dofid = wp.tid()
+
+  island_id = tree_island_in[worldid, dof_treeid[dofid]]
+  dof_island_out[worldid, dofid] = island_id
+  if island_id >= 0:
+    wp.atomic_add(island_nv_out, worldid, island_id, 1)
+
+
+@wp.kernel
+def _island_scan_sizes(
+  nisland_in: wp.array[int],
+  island_idofadr_out: wp.array2d[int],
+  island_nv_inout: wp.array2d[int],
+  island_nefc_inout: wp.array2d[int],
+  island_iefcadr_out: wp.array2d[int],
+  nidof_out: wp.array[int],
+):
+  worldid = wp.tid()
+
+  nisland = nisland_in[worldid]
+  if nisland == 0:
+    nidof_out[worldid] = 0
+    return
+
+  # Scan DOFs and Constraints
+  island_idofadr_out[worldid, 0] = 0
+  island_iefcadr_out[worldid, 0] = 0
+  for i in range(1, nisland):
+    island_idofadr_out[worldid, i] = island_idofadr_out[worldid, i - 1] + island_nv_inout[worldid, i - 1]
+    island_iefcadr_out[worldid, i] = island_iefcadr_out[worldid, i - 1] + island_nefc_inout[worldid, i - 1]
+
+  nidof = island_idofadr_out[worldid, nisland - 1] + island_nv_inout[worldid, nisland - 1]
+  nidof_out[worldid] = nidof
+
+  # Reset for recount
+  for i in range(nisland):
+    island_nv_inout[worldid, i] = 0
+    island_nefc_inout[worldid, i] = 0
+
+
+@wp.kernel
+def _island_map_dofs(
+  nv: int,
+  dof_island_in: wp.array2d[int],
+  island_idofadr_in: wp.array2d[int],
+  nidof_in: wp.array[int],
+  island_nv_inout: wp.array2d[int],
+  map_dof2idof_out: wp.array2d[int],
+  map_idof2dof_out: wp.array2d[int],
+  idof_islandid_out: wp.array2d[int],
+  unconstrained_cnt_inout: wp.array2d[int],
+):
+  worldid, dofid = wp.tid()
+
+  nidof = nidof_in[worldid]
+  island_id = dof_island_in[worldid, dofid]
+
+  if island_id >= 0:
+    local_idx = wp.atomic_add(island_nv_inout, worldid, island_id, 1)
+    idof = island_idofadr_in[worldid, island_id] + local_idx
+    idof_islandid_out[worldid, idof] = island_id
+  else:
+    cnt = wp.atomic_add(unconstrained_cnt_inout, worldid, 0, 1)
+    idof = nidof + cnt
+
+  map_dof2idof_out[worldid, dofid] = idof
+  map_idof2dof_out[worldid, idof] = dofid
+
+
+@wp.kernel
+def _island_count_constraints(
+  nefc_in: wp.array[int],
+  njmax_in: int,
+  efc_tree_in: wp.array2d[int],
+  tree_island_in: wp.array2d[int],
+  efc_type_in: wp.array2d[int],
+  efc_island_out: wp.array2d[int],
+  island_nefc_out: wp.array2d[int],
+  island_ne_out: wp.array2d[int],
+  island_nf_out: wp.array2d[int],
+):
+  worldid, efcid = wp.tid()
+  if efcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  efc_tree = efc_tree_in[worldid, efcid]
+  if efc_tree < 0:
+    efc_island_out[worldid, efcid] = -1
+    return
+  island_id = tree_island_in[worldid, efc_tree]
+  efc_island_out[worldid, efcid] = island_id
+
+  if island_id >= 0:
+    wp.atomic_add(island_nefc_out, worldid, island_id, 1)
+
+    efc_type = efc_type_in[worldid, efcid]
+    if efc_type == ConstraintType.EQUALITY:
+      wp.atomic_add(island_ne_out, worldid, island_id, 1)
+    elif efc_type == ConstraintType.FRICTION_DOF or efc_type == ConstraintType.FRICTION_TENDON:
+      wp.atomic_add(island_nf_out, worldid, island_id, 1)
+
+
+@wp.kernel
+def _island_map_constraints(
+  nefc_in: wp.array[int],
+  njmax_in: int,
+  efc_island_in: wp.array2d[int],
+  island_iefcadr_in: wp.array2d[int],
+  island_ne_in: wp.array2d[int],
+  island_nf_in: wp.array2d[int],
+  efc_type_in: wp.array2d[int],
+  # Counters (inout):
+  island_ne_mapped_inout: wp.array2d[int],
+  island_nf_mapped_inout: wp.array2d[int],
+  island_nother_mapped_inout: wp.array2d[int],
+  island_nefc_inout: wp.array2d[int],
+  # Out:
+  map_efc2iefc_out: wp.array2d[int],
+  map_iefc2efc_out: wp.array2d[int],
+  iefc_islandid_out: wp.array2d[int],
+):
+  worldid, efcid = wp.tid()
+  if efcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  island_id = efc_island_in[worldid, efcid]
+  if island_id >= 0:
+    efc_type = efc_type_in[worldid, efcid]
+
+    # 1. Determine local index and absolute index ic based on category
+    if efc_type == ConstraintType.EQUALITY:
+      local_idx = wp.atomic_add(island_ne_mapped_inout, worldid, island_id, 1)
+      ic = island_iefcadr_in[worldid, island_id] + local_idx
+    elif efc_type == ConstraintType.FRICTION_DOF or efc_type == ConstraintType.FRICTION_TENDON:
+      local_idx = wp.atomic_add(island_nf_mapped_inout, worldid, island_id, 1)
+      ic = island_iefcadr_in[worldid, island_id] + island_ne_in[worldid, island_id] + local_idx
+    else:
+      local_idx = wp.atomic_add(island_nother_mapped_inout, worldid, island_id, 1)
+      ic = (
+        island_iefcadr_in[worldid, island_id] + island_ne_in[worldid, island_id] + island_nf_in[worldid, island_id] + local_idx
+      )
+
+    # 2. Increment overall island_nefc counter to reconstruct d.island_nefc
+    wp.atomic_add(island_nefc_inout, worldid, island_id, 1)
+
+    # 3. Store mappings
+    map_efc2iefc_out[worldid, efcid] = ic
+    map_iefc2efc_out[worldid, ic] = efcid
+    iefc_islandid_out[worldid, ic] = island_id
+
+
+@wp.kernel
+def _island_scan_sparse_rows(
+  nisland_in: wp.array[int],
+  efc_J_rownnz_in: wp.array2d[int],
+  island_nefc_in: wp.array2d[int],
+  island_iefcadr_in: wp.array2d[int],
+  map_iefc2efc_in: wp.array2d[int],
+  iefc_J_rownnz_out: wp.array2d[int],
+  iefc_J_rowadr_out: wp.array2d[int],
+):
+  worldid = wp.tid()
+
+  nisland = nisland_in[worldid]
+  if nisland == 0:
+    return
+
+  total_gathered_efc = island_iefcadr_in[worldid, nisland - 1] + island_nefc_in[worldid, nisland - 1]
+
+  running_rowadr = int(0)
+  for ic in range(total_gathered_efc):
+    c = map_iefc2efc_in[worldid, ic]
+    rownnz = efc_J_rownnz_in[worldid, c]
+    iefc_J_rowadr_out[worldid, ic] = running_rowadr
+    iefc_J_rownnz_out[worldid, ic] = rownnz
+    running_rowadr += rownnz
+
+
+@wp.kernel
+def _compute_efc_tree(
+  # Model:
+  nv: int,
+  body_treeid: wp.array[int],
+  jnt_dofadr: wp.array[int],
+  dof_treeid: wp.array[int],
+  geom_bodyid: wp.array[int],
+  site_bodyid: wp.array[int],
+  eq_type: wp.array[int],
+  eq_obj1id: wp.array[int],
+  eq_obj2id: wp.array[int],
+  eq_objtype: wp.array[int],
+  is_sparse: bool,
+  # Data in:
+  nefc_in: wp.array[int],
+  contact_geom_in: wp.array[wp.vec2i],
+  efc_type_in: wp.array2d[int],
+  efc_id_in: wp.array2d[int],
+  efc_J_in: wp.array3d[float],
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
+  njmax_in: int,
+  # Out:
+  efc_tree_out: wp.array2d[int],
+):
+  """Compute the first non-negative tree for each constraint."""
+  worldid, efcid = wp.tid()
+
+  if efcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  efc_type = efc_type_in[worldid, efcid]
+  efc_id = efc_id_in[worldid, efcid]
+
+  tree = int(-1)
+  use_generic = int(0)
+
+  # equality (connect/weld)
+  if efc_type == ConstraintType.EQUALITY:
+    eq_t = eq_type[efc_id]
+
+    if eq_t == EqType.CONNECT or eq_t == EqType.WELD:
+      b1 = eq_obj1id[efc_id]
+      b2 = eq_obj2id[efc_id]
+
+      if eq_objtype[efc_id] == ObjType.SITE:
+        b1 = site_bodyid[b1]
+        b2 = site_bodyid[b2]
+
+      t1 = body_treeid[b1]
+      t2 = body_treeid[b2]
+      if t1 >= 0:
+        tree = t1
+      else:
+        tree = t2
+    else:
+      # JOINT, TENDON, FLEX: generic scan
+      use_generic = 1
+
+  # joint friction
+  elif efc_type == ConstraintType.FRICTION_DOF:
+    tree = dof_treeid[efc_id]
+
+  # joint limit
+  elif efc_type == ConstraintType.LIMIT_JOINT:
+    tree = dof_treeid[jnt_dofadr[efc_id]]
+
+  # contact
+  elif (
+    efc_type == ConstraintType.CONTACT_FRICTIONLESS
+    or efc_type == ConstraintType.CONTACT_PYRAMIDAL
+    or efc_type == ConstraintType.CONTACT_ELLIPTIC
+  ):
+    geom_pair = contact_geom_in[efc_id]
+    g1 = geom_pair[0]
+    g2 = geom_pair[1]
+
+    if g1 >= 0 and g2 >= 0:
+      t1 = body_treeid[geom_bodyid[g1]]
+      t2 = body_treeid[geom_bodyid[g2]]
+      if t1 >= 0:
+        tree = t1
+      else:
+        tree = t2
+    else:
+      # flex contacts: generic scan
+      use_generic = 1
+
+  else:
+    # generic: scan Jacobian row
+    use_generic = 1
+
+  if use_generic:
+    count = nv
+    rowadr = 0
+    if is_sparse:
+      count = efc_J_rownnz_in[worldid, efcid]
+      rowadr = efc_J_rowadr_in[worldid, efcid]
+
+    for i in range(count):
+      dof = i
+      if is_sparse:
+        sparseid = rowadr + i
+        dof = efc_J_colind_in[worldid, 0, sparseid]
+      else:
+        J_val = efc_J_in[worldid, efcid, dof]
+        if J_val == 0.0:
+          continue
+
+      t = dof_treeid[dof]
+      if t >= 0:
+        tree = t
+        break
+
+  efc_tree_out[worldid, efcid] = tree
+
+
+@wp.kernel
+def _gather_efc_and_jacobian(
+  # Model:
+  is_sparse: bool,
+  # Data in:
+  nefc_in: wp.array[int],
+  efc_D_in: wp.array2d[float],
+  efc_type_in: wp.array2d[int],
+  efc_id_in: wp.array2d[int],
+  efc_frictionloss_in: wp.array2d[float],
+  efc_aref_in: wp.array2d[float],
+  efc_J_in: wp.array3d[float],
+  # Sparse Jacobian arrays:
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
+  iefc_J_rowadr_in: wp.array2d[int],
+  # In:
+  njmax_in: int,
+  map_iefc2efc_in: wp.array2d[int],
+  map_idof2dof_in: wp.array2d[int],
+  map_dof2idof_in: wp.array2d[int],
+  nidof_in: wp.array[int],
+  # Out:
+  iefc_D_out: wp.array2d[float],
+  iefc_type_out: wp.array2d[int],
+  iefc_id_out: wp.array2d[int],
+  iefc_frictionloss_out: wp.array2d[float],
+  iefc_aref_out: wp.array2d[float],
+  iefc_J_out: wp.array3d[float],
+  iefc_J_colind_out: wp.array3d[int],
+):
+  """Gather constraint arrays and Jacobian into island-local dense order."""
+  worldid, iefcid = wp.tid()
+
+  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  c = map_iefc2efc_in[worldid, iefcid]
+
+  # Scalar constraint fields
+  iefc_D_out[worldid, iefcid] = efc_D_in[worldid, c]
+  iefc_type_out[worldid, iefcid] = efc_type_in[worldid, c]
+  iefc_id_out[worldid, iefcid] = efc_id_in[worldid, c]
+  iefc_frictionloss_out[worldid, iefcid] = efc_frictionloss_in[worldid, c]
+  iefc_aref_out[worldid, iefcid] = efc_aref_in[worldid, c]
+
+  # Jacobian: convert to island-local dense format
+  nid = nidof_in[worldid]
+
+  if is_sparse:
+    rownnz = efc_J_rownnz_in[worldid, c]
+    rowadr_in = efc_J_rowadr_in[worldid, c]
+    rowadr_out = iefc_J_rowadr_in[worldid, iefcid]
+    for i in range(rownnz):
+      sparseid_in = rowadr_in + i
+      sparseid_out = rowadr_out + i
+      dof = efc_J_colind_in[worldid, 0, sparseid_in]
+      idof = map_dof2idof_in[worldid, dof]
+      # Store in sparse iefc_J_out and iefc_J_colind_out
+      iefc_J_out[worldid, 0, sparseid_out] = efc_J_in[worldid, 0, sparseid_in]
+      iefc_J_colind_out[worldid, 0, sparseid_out] = idof
+  else:
+    # Dense path: reorder rows by iefc, columns by idof
+    for idof in range(nid):
+      dof = map_idof2dof_in[worldid, idof]
+      iefc_J_out[worldid, iefcid, idof] = efc_J_in[worldid, c, dof]
+
+
+@wp.kernel
+def _gather_dof_arrays(
+  # Data in:
+  qacc_in: wp.array2d[float],
+  qacc_smooth_in: wp.array2d[float],
+  qfrc_smooth_in: wp.array2d[float],
+  # In:
+  nidof_in: wp.array[int],
+  map_idof2dof_in: wp.array2d[int],
+  # Out:
+  iacc_out: wp.array2d[float],
+  iacc_smooth_out: wp.array2d[float],
+  ifrc_smooth_out: wp.array2d[float],
+):
+  """Gather DOF arrays into island-local order."""
+  worldid, idofid = wp.tid()
+
+  if idofid >= nidof_in[worldid]:
+    return
+
+  dof = map_idof2dof_in[worldid, idofid]
+  iacc_out[worldid, idofid] = qacc_in[worldid, dof]
+  iacc_smooth_out[worldid, idofid] = qacc_smooth_in[worldid, dof]
+  ifrc_smooth_out[worldid, idofid] = qfrc_smooth_in[worldid, dof]
+
+
+@wp.kernel
+def _scatter_dof_arrays(
+  # In:
+  qacc_smooth_in: wp.array2d[float],
+  qfrc_smooth_in: wp.array2d[float],
+  dof_island_in: wp.array2d[int],
+  iacc_in: wp.array2d[float],
+  ifrc_constraint_in: wp.array2d[float],
+  iMa_in: wp.array2d[float],
+  map_dof2idof_in: wp.array2d[int],
+  scatter_Ma: bool,
+  # Out:
+  qacc_out: wp.array2d[float],
+  qfrc_constraint_out: wp.array2d[float],
+  Ma_out: wp.array2d[float],
+):
+  """Scatter island results to global arrays, copy qacc_smooth for non-island DOFs."""
+  worldid, dofid = wp.tid()
+
+  if dof_island_in[worldid, dofid] < 0:
+    qacc_out[worldid, dofid] = qacc_smooth_in[worldid, dofid]
+    qfrc_constraint_out[worldid, dofid] = 0.0
+    if scatter_Ma:
+      Ma_out[worldid, dofid] = qfrc_smooth_in[worldid, dofid]
+  else:
+    idof = map_dof2idof_in[worldid, dofid]
+    qacc_out[worldid, dofid] = iacc_in[worldid, idof]
+    qfrc_constraint_out[worldid, dofid] = ifrc_constraint_in[worldid, idof]
+    if scatter_Ma:
+      Ma_out[worldid, dofid] = iMa_in[worldid, idof]
+
+
+@wp.kernel
+def _scatter_efc_arrays(
+  # In:
+  nefc_in: wp.array[int],
+  njmax_in: int,
+  map_iefc2efc_in: wp.array2d[int],
+  iefc_force_in: wp.array2d[float],
+  iefc_state_in: wp.array2d[int],
+  # Out:
+  efc_force_out: wp.array2d[float],
+  efc_state_out: wp.array2d[int],
+):
+  """Scatter island-local constraint results back to global order."""
+  worldid, iefcid = wp.tid()
+
+  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  c = map_iefc2efc_in[worldid, iefcid]
+  efc_force_out[worldid, c] = iefc_force_in[worldid, iefcid]
+  efc_state_out[worldid, c] = iefc_state_in[worldid, iefcid]
+
+
+@wp.kernel
+def _init_island_arrays(
+  island_idofadr_out: wp.array2d[int],
+  island_nv_out: wp.array2d[int],
+  island_nefc_out: wp.array2d[int],
+  island_ne_out: wp.array2d[int],
+  island_nf_out: wp.array2d[int],
+  island_iefcadr_out: wp.array2d[int],
+  nidof_out: wp.array[int],
+):
+  worldid, islandid = wp.tid()
+  island_nv_out[worldid, islandid] = 0
+  island_nefc_out[worldid, islandid] = 0
+  island_ne_out[worldid, islandid] = 0
+  island_nf_out[worldid, islandid] = 0
+  island_idofadr_out[worldid, islandid] = 0
+  island_iefcadr_out[worldid, islandid] = 0
+  if islandid == 0:
+    nidof_out[worldid] = 0
+
+
+@wp.kernel
+def _init_dof_arrays(
+  dof_island_out: wp.array2d[int],
+  map_dof2idof_out: wp.array2d[int],
+  map_idof2dof_out: wp.array2d[int],
+  idof_islandid_out: wp.array2d[int],
+):
+  worldid, dofid = wp.tid()
+  dof_island_out[worldid, dofid] = -1
+  map_dof2idof_out[worldid, dofid] = 0
+  map_idof2dof_out[worldid, dofid] = 0
+  idof_islandid_out[worldid, dofid] = -1
+
+
+@wp.kernel
+def _init_efc_arrays(
+  efc_island_out: wp.array2d[int],
+  map_efc2iefc_out: wp.array2d[int],
+  map_iefc2efc_out: wp.array2d[int],
+  iefc_islandid_out: wp.array2d[int],
+  efc_tree_out: wp.array2d[int],
+):
+  worldid, efcid = wp.tid()
+  efc_island_out[worldid, efcid] = -1
+  map_efc2iefc_out[worldid, efcid] = 0
+  map_iefc2efc_out[worldid, efcid] = 0
+  iefc_islandid_out[worldid, efcid] = -1
+  efc_tree_out[worldid, efcid] = -1
+
+
+@event_scope
+def compute_island_mapping(m: types.Model, d: types.Data, ctx: IslandSolverContext):
+  """Compute DOF/constraint island mappings after island discovery.
+
+  Populates island solver context arrays via ctx: nv, nefc, ne, nf,
+  iefcadr, nidof, map_dof2idof, map_idof2dof, dof_islandid, map_efc2iefc,
+  map_iefc2efc, efc_islandid. Also populates d.dof_island, d.efc.island,
+  and d.island_dofadr.
+
+  Args:
+    m: Model.
+    d: Data.
+    ctx: IslandSolverContext.
+  """
+  # Ensure dof_islandid / efc_islandid are allocated at the right shape
+  if d.dof_islandid.shape[1] != m.nv:
+    d.dof_islandid = wp.empty((d.nworld, m.nv), dtype=int)
+  if d.efc_islandid.shape[1] != d.njmax:
+    d.efc_islandid = wp.empty((d.nworld, d.njmax), dtype=int)
+
+  # Ensure island-local DOF arrays are allocated at the right shape
+  if d.iqacc.shape[1] != m.nv:
+    nw = d.nworld
+    d.iqacc = wp.empty((nw, m.nv), dtype=float)
+    d.iqacc_smooth = wp.empty((nw, m.nv), dtype=float)
+    d.iqfrc_smooth = wp.empty((nw, m.nv), dtype=float)
+    d.iqfrc_constraint = wp.empty((nw, m.nv), dtype=float)
+  wp.launch(
+    _init_island_arrays,
+    dim=(d.nworld, m.ntree),
+    inputs=[],
+    outputs=[
+      d.island_dofadr,
+      d.island_nv,
+      d.island_nefc,
+      d.island_ne,
+      d.island_nf,
+      d.island_efcadr,
+      d.nidof,
+    ],
+  )
+  wp.launch(
+    _init_dof_arrays,
+    dim=(d.nworld, m.nv),
+    inputs=[],
+    outputs=[d.dof_island, d.map_dof2idof, d.map_idof2dof, d.dof_islandid],
+  )
+  efc_tree = wp.empty((d.nworld, d.njmax), dtype=int)
+  wp.launch(
+    _init_efc_arrays,
+    dim=(d.nworld, d.njmax),
+    inputs=[],
+    outputs=[d.efc.island, d.map_efc2iefc, d.map_iefc2efc, d.efc_islandid, efc_tree],
+  )
 
   wp.launch(
-    _flood_fill,
+    _compute_efc_tree,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.nv,
+      m.body_treeid,
+      m.jnt_dofadr,
+      m.dof_treeid,
+      m.geom_bodyid,
+      m.site_bodyid,
+      m.eq_type,
+      m.eq_obj1id,
+      m.eq_obj2id,
+      m.eq_objtype,
+      m.is_sparse,
+      d.nefc,
+      d.contact.geom,
+      d.efc.type,
+      d.efc.id,
+      d.efc.J,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      d.njmax,
+    ],
+    outputs=[efc_tree],
+  )
+
+  # 1. Count DOFs per island
+  wp.launch(
+    _island_count_dofs,
+    dim=(d.nworld, m.nv),
+    inputs=[m.dof_treeid, d.tree_island],
+    outputs=[d.dof_island, d.island_nv],
+  )
+
+  # 2. Count Constraints per island
+  wp.launch(
+    _island_count_constraints,
+    dim=(d.nworld, d.njmax),
+    inputs=[d.nefc, d.njmax, efc_tree, d.tree_island, d.efc.type],
+    outputs=[d.efc.island, d.island_nefc, d.island_ne, d.island_nf],
+  )
+
+  # 3. Scan sizes and reset counters for mapping
+  wp.launch(
+    _island_scan_sizes,
     dim=d.nworld,
-    inputs=[m.ntree, tree_tree, d.tree_island, stack_scratch],
-    outputs=[d.nisland, d.tree_island, stack_scratch],
+    inputs=[d.nisland],
+    outputs=[d.island_dofadr, d.island_nv, d.island_nefc, d.island_efcadr, d.nidof],
+  )
+
+  # 4. Map DOFs
+  unconstrained_cnt = wp.zeros((d.nworld, 1), dtype=int)
+  wp.launch(
+    _island_map_dofs,
+    dim=(d.nworld, m.nv),
+    inputs=[m.nv, d.dof_island, d.island_dofadr, d.nidof],
+    outputs=[d.island_nv, d.map_dof2idof, d.map_idof2dof, d.dof_islandid, unconstrained_cnt],
+  )
+
+  # 5. Map Constraints
+  ne_mapped = wp.zeros((d.nworld, m.ntree), dtype=int)
+  nf_mapped = wp.zeros((d.nworld, m.ntree), dtype=int)
+  nother_mapped = wp.zeros((d.nworld, m.ntree), dtype=int)
+
+  wp.launch(
+    _island_map_constraints,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      d.nefc,
+      d.njmax,
+      d.efc.island,
+      d.island_efcadr,
+      d.island_ne,
+      d.island_nf,
+      d.efc.type,
+      ne_mapped,
+      nf_mapped,
+      nother_mapped,
+    ],
+    outputs=[d.island_nefc, d.map_efc2iefc, d.map_iefc2efc, d.efc_islandid],
+  )
+
+  # 6. Scan Sparse Rows (if sparse)
+  if m.is_sparse:
+    wp.launch(
+      _island_scan_sparse_rows,
+      dim=d.nworld,
+      inputs=[d.nisland, d.efc.J_rownnz, d.island_nefc, d.island_efcadr, d.map_iefc2efc],
+      outputs=[d.efc.iJ_rownnz, d.efc.iJ_rowadr],
+    )
+
+
+@event_scope
+def gather_island_inputs(m: types.Model, d: types.Data, ctx: IslandSolverContext):
+  """Gather constraint and DOF arrays into island-local order.
+
+  Populates d.iefc (D, type, id, frictionloss, aref, J, J_colind) and
+  d.iqacc, d.iqacc_smooth, d.iqfrc_smooth.
+
+  Must be called after compute_island_mapping() and before per-island solving.
+
+  Args:
+    m: Model.
+    d: Data.
+    ctx: IslandSolverContext whose arrays are populated.
+  """
+  # Gather constraint arrays and dense Jacobian (fused)
+  wp.launch(
+    _gather_efc_and_jacobian,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.is_sparse,
+      d.nefc,
+      d.efc.D,
+      d.efc.type,
+      d.efc.id,
+      d.efc.frictionloss,
+      d.efc.aref,
+      d.efc.J,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      d.efc.iJ_rowadr,
+      d.njmax,
+      d.map_iefc2efc,
+      d.map_idof2dof,
+      d.map_dof2idof,
+      d.nidof,
+    ],
+    outputs=[
+      d.efc.iD,
+      d.efc.itype,
+      d.efc.iid,
+      d.efc.ifrictionloss,
+      d.efc.iaref,
+      d.efc.iJ,
+      d.efc.iJ_colind,
+    ],
+  )
+
+  # Gather DOF arrays
+  wp.launch(
+    _gather_dof_arrays,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      d.qacc,
+      d.qacc_smooth,
+      d.qfrc_smooth,
+      d.nidof,
+      d.map_idof2dof,
+    ],
+    outputs=[
+      d.iqacc,
+      d.iqacc_smooth,
+      d.iqfrc_smooth,
+    ],
+  )
+
+
+@event_scope
+def scatter_island_results(m: types.Model, d: types.Data, ctx: IslandSolverContext, scatter_Ma: bool):
+  """Scatter island-local solver results back to global arrays.
+
+  Reads ctx qacc, qfrc_constraint, Ma, d.efc iforce, istate and
+  writes them back to d.qacc, d.qfrc_constraint, d.efc.Ma, d.efc.force,
+  d.efc.state. Unconstrained DOFs receive qacc_smooth and zero qfrc.
+
+  Args:
+    m: Model.
+    d: Data.
+    ctx: IslandSolverContext which contains results.
+    scatter_Ma: Whether to scatter Ma for Euler/implicit integrators.
+  """
+  # Scatter DOF results (and optionally Ma for Euler/implicit integrators)
+  wp.launch(
+    _scatter_dof_arrays,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      d.qacc_smooth,
+      d.qfrc_smooth,
+      d.dof_island,
+      d.iqacc,
+      d.iqfrc_constraint,
+      ctx.Ma,
+      d.map_dof2idof,
+      scatter_Ma,
+    ],
+    outputs=[
+      d.qacc,
+      d.qfrc_constraint,
+      d.efc.Ma,
+    ],
+  )
+
+  # Scatter constraint results (force and state from island-local arrays)
+  wp.launch(
+    _scatter_efc_arrays,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      d.nefc,
+      d.njmax,
+      d.map_iefc2efc,
+      d.efc.iforce,
+      d.efc.istate,
+    ],
+    outputs=[
+      d.efc.force,
+      d.efc.state,
+    ],
   )

--- a/mujoco_warp/_src/island_test.py
+++ b/mujoco_warp/_src/island_test.py
@@ -21,7 +21,29 @@ from absl.testing import absltest
 
 import mujoco_warp as mjwarp
 from mujoco_warp import test_data
+from mujoco_warp._src import io
 from mujoco_warp._src import island
+from mujoco_warp._src import solver
+from mujoco_warp._src import types
+
+# Shared XML models used across multiple island tests.
+# Basic weld constraint model.
+_WELD_XML = """
+<mujoco>
+  <worldbody>
+    <body name="b1">
+      <joint type="free"/>
+      <geom size=".1"/>
+    </body>
+    <body name="b2" pos="1 0 0">
+      <joint type="free"/>
+      <geom size=".1"/>
+    </body>
+  </worldbody>
+  <equality>
+    <weld body1="b1" body2="b2"/>
+  </equality>
+</mujoco>"""
 
 
 class IslandEdgeDiscoveryTest(absltest.TestCase):
@@ -381,6 +403,14 @@ class IslandEdgeDiscoveryTest(absltest.TestCase):
 
 
 class IslandDiscoveryTest(absltest.TestCase):
+  def setUp(self):
+    super().setUp()
+    io.ENABLE_ISLANDS = True
+
+  def tearDown(self):
+    io.ENABLE_ISLANDS = False
+    super().tearDown()
+
   """Tests for full island discovery."""
 
   def test_two_trees_one_constraint_one_island(self):
@@ -651,6 +681,310 @@ class IslandDiscoveryTest(absltest.TestCase):
     tree_island = d.tree_island.numpy()[0]
     self.assertEqual(tree_island[0], tree_island[1])
     self.assertEqual(tree_island[1], tree_island[2])
+
+
+class IslandMappingTest(absltest.TestCase):
+  def setUp(self):
+    super().setUp()
+    io.ENABLE_ISLANDS = True
+
+  def tearDown(self):
+    io.ENABLE_ISLANDS = False
+    super().tearDown()
+
+  """Tests for island DOF/constraint mapping and gather/scatter."""
+
+  def test_two_body_weld_mapping(self):
+    """Two free bodies with a weld: 1 island, all DOFs constrained."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+
+    nisland = d.nisland.numpy()[0]
+    self.assertEqual(nisland, 1)
+
+    # all DOFs should be in island 0
+    dof_island = d.dof_island.numpy()[0, : m.nv]
+    np.testing.assert_array_equal(dof_island, np.zeros(m.nv, dtype=int))
+
+    # nidof == nv (all DOFs are in islands)
+    nidof = d.nidof.numpy()[0]
+    self.assertEqual(nidof, m.nv)
+
+    # island_nv[0] == nv
+    island_nv = d.island_nv.numpy()[0]
+    self.assertEqual(island_nv[0], m.nv)
+
+  def test_two_disconnected_pairs_mapping(self):
+    """Two pairs of welded bodies: 2 islands, each with 12 DOFs."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="a1">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+          <body name="a2" pos="1 0 0">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+          <body name="b1" pos="5 0 0">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+          <body name="b2" pos="6 0 0">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+        </worldbody>
+        <equality>
+          <weld body1="a1" body2="a2"/>
+          <weld body1="b1" body2="b2"/>
+        </equality>
+      </mujoco>
+      """
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+
+    nisland = d.nisland.numpy()[0]
+    self.assertEqual(nisland, 2)
+
+    # nidof == nv (all DOFs are in islands)
+    nidof = d.nidof.numpy()[0]
+    self.assertEqual(nidof, m.nv)
+
+    # each island has 12 DOFs (2 free joints = 12 DOFs)
+    island_nv = d.island_nv.numpy()[0]
+    self.assertEqual(island_nv[0], 12)
+    self.assertEqual(island_nv[1], 12)
+
+  def test_unconstrained_body_excluded(self):
+    """Body with no constraints gets dof_island=-1, is not in nidof."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="constrained1">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+          <body name="constrained2" pos="1 0 0">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+          <body name="unconstrained" pos="5 0 0">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+        </worldbody>
+        <equality>
+          <weld body1="constrained1" body2="constrained2"/>
+        </equality>
+      </mujoco>
+      """
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+
+    nisland = d.nisland.numpy()[0]
+    self.assertEqual(nisland, 1)
+
+    dof_island = d.dof_island.numpy()[0, : m.nv]
+    # first 12 DOFs (2 constrained bodies) in island 0
+    np.testing.assert_array_equal(dof_island[:12], np.zeros(12, dtype=int))
+    # last 6 DOFs (unconstrained body) should be -1
+    np.testing.assert_array_equal(dof_island[12:18], -np.ones(6, dtype=int))
+
+    # nidof == 12
+    nidof = d.nidof.numpy()[0]
+    self.assertEqual(nidof, 12)
+
+  def test_map_roundtrip(self):
+    """map_dof2idof and map_idof2dof are inverses for island DOFs."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+
+    nidof = d.nidof.numpy()[0]
+    map_d2i = d.map_dof2idof.numpy()[0, : m.nv]
+    map_i2d = d.map_idof2dof.numpy()[0, : m.nv]
+
+    # roundtrip: for island DOFs, map_idof2dof[map_dof2idof[d]] == d
+    for dof in range(m.nv):
+      island_id = d.dof_island.numpy()[0, dof]
+      if island_id >= 0:
+        idof = map_d2i[dof]
+        self.assertEqual(map_i2d[idof], dof)
+
+  def test_efc_map_roundtrip(self):
+    """map_efc2iefc and map_iefc2efc are inverses."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+
+    nefc = d.nefc.numpy()[0]
+    map_e2i = d.map_efc2iefc.numpy()[0, :nefc]
+    map_i2e = d.map_iefc2efc.numpy()[0, :nefc]
+
+    # roundtrip: map_iefc2efc[map_efc2iefc[c]] == c
+    for c in range(nefc):
+      ic = map_e2i[c]
+      self.assertEqual(map_i2e[ic], c)
+
+  def test_mujoco_parity_mapping(self):
+    """Compare DOF/constraint mapping arrays against MuJoCo C."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="a1">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+          <body name="a2" pos="1 0 0">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+          <body name="b1" pos="5 0 0">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+          <body name="b2" pos="6 0 0">
+            <joint type="free"/>
+            <geom size=".1"/>
+          </body>
+        </worldbody>
+        <equality>
+          <weld body1="a1" body2="a2"/>
+          <weld body1="b1" body2="b2"/>
+        </equality>
+      </mujoco>
+      """
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+
+    nv = mjm.nv
+    nisland = mjd.nisland
+    nefc = mjd.nefc
+
+    # Compare mapping arrays with MuJoCo C
+    np.testing.assert_array_equal(
+      d.island_nv.numpy()[0, :nisland],
+      mjd.island_nv[:nisland],
+    )
+    np.testing.assert_array_equal(
+      d.island_nefc.numpy()[0, :nisland],
+      mjd.island_nefc[:nisland],
+    )
+    np.testing.assert_array_equal(
+      d.island_dofadr.numpy()[0, :nisland],
+      mjd.island_idofadr[:nisland],
+    )
+    np.testing.assert_array_equal(
+      d.island_efcadr.numpy()[0, :nisland],
+      mjd.island_iefcadr[:nisland],
+    )
+    np.testing.assert_array_equal(
+      d.dof_island.numpy()[0, :nv],
+      mjd.dof_island[:nv],
+    )
+    np.testing.assert_array_equal(
+      d.map_dof2idof.numpy()[0, :nv],
+      mjd.map_dof2idof[:nv],
+    )
+    np.testing.assert_array_equal(
+      d.map_idof2dof.numpy()[0, :nv],
+      mjd.map_idof2dof[:nv],
+    )
+    np.testing.assert_array_equal(
+      d.efc.island.numpy()[0, :nefc],
+      mjd.efc_island[:nefc],
+    )
+    np.testing.assert_array_equal(
+      d.map_efc2iefc.numpy()[0, :nefc],
+      mjd.map_efc2iefc[:nefc],
+    )
+    np.testing.assert_array_equal(
+      d.map_iefc2efc.numpy()[0, :nefc],
+      mjd.map_iefc2efc[:nefc],
+    )
+
+  def test_gather_scatter_roundtrip(self):
+    """Gather then scatter recovers original DOF arrays."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+
+    # Save originals
+    qacc_orig = d.qacc.numpy().copy()
+    qfrc_constraint_orig = d.qfrc_constraint.numpy().copy()
+
+    # Gather
+    island.gather_island_inputs(m, d, ctx)
+
+    # Verify gathered arrays are non-trivially reordered
+    iacc = d.iqacc.numpy()
+    nidof = d.nidof.numpy()[0]
+
+    # Simulate solver output: copy qacc_smooth into iacc (as solver would)
+    # and set ifrc_constraint to some values
+    wp.copy(d.iqacc, d.iqacc_smooth)
+    d.iqfrc_constraint.zero_()
+
+    # Scatter back
+    island.scatter_island_results(m, d, ctx, scatter_Ma=False)
+
+    # After scatter, qacc should equal qacc_smooth at island DOF positions
+    qacc_scattered = d.qacc.numpy()[0, : m.nv]
+    qacc_smooth = d.qacc_smooth.numpy()[0, : m.nv]
+    dof_island = d.dof_island.numpy()[0, : m.nv]
+
+    for dof in range(m.nv):
+      if dof_island[dof] >= 0:
+        np.testing.assert_allclose(qacc_scattered[dof], qacc_smooth[dof], atol=1e-12)
+
+  def test_gather_efc_ordering(self):
+    """Gathered EFC arrays preserve values via island mapping."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+    island.gather_island_inputs(m, d, ctx)
+
+    nefc = d.nefc.numpy()[0]
+    efc_D = d.efc.D.numpy()[0]
+    iefc_D = d.efc.iD.numpy()[0]
+    map_i2e = d.map_iefc2efc.numpy()[0]
+
+    # iefc_D[ic] == efc_D[map_iefc2efc[ic]]
+    for ic in range(nefc):
+      c = map_i2e[ic]
+      np.testing.assert_allclose(iefc_D[ic], efc_D[c], atol=1e-12)
+
+  def test_island_ne_nf_parity(self):
+    """island_ne and island_nf match MuJoCo C values."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+
+    nisland = mjd.nisland
+
+    if nisland > 0:
+      np.testing.assert_array_equal(
+        d.island_ne.numpy()[0, :nisland],
+        mjd.island_ne[:nisland],
+      )
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -13,18 +13,21 @@
 # limitations under the License.
 # ==============================================================================
 
-import dataclasses
 from math import ceil
 from math import sqrt
 
 import warp as wp
 
+from mujoco_warp._src import island
 from mujoco_warp._src import math
 from mujoco_warp._src import smooth
 from mujoco_warp._src import support
 from mujoco_warp._src import types
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_factorize_solve_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_func
+from mujoco_warp._src.types import InverseContext
+from mujoco_warp._src.types import IslandSolverContext
+from mujoco_warp._src.types import SolverContext
 from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 from mujoco_warp._src.warp_util import scoped_mathdx_gemm_disabled
@@ -34,55 +37,12 @@ wp.set_module_options({"enable_backward": False})
 _BLOCK_CHOLESKY_DIM = 32
 
 
-@dataclasses.dataclass
-class InverseContext:
-  """Workspace arrays for inverse dynamics."""
-
-  Jaref: wp.array2d[float]
-  search_dot: wp.array[float]
-  gauss: wp.array[float]
-  cost: wp.array[float]
-  prev_cost: wp.array[float]
-  done: wp.array[bool]
-  changed_efc_ids: wp.array2d[int]
-  changed_efc_count: wp.array[int]
-
-
-@dataclasses.dataclass
-class SolverContext:
-  """Workspace arrays for constraint solver."""
-
-  Jaref: wp.array2d[float]
-  search_dot: wp.array[float]
-  gauss: wp.array[float]
-  cost: wp.array[float]
-  prev_cost: wp.array[float]
-  done: wp.array[bool]
-  grad: wp.array2d[float]
-  grad_dot: wp.array[float]
-  Mgrad: wp.array2d[float]
-  search: wp.array2d[float]
-  mv: wp.array2d[float]
-  jv: wp.array2d[float]
-  quad: wp.array2d[wp.vec3]
-  quad_gauss: wp.array[wp.vec3]
-  alpha: wp.array[float]
-  prev_grad: wp.array2d[float]
-  prev_Mgrad: wp.array2d[float]
-  beta: wp.array[float]
-  h: wp.array3d[float]
-  hfactor: wp.array3d[float]
-  # Incremental Hessian update (Newton only)
-  changed_efc_ids: wp.array2d[int]
-  changed_efc_count: wp.array[int]
-
-
 def create_inverse_context(m: types.Model, d: types.Data) -> InverseContext:
   """Create an InverseContext with allocated workspace arrays.
 
   Args:
-    m: Model containing nv, nv_pad, and solver type.
-    d: Data containing nworld and njmax.
+    m: Model.
+    d: Data.
 
   Returns:
     InverseContext with allocated arrays.
@@ -102,12 +62,55 @@ def create_inverse_context(m: types.Model, d: types.Data) -> InverseContext:
   )
 
 
+def create_island_solver_context(m: types.Model, d: types.Data) -> IslandSolverContext:
+  """Create an IslandSolverContext with allocated workspace arrays.
+
+  Args:
+    m: Model.
+    d: Data.
+
+  Returns:
+    IslandSolverContext with allocated arrays.
+  """
+  nworld = d.nworld
+  nv = m.nv
+  nv_pad = m.nv_pad
+  njmax = d.njmax
+  ntree = m.ntree
+
+  alloc_h = m.opt.solver == types.SolverType.NEWTON
+  alloc_island_cg = m.opt.solver == types.SolverType.CG
+
+  return IslandSolverContext(
+    Jaref=wp.empty((nworld, njmax), dtype=float),
+    jv=wp.empty((nworld, njmax), dtype=float),
+    search=wp.empty((nworld, nv), dtype=float),
+    mv=wp.empty((nworld, nv), dtype=float),
+    grad=wp.zeros((nworld, nv_pad), dtype=float),
+    Mgrad=wp.zeros((nworld, nv_pad), dtype=float),
+    prev_grad=wp.empty((nworld, nv), dtype=float) if alloc_island_cg else wp.empty((nworld, 0), dtype=float),
+    prev_Mgrad=wp.empty((nworld, nv), dtype=float) if alloc_island_cg else wp.empty((nworld, 0), dtype=float),
+    h=wp.zeros((nworld, nv_pad, nv_pad), dtype=float) if alloc_h else wp.empty((nworld, 0, 0), dtype=float),
+    # Per-island solver scalars
+    cost=wp.empty((nworld, ntree), dtype=float),
+    prev_cost=wp.empty((nworld, ntree), dtype=float),
+    gauss=wp.empty((nworld, ntree), dtype=float),
+    search_dot=wp.empty((nworld, ntree), dtype=float),
+    grad_dot=wp.empty((nworld, ntree), dtype=float),
+    done=wp.empty((nworld, ntree), dtype=bool),
+    solver_niter=wp.empty((nworld, ntree), dtype=int),
+    beta=wp.empty((nworld, ntree), dtype=float) if alloc_island_cg else wp.empty((nworld, 0), dtype=float),
+    alpha=wp.empty((nworld, ntree), dtype=float),
+    Ma=wp.empty((nworld, nv), dtype=float),
+  )
+
+
 def create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
   """Create a SolverContext with allocated workspace arrays.
 
   Args:
-    m: Model containing nv, nv_pad, and solver type.
-    d: Data containing nworld and njmax.
+    m: Model.
+    d: Data.
 
   Returns:
     SolverContext with allocated arrays.
@@ -3346,8 +3349,17 @@ def solve(m: types.Model, d: types.Data):
     wp.copy(d.qacc, d.qacc_smooth)
     d.solver_niter.fill_(0)
   else:
-    ctx = create_solver_context(m, d)
-    _solve(m, d, ctx)
+    if m.ntree > 1 and not (m.opt.disableflags & types.DisableBit.ISLAND):
+      ctx = create_island_solver_context(m, d)
+      island.compute_island_mapping(m, d, ctx)
+      island.gather_island_inputs(m, d, ctx)
+      _solve_islands(m, d, ctx)
+      # Ma is needed by Euler/implicit integrators for implicit damping
+      scatter_Ma = m.opt.integrator != types.IntegratorType.RK4
+      island.scatter_island_results(m, d, ctx, scatter_Ma=scatter_Ma)
+    else:
+      ctx = create_solver_context(m, d)
+      _solve(m, d, ctx)
 
 
 def _solve(m: types.Model, d: types.Data, ctx: SolverContext):
@@ -3388,3 +3400,2104 @@ def _solve(m: types.Model, d: types.Data, ctx: SolverContext):
     # It should be removed when JAX becomes compatible.
     for _ in range(m.opt.iterations):
       _solver_iteration(m, d, ctx, step_size_cost, nsolving)
+
+
+# TODO(team): Consolidate monolithic and island solver code where possible
+@event_scope
+def _solve_islands(m: types.Model, d: types.Data, ctx: IslandSolverContext):
+  """Solve constraints for all islands in parallel.
+
+  All islands are processed simultaneously. Island-local arrays in ctx
+  (iacc, iefc_J, iefc_D, etc.) are indexed by idof/iefc, and each thread
+  determines its island via idof_islandid/iefc_islandid lookup tables.
+  """
+  # Initialize iacc from warmstart or smooth
+  if not (m.opt.disableflags & types.DisableBit.WARMSTART):
+    wp.launch(
+      gather_warmstart_island,
+      dim=(d.nworld, m.nv),
+      inputs=[d.nidof, d.qacc_warmstart, d.map_idof2dof],
+      outputs=[d.iqacc],
+    )
+  else:
+    wp.copy(d.iqacc, d.iqacc_smooth)
+
+  # Initialize island context
+  init_context_island(m, d, ctx)
+
+  # search = -Mgrad
+  wp.launch(
+    solve_init_search_island,
+    dim=(d.nworld, m.nv),
+    inputs=[d.nidof, ctx.Mgrad, d.dof_islandid, ctx.done],
+    outputs=[ctx.search, ctx.search_dot],
+  )
+
+  # nsolving tracks how many active islands still have unconverged globally
+  nsolving = wp.zeros((1,), dtype=int)
+  wp.launch(
+    solve_init_nsolving_island,
+    dim=d.nworld,
+    inputs=[d.nisland],
+    outputs=[nsolving],
+  )
+
+  if m.opt.iterations != 0 and m.opt.graph_conditional:
+    wp.capture_while(
+      nsolving,
+      while_body=_solver_iteration_island,
+      m=m,
+      d=d,
+      ctx=ctx,
+      nsolving=nsolving,
+    )
+  else:
+    for _ in range(m.opt.iterations):
+      _solver_iteration_island(m, d, ctx, nsolving)
+
+
+@wp.kernel
+def gather_warmstart_island(
+  # Data in:
+  nidof_in: wp.array[int],
+  qacc_warmstart_in: wp.array2d[float],
+  map_idof2dof_in: wp.array2d[int],
+  # Out:
+  iacc_out: wp.array2d[float],
+):
+  """Gather qacc_warmstart into island-local order."""
+  worldid, idofid = wp.tid()
+
+  if idofid >= nidof_in[worldid]:
+    return
+
+  dof = map_idof2dof_in[worldid, idofid]
+  iacc_out[worldid, idofid] = qacc_warmstart_in[worldid, dof]
+
+
+@wp.kernel
+def solve_init_efc_island(
+  # Data in:
+  nisland_in: wp.array[int],
+  # Out:
+  island_cost_out: wp.array2d[float],
+  island_search_dot_out: wp.array2d[float],
+  island_done_out: wp.array2d[bool],
+  island_solver_niter_out: wp.array2d[int],
+):
+  """Initialize per-island solver scalars."""
+  worldid, islandid = wp.tid()
+
+  if islandid >= nisland_in[worldid]:
+    return
+
+  island_cost_out[worldid, islandid] = 0.0
+  island_search_dot_out[worldid, islandid] = 0.0
+  island_done_out[worldid, islandid] = False
+  island_solver_niter_out[worldid, islandid] = 0
+
+
+@wp.kernel
+def solve_init_jaref_island(
+  # Model:
+  is_sparse: bool,
+  # Data in:
+  nefc_in: wp.array[int],
+  island_nv_in: wp.array2d[int],
+  njmax_in: int,
+  # In:
+  island_idofadr_in: wp.array2d[int],
+  iefc_J_rownnz_in: wp.array2d[int],
+  iefc_J_rowadr_in: wp.array2d[int],
+  iefc_J_colind_in: wp.array3d[int],
+  iefc_J_in: wp.array3d[float],
+  iacc_in: wp.array2d[float],
+  iefc_aref_in: wp.array2d[float],
+  iefc_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  Jaref_out: wp.array2d[float],
+):
+  """Jaref[iefcid] = iefc_J[iefcid] @ iacc - iefc_aref[iefcid] for all island EFCs."""
+  worldid, iefcid = wp.tid()
+
+  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  islandid = iefc_islandid_in[worldid, iefcid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  acc = float(0.0)
+  if is_sparse:
+    rownnz = iefc_J_rownnz_in[worldid, iefcid]
+    rowadr = iefc_J_rowadr_in[worldid, iefcid]
+    for k in range(rownnz):
+      adr = rowadr + k
+      Ji = iefc_J_in[worldid, 0, adr]
+      idof = iefc_J_colind_in[worldid, 0, adr]
+      acc += Ji * iacc_in[worldid, idof]
+  else:
+    idofadr = island_idofadr_in[worldid, islandid]
+    inv = island_nv_in[worldid, islandid]
+    for i in range(inv):
+      idof = idofadr + i
+      acc += iefc_J_in[worldid, iefcid, idof] * iacc_in[worldid, idof]
+
+  Jaref_out[worldid, iefcid] = acc - iefc_aref_in[worldid, iefcid]
+
+
+@wp.kernel
+def solve_init_search_island(
+  # Data in:
+  nidof_in: wp.array[int],
+  # In:
+  Mgrad_in: wp.array2d[float],
+  idof_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  search_out: wp.array2d[float],
+  island_search_dot_out: wp.array2d[float],
+):
+  """Search = -Mgrad for all island DOFs."""
+  worldid, idofid = wp.tid()
+
+  if idofid >= nidof_in[worldid]:
+    return
+
+  islandid = idof_islandid_in[worldid, idofid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  s = -Mgrad_in[worldid, idofid]
+  search_out[worldid, idofid] = s
+  wp.atomic_add(island_search_dot_out, worldid, islandid, s * s)
+
+
+@wp.kernel
+def update_constraint_init_cost_island(
+  # Data in:
+  nisland_in: wp.array[int],
+  # In:
+  island_cost_in: wp.array2d[float],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  island_gauss_out: wp.array2d[float],
+  island_cost_out: wp.array2d[float],
+  island_prev_cost_out: wp.array2d[float],
+):
+  """Save prev_cost and zero cost/gauss per island."""
+  worldid, islandid = wp.tid()
+
+  if islandid >= nisland_in[worldid]:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  island_prev_cost_out[worldid, islandid] = island_cost_in[worldid, islandid]
+  island_cost_out[worldid, islandid] = 0.0
+  island_gauss_out[worldid, islandid] = 0.0
+
+
+@wp.kernel
+def update_constraint_efc_island(
+  # Model:
+  opt_impratio_invsqrt: wp.array[float],
+  # Data in:
+  nefc_in: wp.array[int],
+  contact_friction_in: wp.array[types.vec5],
+  contact_dim_in: wp.array[int],
+  contact_efc_address_in: wp.array2d[int],
+  island_nefc_in: wp.array2d[int],
+  island_ne_in: wp.array2d[int],
+  island_nf_in: wp.array2d[int],
+  island_efcadr_in: wp.array2d[int],
+  map_efc2iefc_in: wp.array2d[int],
+  njmax_in: int,
+  nacon_in: wp.array[int],
+  # In:
+  iefc_type_in: wp.array2d[int],
+  iefc_id_in: wp.array2d[int],
+  iefc_D_in: wp.array2d[float],
+  iefc_frictionloss_in: wp.array2d[float],
+  Jaref_in: wp.array2d[float],
+  iefc_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  iefc_force_out: wp.array2d[float],
+  iefc_state_out: wp.array2d[int],
+  island_cost_out: wp.array2d[float],
+):
+  """Compute force, state, and cost for each island constraint."""
+  worldid, iefcid = wp.tid()
+
+  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  islandid = iefc_islandid_in[worldid, iefcid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  # Local position within island
+  iefcadr = island_efcadr_in[worldid, islandid]
+  local_iefcid = iefcid - iefcadr
+  ine = island_ne_in[worldid, islandid]
+  inf = island_nf_in[worldid, islandid]
+
+  jaref = Jaref_in[worldid, iefcid]
+  D = iefc_D_in[worldid, iefcid]
+
+  force = float(0.0)
+  state = types.ConstraintState.SATISFIED.value
+  cost = float(0.0)
+
+  # Determine constraint category by position within island
+  if local_iefcid < ine:
+    # Equality constraint: always quadratic
+    force = -D * jaref
+    state = types.ConstraintState.QUADRATIC.value
+    cost = 0.5 * D * jaref * jaref
+  elif local_iefcid < ine + inf:
+    # Friction constraint
+    f = iefc_frictionloss_in[worldid, iefcid]
+    rf = math.safe_div(f, D)
+    if jaref <= -rf:
+      force = f
+      state = types.ConstraintState.LINEARNEG.value
+      cost = -f * (0.5 * rf + jaref)
+    elif jaref >= rf:
+      force = -f
+      state = types.ConstraintState.LINEARPOS.value
+      cost = -f * (0.5 * rf - jaref)
+    else:
+      force = -D * jaref
+      state = types.ConstraintState.QUADRATIC.value
+      cost = 0.5 * D * jaref * jaref
+  elif iefc_type_in[worldid, iefcid] != types.ConstraintType.CONTACT_ELLIPTIC:
+    # Limit, frictionless contact, pyramidal friction cone contact
+    if jaref >= 0.0:
+      force = 0.0
+      state = types.ConstraintState.SATISFIED.value
+      cost = 0.0
+    else:
+      force = -D * jaref
+      state = types.ConstraintState.QUADRATIC.value
+      cost = 0.5 * D * jaref * jaref
+  else:
+    # Elliptic friction cone contact
+    conid = iefc_id_in[worldid, iefcid]
+
+    if conid >= nacon_in[0]:
+      return
+
+    dim = contact_dim_in[conid]
+    friction = contact_friction_in[conid]
+    mu = friction[0] * opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
+
+    # Get island-local index for lead row
+    efcid0_global = contact_efc_address_in[conid, 0]
+    if efcid0_global < 0:
+      return
+    ic0 = map_efc2iefc_in[worldid, efcid0_global]
+
+    N = Jaref_in[worldid, ic0] * mu
+
+    ufrictionj = float(0.0)
+    TT = float(0.0)
+    for j in range(1, dim):
+      efcidj_global = contact_efc_address_in[conid, j]
+      if efcidj_global < 0:
+        return
+      icj = map_efc2iefc_in[worldid, efcidj_global]
+      frictionj = friction[j - 1]
+      uj = Jaref_in[worldid, icj] * frictionj
+      TT += uj * uj
+      if iefcid == icj:
+        ufrictionj = uj * frictionj
+
+    if TT <= 0.0:
+      T = 0.0
+    else:
+      T = wp.sqrt(TT)
+
+    # top zone
+    if (N >= mu * T) or ((T <= 0.0) and (N >= 0.0)):
+      force = 0.0
+      state = types.ConstraintState.SATISFIED.value
+    # bottom zone
+    elif (mu * N + T <= 0.0) or ((T <= 0.0) and (N < 0.0)):
+      force = -D * jaref
+      state = types.ConstraintState.QUADRATIC.value
+      cost = 0.5 * D * jaref * jaref
+    # middle zone
+    else:
+      dm = math.safe_div(iefc_D_in[worldid, ic0], mu * mu * (1.0 + mu * mu))
+      nmt = N - mu * T
+
+      force_normal = -dm * nmt * mu
+
+      if iefcid == ic0:
+        force = force_normal
+        cost = 0.5 * dm * nmt * nmt
+      else:
+        force = -math.safe_div(force_normal, T) * ufrictionj
+
+      state = types.ConstraintState.CONE.value
+
+  iefc_force_out[worldid, iefcid] = force
+  iefc_state_out[worldid, iefcid] = state
+  wp.atomic_add(island_cost_out, worldid, islandid, cost)
+
+
+@wp.kernel
+def update_constraint_init_qfrc_constraint_dense_island(
+  # Data in:
+  nefc_in: wp.array[int],
+  nidof_in: wp.array[int],
+  island_nefc_in: wp.array2d[int],
+  island_efcadr_in: wp.array2d[int],
+  njmax_in: int,
+  # In:
+  iefc_J_in: wp.array3d[float],
+  iefc_force_in: wp.array2d[float],
+  idof_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  ifrc_constraint_out: wp.array2d[float],
+):
+  """ifrc_constraint = iefc_J.T @ iefc_force for all island DOFs."""
+  worldid, idofid = wp.tid()
+
+  if idofid >= nidof_in[worldid]:
+    ifrc_constraint_out[worldid, idofid] = 0.0
+    return
+
+  islandid = idof_islandid_in[worldid, idofid]
+  if islandid < 0:
+    ifrc_constraint_out[worldid, idofid] = 0.0
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  iefcadr = island_efcadr_in[worldid, islandid]
+  inefc = island_nefc_in[worldid, islandid]
+  acc = float(0.0)
+  for iefcid in range(iefcadr, iefcadr + inefc):
+    acc += iefc_J_in[worldid, iefcid, idofid] * iefc_force_in[worldid, iefcid]
+
+  ifrc_constraint_out[worldid, idofid] = acc
+
+
+@wp.kernel
+def update_constraint_init_qfrc_constraint_sparse_island(
+  # Data in:
+  nefc_in: wp.array[int],
+  njmax_in: int,
+  # In:
+  iefc_J_rownnz_in: wp.array2d[int],
+  iefc_J_rowadr_in: wp.array2d[int],
+  iefc_J_colind_in: wp.array3d[int],
+  iefc_J_in: wp.array3d[float],
+  iefc_force_in: wp.array2d[float],
+  iefc_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  ifrc_constraint_out: wp.array2d[float],
+):
+  """ifrc_constraint += iefc_J.T @ iefc_force for all island EFCs (sparse parallel per EFC)."""
+  worldid, iefcid = wp.tid()
+
+  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  islandid = iefc_islandid_in[worldid, iefcid]
+  if islandid < 0:
+    return
+
+  rownnz = iefc_J_rownnz_in[worldid, iefcid]
+  rowadr = iefc_J_rowadr_in[worldid, iefcid]
+  force = iefc_force_in[worldid, iefcid]
+
+  for k in range(rownnz):
+    adr = rowadr + k
+    Ji = iefc_J_in[worldid, 0, adr]
+    idof = iefc_J_colind_in[worldid, 0, adr]
+    wp.atomic_add(ifrc_constraint_out, worldid, idof, Ji * force)
+
+
+@wp.kernel
+def update_constraint_gauss_cost_island(
+  # Data in:
+  nidof_in: wp.array[int],
+  # In:
+  iacc_in: wp.array2d[float],
+  ifrc_smooth_in: wp.array2d[float],
+  iacc_smooth_in: wp.array2d[float],
+  iMa_in: wp.array2d[float],
+  idof_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  island_gauss_out: wp.array2d[float],
+  island_cost_out: wp.array2d[float],
+):
+  """Gauss cost: 0.5 * (Ma - qfrc_smooth).T @ (qacc - qacc_smooth) per island."""
+  worldid, idofid = wp.tid()
+
+  if idofid >= nidof_in[worldid]:
+    return
+
+  islandid = idof_islandid_in[worldid, idofid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  dq = iacc_in[worldid, idofid] - iacc_smooth_in[worldid, idofid]
+  df = iMa_in[worldid, idofid] - ifrc_smooth_in[worldid, idofid]
+  gauss = 0.5 * df * dq
+
+  wp.atomic_add(island_gauss_out, worldid, islandid, gauss)
+  wp.atomic_add(island_cost_out, worldid, islandid, gauss)
+
+
+@wp.kernel
+def update_gradient_grad_island(
+  # Data in:
+  nidof_in: wp.array[int],
+  # In:
+  ifrc_smooth_in: wp.array2d[float],
+  ifrc_constraint_in: wp.array2d[float],
+  iMa_in: wp.array2d[float],
+  idof_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  grad_out: wp.array2d[float],
+  island_grad_dot_out: wp.array2d[float],
+):
+  """Grad = Ma - qfrc_smooth - qfrc_constraint, grad_dot per island."""
+  worldid, idofid = wp.tid()
+
+  if idofid >= nidof_in[worldid]:
+    return
+
+  islandid = idof_islandid_in[worldid, idofid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  g = iMa_in[worldid, idofid] - ifrc_smooth_in[worldid, idofid] - ifrc_constraint_in[worldid, idofid]
+  grad_out[worldid, idofid] = g
+  wp.atomic_add(island_grad_dot_out, worldid, islandid, g * g)
+
+
+@wp.kernel
+def linesearch_jv_island(
+  # Model:
+  is_sparse: bool,
+  # Data in:
+  nefc_in: wp.array[int],
+  nidof_in: wp.array[int],
+  island_nv_in: wp.array2d[int],
+  njmax_in: int,
+  # In:
+  island_idofadr_in: wp.array2d[int],
+  iefc_J_rownnz_in: wp.array2d[int],
+  iefc_J_rowadr_in: wp.array2d[int],
+  iefc_J_colind_in: wp.array3d[int],
+  iefc_J_in: wp.array3d[float],
+  search_in: wp.array2d[float],
+  iefc_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  jv_out: wp.array2d[float],
+):
+  """Jv = iefc_J @ search for all island EFCs."""
+  worldid, iefcid = wp.tid()
+
+  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  islandid = iefc_islandid_in[worldid, iefcid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  acc = float(0.0)
+  if is_sparse:
+    rownnz = iefc_J_rownnz_in[worldid, iefcid]
+    rowadr = iefc_J_rowadr_in[worldid, iefcid]
+    for k in range(rownnz):
+      adr = rowadr + k
+      Ji = iefc_J_in[worldid, 0, adr]
+      idof = iefc_J_colind_in[worldid, 0, adr]
+      acc += Ji * search_in[worldid, idof]
+  else:
+    idofadr = island_idofadr_in[worldid, islandid]
+    inv = island_nv_in[worldid, islandid]
+    for i in range(inv):
+      idof = idofadr + i
+      acc += iefc_J_in[worldid, iefcid, idof] * search_in[worldid, idof]
+
+  jv_out[worldid, iefcid] = acc
+
+
+@wp.func
+def _eval_elliptic_cost_island(
+  # Model:
+  opt_impratio_invsqrt: float,  # kernel_analyzer: off
+  # Data in:
+  contact_friction_in: wp.array[types.vec5],
+  contact_dim_in: wp.array[int],
+  contact_efc_address_in: wp.array2d[int],
+  map_efc2iefc_in: wp.array2d[int],
+  # In:
+  alpha: float,
+  conid: int,
+  iefc_D_in: wp.array2d[float],
+  Jaref_in: wp.array2d[float],
+  jv_in: wp.array2d[float],
+  worldid: int,
+) -> wp.vec3:
+  dim = contact_dim_in[conid]
+  friction = contact_friction_in[conid]
+  mu = friction[0] * opt_impratio_invsqrt
+
+  ic0 = map_efc2iefc_in[worldid, contact_efc_address_in[conid, 0]]
+  D0 = iefc_D_in[worldid, ic0]
+  ja0 = Jaref_in[worldid, ic0]
+  jv0 = jv_in[worldid, ic0]
+
+  # Bottom-zone quad for the full contact (scalar quadratic over all rows)
+  quad = wp.vec3(0.5 * ja0 * ja0 * D0, jv0 * ja0 * D0, 0.5 * jv0 * jv0 * D0)
+
+  u0 = ja0 * mu
+  v0 = jv0 * mu
+  uu = float(0.0)
+  uv = float(0.0)
+  vv = float(0.0)
+
+  for j in range(1, dim):
+    icj = map_efc2iefc_in[worldid, contact_efc_address_in[conid, j]]
+    jaj = Jaref_in[worldid, icj]
+    jvj = jv_in[worldid, icj]
+    dj = iefc_D_in[worldid, icj]
+    DJj = dj * jaj
+
+    quad += wp.vec3(0.5 * jaj * DJj, jvj * DJj, 0.5 * jvj * dj * jvj)
+
+    frictionj = friction[j - 1]
+    uj = jaj * frictionj
+    vj = jvj * frictionj
+    uu += uj * uj
+    uv += uj * vj
+    vv += vj * vj
+
+  mu2 = mu * mu
+  dm = math.safe_div(D0, mu2 * (1.0 + mu2))
+
+  # Compute N, Tsqr
+  N = u0 + alpha * v0
+  Tsqr = uu + alpha * (2.0 * uv + alpha * vv)
+
+  if Tsqr <= 0.0:
+    if N < 0.0:
+      return _eval_pt(quad, alpha)
+    return wp.vec3(0.0)
+
+  T = wp.sqrt(Tsqr)
+
+  # top zone
+  if N >= mu * T:
+    return wp.vec3(0.0)
+  # bottom zone
+  if mu * N + T <= 0.0:
+    return _eval_pt(quad, alpha)
+
+  # middle zone
+  N1 = v0
+  T1 = (uv + alpha * vv) / T
+  T2 = vv / T - (uv + alpha * vv) * T1 / (T * T)
+  nmt = N - mu * T
+  return wp.vec3(
+    0.5 * dm * nmt * nmt,
+    dm * nmt * (N1 - mu * T1),
+    dm * ((N1 - mu * T1) * (N1 - mu * T1) + nmt * (-mu * T2)),
+  )
+
+
+# TODO(team): refactor linesearch_island
+@wp.kernel
+def linesearch_island(
+  # Model:
+  opt_tolerance: wp.array[float],
+  opt_ls_tolerance: wp.array[float],
+  opt_ls_iterations: int,
+  opt_impratio_invsqrt: wp.array[float],
+  stat_meaninertia: wp.array[float],
+  # Data in:
+  nefc_in: wp.array[int],
+  nisland_in: wp.array[int],
+  contact_friction_in: wp.array[types.vec5],
+  contact_dim_in: wp.array[int],
+  contact_efc_address_in: wp.array2d[int],
+  nidof_in: wp.array[int],
+  island_nv_in: wp.array2d[int],
+  island_ne_in: wp.array2d[int],
+  island_nf_in: wp.array2d[int],
+  island_efcadr_in: wp.array2d[int],
+  island_nefc_in: wp.array2d[int],
+  map_efc2iefc_in: wp.array2d[int],
+  njmax_in: int,
+  nacon_in: wp.array[int],
+  island_idofadr_in: wp.array2d[int],
+  # In:
+  iefc_type_in: wp.array2d[int],
+  iefc_id_in: wp.array2d[int],
+  iefc_D_in: wp.array2d[float],
+  iefc_frictionloss_in: wp.array2d[float],
+  Jaref_in: wp.array2d[float],
+  jv_in: wp.array2d[float],
+  mv_in: wp.array2d[float],
+  search_in: wp.array2d[float],
+  ifrc_smooth_in: wp.array2d[float],
+  iMa_in: wp.array2d[float],
+  island_search_dot_in: wp.array2d[float],
+  island_gauss_in: wp.array2d[float],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  island_alpha_out: wp.array2d[float],
+):
+  """Linesearch per island."""
+  worldid, islandid = wp.tid()
+  nisland = nisland_in[worldid]
+  if islandid >= nisland:
+    island_alpha_out[worldid, islandid] = 0.0
+    return
+  nefc = wp.min(njmax_in, nefc_in[worldid])
+  tolerance = opt_tolerance[worldid % opt_tolerance.shape[0]]
+  ls_tolerance = opt_ls_tolerance[worldid % opt_ls_tolerance.shape[0]]
+  meaninertia = stat_meaninertia[worldid % stat_meaninertia.shape[0]]
+  impratio_invsqrt = opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
+
+  if island_done_in[worldid, islandid]:
+    island_alpha_out[worldid, islandid] = 0.0
+    return
+
+  iefcadr = island_efcadr_in[worldid, islandid]
+  ine = island_ne_in[worldid, islandid]
+  inf = island_nf_in[worldid, islandid]
+  inv = island_nv_in[worldid, islandid]
+  idofadr = island_idofadr_in[worldid, islandid]
+
+  # Get island nefc
+  isle_nefc_end = iefcadr + island_nefc_in[worldid, islandid]
+
+  # Compute gauss quad: [gauss, s.T @ (Ma - frc_smooth), 0.5 * s.T @ mv]
+  quad_gauss_1 = float(0.0)
+  quad_gauss_2 = float(0.0)
+  for i in range(inv):
+    idof = idofadr + i
+    s = search_in[worldid, idof]
+    quad_gauss_1 += s * (iMa_in[worldid, idof] - ifrc_smooth_in[worldid, idof])
+    quad_gauss_2 += 0.5 * s * mv_in[worldid, idof]
+  quad_gauss = wp.vec3(island_gauss_in[worldid, islandid], quad_gauss_1, quad_gauss_2)
+
+  # gtol
+  snorm = wp.sqrt(island_search_dot_in[worldid, islandid])
+  scale = meaninertia * float(inv)
+  gtol = wp.max(tolerance * ls_tolerance * snorm * scale, 1e-6)
+
+  # p0: cost/grad/hessian at alpha=0
+  p0 = wp.vec3(quad_gauss[0], quad_gauss[1], 2.0 * quad_gauss[2])
+  for iefcid in range(iefcadr, isle_nefc_end):
+    if iefcid >= nefc:
+      break
+    local_iefcid = iefcid - iefcadr
+    D = iefc_D_in[worldid, iefcid]
+    ja = Jaref_in[worldid, iefcid]
+    jv_val = jv_in[worldid, iefcid]
+    if local_iefcid < ine:
+      # Equality: always active
+      jvD = jv_val * D
+      p0 += wp.vec3(0.5 * D * ja * ja, jvD * ja, jv_val * jvD)
+    elif local_iefcid < ine + inf:
+      # Friction
+      f = iefc_frictionloss_in[worldid, iefcid]
+      rf = math.safe_div(f, D)
+      p0 += _eval_frictionloss_pt(ja, f, rf, jv_val, D)
+    elif iefc_type_in[worldid, iefcid] == types.ConstraintType.CONTACT_ELLIPTIC:
+      conid = iefc_id_in[worldid, iefcid]
+      if conid < nacon_in[0]:
+        ic0 = map_efc2iefc_in[worldid, contact_efc_address_in[conid, 0]]
+        if iefcid == ic0:
+          p0 += _eval_elliptic_cost_island(
+            impratio_invsqrt,
+            contact_friction_in,
+            contact_dim_in,
+            contact_efc_address_in,
+            map_efc2iefc_in,
+            0.0,
+            conid,
+            iefc_D_in,
+            Jaref_in,
+            jv_in,
+            worldid,
+          )
+    else:
+      # Inequality
+      if ja < 0.0:
+        jvD = jv_val * D
+        p0 += wp.vec3(0.5 * D * ja * ja, jvD * ja, jv_val * jvD)
+
+  # Newton step: lo_alpha_in = -p0[1] / p0[2]
+  lo_alpha_in = -math.safe_div(p0[1], p0[2])
+
+  # Evaluate at Newton step
+  lo_in = _eval_pt(quad_gauss, lo_alpha_in)
+  for iefcid in range(iefcadr, isle_nefc_end):
+    if iefcid >= nefc:
+      break
+    local_iefcid = iefcid - iefcadr
+    D = iefc_D_in[worldid, iefcid]
+    ja = Jaref_in[worldid, iefcid]
+    jv_val = jv_in[worldid, iefcid]
+    if local_iefcid < ine:
+      lo_in += _eval_pt_direct(ja, jv_val, D, lo_alpha_in)
+    elif local_iefcid < ine + inf:
+      f = iefc_frictionloss_in[worldid, iefcid]
+      rf = math.safe_div(f, D)
+      x_a = ja + lo_alpha_in * jv_val
+      lo_in += _eval_frictionloss_pt(x_a, f, rf, jv_val, D)
+    elif iefc_type_in[worldid, iefcid] == types.ConstraintType.CONTACT_ELLIPTIC:
+      conid = iefc_id_in[worldid, iefcid]
+      if conid < nacon_in[0]:
+        ic0 = map_efc2iefc_in[worldid, contact_efc_address_in[conid, 0]]
+        if iefcid == ic0:
+          lo_in += _eval_elliptic_cost_island(
+            impratio_invsqrt,
+            contact_friction_in,
+            contact_dim_in,
+            contact_efc_address_in,
+            map_efc2iefc_in,
+            lo_alpha_in,
+            conid,
+            iefc_D_in,
+            Jaref_in,
+            jv_in,
+            worldid,
+          )
+    else:
+      x_a = ja + lo_alpha_in * jv_val
+      if x_a < 0.0:
+        lo_in += _eval_pt_direct(ja, jv_val, D, lo_alpha_in)
+
+  # Accept Newton step if derivative is small and cost improved
+  initial_converged = wp.abs(lo_in[1]) < gtol and lo_in[0] < p0[0]
+
+  if initial_converged:
+    alpha = lo_alpha_in
+  else:
+    alpha = float(0.0)
+
+    # Initialize brackets
+    lo_less = int(0)
+    if lo_in[1] < p0[1]:
+      lo_less = int(1)
+    if lo_less == 1:
+      lo = lo_in
+      lo_alpha = lo_alpha_in
+      hi = p0
+      hi_alpha = float(0.0)
+    else:
+      lo = p0
+      lo_alpha = float(0.0)
+      hi = lo_in
+      hi_alpha = lo_alpha_in
+
+    for _iter in range(opt_ls_iterations):
+      lo_next_alpha = lo_alpha - math.safe_div(lo[1], lo[2])
+      hi_next_alpha = hi_alpha - math.safe_div(hi[1], hi[2])
+      mid_alpha = 0.5 * (lo_alpha + hi_alpha)
+
+      # Evaluate at 3 candidate alphas
+      lo_next = _eval_pt(quad_gauss, lo_next_alpha)
+      hi_next = _eval_pt(quad_gauss, hi_next_alpha)
+      mid = _eval_pt(quad_gauss, mid_alpha)
+
+      for iefcid in range(iefcadr, isle_nefc_end):
+        if iefcid >= nefc:
+          break
+        local_iefcid = iefcid - iefcadr
+        D = iefc_D_in[worldid, iefcid]
+        ja = Jaref_in[worldid, iefcid]
+        jv_val = jv_in[worldid, iefcid]
+        if local_iefcid < ine:
+          r_lo, r_hi, r_mid = _eval_pt_direct_3alphas(ja, jv_val, D, lo_next_alpha, hi_next_alpha, mid_alpha)
+        elif local_iefcid < ine + inf:
+          f = iefc_frictionloss_in[worldid, iefcid]
+          rf = math.safe_div(f, D)
+          x_lo = ja + lo_next_alpha * jv_val
+          x_hi = ja + hi_next_alpha * jv_val
+          x_mid = ja + mid_alpha * jv_val
+          r_lo = _eval_frictionloss_pt(x_lo, f, rf, jv_val, D)
+          r_hi = _eval_frictionloss_pt(x_hi, f, rf, jv_val, D)
+          r_mid = _eval_frictionloss_pt(x_mid, f, rf, jv_val, D)
+        elif iefc_type_in[worldid, iefcid] == types.ConstraintType.CONTACT_ELLIPTIC:
+          conid = iefc_id_in[worldid, iefcid]
+          r_lo = wp.vec3(0.0)
+          r_hi = wp.vec3(0.0)
+          r_mid = wp.vec3(0.0)
+          if conid < nacon_in[0]:
+            ic0 = map_efc2iefc_in[worldid, contact_efc_address_in[conid, 0]]
+            if iefcid == ic0:
+              r_lo = _eval_elliptic_cost_island(
+                impratio_invsqrt,
+                contact_friction_in,
+                contact_dim_in,
+                contact_efc_address_in,
+                map_efc2iefc_in,
+                lo_next_alpha,
+                conid,
+                iefc_D_in,
+                Jaref_in,
+                jv_in,
+                worldid,
+              )
+              r_hi = _eval_elliptic_cost_island(
+                impratio_invsqrt,
+                contact_friction_in,
+                contact_dim_in,
+                contact_efc_address_in,
+                map_efc2iefc_in,
+                hi_next_alpha,
+                conid,
+                iefc_D_in,
+                Jaref_in,
+                jv_in,
+                worldid,
+              )
+              r_mid = _eval_elliptic_cost_island(
+                impratio_invsqrt,
+                contact_friction_in,
+                contact_dim_in,
+                contact_efc_address_in,
+                map_efc2iefc_in,
+                mid_alpha,
+                conid,
+                iefc_D_in,
+                Jaref_in,
+                jv_in,
+                worldid,
+              )
+        else:
+          x_lo = ja + lo_next_alpha * jv_val
+          x_hi = ja + hi_next_alpha * jv_val
+          x_mid = ja + mid_alpha * jv_val
+          r_lo = wp.vec3(0.0)
+          r_hi = wp.vec3(0.0)
+          r_mid = wp.vec3(0.0)
+          if x_lo < 0.0:
+            r_lo = _eval_pt_direct(ja, jv_val, D, lo_next_alpha)
+          if x_hi < 0.0:
+            r_hi = _eval_pt_direct(ja, jv_val, D, hi_next_alpha)
+          if x_mid < 0.0:
+            r_mid = _eval_pt_direct(ja, jv_val, D, mid_alpha)
+        lo_next += r_lo
+        hi_next += r_hi
+        mid += r_mid
+
+      # Bracket swapping
+      swap_lo = int(0)
+      if _in_bracket(lo, lo_next):
+        lo = lo_next
+        lo_alpha = lo_next_alpha
+        swap_lo = int(1)
+      if _in_bracket(lo, mid):
+        lo = mid
+        lo_alpha = mid_alpha
+        swap_lo = int(1)
+      if _in_bracket(lo, hi_next):
+        lo = hi_next
+        lo_alpha = hi_next_alpha
+        swap_lo = int(1)
+
+      swap_hi = int(0)
+      if _in_bracket(hi, hi_next):
+        hi = hi_next
+        hi_alpha = hi_next_alpha
+        swap_hi = int(1)
+      if _in_bracket(hi, mid):
+        hi = mid
+        hi_alpha = mid_alpha
+        swap_hi = int(1)
+      if _in_bracket(hi, lo_next):
+        hi = lo_next
+        hi_alpha = lo_next_alpha
+        swap_hi = int(1)
+
+      # Done check
+      ls_done = (swap_lo == 0 and swap_hi == 0) or (lo[1] < 0.0 and lo[1] > -gtol) or (hi[1] > 0.0 and hi[1] < gtol)
+
+      # Update alpha if improved
+      if lo[0] < p0[0] or hi[0] < p0[0]:
+        if lo[0] < hi[0]:
+          alpha = lo_alpha
+        else:
+          alpha = hi_alpha
+
+      if ls_done:
+        break
+
+  island_alpha_out[worldid, islandid] = alpha
+
+
+@wp.kernel
+def linesearch_qacc_ma_island(
+  # Data in:
+  nidof_in: wp.array[int],
+  # In:
+  search_in: wp.array2d[float],
+  mv_in: wp.array2d[float],
+  island_alpha_in: wp.array2d[float],
+  idof_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  iacc_out: wp.array2d[float],
+  iMa_out: wp.array2d[float],
+):
+  """Update iacc and iMa after linesearch."""
+  worldid, tid = wp.tid()
+
+  # Process DOFs
+  if tid < nidof_in[worldid]:
+    idof = tid
+    islandid = idof_islandid_in[worldid, idof]
+    if islandid >= 0 and not island_done_in[worldid, islandid]:
+      alpha = island_alpha_in[worldid, islandid]
+      iacc_out[worldid, idof] += alpha * search_in[worldid, idof]
+      iMa_out[worldid, idof] += alpha * mv_in[worldid, idof]
+
+
+@wp.kernel
+def linesearch_jaref_island(
+  # Data in:
+  nefc_in: wp.array[int],
+  njmax_in: int,
+  # In:
+  jv_in: wp.array2d[float],
+  island_alpha_in: wp.array2d[float],
+  iefc_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  Jaref_out: wp.array2d[float],
+):
+  """Update Jaref after linesearch."""
+  worldid, iefcid = wp.tid()
+
+  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  islandid = iefc_islandid_in[worldid, iefcid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  alpha = island_alpha_in[worldid, islandid]
+  Jaref_out[worldid, iefcid] += alpha * jv_in[worldid, iefcid]
+
+
+@wp.kernel
+def solve_prev_grad_Mgrad_island(
+  # Data in:
+  nidof_in: wp.array[int],
+  # In:
+  grad_in: wp.array2d[float],
+  Mgrad_in: wp.array2d[float],
+  idof_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  prev_grad_out: wp.array2d[float],
+  prev_Mgrad_out: wp.array2d[float],
+):
+  """Save prev_grad and prev_Mgrad per island DOF."""
+  worldid, idofid = wp.tid()
+
+  if idofid >= nidof_in[worldid]:
+    return
+
+  islandid = idof_islandid_in[worldid, idofid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  prev_grad_out[worldid, idofid] = grad_in[worldid, idofid]
+  prev_Mgrad_out[worldid, idofid] = Mgrad_in[worldid, idofid]
+
+
+@wp.kernel
+def solve_beta_island(
+  # Data in:
+  nisland_in: wp.array[int],
+  island_nv_in: wp.array2d[int],
+  # In:
+  island_idofadr_in: wp.array2d[int],
+  grad_in: wp.array2d[float],
+  Mgrad_in: wp.array2d[float],
+  prev_grad_in: wp.array2d[float],
+  prev_Mgrad_in: wp.array2d[float],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  island_beta_out: wp.array2d[float],
+):
+  """Polak-Ribière beta per island."""
+  worldid, islandid = wp.tid()
+
+  if islandid >= nisland_in[worldid]:
+    return
+
+  if island_done_in[worldid, islandid]:
+    island_beta_out[worldid, islandid] = 0.0
+    return
+
+  idofadr = island_idofadr_in[worldid, islandid]
+  inv = island_nv_in[worldid, islandid]
+
+  beta_num = float(0.0)
+  beta_den = float(0.0)
+  for i in range(inv):
+    idof = idofadr + i
+    pMg = prev_Mgrad_in[worldid, idof]
+    beta_num += grad_in[worldid, idof] * (Mgrad_in[worldid, idof] - pMg)
+    beta_den += prev_grad_in[worldid, idof] * pMg
+
+  island_beta_out[worldid, islandid] = wp.max(0.0, beta_num / wp.max(types.MJ_MINVAL, beta_den))
+
+
+@wp.kernel
+def solve_search_update_island(
+  # Model:
+  opt_solver: int,
+  # Data in:
+  nidof_in: wp.array[int],
+  # In:
+  Mgrad_in: wp.array2d[float],
+  search_in: wp.array2d[float],
+  island_beta_in: wp.array2d[float],
+  idof_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  search_out: wp.array2d[float],
+  island_search_dot_out: wp.array2d[float],
+):
+  """Update search direction per island DOF."""
+  worldid, idofid = wp.tid()
+
+  if idofid >= nidof_in[worldid]:
+    return
+
+  islandid = idof_islandid_in[worldid, idofid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  s = -Mgrad_in[worldid, idofid]
+  if opt_solver == types.SolverType.CG:
+    s += island_beta_in[worldid, islandid] * search_in[worldid, idofid]
+
+  search_out[worldid, idofid] = s
+  wp.atomic_add(island_search_dot_out, worldid, islandid, s * s)
+
+
+@wp.kernel
+def solve_init_nsolving_island(
+  nisland_in: wp.array[int],
+  nsolving_out: wp.array[int],
+):
+  """Initialize active island count nsolving on device without CPU stalls."""
+  worldid = wp.tid()
+  wp.atomic_add(nsolving_out, 0, nisland_in[worldid])
+
+
+@wp.kernel
+def solve_done_island(
+  # Model:
+  opt_tolerance: wp.array[float],
+  opt_iterations: int,
+  stat_meaninertia: wp.array[float],
+  # Data in:
+  nisland_in: wp.array[int],
+  island_nv_in: wp.array2d[int],
+  # In:
+  island_grad_dot_in: wp.array2d[float],
+  island_cost_in: wp.array2d[float],
+  island_prev_cost_in: wp.array2d[float],
+  island_done_in: wp.array2d[bool],
+  # Data out:
+  solver_niter_out: wp.array[int],
+  # Out:
+  island_done_out: wp.array2d[bool],
+  island_solver_niter_out: wp.array2d[int],
+  nsolving_out: wp.array[int],
+):
+  """Check convergence per island."""
+  worldid, islandid = wp.tid()
+
+  if islandid >= nisland_in[worldid]:
+    return
+
+  tolerance = opt_tolerance[worldid % opt_tolerance.shape[0]]
+  meaninertia = stat_meaninertia[worldid % stat_meaninertia.shape[0]]
+
+  if island_done_in[worldid, islandid]:
+    niter = island_solver_niter_out[worldid, islandid]
+    wp.atomic_max(solver_niter_out, worldid, niter)
+    return
+
+  island_solver_niter_out[worldid, islandid] += 1
+  niter = island_solver_niter_out[worldid, islandid]
+  wp.atomic_max(solver_niter_out, worldid, niter)
+
+  inv = island_nv_in[worldid, islandid]
+  improvement = _rescale(inv, meaninertia, island_prev_cost_in[worldid, islandid] - island_cost_in[worldid, islandid])
+  gradient = _rescale(inv, meaninertia, wp.sqrt(island_grad_dot_in[worldid, islandid]))
+  done = (improvement < tolerance) or (gradient < tolerance)
+  if done or niter >= opt_iterations:
+    island_done_out[worldid, islandid] = True
+    wp.atomic_sub(nsolving_out, 0, 1)
+
+
+@wp.kernel
+def update_gradient_JTDAJ_island(
+  # Model:
+  is_sparse: bool,
+  # Data in:
+  nefc_in: wp.array[int],
+  njmax_in: int,
+  island_idofadr_in: wp.array2d[int],
+  island_nv_in: wp.array2d[int],
+  # In:
+  iefc_J_rownnz_in: wp.array2d[int],
+  iefc_J_rowadr_in: wp.array2d[int],
+  iefc_J_colind_in: wp.array3d[int],
+  iefc_J_in: wp.array3d[float],
+  iefc_D_in: wp.array2d[float],
+  iefc_state_in: wp.array2d[int],
+  iefc_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  ih_out: wp.array3d[float],
+):
+  """Build island Hessian: ih += Jᵀ·D·J for active constraints."""
+  worldid, iefcid = wp.tid()
+
+  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
+    return
+
+  islandid = iefc_islandid_in[worldid, iefcid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  state = iefc_state_in[worldid, iefcid]
+  if state != types.ConstraintState.QUADRATIC.value:
+    return
+  D = iefc_D_in[worldid, iefcid]
+
+  idofadr = island_idofadr_in[worldid, islandid]
+  inv = island_nv_in[worldid, islandid]
+  if is_sparse:
+    rownnz = iefc_J_rownnz_in[worldid, iefcid]
+    rowadr = iefc_J_rowadr_in[worldid, iefcid]
+    for k1 in range(rownnz):
+      adr1 = rowadr + k1
+      Ji = iefc_J_in[worldid, 0, adr1]
+      i = iefc_J_colind_in[worldid, 0, adr1]
+
+      for k2 in range(k1 + 1):
+        adr2 = rowadr + k2
+        Jj = iefc_J_in[worldid, 0, adr2]
+        j = iefc_J_colind_in[worldid, 0, adr2]
+
+        h = Ji * Jj * D
+        wp.atomic_add(ih_out[worldid, i], j, h)
+        if i != j:
+          wp.atomic_add(ih_out[worldid, j], i, h)
+  else:
+    for ii in range(inv):
+      i = idofadr + ii
+      Ji = iefc_J_in[worldid, iefcid, i]
+      if Ji == 0.0:
+        continue
+      for jj in range(ii + 1):
+        j = idofadr + jj
+        Jj = iefc_J_in[worldid, iefcid, j]
+        if Jj == 0.0:
+          continue
+        h = Ji * Jj * D
+        wp.atomic_add(ih_out[worldid, i], j, h)
+        if i != j:
+          wp.atomic_add(ih_out[worldid, j], i, h)
+
+
+@wp.kernel
+def update_gradient_set_h_M_sparse_island(
+  # Model:
+  M_fullm_i: wp.array[int],
+  M_fullm_j: wp.array[int],
+  M_elemid: wp.array2d[int],
+  # Data in:
+  nidof_in: wp.array[int],
+  M_in: wp.array3d[float],
+  dof_island_in: wp.array2d[int],
+  map_dof2idof_in: wp.array2d[int],
+  # In:
+  island_done_in: wp.array2d[bool],
+  # Out:
+  ih_out: wp.array3d[float],
+):
+  """Add sparse mass matrix to island Hessian using global-to-island DOF mapping."""
+  worldid, elementid = wp.tid()
+
+  i_global = M_fullm_i[elementid]
+  j_global = M_fullm_j[elementid]
+
+  madr = M_elemid[i_global, j_global]
+  if madr < 0:
+    return
+
+  # Check both DOFs belong to an island
+  island_i = dof_island_in[worldid, i_global]
+  if island_i < 0:
+    return
+  if island_done_in[worldid, island_i]:
+    return
+
+  island_j = dof_island_in[worldid, j_global]
+  if island_j < 0:
+    return
+
+  # Both DOFs must be in the same island
+  if island_i != island_j:
+    return
+
+  idof_i = map_dof2idof_in[worldid, i_global]
+  idof_j = map_dof2idof_in[worldid, j_global]
+
+  val = M_in[worldid, 0, madr]
+  ih_out[worldid, idof_i, idof_j] += val
+  if idof_i != idof_j:
+    ih_out[worldid, idof_j, idof_i] += val
+
+
+@wp.kernel
+def update_gradient_set_h_M_dense_island(
+  # Model:
+  nv: int,
+  # Data in:
+  nidof_in: wp.array[int],
+  M_in: wp.array3d[float],
+  map_idof2dof_in: wp.array2d[int],
+  # In:
+  idof_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  ih_out: wp.array3d[float],
+):
+  """Add dense mass matrix to island Hessian."""
+  worldid, idofid = wp.tid()
+
+  if idofid >= nidof_in[worldid]:
+    return
+
+  islandid = idof_islandid_in[worldid, idofid]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  dof_i = map_idof2dof_in[worldid, idofid]
+
+  # Copy row from M to ih, mapping columns
+  nid = nidof_in[worldid]
+  for jdof in range(nid):
+    dof_j = map_idof2dof_in[worldid, jdof]
+    ih_out[worldid, idofid, jdof] += M_in[worldid, dof_i, dof_j]
+
+
+@wp.kernel
+def update_gradient_JTCJ_island(
+  # Model:
+  opt_impratio_invsqrt: wp.array[float],
+  is_sparse: bool,
+  # Data in:
+  nacon_in: wp.array[int],
+  contact_friction_in: wp.array[types.vec5],
+  contact_dim_in: wp.array[int],
+  contact_efc_address_in: wp.array2d[int],
+  contact_worldid_in: wp.array[int],
+  island_idofadr_in: wp.array2d[int],
+  naconmax_in: int,
+  nidof_in: wp.array[int],
+  map_efc2iefc_in: wp.array2d[int],
+  island_nv_in: wp.array2d[int],
+  # In:
+  iefc_J_rownnz_in: wp.array2d[int],
+  iefc_J_rowadr_in: wp.array2d[int],
+  iefc_J_colind_in: wp.array3d[int],
+  iefc_J_in: wp.array3d[float],
+  iefc_D_in: wp.array2d[float],
+  iefc_state_in: wp.array2d[int],
+  Jaref_in: wp.array2d[float],
+  iefc_islandid_in: wp.array2d[int],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  ih_out: wp.array3d[float],
+):
+  """Add elliptic cone Hessian correction: Jᵀ·C·J for contacts in CONE state."""
+  conid = wp.tid()
+
+  if conid >= wp.min(naconmax_in, nacon_in[0]):
+    return
+
+  worldid = contact_worldid_in[conid]
+  condim = contact_dim_in[conid]
+
+  if condim == 1:
+    return
+
+  efcid0_global = contact_efc_address_in[conid, 0]
+  if efcid0_global < 0:
+    return
+
+  ic0 = map_efc2iefc_in[worldid, efcid0_global]
+  if iefc_state_in[worldid, ic0] != types.ConstraintState.CONE.value:
+    return
+
+  islandid = iefc_islandid_in[worldid, ic0]
+  if islandid < 0:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  inv = island_nv_in[worldid, islandid]
+  idofadr = island_idofadr_in[worldid, islandid]
+
+  fri = contact_friction_in[conid]
+  mu = fri[0] * opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
+  mu2 = mu * mu
+  dm = math.safe_div(iefc_D_in[worldid, ic0], mu2 * (1.0 + mu2))
+
+  if dm == 0.0:
+    return
+
+  # Compute n and u vector
+  n = Jaref_in[worldid, ic0] * mu
+  u = types.vec6(n, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+  tt = float(0.0)
+  for j in range(1, condim):
+    efcidj_global = contact_efc_address_in[conid, j]
+    if efcidj_global < 0:
+      return
+    icj = map_efc2iefc_in[worldid, efcidj_global]
+    uj = Jaref_in[worldid, icj] * fri[j - 1]
+    tt += uj * uj
+    u[j] = uj
+
+  if tt <= 0.0:
+    t = 0.0
+  else:
+    t = wp.sqrt(tt)
+  t = wp.max(t, types.MJ_MINVAL)
+  ttt = wp.max(t * t * t, types.MJ_MINVAL)
+
+  # Accumulate cone correction into ih
+  for dim1id in range(condim):
+    if dim1id == 0:
+      ic1 = ic0
+    else:
+      efcid1_global = contact_efc_address_in[conid, dim1id]
+      if efcid1_global < 0:
+        return
+      ic1 = map_efc2iefc_in[worldid, efcid1_global]
+
+    ui = u[dim1id]
+
+    for dim2id in range(dim1id + 1):
+      if dim2id == 0:
+        ic2 = ic0
+      else:
+        efcid2_global = contact_efc_address_in[conid, dim2id]
+        if efcid2_global < 0:
+          return
+        ic2 = map_efc2iefc_in[worldid, efcid2_global]
+
+      uj = u[dim2id]
+
+      # Cone correction matrix
+      if dim1id == 0 and dim2id == 0:
+        hcone = 1.0
+      elif dim1id == 0:
+        hcone = -math.safe_div(mu, t) * uj
+      elif dim2id == 0:
+        hcone = -math.safe_div(mu, t) * ui
+      else:
+        hcone = mu * math.safe_div(n, ttt) * ui * uj
+        if dim1id == dim2id:
+          hcone += mu2 - mu * math.safe_div(n, t)
+
+      # Scale by dm * friction
+      if dim1id == 0:
+        fri1 = mu
+      else:
+        fri1 = fri[dim1id - 1]
+      if dim2id == 0:
+        fri2 = mu
+      else:
+        fri2 = fri[dim2id - 1]
+
+      hcone *= dm * fri1 * fri2
+
+      if hcone == 0.0:
+        continue
+
+      # Accumulate J1^T * hcone * J2 into ih (lower triangle)
+      if is_sparse:
+        if dim1id == dim2id:
+          rownnz = iefc_J_rownnz_in[worldid, ic1]
+          rowadr = iefc_J_rowadr_in[worldid, ic1]
+          for k1 in range(rownnz):
+            adr1 = rowadr + k1
+            J1 = iefc_J_in[worldid, 0, adr1]
+            i = iefc_J_colind_in[worldid, 0, adr1]
+
+            for k2 in range(k1 + 1):
+              adr2 = rowadr + k2
+              J2 = iefc_J_in[worldid, 0, adr2]
+              j = iefc_J_colind_in[worldid, 0, adr2]
+
+              val = hcone * J1 * J2
+              wp.atomic_add(ih_out[worldid, i], j, val)
+              if i != j:
+                wp.atomic_add(ih_out[worldid, j], i, val)
+        else:
+          rownnz1 = iefc_J_rownnz_in[worldid, ic1]
+          rowadr1 = iefc_J_rowadr_in[worldid, ic1]
+          rownnz2 = iefc_J_rownnz_in[worldid, ic2]
+          rowadr2 = iefc_J_rowadr_in[worldid, ic2]
+
+          for k1 in range(rownnz1):
+            adr1 = rowadr1 + k1
+            J1 = iefc_J_in[worldid, 0, adr1]
+            i = iefc_J_colind_in[worldid, 0, adr1]
+
+            for k2 in range(rownnz2):
+              adr2 = rowadr2 + k2
+              J2 = iefc_J_in[worldid, 0, adr2]
+              j = iefc_J_colind_in[worldid, 0, adr2]
+
+              val = hcone * J1 * J2
+              if i == j:
+                wp.atomic_add(ih_out[worldid, i], j, val * 2.0)
+              else:
+                wp.atomic_add(ih_out[worldid, i], j, val)
+                wp.atomic_add(ih_out[worldid, j], i, val)
+      else:
+        for i in range(inv):
+          J1i = iefc_J_in[worldid, ic1, idofadr + i]
+          if J1i == 0.0:
+            continue
+          for jj in range(i + 1):
+            J2j = iefc_J_in[worldid, ic2, idofadr + jj]
+            if J2j == 0.0:
+              continue
+            val = hcone * J1i * J2j
+            wp.atomic_add(ih_out[worldid, idofadr + i], idofadr + jj, val)
+            if i != jj:
+              wp.atomic_add(ih_out[worldid, idofadr + jj], idofadr + i, val)
+
+            if dim1id != dim2id:
+              J1j = iefc_J_in[worldid, ic1, idofadr + jj]
+              J2i = iefc_J_in[worldid, ic2, idofadr + i]
+              if J1j != 0.0 and J2i != 0.0:
+                val2 = hcone * J1j * J2i
+                wp.atomic_add(ih_out[worldid, idofadr + i], idofadr + jj, val2)
+                if i != jj:
+                  wp.atomic_add(ih_out[worldid, idofadr + jj], idofadr + i, val2)
+
+
+@wp.kernel
+def _cholesky_factorize_solve_island(
+  # Data in:
+  nisland_in: wp.array[int],
+  island_idofadr_in: wp.array2d[int],
+  island_nv_in: wp.array2d[int],
+  # In:
+  grad_in: wp.array2d[float],
+  ih_in: wp.array3d[float],
+  island_done_in: wp.array2d[bool],
+  # Out:
+  Mgrad_out: wp.array2d[float],
+):
+  """Per-island Cholesky factorize and solve: Mgrad = H⁻¹ @ grad.
+
+  One thread per (world, island). Performs dense in-place Cholesky factorization
+  on the island's inv x inv subblock of ih, then forward/backward substitution.
+  """
+  worldid, islandid = wp.tid()
+
+  if islandid >= nisland_in[worldid]:
+    return
+  if island_done_in[worldid, islandid]:
+    return
+
+  inv = island_nv_in[worldid, islandid]
+
+  if inv == 0:
+    return
+
+  adr = island_idofadr_in[worldid, islandid]
+  # Cholesky factorization in-place: L such that H = L @ L^T
+  for i in range(inv):
+    for j in range(i + 1):
+      s = ih_in[worldid, adr + i, adr + j]
+      for k in range(j):
+        s -= ih_in[worldid, adr + i, adr + k] * ih_in[worldid, adr + j, adr + k]
+      if i == j:
+        if s <= 1e-6:
+          s = 1e-6
+        ih_in[worldid, adr + i, adr + j] = wp.sqrt(s)
+      else:
+        div = ih_in[worldid, adr + j, adr + j]
+        ih_in[worldid, adr + i, adr + j] = s / wp.max(1e-6, div)
+
+  # Forward substitution: L @ y = grad  =>  y
+  for i in range(inv):
+    s = grad_in[worldid, adr + i]
+    for k in range(i):
+      s -= ih_in[worldid, adr + i, adr + k] * Mgrad_out[worldid, adr + k]
+    Mgrad_out[worldid, adr + i] = s / wp.max(1e-6, ih_in[worldid, adr + i, adr + i])
+
+  # Backward substitution: L^T @ x = y  =>  x = Mgrad
+  for i_rev in range(inv):
+    i = inv - 1 - i_rev
+    s = Mgrad_out[worldid, adr + i]
+    for k in range(i + 1, inv):
+      s -= ih_in[worldid, adr + k, adr + i] * Mgrad_out[worldid, adr + k]
+    Mgrad_out[worldid, adr + i] = s / wp.max(types.MJ_MINVAL, ih_in[worldid, adr + i, adr + i])
+
+
+def init_context_island(m: types.Model, d: types.Data, ctx: IslandSolverContext):
+  """Initialize island solver context."""
+  # Init per-island scalars
+  d.solver_niter.zero_()
+  wp.launch(
+    solve_init_efc_island,
+    dim=(d.nworld, m.ntree),
+    inputs=[d.nisland],
+    outputs=[ctx.cost, ctx.search_dot, ctx.done, ctx.solver_niter],
+  )
+
+  # Jaref = iefc_J @ iacc - iefc_aref
+  wp.launch(
+    solve_init_jaref_island,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.is_sparse,
+      d.nefc,
+      d.island_nv,
+      d.njmax,
+      d.island_dofadr,
+      d.efc.iJ_rownnz,
+      d.efc.iJ_rowadr,
+      d.efc.iJ_colind,
+      d.efc.iJ,
+      d.iqacc,
+      d.efc.iaref,
+      d.efc_islandid,
+      ctx.done,
+    ],
+    outputs=[ctx.Jaref],
+  )
+
+  # iMa = M @ iacc (all islands in parallel)
+  support.mul_m_island(
+    m,
+    d,
+    ctx.Ma,
+    d.iqacc,
+    d.nidof,
+    d.map_idof2dof,
+    d.map_dof2idof,
+    d.dof_islandid,
+  )
+
+  # Update constraint
+  _update_constraint_island(m, d, ctx)
+
+  # Update gradient
+  if m.opt.solver == types.SolverType.NEWTON:
+    _update_gradient_incremental_island(m, d, ctx)
+  else:
+    _update_gradient_island(m, d, ctx)
+
+
+@event_scope
+def _update_constraint_island(m: types.Model, d: types.Data, ctx: IslandSolverContext):
+  """Update constraint arrays for island solver."""
+  # Save prev cost, zero cost/gauss
+  wp.launch(
+    update_constraint_init_cost_island,
+    dim=(d.nworld, m.ntree),
+    inputs=[d.nisland, ctx.cost, ctx.done],
+    outputs=[ctx.gauss, ctx.cost, ctx.prev_cost],
+  )
+
+  # Compute force, state, cost per EFC
+  wp.launch(
+    update_constraint_efc_island,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.opt.impratio_invsqrt,
+      d.nefc,
+      d.contact.friction,
+      d.contact.dim,
+      d.contact.efc_address,
+      d.island_nefc,
+      d.island_ne,
+      d.island_nf,
+      d.island_efcadr,
+      d.map_efc2iefc,
+      d.njmax,
+      d.nacon,
+      d.efc.itype,
+      d.efc.iid,
+      d.efc.iD,
+      d.efc.ifrictionloss,
+      ctx.Jaref,
+      d.efc_islandid,
+      ctx.done,
+    ],
+    outputs=[d.efc.iforce, d.efc.istate, ctx.cost],
+  )
+
+  # qfrc_constraint = J^T @ force
+  if m.is_sparse:
+    d.iqfrc_constraint.zero_()
+    wp.launch(
+      update_constraint_init_qfrc_constraint_sparse_island,
+      dim=(d.nworld, d.njmax),
+      inputs=[
+        d.nefc,
+        d.njmax,
+        d.efc.iJ_rownnz,
+        d.efc.iJ_rowadr,
+        d.efc.iJ_colind,
+        d.efc.iJ,
+        d.efc.iforce,
+        d.efc_islandid,
+        ctx.done,
+      ],
+      outputs=[d.iqfrc_constraint],
+    )
+  else:
+    wp.launch(
+      update_constraint_init_qfrc_constraint_dense_island,
+      dim=(d.nworld, m.nv),
+      inputs=[
+        d.nefc,
+        d.nidof,
+        d.island_nefc,
+        d.island_efcadr,
+        d.njmax,
+        d.efc.iJ,
+        d.efc.iforce,
+        d.dof_islandid,
+        ctx.done,
+      ],
+      outputs=[d.iqfrc_constraint],
+    )
+
+  # Gauss cost
+  wp.launch(
+    update_constraint_gauss_cost_island,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      d.nidof,
+      d.iqacc,
+      d.iqfrc_smooth,
+      d.iqacc_smooth,
+      ctx.Ma,
+      d.dof_islandid,
+      ctx.done,
+    ],
+    outputs=[ctx.gauss, ctx.cost],
+  )
+
+
+@event_scope
+def _update_gradient_island(m: types.Model, d: types.Data, ctx: IslandSolverContext):
+  """Update gradient for island solver."""
+  # Zero grad_dot per island
+  ctx.grad_dot.zero_()
+
+  # grad = Ma - frc_smooth - frc_constraint, accumulate grad_dot
+  wp.launch(
+    update_gradient_grad_island,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      d.nidof,
+      d.iqfrc_smooth,
+      d.iqfrc_constraint,
+      ctx.Ma,
+      d.dof_islandid,
+      ctx.done,
+    ],
+    outputs=[ctx.grad, ctx.grad_dot],
+  )
+
+  # CG preconditioner: Mgrad = M^{-1} @ grad (direct solve)
+  support.solve_m_island(
+    m,
+    d,
+    ctx.Mgrad,
+    ctx.grad,
+    d.nidof,
+    d.map_idof2dof,
+  )
+
+
+@event_scope
+def _update_gradient_incremental_island(m: types.Model, d: types.Data, ctx: IslandSolverContext):
+  """Full Newton gradient update for islands: build H, factorize, solve."""
+  # Zero grad_dot per island
+  ctx.grad_dot.zero_()
+
+  # grad = Ma - frc_smooth - frc_constraint, accumulate grad_dot
+  wp.launch(
+    update_gradient_grad_island,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      d.nidof,
+      d.iqfrc_smooth,
+      d.iqfrc_constraint,
+      ctx.Ma,
+      d.dof_islandid,
+      ctx.done,
+    ],
+    outputs=[ctx.grad, ctx.grad_dot],
+  )
+
+  # Build H = qM + Jᵀ·D·J
+  ctx.h.zero_()
+
+  # JTDAJ
+  wp.launch(
+    update_gradient_JTDAJ_island,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.is_sparse,
+      d.nefc,
+      d.njmax,
+      d.island_dofadr,
+      d.island_nv,
+      d.efc.iJ_rownnz,
+      d.efc.iJ_rowadr,
+      d.efc.iJ_colind,
+      d.efc.iJ,
+      d.efc.iD,
+      d.efc.istate,
+      d.efc_islandid,
+      ctx.done,
+    ],
+    outputs=[ctx.h],
+  )
+
+  # Add mass matrix
+  if m.is_sparse:
+    wp.launch(
+      update_gradient_set_h_M_sparse_island,
+      dim=(d.nworld, m.M_fullm_i.shape[0]),
+      inputs=[
+        m.M_fullm_i,
+        m.M_fullm_j,
+        m.M_elemid,
+        d.nidof,
+        d.M,
+        d.dof_island,
+        d.map_dof2idof,
+        ctx.done,
+      ],
+      outputs=[ctx.h],
+    )
+  else:
+    wp.launch(
+      update_gradient_set_h_M_dense_island,
+      dim=(d.nworld, m.nv),
+      inputs=[
+        m.nv,
+        d.nidof,
+        d.M,
+        d.map_idof2dof,
+        d.dof_islandid,
+        ctx.done,
+      ],
+      outputs=[ctx.h],
+    )
+
+  # Elliptic cone correction: JTCJ
+  if m.opt.cone == types.ConeType.ELLIPTIC and d.naconmax > 0:
+    wp.launch(
+      update_gradient_JTCJ_island,
+      dim=d.naconmax,
+      inputs=[
+        m.opt.impratio_invsqrt,
+        m.is_sparse,
+        d.nacon,
+        d.contact.friction,
+        d.contact.dim,
+        d.contact.efc_address,
+        d.contact.worldid,
+        d.island_dofadr,
+        d.naconmax,
+        d.nidof,
+        d.map_efc2iefc,
+        d.island_nv,
+        d.efc.iJ_rownnz,
+        d.efc.iJ_rowadr,
+        d.efc.iJ_colind,
+        d.efc.iJ,
+        d.efc.iD,
+        d.efc.istate,
+        ctx.Jaref,
+        d.efc_islandid,
+        ctx.done,
+      ],
+      outputs=[ctx.h],
+    )
+
+  # Cholesky factorize and solve: Mgrad = H⁻¹ @ grad
+  wp.launch(
+    _cholesky_factorize_solve_island,
+    dim=(d.nworld, m.ntree),
+    inputs=[
+      d.nisland,
+      d.island_dofadr,
+      d.island_nv,
+      ctx.grad,
+      ctx.h,
+      ctx.done,
+    ],
+    outputs=[ctx.Mgrad],
+  )
+
+
+@event_scope
+def _linesearch_island(m: types.Model, d: types.Data, ctx: IslandSolverContext):
+  """Linesearch for island solver."""
+  # mv = M @ search (all islands)
+  support.mul_m_island(
+    m,
+    d,
+    ctx.mv,
+    ctx.search,
+    d.nidof,
+    d.map_idof2dof,
+    d.map_dof2idof,
+    d.dof_islandid,
+    island_done=ctx.done,
+  )
+
+  # jv = J @ search
+  wp.launch(
+    linesearch_jv_island,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.is_sparse,
+      d.nefc,
+      d.nidof,
+      d.island_nv,
+      d.njmax,
+      d.island_dofadr,
+      d.efc.iJ_rownnz,
+      d.efc.iJ_rowadr,
+      d.efc.iJ_colind,
+      d.efc.iJ,
+      ctx.search,
+      d.efc_islandid,
+      ctx.done,
+    ],
+    outputs=[ctx.jv],
+  )
+
+  # linesearch
+  wp.launch(
+    linesearch_island,
+    dim=(d.nworld, m.ntree),
+    inputs=[
+      m.opt.tolerance,
+      m.opt.ls_tolerance,
+      m.opt.ls_iterations,
+      m.opt.impratio_invsqrt,
+      m.stat.meaninertia,
+      d.nefc,
+      d.nisland,
+      d.contact.friction,
+      d.contact.dim,
+      d.contact.efc_address,
+      d.nidof,
+      d.island_nv,
+      d.island_ne,
+      d.island_nf,
+      d.island_efcadr,
+      d.island_nefc,
+      d.map_efc2iefc,
+      d.njmax,
+      d.nacon,
+      d.island_dofadr,
+      d.efc.itype,
+      d.efc.iid,
+      d.efc.iD,
+      d.efc.ifrictionloss,
+      ctx.Jaref,
+      ctx.jv,
+      ctx.mv,
+      ctx.search,
+      d.iqfrc_smooth,
+      ctx.Ma,
+      ctx.search_dot,
+      ctx.gauss,
+      ctx.done,
+    ],
+    outputs=[ctx.alpha],
+  )
+
+  # Update iacc, iMa
+  wp.launch(
+    linesearch_qacc_ma_island,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      d.nidof,
+      ctx.search,
+      ctx.mv,
+      ctx.alpha,
+      d.dof_islandid,
+      ctx.done,
+    ],
+    outputs=[d.iqacc, ctx.Ma],
+  )
+
+  # Update Jaref
+  wp.launch(
+    linesearch_jaref_island,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      d.nefc,
+      d.njmax,
+      ctx.jv,
+      ctx.alpha,
+      d.efc_islandid,
+      ctx.done,
+    ],
+    outputs=[ctx.Jaref],
+  )
+
+
+@event_scope
+def _solver_iteration_island(
+  m: types.Model,
+  d: types.Data,
+  ctx: IslandSolverContext,
+  nsolving: wp.array[int],
+):
+  """One iteration of island solver for all islands in parallel."""
+  _linesearch_island(m, d, ctx)
+
+  is_newton = m.opt.solver == types.SolverType.NEWTON
+  is_cg = not is_newton
+
+  # Save prev_grad, prev_Mgrad for CG
+  if is_cg:
+    wp.launch(
+      solve_prev_grad_Mgrad_island,
+      dim=(d.nworld, m.nv),
+      inputs=[d.nidof, ctx.grad, ctx.Mgrad, d.dof_islandid, ctx.done],
+      outputs=[ctx.prev_grad, ctx.prev_Mgrad],
+    )
+
+  # Update constraint
+  _update_constraint_island(m, d, ctx)
+
+  # Update gradient
+  if is_newton:
+    _update_gradient_incremental_island(m, d, ctx)
+  else:
+    _update_gradient_island(m, d, ctx)
+
+  # Polak-Ribière beta (CG only)
+  if is_cg:
+    wp.launch(
+      solve_beta_island,
+      dim=(d.nworld, m.ntree),
+      inputs=[
+        d.nisland,
+        d.island_nv,
+        d.island_dofadr,
+        ctx.grad,
+        ctx.Mgrad,
+        ctx.prev_grad,
+        ctx.prev_Mgrad,
+        ctx.done,
+      ],
+      outputs=[ctx.beta],
+    )
+
+  # Zero search_dot
+  ctx.search_dot.zero_()
+
+  # Search update
+  wp.launch(
+    solve_search_update_island,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      m.opt.solver,
+      d.nidof,
+      ctx.Mgrad,
+      ctx.search,
+      ctx.beta,
+      d.dof_islandid,
+      ctx.done,
+    ],
+    outputs=[ctx.search, ctx.search_dot],
+  )
+
+  # Convergence check
+  d.solver_niter.zero_()
+  wp.launch(
+    solve_done_island,
+    dim=(d.nworld, m.ntree),
+    inputs=[
+      m.opt.tolerance,
+      m.opt.iterations,
+      m.stat.meaninertia,
+      d.nisland,
+      d.island_nv,
+      ctx.grad_dot,
+      ctx.cost,
+      ctx.prev_cost,
+      ctx.done,
+    ],
+    outputs=[d.solver_niter, ctx.done, ctx.solver_niter, nsolving],
+  )

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -25,7 +25,10 @@ import mujoco_warp as mjw
 from mujoco_warp import ConeType
 from mujoco_warp import SolverType
 from mujoco_warp import test_data
+from mujoco_warp._src import io
+from mujoco_warp._src import island
 from mujoco_warp._src import solver
+from mujoco_warp._src import types
 from mujoco_warp._src.util_pkg import check_version
 
 # tolerance for difference between MuJoCo and MJWarp solver calculations - mostly
@@ -285,32 +288,51 @@ class SolverTest(parameterized.TestCase):
     _assert_eq(Jaref_iterative, Jaref_parallel, name="Jaref")
 
   @parameterized.parameters(
-    (ConeType.PYRAMIDAL, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE, False),
-    (ConeType.ELLIPTIC, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE, False),
-    (ConeType.PYRAMIDAL, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_SPARSE, False),
-    (ConeType.ELLIPTIC, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_SPARSE, False),
-    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_DENSE, False),
-    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_DENSE, False),
-    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_SPARSE, False),
-    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_SPARSE, False),
-    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 64, mujoco.mjtJacobian.mjJAC_SPARSE, True),
-    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 64, mujoco.mjtJacobian.mjJAC_SPARSE, True),
+    (ConeType.PYRAMIDAL, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE, False, False),
+    (ConeType.ELLIPTIC, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE, False, False),
+    (ConeType.PYRAMIDAL, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_SPARSE, False, False),
+    (ConeType.ELLIPTIC, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_SPARSE, False, False),
+    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_DENSE, False, False),
+    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_DENSE, False, False),
+    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_SPARSE, False, False),
+    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_SPARSE, False, False),
+    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 64, mujoco.mjtJacobian.mjJAC_SPARSE, True, False),
+    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 64, mujoco.mjtJacobian.mjJAC_SPARSE, True, False),
+    # Island Solver Paths:
+    (ConeType.PYRAMIDAL, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE, False, True),
+    (ConeType.ELLIPTIC, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE, False, True),
+    (ConeType.PYRAMIDAL, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_SPARSE, False, True),
+    (ConeType.ELLIPTIC, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_SPARSE, False, True),
+    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_DENSE, False, True),
+    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_DENSE, False, True),
+    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_SPARSE, False, True),
+    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_SPARSE, False, True),
   )
-  def test_solve(self, cone, solver_, iterations, ls_iterations, jacobian, ls_parallel):
+  def test_solve(self, cone, solver_, iterations, ls_iterations, jacobian, ls_parallel, enable_islands):
     """Tests solve."""
     for keyframe in range(3):
-      mjm, mjd, m, d = test_data.fixture(
-        "constraints.xml",
-        keyframe=keyframe,
-        overrides={
-          "opt.jacobian": jacobian,
-          "opt.cone": cone,
-          "opt.solver": solver_,
-          "opt.iterations": iterations,
-          "opt.ls_iterations": ls_iterations,
-          "opt.ls_parallel": ls_parallel,
-        },
-      )
+      if enable_islands:
+        io.ENABLE_ISLANDS = True
+      try:
+        mjm, mjd, m, d = test_data.fixture(
+          "constraints.xml",
+          keyframe=keyframe,
+          overrides={
+            "opt.jacobian": jacobian,
+            "opt.cone": cone,
+            "opt.solver": solver_,
+            "opt.iterations": iterations,
+            "opt.ls_iterations": ls_iterations,
+            "opt.ls_parallel": ls_parallel,
+          },
+        )
+      finally:
+        if enable_islands:
+          io.ENABLE_ISLANDS = False
+
+      if enable_islands:
+        m.opt.disableflags &= ~types.DisableBit.ISLAND
+        island.island(m, d)
 
       mujoco.mj_forward(mjm, mjd)
 
@@ -558,14 +580,28 @@ class SolverTest(parameterized.TestCase):
       world2_forces = np.concatenate([world2_eq_forces, world2_ineq_forces])
       _assert_eq(world2_forces, mjd2.efc_force, "efc_force2")
 
-  @parameterized.parameters(
-    mujoco.mjtJacobian.mjJAC_DENSE,
-    mujoco.mjtJacobian.mjJAC_SPARSE,
+  @parameterized.product(
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+    enable_islands=(True, False),
   )
-  def test_frictionloss(self, jacobian):
+  def test_frictionloss(self, jacobian, enable_islands):
     """Tests solver with frictionloss."""
     for keyframe in range(3):
-      _, mjd, m, d = test_data.fixture("constraints.xml", keyframe=keyframe, overrides={"opt.jacobian": jacobian})
+      overrides = {"opt.jacobian": jacobian}
+      if enable_islands:
+        io.ENABLE_ISLANDS = True
+      try:
+        _, mjd, m, d = test_data.fixture(
+          "constraints.xml",
+          keyframe=keyframe,
+          overrides=overrides,
+        )
+      finally:
+        if enable_islands:
+          io.ENABLE_ISLANDS = False
+      if enable_islands:
+        m.opt.disableflags &= ~types.DisableBit.ISLAND
+        island.island(m, d)
       mjw.solve(m, d)
 
       _assert_eq(d.nf.numpy()[0], mjd.nf, "nf")
@@ -677,6 +713,1563 @@ class SolverTest(parameterized.TestCase):
       _assert_eq(qacc_inc, qacc_full, f"qacc keyframe={keyframe}")
 
     self.assertTrue(total_any_changes, "no state changes detected across any keyframe")
+
+
+# Basic weld constraint model.
+_WELD_XML = """
+<mujoco>
+  <worldbody>
+    <body name="b1">
+      <joint type="free"/>
+      <geom size=".1"/>
+    </body>
+    <body name="b2" pos="1 0 0">
+      <joint type="free"/>
+      <geom size=".1"/>
+    </body>
+  </worldbody>
+  <equality>
+    <weld body1="b1" body2="b2"/>
+  </equality>
+</mujoco>"""
+
+# Mixed-constraint model (taken from mujoco's island_efc.xml C test).
+_RICH_MODEL_XML = """
+<mujoco>
+  <default>
+    <geom size=".1"/>
+  </default>
+
+  <worldbody>
+    <body>
+      <joint type="slide" axis="0 0 1" range="0 1" limited="true"/>
+      <geom/>
+    </body>
+
+    <body pos=".25 0 0">
+      <joint type="slide" axis="1 0 0"/>
+      <geom/>
+    </body>
+
+    <body pos="0 0 0.25">
+      <joint type="slide" axis="0 0 1"/>
+      <geom/>
+      <body pos="0 -.15 0">
+        <joint name="hinge1" axis="0 1 0"/>
+        <geom type="capsule" size="0.03" fromto="0 0 0 -.2 0 0"/>
+        <body pos="-.2 0 0">
+          <joint axis="0 1 0"/>
+          <geom type="capsule" size="0.03" fromto="0 0 0 -.2 0 0"/>
+        </body>
+      </body>
+    </body>
+
+    <body pos=".5 0 0">
+      <joint type="slide" axis="0 0 1" frictionloss="15"/>
+      <geom type="box" size=".08 .08 .02" euler="0 10 0"/>
+    </body>
+
+    <body pos="-.5 0 0">
+      <joint axis="0 1 0" frictionloss=".01"/>
+      <geom type="capsule" size="0.03" fromto="0 0 0 -.2 0 0"/>
+    </body>
+
+    <body pos="0 0 .5">
+      <joint name="hinge2" axis="0 1 0"/>
+      <geom type="box" size=".08 .02 .08"/>
+    </body>
+
+    <body pos=".5 0 .1">
+      <freejoint/>
+      <geom type="box" size=".03 .03 .03" pos="0.01 0.01 0.01"/>
+    </body>
+
+    <site name="0" pos="-.45 -.05 .35"/>
+    <body pos="-.5 0 .3" name="connect">
+      <freejoint/>
+      <geom type="box" size=".05 .05 .05"/>
+      <site name="1" pos=".05 -.05 .05"/>
+    </body>
+  </worldbody>
+
+  <equality>
+    <joint joint1="hinge1" joint2="hinge2"/>
+    <connect body1="connect" body2="world" anchor="-.05 -.05 .05"/>
+    <connect site1="0" site2="1"/>
+  </equality>
+</mujoco>"""
+
+# Leg & hfield model (adapted from mujoco's 2humanoid100.xml C test).
+_LEGS_HFIELD_XML = """
+<mujoco>
+  <option density="1.225" viscosity="1.8e-5" wind="0 0 1">
+    <flag energy="enable"/>
+  </option>
+
+  <asset>
+    <hfield name="hfield" nrow="3" ncol="3" size=".2 .2 .03 .03"
+            elevation="1 0 1
+                       0 1 0
+                       1 0 1"/>
+  </asset>
+
+  <default>
+    <joint armature="1" damping="10"/>
+    <default class="hip0">
+      <joint springref="30" stiffness="60"/>
+    </default>
+    <default class="hip1">
+      <joint limited="true" range="-60 60" stiffness="10"/>
+    </default>
+  </default>
+
+  <worldbody>
+    <geom name="floor" type="plane" size="4 4 .1" margin="0.01" gap="0.005"/>
+    <geom type="hfield" hfield="hfield" pos="-.4 .6 .05"/>
+    <body name="head" pos="0 0 .7" gravcomp="0.5">
+      <geom type="ellipsoid" size=".2 .2 .4" density="200"/>
+      <freejoint/>
+      <body euler="0 0 0" pos=".2 0 -.2">
+        <joint name="hipz_0" class="hip1" axis="0 0 1"/>
+        <joint name="hipy_0" class="hip0" axis="0 1 0"/>
+        <geom type="capsule" size=".04" fromto="0 0 0 .2 0 -.25"/>
+        <body pos=".2 0 -.25">
+          <joint name="knee_0" axis="0 1 0"
+                 limited="true" range="-160 -2" stiffness="40" springref="-30"/>
+          <geom type="capsule" size=".03" fromto="0 0 0 -.2 0 -.25"/>
+        </body>
+      </body>
+      <body euler="0 0 180" pos="-.2 0 -.2">
+        <joint name="hipz_1" class="hip1" axis="0 0 1"/>
+        <joint name="hipy_1" class="hip0" axis="0 1 0"/>
+        <geom type="capsule" size=".04" fromto="0 0 0 .2 0 -.25"/>
+        <body pos=".2 0 -.25">
+          <joint name="knee_1" axis="0 1 0"
+                 limited="true" range="-160 -2" stiffness="40" springref="-30"/>
+          <geom type="capsule" size=".03" fromto="0 0 0 -.2 0 -.25"/>
+        </body>
+      </body>
+    </body>
+    <body name="box1" pos=".5 0 .1">
+      <freejoint/>
+      <geom type="box" size=".05 .05 .05"/>
+    </body>
+    <body name="box2" pos="-.5 0 .1">
+      <freejoint/>
+      <geom type="box" size=".05 .05 .05"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+
+
+class IslandSolverTest(parameterized.TestCase):
+  """Tests for the parallel island solver."""
+
+  def setUp(self):
+    super().setUp()
+    io.ENABLE_ISLANDS = True
+
+  def tearDown(self):
+    io.ENABLE_ISLANDS = False
+    super().tearDown()
+
+  @parameterized.parameters(
+    (ConeType.PYRAMIDAL, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE, False),
+    (ConeType.ELLIPTIC, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE, False),
+    (ConeType.PYRAMIDAL, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_SPARSE, False),
+    (ConeType.ELLIPTIC, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_SPARSE, False),
+    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_DENSE, False),
+    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_DENSE, False),
+    (ConeType.PYRAMIDAL, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_SPARSE, False),
+    (ConeType.ELLIPTIC, SolverType.NEWTON, 5, 10, mujoco.mjtJacobian.mjJAC_SPARSE, False),
+  )
+  def test_solve(self, cone, solver_, iterations, ls_iterations, jacobian, ls_parallel):
+    """Tests solve parity with islands enabled."""
+    for keyframe in range(3):
+      mjm, mjd, m, d = test_data.fixture(
+        "constraints.xml",
+        keyframe=keyframe,
+        overrides={
+          "opt.jacobian": jacobian,
+          "opt.cone": cone,
+          "opt.solver": solver_,
+          "opt.iterations": iterations,
+          "opt.ls_iterations": ls_iterations,
+          "opt.ls_parallel": ls_parallel,
+        },
+      )
+
+      # Run island execution
+      m.opt.disableflags &= ~types.DisableBit.ISLAND
+      island.island(m, d)
+
+      mujoco.mj_forward(mjm, mjd)
+
+      d.qacc.fill_(wp.inf)
+      d.qfrc_constraint.fill_(wp.inf)
+      d.efc.force.fill_(wp.inf)
+
+      if solver_ == mujoco.mjtSolver.mjSOL_CG:
+        mjw.factor_m(m, d)
+      mjw.solve(m, d)
+
+      def cost(qacc):
+        jaref = np.zeros(mjd.nefc, dtype=float)
+        cost = np.zeros(1)
+        mujoco.mj_mulJacVec(mjm, mjd, jaref, qacc)
+        mujoco.mj_constraintUpdate(mjm, mjd, jaref - mjd.efc_aref, cost, 0)
+        return cost
+
+      mj_cost = cost(mjd.qacc)
+      mjwarp_cost = cost(d.qacc.numpy()[0])
+      self.assertLessEqual(mjwarp_cost, mj_cost * 1.025)
+
+  @parameterized.parameters(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE)
+  def test_frictionloss(self, jacobian):
+    """Tests solver with frictionloss under islands."""
+    for keyframe in range(3):
+      overrides = {"opt.jacobian": jacobian}
+      _, mjd, m, d = test_data.fixture(
+        "constraints.xml",
+        keyframe=keyframe,
+        overrides=overrides,
+      )
+      m.opt.disableflags &= ~types.DisableBit.ISLAND
+      island.island(m, d)
+      mjw.solve(m, d)
+
+      _assert_eq(d.nf.numpy()[0], mjd.nf, "nf")
+      _assert_eq(d.qacc.numpy()[0], mjd.qacc, "qacc")
+      _assert_eq(d.qfrc_constraint.numpy()[0], mjd.qfrc_constraint, "qfrc_constraint")
+      _assert_eq(d.efc.force.numpy()[0, : mjd.nefc], mjd.efc_force, "efc_force")
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_single_island_weld(self, solver, jacobian):
+    """Single island: weld constraint between two free bodies."""
+    xml = _WELD_XML
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+    nefc = d_monolithic.nefc.numpy()[0]
+    np.testing.assert_allclose(
+      d_island.efc.force.numpy()[0, :nefc],
+      d_monolithic.efc.force.numpy()[0, :nefc],
+      atol=1e-4,
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_multi_island_weld(self, solver, jacobian):
+    """Two independent weld pairs form two separate islands."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <body name="a1">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="a2" pos="1 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b1" pos="10 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b2" pos="11 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+      </worldbody>
+      <equality>
+        <weld body1="a1" body2="a2"/>
+        <weld body1="b1" body2="b2"/>
+      </equality>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_three_islands(self, solver, jacobian):
+    """Three independent weld pairs form three separate islands."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <body name="a1">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="a2" pos="1 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b1" pos="5 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b2" pos="6 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="c1" pos="10 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="c2" pos="11 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+      </worldbody>
+      <equality>
+        <weld body1="a1" body2="a2"/>
+        <weld body1="b1" body2="b2"/>
+        <weld body1="c1" body2="c2"/>
+      </equality>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_contact_constraint(self, solver, jacobian):
+    """Contact constraints from ground plane collision."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <geom type="plane" size="10 10 .01"/>
+        <body name="box1" pos="0 0 0.15">
+          <joint type="free"/>
+          <geom type="box" size=".1 .1 .1" condim="1"/>
+        </body>
+        <body name="box2" pos="5 0 0.15">
+          <joint type="free"/>
+          <geom type="box" size=".1 .1 .1" condim="1"/>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-3)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-3)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_contact_with_friction(self, solver, jacobian):
+    """Contact constraints with friction (condim=3, pyramidal)."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <geom type="plane" size="10 10 .01"/>
+        <body name="box" pos="0 0 0.15">
+          <joint type="free"/>
+          <geom type="box" size=".1 .1 .1" condim="3" friction="0.5"/>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-3)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-3)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_friction_joint(self, solver, jacobian):
+    """Hinge joint with frictionloss generates friction constraints."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <body name="arm1">
+          <joint type="hinge" axis="0 0 1" frictionloss="0.1"/>
+          <geom type="capsule" fromto="0 0 0 0.5 0 0" size=".05"/>
+          <body name="arm2" pos="0.5 0 0">
+            <joint type="hinge" axis="0 0 1" frictionloss="0.2"/>
+            <geom type="capsule" fromto="0 0 0 0.5 0 0" size=".05"/>
+          </body>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+    nefc = d_monolithic.nefc.numpy()[0]
+    np.testing.assert_allclose(
+      d_island.efc.force.numpy()[0, :nefc],
+      d_monolithic.efc.force.numpy()[0, :nefc],
+      atol=1e-4,
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_joint_limit(self, solver, jacobian):
+    """Joint with active limits generates inequality constraints."""
+    xml = """
+    <mujoco>
+      <compiler autolimits="true"/>
+
+      <worldbody>
+        <body name="arm">
+          <joint type="hinge" axis="0 0 1" range="-30 30" damping="0.5"/>
+          <geom type="capsule" fromto="0 0 0 0.5 0 0" size=".05"/>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-3)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-3)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_connect_constraint(self, solver, jacobian):
+    """Connect (point) constraint between two bodies."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <body name="b1">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b2" pos="1 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+      </worldbody>
+      <equality>
+        <connect body1="b1" body2="b2" anchor="0.5 0 0"/>
+      </equality>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+    nefc = d_monolithic.nefc.numpy()[0]
+    np.testing.assert_allclose(
+      d_island.efc.force.numpy()[0, :nefc],
+      d_monolithic.efc.force.numpy()[0, :nefc],
+      atol=1e-4,
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_mixed_constrained_unconstrained(self, solver, jacobian):
+    """Mix of constrained bodies (forming islands) and unconstrained bodies."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <body name="free1" pos="-5 0 1">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="a1">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="a2" pos="1 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="free2" pos="5 0 1">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+      </worldbody>
+      <equality>
+        <weld body1="a1" body2="a2"/>
+      </equality>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_multi_world(self, solver, jacobian):
+    """Island solver with multiple parallel worlds (nworld=4)."""
+    xml = _WELD_XML
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      nworld=4,
+      overrides={
+        "opt.solver": solver,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 100,
+        "opt.tolerance": "1e-10",
+      },
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(xml=xml, nworld=4)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    for w in range(4):
+      np.testing.assert_allclose(d_island.qacc.numpy()[w], d_monolithic.qacc.numpy()[w], atol=1e-4)
+      np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[w], d_monolithic.qfrc_constraint.numpy()[w], atol=1e-4)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_warmstart_disabled(self, solver, jacobian):
+    """Island solver with warmstart disabled."""
+    xml = _WELD_XML
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+      "opt.disableflags": types.DisableBit.WARMSTART,
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_mujoco_c_parity(self, solver, jacobian):
+    """Island solver qacc should be close to MuJoCo C reference."""
+    xml = _WELD_XML
+
+    mjm, mjd, m, d = test_data.fixture(
+      xml=xml,
+      overrides={
+        "opt.solver": solver,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 100,
+        "opt.tolerance": "1e-10",
+      },
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    # MuJoCo C reference
+    mujoco.mj_forward(mjm, mjd)
+    qacc_mjc = mjd.qacc.copy()
+
+    # MuJoCo Warp island solver
+    mjw.forward(m, d)
+    qacc_warp = d.qacc.numpy()[0]
+
+    np.testing.assert_allclose(
+      qacc_warp,
+      qacc_mjc,
+      atol=1e-3,
+      err_msg="qacc mismatch between island solver and MuJoCo C",
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_multi_step(self, solver, jacobian):
+    """Island solver produces stable multi-step simulation."""
+    xml = _WELD_XML
+
+    mjm, mjd, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides={
+        "opt.solver": solver,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 100,
+        "opt.tolerance": "1e-10",
+      },
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    # Run 10 steps with island solver
+    for _ in range(10):
+      mjw.forward(m, d_island)
+      mjw.step(m, d_island)
+
+    qacc = d_island.qacc.numpy()[0]
+    # Check that accelerations are finite and not NaN
+    self.assertTrue(np.all(np.isfinite(qacc)), msg=f"Non-finite qacc after 10 steps: {qacc}")
+
+    # Verify reasonable magnitude (shouldn't blow up)
+    self.assertLess(np.max(np.abs(qacc)), 1e6, msg=f"qacc magnitude too large: {np.max(np.abs(qacc))}")
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_chain_single_island(self, solver, jacobian):
+    """Three bodies in a chain form one island with two welds."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <body name="b1">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b2" pos="1 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b3" pos="2 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+      </worldbody>
+      <equality>
+        <weld body1="b1" body2="b2"/>
+        <weld body1="b2" body2="b3"/>
+      </equality>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+    nefc = d_monolithic.nefc.numpy()[0]
+    np.testing.assert_allclose(
+      d_island.efc.force.numpy()[0, :nefc],
+      d_monolithic.efc.force.numpy()[0, :nefc],
+      atol=1e-4,
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_asymmetric_islands(self, solver, jacobian):
+    """Islands of different sizes: one small (1 weld) and one large (chain)."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <body name="a1">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="a2" pos="1 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b1" pos="5 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b2" pos="6 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b3" pos="7 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b4" pos="8 0 0">
+          <joint type="free"/>
+          <geom size=".1"/>
+        </body>
+      </worldbody>
+      <equality>
+        <weld body1="a1" body2="a2"/>
+        <weld body1="b1" body2="b2"/>
+        <weld body1="b2" body2="b3"/>
+        <weld body1="b3" body2="b4"/>
+      </equality>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_hinge_chain_with_limits(self, solver, jacobian):
+    """Kinematic chain with hinge joints and active limits."""
+    xml = """
+    <mujoco>
+      <compiler autolimits="true"/>
+
+      <worldbody>
+        <body name="link1">
+          <joint type="hinge" axis="0 1 0" range="-45 45" damping="0.1"/>
+          <geom type="capsule" fromto="0 0 0 0.5 0 0" size=".03"/>
+          <body name="link2" pos="0.5 0 0">
+            <joint type="hinge" axis="0 1 0" range="-45 45" damping="0.1"/>
+            <geom type="capsule" fromto="0 0 0 0.5 0 0" size=".03"/>
+          </body>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-3)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-3)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_ball_joint_limit(self, solver, jacobian):
+    """Ball joint with active limit generates inequality constraints."""
+    xml = """
+    <mujoco>
+      <compiler autolimits="true"/>
+
+      <worldbody>
+        <body>
+          <joint type="ball" range="0 30"/>
+          <geom type="box" size=".1 .2 .3" pos=".1 .2 .3"/>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-3)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-3)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_contact_elliptic(self, solver, jacobian):
+    """Contact constraints with elliptic friction cone (condim=3)."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <geom type="plane" size="10 10 .01"/>
+        <body name="box" pos="0 0 0.15">
+          <joint type="free"/>
+          <geom type="box" size=".1 .1 .1" condim="3" friction="0.5"/>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.cone": types.ConeType.ELLIPTIC,
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-3)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-3)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_contact_elliptic_condim4(self, solver, jacobian):
+    """Elliptic friction cones with condim=4 (normal + 2 tangential + spin)."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <geom name="floor" type="plane" size="10 10 .01"/>
+        <body name="box" pos="0 0 0.15">
+          <joint type="free"/>
+          <geom name="box" type="box" size=".1 .1 .1" condim="4" friction="0.5 0.3 0.01"/>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.cone": types.ConeType.ELLIPTIC,
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-3)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-3)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_contact_elliptic_multi_island(self, solver, jacobian):
+    """Two separate bodies with elliptic contacts forming separate islands."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <geom type="plane" size="10 10 .01"/>
+        <body name="box1" pos="0 0 0.15">
+          <joint type="free"/>
+          <geom type="box" size=".1 .1 .1" condim="3" friction="0.5"/>
+        </body>
+        <body name="box2" pos="5 0 0.15">
+          <joint type="free"/>
+          <geom type="box" size=".1 .1 .1" condim="3" friction="0.5"/>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.cone": types.ConeType.ELLIPTIC,
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-3)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-3)
+
+  @parameterized.product(
+    warmstart=[False, True],
+    solver=list(types.SolverType),
+    cone=list(types.ConeType),
+  )
+  def test_islands_equivalent_forward(self, warmstart, solver, cone):
+    """Island vs. monolithic forward parity across solver/cone/warmstart combos.
+
+    Mirrors MuJoCo C's IslandsEquivalentForward test: a single forward call
+    comparing island and monolithic solvers across all combinations of
+    solver type, cone type, and warmstart on a rich model with mixed
+    constraint types.
+    """
+    xml = _RICH_MODEL_XML
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.cone": cone,
+      "opt.iterations": 100,
+      "opt.tolerance": "0",
+      "opt.ls_iterations": 20,
+    }
+    if not warmstart:
+      overrides["opt.disableflags"] = types.DisableBit.WARMSTART
+
+    # Monolithic (islands disabled by default via DisableBit.ISLAND)
+    overrides_monolithic = dict(overrides)
+    _, _, m_monolithic, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides_monolithic,
+    )
+    m_monolithic.opt.disableflags |= types.DisableBit.ISLAND
+
+    # step once to populate warmstart, then forward
+    mjw.step(m_monolithic, d_monolithic)
+    mjw.forward(m_monolithic, d_monolithic)
+
+    # Island
+    _, _, m_island, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m_island.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.step(m_island, d_island)
+    mjw.forward(m_island, d_island)
+
+    np.testing.assert_allclose(
+      d_island.qacc.numpy()[0],
+      d_monolithic.qacc.numpy()[0],
+      atol=1e-2 if solver == types.SolverType.CG else 1e-3,
+      rtol=1e-2,
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_islands_equivalent(self, solver, jacobian):
+    """Multi-step island vs. monolithic parity with synchronized state.
+
+    Mirrors MuJoCo C's IslandsEquivalent test: runs multiple forward calls
+    comparing island and monolithic solvers while keeping the state
+    synchronized, verifying convergence agreement over time.
+    """
+    xml = _RICH_MODEL_XML
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 60,
+      "opt.tolerance": "0",
+      "opt.ls_iterations": 60,
+    }
+
+    _, _, m_monolithic, d_monolithic = test_data.fixture(xml=xml, overrides=overrides)
+    m_monolithic.opt.disableflags |= types.DisableBit.ISLAND
+    _, _, m_island, d_island = test_data.fixture(xml=xml, overrides=overrides)
+    m_island.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    nv = m_monolithic.nv
+
+    # Run 5 synchronized steps
+    for step in range(5):
+      # Synchronize state: copy monolithic qpos/qvel to island
+      d_island.qpos.assign(d_monolithic.qpos)
+      d_island.qvel.assign(d_monolithic.qvel)
+
+      mjw.forward(m_monolithic, d_monolithic)
+      mjw.forward(m_island, d_island)
+
+      np.testing.assert_allclose(
+        d_island.qacc.numpy()[0, :nv],
+        d_monolithic.qacc.numpy()[0, :nv],
+        atol=1e-2 if solver == types.SolverType.CG else 1e-3,
+        rtol=1e-2,
+        err_msg=f"qacc mismatch at step {step}, solver={solver.name}",
+      )
+
+      mjw.step(m_monolithic, d_monolithic)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+    keyframe=(0, 1, 2),
+  )
+  def test_constraints_xml_island_parity(self, solver, jacobian, keyframe):
+    """Complex multi-island model: constraints.xml with 5-9 islands.
+
+    Exercises tendon limits, tendon friction, joint equality, tendon equality,
+    ball joint limits, connect/weld, and mixed contact dimensions (1/3/4/6).
+    Keyframe 0: 5 islands, no contacts. Keyframe 1: 9 islands, frictionless
+    and pyramidal contacts. Keyframe 2: 9 islands, joint limits active.
+    """
+    _, _, m, d_monolithic = test_data.fixture(
+      "constraints.xml",
+      keyframe=keyframe,
+      overrides={
+        "opt.solver": solver,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 100,
+        "opt.tolerance": "1e-10",
+      },
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      "constraints.xml",
+      keyframe=keyframe,
+      overrides={
+        "opt.solver": solver,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 100,
+        "opt.tolerance": "1e-10",
+      },
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    qacc_island = d_island.qacc.numpy()[0]
+    qacc_monolithic = d_monolithic.qacc.numpy()[0]
+    scale = 0.5 * (np.linalg.norm(qacc_island) + np.linalg.norm(qacc_monolithic))
+    rtol = 1e-3 if solver == types.SolverType.CG else 1e-4
+    tol = max(scale * rtol, 1e-8)
+    np.testing.assert_allclose(
+      qacc_island,
+      qacc_monolithic,
+      atol=tol,
+      err_msg=f"qacc mismatch: solver={solver.name}, jacobian={jacobian}, keyframe={keyframe}",
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_tendon_limit_and_friction(self, solver, jacobian):
+    """Tendon limits and friction exercise generic Jacobian scan in edge discovery."""
+    xml = """
+    <mujoco>
+      <compiler autolimits="true"/>
+      <worldbody>
+        <body name="b1">
+          <joint name="j1" type="hinge" axis="1 0 0"/>
+          <geom size=".1"/>
+        </body>
+        <body name="b2" pos="1 0 0">
+          <joint name="j2" type="hinge" axis="1 0 0"/>
+          <geom size=".1"/>
+        </body>
+      </worldbody>
+      <tendon>
+        <fixed name="t1" range="-0.5 0.5" frictionloss="0.1">
+          <joint joint="j1" coef="1"/>
+          <joint joint="j2" coef="-1"/>
+        </fixed>
+      </tendon>
+    </mujoco>"""
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+    nefc = d_monolithic.nefc.numpy()[0]
+    np.testing.assert_allclose(
+      d_island.efc.force.numpy()[0, :nefc],
+      d_monolithic.efc.force.numpy()[0, :nefc],
+      atol=1e-4,
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_contact_elliptic_condim6(self, solver, jacobian):
+    """Elliptic friction cones with condim=6 (normal + 2 tangential + torsional + 2 rolling)."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <geom type="plane" size="10 10 .01"/>
+        <body name="box" pos="0 0 0.15">
+          <joint type="free"/>
+          <geom type="box" size=".1 .1 .1" condim="6" friction="0.5 0.3 0.01"/>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    overrides = {
+      "opt.cone": types.ConeType.ELLIPTIC,
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-3)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-3)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_island_solver_no_graph_conditional(self, solver, jacobian):
+    """Island solver with graph_conditional=False uses Python for loop."""
+    xml = _WELD_XML
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "1e-10",
+    }
+
+    _, _, m, d_monolithic = test_data.fixture(
+      xml=xml,
+      overrides=overrides,
+    )
+    m.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m, d_monolithic)
+
+    _, _, m, d_island = test_data.fixture(
+      xml=xml,
+      overrides={**overrides, "opt.graph_conditional": False},
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m, d_island)
+
+    np.testing.assert_allclose(d_island.qacc.numpy()[0], d_monolithic.qacc.numpy()[0], atol=1e-4)
+    np.testing.assert_allclose(d_island.qfrc_constraint.numpy()[0], d_monolithic.qfrc_constraint.numpy()[0], atol=1e-4)
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+    cone=list(types.ConeType),
+  )
+  def test_constraint_update_island_parity(self, solver, jacobian, cone):
+    """Per-island constraint force parity across sparsity and cone types.
+
+    Mirrors MuJoCo C's ConstraintUpdateImpl test in
+    engine_core_constraint_test.cc: simulates for several steps, then
+    verifies that the island solver produces the same qacc and efc_state
+    as the monolithic solver across all combinations of Jacobian sparsity
+    and cone type.
+    """
+    # This is the island_efc.xml model used in the C test:
+    # 7 equalities (1:joint, 6:connect), 1 limit, 2 friction constraints,
+    # 1 unconstrained dof, 4 islands, 2 with non-contiguous dofs.
+    xml = _RICH_MODEL_XML
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.cone": cone,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 100,
+      "opt.tolerance": "0",
+      "opt.ls_iterations": 20,
+    }
+    _, _, m_monolithic, d_monolithic = test_data.fixture(xml=xml, overrides=overrides)
+    m_monolithic.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m_monolithic, d_monolithic)
+
+    _, _, m_island, d_island = test_data.fixture(xml=xml, overrides=overrides)
+    m_island.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m_island, d_island)
+
+    np.testing.assert_allclose(
+      d_island.qacc.numpy()[0],
+      d_monolithic.qacc.numpy()[0],
+      atol=1e-3,
+      err_msg=f"qacc mismatch: solver={solver.name}, jac={jacobian}, cone={cone.name}",
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    iterations=[30, 60],
+  )
+  def test_solver_model_island_parity(self, solver, iterations):
+    """Rich model island parity with iteration count sweep.
+
+    Mirrors MuJoCo C's IslandsEquivalent test in engine_solver_test.cc:
+    uses a complex model with mesh, heightfield, fluid, gravcomp, and
+    multiple legs. Tests at different iteration counts to verify
+    convergence behavior. The C test uses model.xml with CG+Sparse.
+    """
+    xml = _LEGS_HFIELD_XML
+
+    overrides_monolithic = {
+      "opt.solver": solver,
+      "opt.tolerance": "0",
+      "opt.iterations": iterations,
+      "opt.ls_iterations": iterations,
+    }
+    # Single forward to establish contact
+    _, _, m_monolithic, d_monolithic = test_data.fixture(xml=xml, overrides=overrides_monolithic)
+    m_monolithic.opt.disableflags |= types.DisableBit.ISLAND
+    mjw.forward(m_monolithic, d_monolithic)
+
+    _, _, m_island, d_island = test_data.fixture(xml=xml, overrides=overrides_monolithic)
+    m_island.opt.disableflags &= ~types.DisableBit.ISLAND
+    mjw.forward(m_island, d_island)
+
+    np.testing.assert_allclose(
+      d_island.qacc.numpy()[0],
+      d_monolithic.qacc.numpy()[0],
+      atol=1e-3,
+      err_msg=f"qacc mismatch: solver={solver.name}, iters={iterations}",
+    )
+
+  @parameterized.product(
+    solver=list(types.SolverType),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_solver_model_island_multi_step(self, solver, jacobian):
+    """Multi-step island parity on a rich model with synchronized state.
+
+    Mirrors MuJoCo C's IslandsEquivalent test multi-step pattern:
+    runs multiple steps, synchronizing state between island and monolithic
+    after each step to prevent divergence. Uses the same rich model with
+    mesh, heightfield, fluid, and multiple contact islands.
+    """
+    xml = _LEGS_HFIELD_XML
+
+    nsteps = 10
+    nv = 26  # 6 (head freejoint) + 2*4 (legs) + 2*6 (boxes) = 26
+
+    overrides = {
+      "opt.solver": solver,
+      "opt.jacobian": jacobian,
+      "opt.iterations": 60,
+      "opt.tolerance": "0",
+    }
+
+    _, _, m_monolithic, d_monolithic = test_data.fixture(xml=xml, overrides=overrides)
+    m_monolithic.opt.disableflags |= types.DisableBit.ISLAND
+    _, _, m_island, d_island = test_data.fixture(xml=xml, overrides=overrides)
+    m_island.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    for step in range(nsteps):
+      mjw.forward(m_monolithic, d_monolithic)
+      mjw.forward(m_island, d_island)
+
+      np.testing.assert_allclose(
+        d_island.qacc.numpy()[0, :nv],
+        d_monolithic.qacc.numpy()[0, :nv],
+        atol=1e-2 if solver == types.SolverType.CG else 1e-3,
+        rtol=1e-2,
+        err_msg=f"qacc mismatch at step {step}: solver={solver.name}",
+      )
+
+      # Integrate monolithic, then sync state to island
+      mjw.step(m_monolithic, d_monolithic)
+      d_island.qpos.assign(d_monolithic.qpos)
+      d_island.qvel.assign(d_monolithic.qvel)
+      d_island.act.assign(d_monolithic.act)
+      d_island.time.assign(d_monolithic.time)
+      d_island.qacc_warmstart.assign(d_monolithic.qacc_warmstart)
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -172,6 +172,340 @@ def mul_m(
 
 
 @wp.kernel
+def _mul_m_island_sparse(
+  # Model:
+  M_mulm_rowadr: wp.array[int],
+  M_mulm_col: wp.array[int],
+  M_mulm_madr: wp.array[int],
+  # Data in:
+  nidof_in: wp.array[int],
+  M_in: wp.array3d[float],
+  map_dof2idof_in: wp.array2d[int],
+  map_idof2dof_in: wp.array2d[int],
+  # In:
+  idof_islandid_in: wp.array2d[int],
+  vec: wp.array2d[float],
+  island_done_in: wp.array2d[bool],
+  check_skip: int,
+  # Out:
+  res: wp.array2d[float],
+):
+  """Sparse island mul_m for ALL islands in parallel."""
+  worldid, idofid = wp.tid()
+
+  nidof = nidof_in[worldid]
+  if idofid >= nidof:
+    return
+
+  islandid = idof_islandid_in[worldid, idofid]
+  if islandid < 0:
+    return
+
+  if check_skip:
+    if island_done_in[worldid, islandid]:
+      return
+
+  dof = map_idof2dof_in[worldid, idofid]
+
+  acc = float(0.0)
+  start = M_mulm_rowadr[dof]
+  end = M_mulm_rowadr[dof + 1]
+  for k in range(start, end):
+    col = M_mulm_col[k]
+    madr = M_mulm_madr[k]
+    col_idof = map_dof2idof_in[worldid, col]
+    # skip unconstrained DOFs
+    if col_idof < nidof:
+      acc += M_in[worldid, 0, madr] * vec[worldid, col_idof]
+
+  res[worldid, idofid] = acc
+
+
+@wp.kernel
+def _mul_m_island_dense(
+  # Model:
+  nv: int,
+  # Data in:
+  nidof_in: wp.array[int],
+  M_in: wp.array3d[float],
+  map_dof2idof_in: wp.array2d[int],
+  map_idof2dof_in: wp.array2d[int],
+  # In:
+  idof_islandid_in: wp.array2d[int],
+  vec: wp.array2d[float],
+  island_done_in: wp.array2d[bool],
+  check_skip: int,
+  # Out:
+  res: wp.array2d[float],
+):
+  """Dense island mul_m for ALL islands in parallel."""
+  worldid, idofid = wp.tid()
+
+  nidof = nidof_in[worldid]
+  if idofid >= nidof:
+    return
+
+  islandid = idof_islandid_in[worldid, idofid]
+  if islandid < 0:
+    return
+
+  if check_skip:
+    if island_done_in[worldid, islandid]:
+      return
+
+  dof = map_idof2dof_in[worldid, idofid]
+
+  acc = float(0.0)
+  for j in range(nv):
+    col_idof = map_dof2idof_in[worldid, j]
+    # skip unconstrained DOFs
+    if col_idof < nidof:
+      acc += M_in[worldid, dof, j] * vec[worldid, col_idof]
+
+  res[worldid, idofid] = acc
+
+
+@event_scope
+def mul_m_island(
+  m: Model,
+  d: Data,
+  res: wp.array2d[float],
+  vec: wp.array2d[float],
+  nidof: wp.array[int],
+  map_idof2dof: wp.array2d[int],
+  map_dof2idof: wp.array2d[int],
+  idof_islandid: wp.array2d[int],
+  island_done: Optional[wp.array] = None,
+  M: Optional[wp.array] = None,
+):
+  """Multiply island-local vectors by inertia matrix for all islands in parallel.
+
+  Args:
+    m: The model containing kinematic and dynamic information.
+    d: The data object containing the current state and output arrays.
+    res: Result: qM @ vec (island-local DOF order).
+    vec: Input vector (island-local DOF order).
+    nidof: Number of island DOFs per world.
+    map_idof2dof: Island-local DOF → global DOF map.
+    map_dof2idof: Global DOF → island-local DOF map.
+    idof_islandid: Island ID per island-local DOF.
+    island_done: Per-island done flags (nworld, ntree).
+    M: Optional mass matrix override.
+  """
+  check_skip = int(island_done is not None)
+  island_done = island_done or wp.empty((0, 0), dtype=bool)
+
+  if M is None:
+    M = d.M
+
+  if m.is_sparse:
+    wp.launch(
+      _mul_m_island_sparse,
+      dim=(d.nworld, m.nv),
+      inputs=[
+        m.M_mulm_rowadr,
+        m.M_mulm_col,
+        m.M_mulm_madr,
+        nidof,
+        M,
+        map_dof2idof,
+        map_idof2dof,
+        idof_islandid,
+        vec,
+        island_done,
+        check_skip,
+      ],
+      outputs=[res],
+    )
+  else:
+    wp.launch(
+      _mul_m_island_dense,
+      dim=(d.nworld, m.nv),
+      inputs=[
+        m.nv,
+        nidof,
+        M,
+        map_dof2idof,
+        map_idof2dof,
+        idof_islandid,
+        vec,
+        island_done,
+        check_skip,
+      ],
+      outputs=[res],
+    )
+
+
+@cache_kernel
+def _solve_LD_sparse_island(nv: int, nlevels: int):
+  """Sparse backsubstitution with island-local index remapping.
+
+  Same algorithm as _solve_LD_sparse_fused, but reads/writes x/y in
+  island-local DOF order. The L/D factorization stays in global DOF order.
+  """
+
+  @wp.func_native(snippet="WP_TILE_SYNC();")
+  def _syncthreads():
+    pass
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    nidof_in: wp.array[int],
+    map_dof2idof_in: wp.array2d[int],
+    map_idof2dof_in: wp.array2d[int],
+    # In:
+    L: wp.array3d[float],
+    D: wp.array2d[float],
+    all_updates: wp.array[wp.vec3i],
+    level_offsets: wp.array[int],
+    y: wp.array2d[float],
+    # Out:
+    x_out: wp.array2d[float],
+  ):
+    worldid, tid = wp.tid()
+    NLEVELS = wp.static(nlevels)
+    BLOCK_DIM = wp.block_dim()
+    nid = nidof_in[worldid]
+
+    # Copy y to x_out (island-local, only iterate up to nid)
+    for idof in range(tid, nid, BLOCK_DIM):
+      x_out[worldid, idof] = y[worldid, idof]
+    _syncthreads()
+
+    # Forward substitution
+    for level in range(NLEVELS):
+      level_idx = NLEVELS - 1 - level
+      level_offset = level_offsets[level_idx]
+      level_size = level_offsets[level_idx + 1] - level_offset
+
+      for u in range(tid, level_size, BLOCK_DIM):
+        update = all_updates[level_offset + u]
+        i, k, Madr_ki = update[0], update[1], update[2]
+        idof_i = map_dof2idof_in[worldid, i]
+        if idof_i < nid:
+          idof_k = map_dof2idof_in[worldid, k]
+          wp.atomic_sub(x_out[worldid], idof_i, L[worldid, 0, Madr_ki] * x_out[worldid, idof_k])
+      _syncthreads()
+
+    # Diagonal multiply (only iterate up to nid)
+    for idof in range(tid, nid, BLOCK_DIM):
+      dofid = map_idof2dof_in[worldid, idof]
+      x_out[worldid, idof] *= D[worldid, dofid]
+    _syncthreads()
+
+    # Backward substitution
+    for level in range(NLEVELS):
+      level_idx = level
+      level_offset = level_offsets[level_idx]
+      level_size = level_offsets[level_idx + 1] - level_offset
+
+      for u in range(tid, level_size, BLOCK_DIM):
+        update = all_updates[level_offset + u]
+        i, k, Madr_ki = update[0], update[1], update[2]
+        idof_k = map_dof2idof_in[worldid, k]
+        if idof_k < nid:
+          idof_i = map_dof2idof_in[worldid, i]
+          wp.atomic_sub(x_out[worldid], idof_k, L[worldid, 0, Madr_ki] * x_out[worldid, idof_i])
+      _syncthreads()
+
+  return kernel
+
+
+@cache_kernel
+def _tile_cholesky_solve_island(tile):
+  """Dense Cholesky backsubstitution with island-local index remapping.
+
+  L is loaded from global DOF offsets (factorization unchanged).
+  y/x are loaded/stored at island-local DOF offsets via map_dof2idof.
+  """
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def cholesky_solve(
+    # Data in:
+    nidof_in: wp.array[int],
+    map_dof2idof_in: wp.array2d[int],
+    # In:
+    L: wp.array3d[float],
+    y: wp.array2d[float],
+    adr: wp.array[int],
+    # Out:
+    x: wp.array2d[float],
+  ):
+    worldid, nodeid = wp.tid()
+    TILE_SIZE = wp.static(tile.size)
+
+    dofid = adr[nodeid]
+    idofid = map_dof2idof_in[worldid, dofid]
+
+    # Skip unconstrained trees (uniform branch — all threads in block agree)
+    if idofid >= nidof_in[worldid]:
+      return
+
+    # L stays in global order
+    L_tile = wp.tile_load(L[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid))
+    # y and x use island-local offsets
+    y_slice = wp.tile_load(y[worldid], shape=(TILE_SIZE,), offset=(idofid,))
+    x_slice = wp.tile_cholesky_solve(L_tile, y_slice)
+    wp.tile_store(x[worldid], x_slice, offset=(idofid,))
+
+  return cholesky_solve
+
+
+@event_scope
+def solve_m_island(
+  m: Model,
+  d: Data,
+  res: wp.array2d[float],
+  vec: wp.array2d[float],
+  nidof: wp.array[int],
+  map_idof2dof: wp.array2d[int],
+):
+  """Compute res = M^{-1} @ vec for island-local DOFs.
+
+  Args:
+    m: Model.
+    d: Data.
+    res: Output in island-local DOF order.
+    vec: Input in island-local DOF order.
+    nidof: Number of island DOFs per world.
+    map_idof2dof: Island-local DOF -> global DOF map.
+  """
+  if m.is_sparse:
+    nlevels = len(m.qLD_updates)
+    if wp.get_device().is_cuda:
+      dim_block = m.block_dim.solve_LD_sparse_fused
+    else:
+      dim_block = 1
+
+    wp.launch(
+      _solve_LD_sparse_island(m.nv, nlevels),
+      dim=(d.nworld, dim_block),
+      inputs=[
+        d.nidof,
+        d.map_dof2idof,
+        map_idof2dof,
+        d.qLD,
+        d.qLDiagInv,
+        m.qLD_all_updates,
+        m.qLD_level_offsets,
+        vec,
+      ],
+      outputs=[res],
+      block_dim=dim_block,
+    )
+  else:
+    for tile in m.M_tiles:
+      wp.launch_tiled(
+        _tile_cholesky_solve_island(tile),
+        dim=(d.nworld, tile.adr.size),
+        inputs=[d.nidof, d.map_dof2idof, d.qLD, vec, tile.adr],
+        outputs=[res],
+        block_dim=m.block_dim.cholesky_solve,
+      )
+
+
+@wp.kernel
 def _apply_ft(
   # Model:
   nbody: int,

--- a/mujoco_warp/_src/support_test.py
+++ b/mujoco_warp/_src/support_test.py
@@ -25,6 +25,11 @@ import mujoco_warp as mjwarp
 from mujoco_warp import ConeType
 from mujoco_warp import State
 from mujoco_warp import test_data
+from mujoco_warp._src import io
+from mujoco_warp._src import island
+from mujoco_warp._src import solver
+from mujoco_warp._src import support
+from mujoco_warp._src import types
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_factorize_solve_func
 
 # tolerance for difference between MuJoCo and MJWarp support calculations - mostly
@@ -39,6 +44,14 @@ def _assert_eq(a, b, name):
 
 
 class SupportTest(parameterized.TestCase):
+  def setUp(self):
+    super().setUp()
+    io.ENABLE_ISLANDS = True
+
+  def tearDown(self):
+    io.ENABLE_ISLANDS = False
+    super().tearDown()
+
   @parameterized.parameters(mujoco.mjtJacobian.mjJAC_SPARSE, mujoco.mjtJacobian.mjJAC_DENSE)
   def test_mul_m(self, jacobian):
     """Tests mul_m."""
@@ -391,6 +404,64 @@ class SupportTest(parameterized.TestCase):
     for w in range(2):
       _assert_eq(jacp_wp.numpy()[w], jacp_mj, f"jacp world {w}")
       _assert_eq(jacr_wp.numpy()[w], jacr_mj, f"jacr world {w}")
+
+  @parameterized.parameters(
+    mujoco.mjtJacobian.mjJAC_SPARSE,
+    mujoco.mjtJacobian.mjJAC_DENSE,
+  )
+  def test_mul_m_island(self, jacobian):
+    """Tests mul_m_island matches mul_m for all islands in parallel."""
+    mjm, mjd, m, d = test_data.fixture(
+      "constraints.xml",
+      overrides={"opt.jacobian": jacobian},
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    ctx = solver.create_island_solver_context(m, d)
+    island.compute_island_mapping(m, d, ctx)
+
+    # Random vector in global DOF order
+    np.random.seed(0)
+    vec_np = np.random.randn(1, m.nv).astype(np.float32)
+
+    # Global mul_m
+    vec_global = wp.from_numpy(vec_np, dtype=float)
+    res_global = wp.zeros((1, m.nv), dtype=float)
+    mjwarp.mul_m(m, d, res_global, vec_global)
+    res_global_np = res_global.numpy()[0]
+
+    # Gather vec into island-local order
+    nidof = d.nidof.numpy()[0]
+    map_idof2dof = d.map_idof2dof.numpy()[0]
+    vec_island_np = np.zeros((1, m.nv), dtype=np.float32)
+    for idof in range(nidof):
+      vec_island_np[0, idof] = vec_np[0, map_idof2dof[idof]]
+
+    vec_island = wp.from_numpy(vec_island_np, dtype=float)
+    res_island = wp.zeros((1, m.nv), dtype=float)
+
+    support.mul_m_island(
+      m,
+      d,
+      res_island,
+      vec_island,
+      d.nidof,
+      d.map_idof2dof,
+      d.map_dof2idof,
+      d.dof_islandid,
+    )
+
+    # Scatter result back to global order and compare
+    res_island_np = res_island.numpy()[0]
+    for idof in range(nidof):
+      dof = map_idof2dof[idof]
+      dof_isl = d.dof_island.numpy()[0, dof]
+      if dof_isl >= 0:
+        _assert_eq(
+          res_island_np[idof],
+          res_global_np[dof],
+          f"mul_m_island idof={idof} dof={dof}",
+        )
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1755,6 +1755,20 @@ class Constraint:
     frictionloss: frictionloss (friction)             (nworld, njmax)
     force: constraint force in constraint space       (nworld, njmax)
     state: constraint state                           (nworld, njmax_pad)
+    island: island ID per constraint                  (nworld, njmax)
+    itype: island constraint type                     (nworld, njmax)
+    iid: island constraint id                         (nworld, njmax)
+    iJ_rownnz: island J_rownnz                        (nworld, njmax)
+    iJ_rowadr: island J_rowadr                        (nworld, njmax)
+    iJ_colind: island J_colind                        (nworld, 0, 0) dense
+                                                      (nworld, 1, njmax_nnz) sparse
+    iJ: island J                                      (nworld, njmax, nv) dense
+                                                      (nworld, 1, njmax_nnz) sparse
+    iD: island constraint mass                        (nworld, njmax_pad)
+    iaref: island aref                                (nworld, njmax)
+    ifrictionloss: island frictionloss                (nworld, njmax)
+    iforce: island force                              (nworld, njmax)
+    istate: island state                              (nworld, njmax_pad)
   warp only fields:
     Ma: M*qacc                                        (nworld, nv)
     Jqvel: J*qvel                                     (nworld, njmax)
@@ -1762,8 +1776,8 @@ class Constraint:
 
   type: array("nworld", "njmax", int)
   id: array("nworld", "njmax", int)
-  J_rownnz: wp.array2d[int]
-  J_rowadr: wp.array2d[int]
+  J_rownnz: array("nworld", "njmax", int)
+  J_rowadr: array("nworld", "njmax", int)
   J_colind: wp.array3d[int]
   J: wp.array3d[float]
   pos: array("nworld", "njmax", float)
@@ -1774,8 +1788,21 @@ class Constraint:
   frictionloss: array("nworld", "njmax", float)
   force: array("nworld", "njmax", float)
   state: array("nworld", "njmax_pad", int)
+  island: array("nworld", "njmax", int)
   Ma: array("nworld", "nv", float)
   Jqvel: array("nworld", "njmax", float)
+
+  itype: array("nworld", "njmax", int)
+  iid: array("nworld", "njmax", int)
+  iJ_rownnz: array("nworld", "njmax", int)
+  iJ_rowadr: array("nworld", "njmax", int)
+  iJ_colind: wp.array3d[int]
+  iJ: wp.array3d[float]
+  iD: array("nworld", "njmax_pad", float)
+  iaref: array("nworld", "njmax", float)
+  ifrictionloss: array("nworld", "njmax", float)
+  iforce: array("nworld", "njmax", float)
+  istate: array("nworld", "njmax_pad", int)
 
 
 @dataclasses.dataclass
@@ -1789,6 +1816,7 @@ class Data:
     nl: number of limit constraints                             (nworld,)
     nefc: number of constraints                                 (nworld,)
     nisland: number of constraint islands                       (nworld,)
+    nidof: total DOFs in islands                                (nworld,)
     time: simulation time                                       (nworld,)
     energy: potential, kinetic energy                           (nworld, 2)
     qpos: position                                              (nworld, nq)
@@ -1869,6 +1897,23 @@ class Data:
     contact: contact data
     efc: constraint data
     tree_island: island ID per tree (-1 if unconstrained)       (nworld, ntree)
+    dof_island: island ID per DOF (-1 if unconstrained)         (nworld, nv)
+    island_dofadr: island start address in dof vector           (nworld, ntree)
+    island_nv: DOFs per island                                  (nworld, ntree)
+    island_nefc: constraints per island                         (nworld, ntree)
+    island_ne: equality constraints per island                  (nworld, ntree)
+    island_nf: friction constraints per island                  (nworld, ntree)
+    island_efcadr: island start address in efc vector           (nworld, ntree)
+    map_dof2idof: global DOF -> island-local DOF                (nworld, nv)
+    map_idof2dof: island-local DOF -> global DOF                (nworld, nv)
+    map_efc2iefc: global EFC -> island-local EFC                (nworld, njmax)
+    map_iefc2efc: island-local EFC -> global EFC                (nworld, njmax)
+    dof_islandid: island ID per island-DOF                      (nworld, nv)
+    efc_islandid: island ID per island-EFC                      (nworld, njmax)
+    iqacc: island-local qacc                                    (nworld, nv)
+    iqacc_smooth: island-local qacc_smooth                      (nworld, nv)
+    iqfrc_smooth: island-local qfrc_smooth                      (nworld, nv)
+    iqfrc_constraint: island-local qfrc_constraint              (nworld, nv)
 
   warp only fields:
     nworld: number of worlds
@@ -1887,6 +1932,7 @@ class Data:
   nl: array("nworld", int)
   nefc: array("nworld", int)
   nisland: array("nworld", int)
+  nidof: array("nworld", int)
   time: array("nworld", float)
   energy: array("nworld", wp.vec2)
   qpos: array("nworld", "nq", float)
@@ -1963,6 +2009,23 @@ class Data:
   contact: Contact
   efc: Constraint
   tree_island: array("nworld", "ntree", int)
+  dof_island: array("nworld", "nv", int)
+  island_dofadr: array("nworld", "ntree", int)
+  island_nv: array("nworld", "ntree", int)
+  island_nefc: array("nworld", "ntree", int)
+  island_ne: array("nworld", "ntree", int)
+  island_nf: array("nworld", "ntree", int)
+  island_efcadr: array("nworld", "ntree", int)
+  map_dof2idof: array("nworld", "nv", int)
+  map_idof2dof: array("nworld", "nv", int)
+  map_efc2iefc: array("nworld", "njmax", int)
+  map_iefc2efc: array("nworld", "njmax", int)
+  dof_islandid: array("nworld", "nv", int)
+  efc_islandid: array("nworld", "njmax", int)
+  iqacc: wp.array2d[float]
+  iqacc_smooth: wp.array2d[float]
+  iqfrc_smooth: wp.array2d[float]
+  iqfrc_constraint: wp.array2d[float]
 
   # warp only fields:
   nworld: int
@@ -1973,6 +2036,77 @@ class Data:
   njmax_nnz: int
   nacon: array(1, int)
   ncollision: array(1, int)
+
+
+@dataclasses.dataclass
+class InverseContext:
+  """Workspace arrays for inverse dynamics."""
+
+  Jaref: wp.array2d[float]
+  search_dot: wp.array[float]
+  gauss: wp.array[float]
+  cost: wp.array[float]
+  prev_cost: wp.array[float]
+  done: wp.array[bool]
+  changed_efc_ids: wp.array2d[int]
+  changed_efc_count: wp.array[int]
+
+
+@dataclasses.dataclass
+class IslandSolverContext:
+  """Workspace arrays for island constraint solver."""
+
+  # Re-ordered workspace arrays (sized per-dof / per-constraint)
+  Jaref: wp.array2d[float]
+  jv: wp.array2d[float]
+  search: wp.array2d[float]
+  mv: wp.array2d[float]
+  grad: wp.array2d[float]
+  Mgrad: wp.array2d[float]
+  prev_grad: wp.array2d[float]
+  prev_Mgrad: wp.array2d[float]
+  h: wp.array3d[float]
+
+  # Per-island solver scalars (nworld, ntree)
+  cost: wp.array2d[float]
+  prev_cost: wp.array2d[float]
+  gauss: wp.array2d[float]
+  search_dot: wp.array2d[float]
+  grad_dot: wp.array2d[float]
+  done: wp.array2d[bool]  # per-island convergence
+  solver_niter: wp.array2d[int]  # iterations per island
+  beta: wp.array2d[float]
+  alpha: wp.array2d[float]
+  Ma: wp.array2d[float]  # island-local Ma (nworld, nv)
+
+
+@dataclasses.dataclass
+class SolverContext:
+  """Workspace arrays for constraint solver."""
+
+  Jaref: wp.array2d[float]
+  search_dot: wp.array[float]
+  gauss: wp.array[float]
+  cost: wp.array[float]
+  prev_cost: wp.array[float]
+  done: wp.array[bool]
+  grad: wp.array2d[float]
+  grad_dot: wp.array[float]
+  Mgrad: wp.array2d[float]
+  search: wp.array2d[float]
+  mv: wp.array2d[float]
+  jv: wp.array2d[float]
+  quad: wp.array2d[wp.vec3]
+  quad_gauss: wp.array[wp.vec3]
+  alpha: wp.array[float]
+  prev_grad: wp.array2d[float]
+  prev_Mgrad: wp.array2d[float]
+  beta: wp.array[float]
+  h: wp.array3d[float]
+  hfactor: wp.array3d[float]
+  # Incremental Hessian update (Newton only)
+  changed_efc_ids: wp.array2d[int]
+  changed_efc_count: wp.array[int]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
add island solver
- jacobian: dense, sparse
- solver: newton, cg

additionally, fixes a bug with island discovery where the adjacency matrix `tree_tree` was not properly constructed

---

**humanoid: monolithic, newton, dense**

```
mjwarp-testspeed benchmarks/humanoid/humanoid.xml --nworld=8192 --nconmax=24 --njmax=64 -o "opt.use_islands=False" -o "opt.solver="newton"" -o "opt.jacobian="dense"" --event_trace --memory --info --measure_alloc --measure_solver
```

```

Summary for 8192 parallel rollouts

Total JIT time: 0.37 s
Total simulation time: 1.99 s
Total steps per second: 4,107,666
Total realtime factor: 20,538.33 x
Total time per step: 243.45 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 241.46
  
    solve: 122.45
      mul_m: 5.97
    sensor_acc: 3.18

nacon alloc:

mean    std      min     max   
-------------------------------
125330  42559.5   49152  188823
184071    12864  151170  193299
190897  1166.86  189094  192776
191825  703.674  189959  192596
190507  688.169  189219  191474
189070  288.936  188687  189631
189313  184.752  188949  189676
188363  218.536  188108  188994
188766   495.19  188152  189892
191547  934.322  189962  193035

nefc alloc:

mean   std       min  max
-------------------------
36.32   12.1679   11   49
 48.7   1.23693   47   51
51.65   1.26787   50   55
   55         0   55   55
   55         0   55   55
   55         0   55   55
   55         0   55   55
55.31  0.462493   55   56
55.86  0.632772   55   57
56.41  0.491833   56   57

solver niter:

mean     std       min  max
---------------------------
 1.9597  0.991898    1    8
1.81859  0.863628    1    7
1.27772  0.552244    1    8
1.27851   0.61241    1    8
1.34154  0.623869    1    8
1.32148  0.576217    1    7
1.38368  0.641771    1    8
1.39315  0.645936    1    8
1.35529  0.615481    1    8
1.35027  0.610405    1    8

Model memory 0.03 MiB (0.01% of used memory):
 (no field >= 1% of used memory)
Data memory 247.91 MiB (67.37% of used memory):

Other memory: 120.06 MiB (32.62% of used memory)
Total memory: 368.00 MiB (0.76% of total device memory)
```

**humanoid: island, newton, dense**

```
mjwarp-testspeed benchmarks/humanoid/humanoid.xml --nworld=8192 --nconmax=24 --njmax=64 -o "opt.use_islands=True" -o "opt.solver="newton"" -o "opt.jacobian="dense"" --event_trace --memory --info --measure_alloc --measure_solver
```

```
Summary for 8192 parallel rollouts

Total JIT time: 0.29 s
Total simulation time: 6.85 s
Total steps per second: 1,195,074
Total realtime factor: 5,975.37 x
Total time per step: 836.77 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 834.76

      island: 3.88
        tree_edges: 2.42
        flood_fill: 0.66
    
    solve: 711.57
      compute_island_mapping: 9.28
      gather_island_inputs: 34.33
      _solve_islands: 664.56
        mul_m_island: 8.40
        _update_constraint_island: 6.85
        _update_gradient_island_newton: 159.25
      scatter_island_results: 2.08

nacon alloc:

mean    std      min     max   
-------------------------------
125330  42559.6   49152  188823
184071  12863.9  151171  193289
190897  1165.86  189112  192771
191837  706.376  189961  192618
190522  690.813  189255  191488
189088  292.398  188699  189657
189348  178.284  188998  189702
188391  227.155  188125  189025
188766   483.26  188171  189902
191529  938.436  189930  193036

nefc alloc:

mean   std       min  max
-------------------------
36.32   12.1679   11   49
 48.7   1.23693   47   51
51.65   1.26787   50   55
   55         0   55   55
55.03  0.298496   55   58
   55         0   55   55
   55         0   55   55
55.62  0.596322   55   57
55.79  0.604897   55   57
56.34  0.751266   56   58

solver niter:

mean        std       min  max
------------------------------
 0.0260046  0.291834    0    8
0.00376831  0.138823    0    7
0.00198242  0.104657    0    8
 0.0025061  0.122892    0    8
0.00230591  0.113185    0    8
0.00231934  0.110295    0    7
0.00319702  0.129615    0    8
0.00237427  0.113947    0    9
0.00185547  0.105415    0    9
0.00218384  0.112463    0    9

Model memory 0.03 MiB (0.01% of used memory):
 (no field >= 1% of used memory)
Data memory 247.91 MiB (57.65% of used memory):

Other memory: 182.06 MiB (42.34% of used memory)
Total memory: 430.00 MiB (0.88% of total device memory)
```

**three_humanoids: monolithic, newton, sparse**

```
mjwarp-testspeed benchmarks/humanoid/three_humanoids.xml --nworld=8192 --nconmax=100 --njmax=192 -o "opt.use_islands=False" -o "opt.solver="newton"" -o "opt.jacobian="sparse"" --event_trace --memory --info --measure_alloc --measure_solver
```

```
Summary for 8192 parallel rollouts

Total JIT time: 10.86 s
Total simulation time: 11.71 s
Total steps per second: 699,736
Total realtime factor: 3,498.68 x
Total time per step: 1429.11 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 1426.72

    solve: 1014.63
      mul_m: 6.75

nacon alloc:

mean    std      min     max   
-------------------------------
224216  59100.8  150536  331934
288903  31706.9  230056  330433
377805  29018.2  330938  416367
436762  10552.4  416516  458325
484967  14660.3  458858  508841
526886  8554.28  509286  538758
544362  2906.76  538925  548691
552115  2043.23  548664  555391
558604  1947.16  555447  562082
565599  1798.22  562115  568480

nefc alloc:

mean    std       min  max
--------------------------
104.39   14.3833   78  126
 120.1   3.02159  115  132
145.11   13.4855  130  171
175.76    1.3647  168  176
175.98  0.198997  174  176
175.74   0.54074  174  176
175.87  0.559553  175  177
176.83  0.375633  176  177
176.07  0.815537  173  177
175.04   1.78841  169  177

solver niter:

mean     std       min  max
---------------------------
2.61624   1.16035    1   10
2.78211    1.0825    1   10
3.31995   1.10896    1   12
3.38718   1.14931    1   11
 3.1064   1.17156    1   10
2.96407   1.18365    1   10
 2.6378   1.07454    1   10
2.43273   1.00831    1    9
2.31909  0.965218    1    9
2.28188  0.946758    1   10

Model memory 0.15 MiB (0.01% of used memory):
 (no field >= 1% of used memory)
Data memory 886.13 MiB (55.38% of used memory):

Other memory: 713.72 MiB (44.61% of used memory)
Total memory: 1600.00 MiB (3.29% of total device memory)
```

**three humanoids: island, newton, sparse**

```
mjwarp-testspeed benchmarks/humanoid/three_humanoids.xml --nworld=8192 --nconmax=100 --njmax=192 -o "opt.use_islands=True" -o "opt.solver="newton"" -o "opt.jacobian="sparse"" --event_trace --memory --info --measure_alloc --measure_solver
```

```
Summary for 8192 parallel rollouts

Total JIT time: 0.28 s
Total simulation time: 26.98 s
Total steps per second: 303,619
Total realtime factor: 1,518.09 x
Total time per step: 3293.60 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 3290.98
 
      island: 5.08
        tree_edges: 3.43
        flood_fill: 0.85
      transmission: 4.84
    
    solve: 2878.30
      compute_island_mapping: 28.13
      gather_island_inputs: 57.49
      _solve_islands: 2785.06
        mul_m_island: 8.56
        _update_constraint_island: 34.67
        _update_gradient_island_newton: 530.51
      scatter_island_results: 6.10

nacon alloc:

mean    std      min     max   
-------------------------------
224217  59100.9  150535  331936
288904  31709.5  230058  330465
377806  29025.7  330944  416372
436713  10558.6  416531  458334
485029  14697.6  458819  509005
526952  8575.69  509425  538741
544390  2922.58  538876  548758
552263  2008.89  548850  555522
558674  1896.63  555596  562175
565614  1783.01  562196  568487

nefc alloc:

mean    std       min  max
--------------------------
104.38    14.372   78  126
 120.1   3.02159  115  132
145.15   13.5058  130  171
175.72   1.41478  168  176
175.98  0.198997  174  176
175.84  0.463033  174  176
175.85   0.68374  172  177
176.83  0.375633  176  177
176.14  0.693109  173  177
175.02   1.84922  169  177

solver niter:

mean        std       min  max
------------------------------
0.00486572  0.164696    0    9
0.00425171  0.172917    0   10
0.00282959  0.154298    0   11
0.00293213  0.155729    0   11
0.00326416  0.161586    0   11
0.00332397  0.163264    0   10
0.00326904  0.155707    0    9
 0.0025415  0.132411    0    9
0.00355957  0.151931    0    9
0.00260254  0.131827    0    9

Model memory 0.15 MiB (0.01% of used memory):
 (no field >= 1% of used memory)
Data memory 886.13 MiB (52.81% of used memory):

Other memory: 791.72 MiB (47.18% of used memory)
Total memory: 1678.00 MiB (3.45% of total device memory)
```

**three humanoids: monolithic, cg, sparse**

```
mjwarp-testspeed benchmarks/humanoid/three_humanoids.xml --nworld=8192 --nconmax=100 --njmax=192 -o "opt.use_islands=False" -o "opt.solver="cg"" -o "opt.jacobian="sparse"" --event_trace --memory --info --measure_alloc --measure_solver
```

```
Summary for 8192 parallel rollouts

Total JIT time: 0.33 s
Total simulation time: 33.74 s
Total steps per second: 242,806
Total realtime factor: 1,214.03 x
Total time per step: 4118.51 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 4115.81
  
    solve: 3687.33
      mul_m: 6.94
      solve_m: 15.27

nacon alloc:

mean    std      min     max   
-------------------------------
224217  59101.7  150512  331930
288882  31718.9  230056  330323
377776  28998.7  330903  416225
436806  10619.1  416174  458339
484965  14652.1  458917  508970
526865  8572.93  509354  538756
544557  2922.69  538917  548920
552382  2029.46  548924  555606
558565  1879.09  555643  562005
565493  1817.36  562007  568497

nefc alloc:

mean    std       min  max
--------------------------
104.38    14.372   78  126
120.07   3.10243  114  133
145.06   13.8281  131  177
175.84      1.12  168  176
175.96      0.28  174  176
175.72  0.735935  174  178
175.84  0.703136  174  177
 176.7  0.458258  176  177
175.81   0.85668  172  177
175.15   1.82414  171  177

solver niter:

mean     std      min  max
--------------------------
27.5409  10.0002   10  100
 28.498  9.08936   11  100
29.4747   6.8135   11  100
29.6585  7.92503   11  100
27.8478  9.50745    9  100
25.5289  9.20017    9  100
21.9026  6.38348    9  100
20.1549  5.39458    9  100
 19.209  4.89946    8   89
18.8773  4.70942    8   90

Model memory 0.15 MiB (0.01% of used memory):
 (no field >= 1% of used memory)
Data memory 886.13 MiB (80.41% of used memory):

Other memory: 215.72 MiB (19.58% of used memory)
Total memory: 1102.00 MiB (2.27% of total device memory)
```

**three humanoids: island, cg, sparse**

```
mjwarp-testspeed benchmarks/humanoid/three_humanoids.xml --nworld=8192 --nconmax=100 --njmax=192 -o "opt.use_islands=True" -o "opt.solver="cg"" -o "opt.jacobian="sparse"" --event_trace --memory --info --measure_alloc --measure_solver
```

```
Summary for 8192 parallel rollouts

Total JIT time: 0.29 s
Total simulation time: 47.24 s
Total steps per second: 173,406
Total realtime factor: 867.03 x
Total time per step: 5766.81 ns
Total converged worlds: 8192 / 8192

Event trace:

step: 5763.58
  
      island: 5.23
        tree_edges: 3.53
        flood_fill: 0.88
      transmission: 5.48
  
    solve: 5339.11
      compute_island_mapping: 29.21
      gather_island_inputs: 58.13
      _solve_islands: 5246.01
        mul_m_island: 8.73
        _update_constraint_island: 35.15
        _update_gradient_island: 19.75
          solve_m_island: 16.78
            solve_m: 14.50
      scatter_island_results: 4.20

nacon alloc:

mean    std      min     max   
-------------------------------
224211  59095.7  150512  331915
288909  31710.1  230070  330434
377803  29019.5  330932  416423
436818  10637.2  416465  458623
484883  14598.4  459070  508660
526722   8530.3  509045  538608
544214  2895.52  538823  548552
552003  2021.19  548496  555328
558471  1939.71  555388  562051
565668  1776.79  562198  568506

nefc alloc:

mean    std       min  max
--------------------------
104.39   14.3833   78  126
120.03   3.04123  115  132
144.92   13.1967  131  170
175.72   1.41478  168  176
175.96      0.28  174  176
175.64  0.574804  174  176
175.84  0.595315  175  177
176.82  0.384187  176  177
175.86   0.76184  172  178
174.98   1.68511  172  177

solver niter:

mean        std       min  max
------------------------------
 0.0083606  0.679955    0   99
 0.0097876  0.829331    0  100
0.00935303  0.817928    0  100
 0.0113013  0.965254    0  100
  0.013302   1.10927    0  100
  0.016488   1.25677    0  100
0.00970459  0.872545    0  100
0.00866699  0.756244    0  100
 0.0072522   0.64194    0  100
0.00717285  0.632332    0  100

Model memory 0.15 MiB (0.01% of used memory):
 (no field >= 1% of used memory)
Data memory 886.13 MiB (57.17% of used memory):

Other memory: 663.72 MiB (42.82% of used memory)
Total memory: 1550.00 MiB (3.19% of total device memory)
```

**mujoco/model/humanoid/22humanoids.xml: monolithic, newton, sparse**

```
mjwarp-testspeed ../mujoco/model/humanoid/22_humanoids.xml --nworld=4096 --nconmax=1000 --njmax=4000 --nstep=100 -o "opt.use_islands=False" -o "opt.solver="newton"" -o "opt.jacobian="sparse"" --event_trace --memory --info --measure_alloc --measure_solver
```

```
Summary for 4096 parallel rollouts

Total JIT time: 10.52 s
Total simulation time: 53.80 s
Total steps per second: 7,614
Total realtime factor: 38.07 x
Total time per step: 131344.97 ns
Total converged worlds: 4096 / 4096

Event trace:

step: 131266.59
 
    solve: 127252.48
      mul_m: 54.63

nacon alloc:

mean    std      min     max   
-------------------------------
711248  18989.1  655360  720896
706247  5654.76  696549  712704
703544  8848.23  696059  719440
702937  2632.66  701227  710060
700257  749.916  699387  701810
706327  2852.91  701757  709159
704144  3620.84  696059  708303
723380  52129.3  684685  841684
929273  16399.2  889214  945130
812146  66219.7  698727  903521

nefc alloc:

mean   std      min  max
------------------------
695.2  18.7446  640  704
695.5  1.56525  692  698
705.7  11.6795  692  725
710.4  2.87054  707  717
719.3  5.25452  712  728
  739  5.31037  728  745
746.5  4.29535  740  752
749.5  3.10644  747  758
807.3  15.7991  771  824
785.9  6.39453  778  802

solver niter:

mean     std       min  max
---------------------------
1.78958  0.752719    1    5
1.75471  0.716038    1    6
3.00054  0.865771    1    7
2.46475  0.808027    1    7
3.43237   1.00803    1    8
3.58306  0.951092    1    8
3.33528   1.02608    1    9
3.98877   1.12086    1   10
4.93096   1.30705    2   13
4.38918   1.15871    2   12

Model memory 4.57 MiB (0.02% of used memory):
 (no field >= 1% of used memory)
Data memory 6381.59 MiB (34.50% of used memory):

Other memory: 12109.83 MiB (65.47% of used memory)
Total memory: 18496.00 MiB (38.03% of total device memory)
```

**mujoco/model/humanoid/22humanoids.xml: island, newton, sparse**

```
mjwarp-testspeed ../mujoco/model/humanoid/22_humanoids.xml --nworld=4096 --nconmax=1000 --njmax=4000 --nstep=100 -o "opt.use_islands=True" -o "opt.solver="newton"" -o "opt.jacobian="sparse"" --event_trace --memory --info --measure_alloc --measure_solver
```

```
Summary for 4096 parallel rollouts

Total JIT time: 0.28 s
Total simulation time: 14.68 s
Total steps per second: 27,905
Total realtime factor: 139.52 x
Total time per step: 35836.30 ns
Total converged worlds: 4096 / 4096

Event trace:

step: 35772.01
 
      island: 47.53
        tree_edges: 26.21
        flood_fill: 19.21
      transmission: 105.94
  
    solve: 31673.63
      compute_island_mapping: 327.25
      gather_island_inputs: 505.67
      _solve_islands: 30792.58
        mul_m_island: 81.59
        _update_constraint_island: 308.61
        _update_gradient_island_newton: 7285.73
      scatter_island_results: 43.99

nacon alloc:

mean    std      min     max   
-------------------------------
711248  18989.1  655360  720896
706247  5654.45  696549  712704
703543  8848.42  696059  719440
702938  2631.69  701237  710059
700260  754.304  699373  701824
706332  2852.75  701764  709191
704143  3620.04  696085  708282
723386  52124.1  684743  841685
929272  16396.7  889218  945129
812140  66219.4  698725  903517

nefc alloc:

mean   std      min  max
------------------------
695.2  18.7446  640  704
695.5  1.56525  692  698
705.7  11.6795  692  725
710.4  2.87054  707  717
719.3  5.25452  712  728
  739  5.31037  728  745
746.5  4.29535  740  752
749.5  3.10644  747  758
807.7     14.9  775  824
785.9  6.39453  778  802

solver niter:

mean        std       min  max
------------------------------
 0.0313477  0.354097    0    5
0.00649414  0.167725    0    5
0.00952148   0.23135    0    8
0.00568848   0.17425    0    7
0.00717773    0.2074    0    6
 0.0119141  0.269647    0    7
0.00888672  0.234415    0    7
 0.0154785  0.314454    0    8
 0.0114014  0.296203    0    9
0.00786133  0.246036    0    9

Model memory 4.57 MiB (0.03% of used memory):
 (no field >= 1% of used memory)
Data memory 6381.59 MiB (37.88% of used memory):

Other memory: 10459.83 MiB (62.09% of used memory)
Total memory: 16846.00 MiB (34.63% of total device memory)
```

**mujoco/model/humanoid/22humanoids.xml: monolithic, cg, sparse**

```
mjwarp-testspeed ../mujoco/model/humanoid/22_humanoids.xml --nworld=4096 --nconmax=1000 --njmax=4000 --nstep=100 -o "opt.use_islands=False" -o "opt.solver="cg"" -o "opt.jacobian="sparse"" --event_trace --memory --info --measure_alloc --measure_solver
```

```
Summary for 4096 parallel rollouts

Total JIT time: 0.33 s
Total simulation time: 34.06 s
Total steps per second: 12,025
Total realtime factor: 60.13 x
Total time per step: 83157.11 ns
Total converged worlds: 4096 / 4096

Event trace:

step: 83131.55
  
    solve: 78942.95
      mul_m: 55.65
      solve_m: 143.38

nacon alloc:

mean    std      min     max   
-------------------------------
711246  18988.9  655360  720896
706233   5654.1  696546  712704
703546  8851.73  696059  719444
702935  2634.98  701203  710061
700263  750.976  699378  701807
706384  2879.24  701762  709328
704160   3597.8  696117  708285
723624  52396.3  684669  842352
929384  16242.5  889907  945167
811813    66394  698012  903398

nefc alloc:

mean   std      min  max
------------------------
695.2  18.7446  640  704
695.5  1.56525  692  698
705.7  11.6795  692  725
710.4  2.87054  707  717
719.4   5.2192  712  728
738.4  4.88262  728  745
746.5  4.29535  740  752
749.6  3.44093  746  759
807.6  15.6346  771  823
785.9  6.39453  778  802

solver niter:

mean     std      min  max
--------------------------
18.1097  4.81382   12   33
 18.736  5.88986   10   39
  27.64  4.47904   14   47
23.9244  3.99587   13   64
35.5156   10.787   13   88
31.9945  7.14788   17   87
30.5227  5.96464   16   59
39.2051  8.93398   17   74
64.0329  6.79207   39   90
57.0233  6.86902   25   81

Model memory 4.57 MiB (0.06% of used memory):
 (no field >= 1% of used memory)
Data memory 6381.59 MiB (89.65% of used memory):

Other memory: 731.83 MiB (10.28% of used memory)
Total memory: 7118.00 MiB (14.63% of total device memory)
```

**mujoco/model/humanoid/22humanoids.xml: island, cg, sparse**

```
mjwarp-testspeed ../mujoco/model/humanoid/22_humanoids.xml --nworld=4096 --nconmax=1000 --njmax=4000 --nstep=100 -o "opt.use_islands=True" -o "opt.solver="cg"" -o "opt.jacobian="sparse"" --event_trace --memory --info --measure_alloc --measure_solver
```

```
Summary for 4096 parallel rollouts

Total JIT time: 0.28 s
Total simulation time: 15.59 s
Total steps per second: 26,279
Total realtime factor: 131.39 x
Total time per step: 38053.35 ns
Total converged worlds: 4096 / 4096

Event trace:

step: 38010.27

      island: 50.80
        tree_edges: 27.72
        flood_fill: 20.85
      transmission: 114.01
   
    solve: 33755.45
      compute_island_mapping: 343.38
      gather_island_inputs: 510.59
      _solve_islands: 32857.43
        mul_m_island: 83.20
        _update_constraint_island: 316.31
        _update_gradient_island: 171.70
          solve_m_island: 155.55
            solve_m: 144.50
      scatter_island_results: 39.68

nacon alloc:

mean    std      min     max   
-------------------------------
711246  18988.8  655360  720896
706240  5654.66  696547  712704
703548  8853.29  696058  719440
702935  2631.29  701209  710060
700264  744.981  699382  701798
706346  2862.43  701767  709176
704148  3605.46  696116  708294
723398  52154.6  684666  841734
929282  16377.2  889299  945133
812101  66248.8  698645  903521

nefc alloc:

mean   std      min  max
------------------------
695.2  18.7446  640  704
695.5  1.56525  692  698
705.7  11.6795  692  725
710.4  2.87054  707  717
719.3  5.25452  712  728
739.4  4.90306  728  745
746.6  4.15211  741  752
749.7  3.34813  747  759
807.5  15.3704  775  824
785.5  6.91737  778  802

solver niter:

mean        std       min  max
------------------------------
0.00898437  0.428897    0   32
 0.0114258  0.592817    0   43
 0.0178223  0.816561    0   51
 0.0133057  0.836102    0   89
  0.019458   1.25304    0  100
 0.0177002   1.05081    0   75
 0.0158447   0.86123    0   57
 0.0179932   1.05533    0   75
 0.0167969   1.07978    0   82
 0.0204346   1.25942    0  100

Model memory 4.57 MiB (0.04% of used memory):
 (no field >= 1% of used memory)
Data memory 6381.59 MiB (54.87% of used memory):

Other memory: 5243.83 MiB (45.09% of used memory)
Total memory: 11630.00 MiB (23.91% of total device memory)
```

---

summary: monolithic v island

humanoid newton dense: 4,107,666 v 1,195,074

three humanoid newton sparse 699,736 v 303,619
three humanoid cg sparse 242,806 v 173,406

22 humanoids newton sparse 7,614 v 27,905
22 humanoids cg sparse 12,025 v 26,279

---

```
mjwarp-viewer ../mujoco/model/humanoid/22_humanoids.xml --nconmax=1000 --njmax=4000 -o "opt.use_islands=True"
```

https://github.com/user-attachments/assets/2e2cd5de-a005-4a49-96e0-41298f1df2a5

results are with an `NVIDIA A6000 (Ada)` gpu