### PR TITLE
Optimize blocked Cholesky: inplace factor and view-based backward sub

### DIFF
--- a/mujoco_warp/_src/block_cholesky.py
+++ b/mujoco_warp/_src/block_cholesky.py
@@ -45,8 +45,8 @@ def create_blocked_cholesky_func(block_size: int):
         wp.tile_matmul(L_block, wp.tile_transpose(L_block), A_kk_tile, alpha=-1.0)
 
       # Compute the Cholesky factorization for the block
-      L_kk_tile = wp.tile_cholesky(A_kk_tile)
-      wp.tile_store(L, L_kk_tile, offset=(k, k))
+      wp.tile_cholesky_inplace(A_kk_tile)
+      wp.tile_store(L, A_kk_tile, offset=(k, k))
 
       # Process the blocks below the current block
       for i in range(end, matrix_size, block_size):
@@ -57,7 +57,7 @@ def create_blocked_cholesky_func(block_size: int):
           L_2_tile = wp.tile_load(L, shape=(block_size, block_size), offset=(k, j), storage="shared")
           wp.tile_matmul(L_tile, wp.tile_transpose(L_2_tile), A_ik_tile, alpha=-1.0)
 
-        wp.tile_lower_solve_inplace(L_kk_tile, wp.tile_transpose(A_ik_tile))
+        wp.tile_lower_solve_inplace(A_kk_tile, wp.tile_transpose(A_ik_tile))
         wp.tile_store(L, A_ik_tile, offset=(i, k))
 
   return blocked_cholesky_func
@@ -98,11 +98,12 @@ def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int)
       tmp_tile = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(i, 0))
       for j in range(i_end, matrix_size, block_size):
         L_tile = wp.tile_load(L, shape=(block_size, block_size), offset=(j, i), storage="shared")
-        x_tile = wp.tile_load(x, shape=(block_size, 1), offset=(j, 0), storage="shared", bounds_check=False)
+        x_tile = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(j, 0))
         wp.tile_matmul(wp.tile_transpose(L_tile), x_tile, tmp_tile, alpha=-1.0)
       L_tile = wp.tile_load(L, shape=(block_size, block_size), offset=(i, i), storage="shared")
 
       wp.tile_upper_solve_inplace(wp.tile_transpose(L_tile), tmp_tile)
-      wp.tile_store(x, tmp_tile, offset=(i, 0), bounds_check=False)
+
+    wp.tile_store(x, rhs_tile, offset=(0, 0), bounds_check=False)
 
   return blocked_cholesky_solve_func


### PR DESCRIPTION
## Summary

Two small changes to `mujoco_warp/_src/block_cholesky.py` that speed up the blocked Cholesky kernels without altering their contract:

1. **`tile_cholesky_inplace` on the diagonal block.** The inplace variant zeros the strict upper triangle per Warp's contract, so storing `A_kk_tile` as `L[k:end, k:end]` is correct. Later `tile_lower_solve_inplace` calls read only the lower triangle. Halves shared memory for the factor step (no separate `L_kk_tile`).

2. **Read `x_j` via `tile_view(rhs_tile, …)` in backward substitution.** Forward substitution already did this for `y_j`; backward substitution was re-loading `x_j` from global memory even though it's resident in the `rhs_tile` shared-memory buffer. The per-iteration `tile_store` is hoisted to a single coalesced final store. Eliminates O((N/bs)²) global loads plus one store per block iteration.

## Benchmarks

`mjwarp-testspeed benchmarks/humanoid/three_humanoids.xml --nworld=8192 --nconmax=100 --njmax=192 --nstep=500` on RTX PRO 6000 Blackwell, kernel times from `nsys profile --cuda-graph-trace=node`:

| Kernel | Invocations | Main median | Branch median | Δmed | Main avg | Branch avg | Δavg |
|---|---:|---:|---:|---:|---:|---:|---:|
| `update_gradient_cholesky_blocked` (factor+solve) | 500 | 703 µs | 703 µs | 0% | 801 µs | 711 µs | **−11.3%** |
| `update_gradient_cholesky_blocked_skip_unchanged` (solve-mostly) | ~3930 | 153 µs | 148 µs | **−3.1%** | 287 µs | 281 µs | −2.0% |

Combined cholesky kernel time: 1527 → 1464 ms (**−4.1%**).

Tail-latency drop on the factor+solve path is notable: stddev 276 → 70 µs, max 2236 → 1809 µs — likely the extra `L_kk_tile` allocation was pushing occupancy down on some launches.

## Correctness

- `uv run pytest mujoco_warp/_src/support_test.py -k test_block_cholesky` — passes.
- `uv run pytest mujoco_warp/_src/solver_test.py` — all 40 cases pass.

## Test plan

- [ ] CI passes.