### PR TITLE
midpoint integrator

### DIFF
--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -257,6 +257,249 @@ def _next_time(
       wp.printf("narrowphase overflow - please increase nconmax to %u or naconmax to %u\n", nconmax, nacon_in[0])
 
 
+@wp.kernel
+def _midpoint(
+  # Model:
+  opt_timestep: wp.array[float],
+  body_ipos: wp.array2d[wp.vec3],
+  body_iquat: wp.array2d[wp.quat],
+  body_mass: wp.array2d[float],
+  body_inertia: wp.array2d[wp.vec3],
+  jnt_dofadr: wp.array[int],
+  jnt_bodyid: wp.array[int],
+  jnt_midpoint: wp.array[int],
+  # Data in:
+  qvel_in: wp.array2d[float],
+  xquat_in: wp.array2d[wp.quat],
+  qfrc_bias_in: wp.array2d[float],
+  qfrc_smooth_in: wp.array2d[float],
+  qfrc_constraint_in: wp.array2d[float],
+  # In:
+  gravity: wp.array[wp.vec3],
+  disableflags: int,
+  # Out:
+  qvel_new_out: wp.array3d[float],
+  qvel_mid_out: wp.array2d[float],
+):
+  worldid, idx = wp.tid()
+  jntid = jnt_midpoint[idx]
+
+  timestep = opt_timestep[worldid % opt_timestep.shape[0]]
+  bodyid = jnt_bodyid[jntid]
+  dofadr = jnt_dofadr[jntid]
+
+  mass = body_mass[worldid % body_mass.shape[0], bodyid]
+  inertia = body_inertia[worldid % body_inertia.shape[0], bodyid]
+  ipos = body_ipos[worldid % body_ipos.shape[0], bodyid]
+  iquat = body_iquat[worldid % body_iquat.shape[0], bodyid]
+  xquat_body = xquat_in[worldid, bodyid]
+
+  qvel_old = wp.spatial_vector(
+    qvel_in[worldid, dofadr],
+    qvel_in[worldid, dofadr + 1],
+    qvel_in[worldid, dofadr + 2],
+    qvel_in[worldid, dofadr + 3],
+    qvel_in[worldid, dofadr + 4],
+    qvel_in[worldid, dofadr + 5],
+  )
+
+  qfrc_total = wp.spatial_vector(
+    qfrc_smooth_in[worldid, dofadr] + qfrc_constraint_in[worldid, dofadr] + qfrc_bias_in[worldid, dofadr],
+    qfrc_smooth_in[worldid, dofadr + 1] + qfrc_constraint_in[worldid, dofadr + 1] + qfrc_bias_in[worldid, dofadr + 1],
+    qfrc_smooth_in[worldid, dofadr + 2] + qfrc_constraint_in[worldid, dofadr + 2] + qfrc_bias_in[worldid, dofadr + 2],
+    qfrc_smooth_in[worldid, dofadr + 3] + qfrc_constraint_in[worldid, dofadr + 3] + qfrc_bias_in[worldid, dofadr + 3],
+    qfrc_smooth_in[worldid, dofadr + 4] + qfrc_constraint_in[worldid, dofadr + 4] + qfrc_bias_in[worldid, dofadr + 4],
+    qfrc_smooth_in[worldid, dofadr + 5] + qfrc_constraint_in[worldid, dofadr + 5] + qfrc_bias_in[worldid, dofadr + 5],
+  )
+
+  if not (disableflags & DisableBit.GRAVITY):
+    g = gravity[worldid % gravity.shape[0]]
+  else:
+    g = wp.vec3(0.0, 0.0, 0.0)
+
+  # transform angular velocity and torque to inertial frame
+  iquat_neg = math.quat_inv(iquat)
+
+  v = wp.vec3(qvel_old[0], qvel_old[1], qvel_old[2])
+  w = wp.vec3(qvel_old[3], qvel_old[4], qvel_old[5])
+
+  force = wp.vec3(qfrc_total[0], qfrc_total[1], qfrc_total[2])
+  tau = wp.vec3(qfrc_total[3], qfrc_total[4], qfrc_total[5])
+
+  w_inertial = math.rot_vec_quat(w, iquat_neg)
+  tau_inertial = math.rot_vec_quat(tau, iquat_neg)
+
+  aligned = ipos[0] == 0.0 and ipos[1] == 0.0 and ipos[2] == 0.0
+
+  r_com = wp.vec3(0.0)
+  tau_com = tau_inertial
+  rot_x2i = wp.quat(1.0, 0.0, 0.0, 0.0)
+  force_inertial = wp.vec3(0.0)
+
+  if not aligned:
+    xquat_neg = math.quat_inv(xquat_body)
+    rot_x2i = math.mul_quat(iquat_neg, xquat_neg)
+    force_inertial = math.rot_vec_quat(force, rot_x2i)
+    r_com = math.rot_vec_quat(ipos, iquat_neg)
+    tau_com = tau_inertial - wp.cross(r_com, force_inertial)
+
+  # solve for midpoint angular velocity
+  i2h = 2.0 / timestep
+  dI = wp.vec3(inertia[2] - inertia[1], inertia[0] - inertia[2], inertia[1] - inertia[0])
+  i2h_I = wp.vec3(i2h * inertia[0], i2h * inertia[1], i2h * inertia[2])
+
+  w_mid = w_inertial
+  tol = 1e-6
+
+  converged = bool(False)
+  for niter in range(10):
+    Iw = wp.vec3(inertia[0] * w_mid[0], inertia[1] * w_mid[1], inertia[2] * w_mid[2])
+    coriolis = wp.cross(w_mid, Iw)
+
+    f = wp.vec3(
+      i2h_I[0] * (w_mid[0] - w_inertial[0]) + coriolis[0] - tau_com[0],
+      i2h_I[1] * (w_mid[1] - w_inertial[1]) + coriolis[1] - tau_com[1],
+      i2h_I[2] * (w_mid[2] - w_inertial[2]) + coriolis[2] - tau_com[2],
+    )
+
+    fnorm = wp.length(f)
+    if fnorm < tol * (1.0 + i2h * wp.length(Iw)):
+      converged = True
+      break
+
+    J = wp.mat33(
+      i2h_I[0],
+      w_mid[2] * dI[0],
+      w_mid[1] * dI[0],
+      w_mid[2] * dI[1],
+      i2h_I[1],
+      w_mid[0] * dI[1],
+      w_mid[1] * dI[2],
+      w_mid[0] * dI[2],
+      i2h_I[2],
+    )
+
+    neg_f = -f
+    delta = math.solve3(J, neg_f)
+
+    step = float(1.0)
+    for ls in range(5):
+      w_try = w_mid + step * delta
+      Iw_try = wp.vec3(inertia[0] * w_try[0], inertia[1] * w_try[1], inertia[2] * w_try[2])
+      coriolis_try = wp.cross(w_try, Iw_try)
+
+      f_try = wp.vec3(
+        i2h_I[0] * (w_try[0] - w_inertial[0]) + coriolis_try[0] - tau_com[0],
+        i2h_I[1] * (w_try[1] - w_inertial[1]) + coriolis_try[1] - tau_com[1],
+        i2h_I[2] * (w_try[2] - w_inertial[2]) + coriolis_try[2] - tau_com[2],
+      )
+
+      if wp.length(f_try) < fnorm:
+        w_mid = w_try
+        break
+
+      step = step * 0.5
+
+  if not converged:
+    wp.printf("midpoint Newton solver did not converge, jntid = %d, worldid = %d\n", jntid, worldid)
+
+  w_new = 2.0 * w_mid - w_inertial
+  w_new_body = math.rot_vec_quat(w_new, iquat)
+  w_mid_body = math.rot_vec_quat(w_mid, iquat)
+
+  # write angular DOFs to both qvel_new (3D) and qvel_mid (flat)
+  for k in range(3):
+    qvel_new_out[worldid, jntid, k + 3] = w_new_body[k]
+    qvel_mid_out[worldid, dofadr + k + 3] = w_mid_body[k]
+
+  if aligned:
+    qvel_new_out[worldid, jntid, 0] = v[0]
+    qvel_new_out[worldid, jntid, 1] = v[1]
+    qvel_new_out[worldid, jntid, 2] = v[2]
+  else:
+    # zero linear DOFs at midpoint for non-aligned bodies
+    qvel_mid_out[worldid, dofadr] = 0.0
+    qvel_mid_out[worldid, dofadr + 1] = 0.0
+    qvel_mid_out[worldid, dofadr + 2] = 0.0
+
+    v_inertial = math.rot_vec_quat(v, rot_x2i)
+    vcom = v_inertial + wp.cross(w_inertial, r_com)
+
+    b = force_inertial / mass + i2h * vcom
+    if not (disableflags & DisableBit.GRAVITY):
+      g_inertial = math.rot_vec_quat(g, rot_x2i)
+      b = b + g_inertial
+
+    wnorm2 = wp.dot(w_mid, w_mid)
+    denom = i2h * i2h + wnorm2
+    w_dot_b = wp.dot(w_mid, b)
+    w_cross_b = wp.cross(w_mid, b)
+
+    vcom_mid = (i2h * b + (w_dot_b / i2h) * w_mid - w_cross_b) / denom
+
+    v_mid = vcom_mid - wp.cross(w_mid, r_com)
+    v_new = 2.0 * v_mid - v_inertial
+
+    axis = w_mid_body
+    axis, wnorm = math.normalize_with_norm(axis)
+    qrot_new = math.axis_angle_to_quat(axis, timestep * wnorm)
+    xquat_new = math.mul_quat(xquat_body, qrot_new)
+
+    v_body = math.rot_vec_quat(v_new, iquat)
+    v_world = math.rot_vec_quat(v_body, xquat_new)
+
+    qvel_new_out[worldid, jntid, 0] = v_world[0]
+    qvel_new_out[worldid, jntid, 1] = v_world[1]
+    qvel_new_out[worldid, jntid, 2] = v_world[2]
+
+
+@wp.kernel
+def _prepare_qvel_mid_default(
+  # Model:
+  opt_timestep: wp.array[float],
+  # Data in:
+  qvel_in: wp.array2d[float],
+  qacc_in: wp.array2d[float],
+  # Out:
+  qvel_mid_out: wp.array2d[float],
+):
+  worldid, dofid = wp.tid()
+  timestep = opt_timestep[worldid % opt_timestep.shape[0]]
+  qvel_mid_out[worldid, dofid] = qvel_in[worldid, dofid] + timestep * qacc_in[worldid, dofid]
+
+
+@wp.kernel
+def _overwrite_midpoint_qvel_qacc(
+  # Model:
+  opt_timestep: wp.array[float],
+  body_ipos: wp.array2d[wp.vec3],
+  jnt_dofadr: wp.array[int],
+  jnt_bodyid: wp.array[int],
+  jnt_midpoint: wp.array[int],
+  # In:
+  qvel_old: wp.array2d[float],
+  qvel_new_from_solver: wp.array3d[float],
+  # Data out:
+  qvel_out: wp.array2d[float],
+  qacc_out: wp.array2d[float],
+):
+  worldid, idx = wp.tid()
+  jntid = jnt_midpoint[idx]
+
+  timestep = opt_timestep[worldid % opt_timestep.shape[0]]
+  dofadr = jnt_dofadr[jntid]
+
+  ipos = body_ipos[worldid % body_ipos.shape[0], jnt_bodyid[jntid]]
+  aligned = ipos[0] == 0.0 and ipos[1] == 0.0 and ipos[2] == 0.0
+
+  for dof_offset in range(6):
+    dofid = dofadr + dof_offset
+    if not (aligned and dof_offset < 3):
+      qvel_n = qvel_new_from_solver[worldid, jntid, dof_offset]
+      qvel_out[worldid, dofid] = qvel_n
+      qacc_out[worldid, dofid] = (qvel_n - qvel_old[worldid, dofid]) / timestep
+
+
 def _advance(m: Model, d: Data, qacc: wp.array, qvel: Optional[wp.array] = None):
   """Advance state and time given activation derivatives and acceleration."""
   # TODO(team): can we assume static timesteps?
@@ -585,7 +828,66 @@ def implicit(m: Model, d: Data):
     derivative.deriv_smooth_vel(m, d, qDeriv)
     qacc = wp.empty((d.nworld, m.nv), dtype=float)
     smooth.factor_solve_i(m, d, qDeriv, qLD, qLDiagInv, qacc, d.efc.Ma)
-    _advance(m, d, qacc)
+
+    if m.jnt_midpoint.shape[0] > 0 and not (m.opt.enableflags & EnableBit.INVDISCRETE):
+      qvel_old_arr = wp.clone(d.qvel)
+      qvel_new_arr = wp.zeros((d.nworld, m.njnt, 6), dtype=float)
+
+      # set default qvel_mid for all DOFs (non-midpoint DOFs keep this value)
+      qvel_mid_full = wp.empty((d.nworld, m.nv), dtype=float)
+      wp.launch(
+        _prepare_qvel_mid_default,
+        dim=(d.nworld, m.nv),
+        inputs=[
+          m.opt.timestep,
+          d.qvel,
+          qacc,
+        ],
+        outputs=[qvel_mid_full],
+      )
+
+      # midpoint solver overwrites midpoint DOFs directly in qvel_mid_full
+      wp.launch(
+        _midpoint,
+        dim=(d.nworld, m.jnt_midpoint.shape[0]),
+        inputs=[
+          m.opt.timestep,
+          m.body_ipos,
+          m.body_iquat,
+          m.body_mass,
+          m.body_inertia,
+          m.jnt_dofadr,
+          m.jnt_bodyid,
+          m.jnt_midpoint,
+          d.qvel,
+          d.xquat,
+          d.qfrc_bias,
+          d.qfrc_smooth,
+          d.qfrc_constraint,
+          m.opt.gravity,
+          m.opt.disableflags,
+        ],
+        outputs=[qvel_new_arr, qvel_mid_full],
+      )
+
+      _advance(m, d, qacc, qvel_mid_full)
+
+      wp.launch(
+        _overwrite_midpoint_qvel_qacc,
+        dim=(d.nworld, m.jnt_midpoint.shape[0]),
+        inputs=[
+          m.opt.timestep,
+          m.body_ipos,
+          m.jnt_dofadr,
+          m.jnt_bodyid,
+          m.jnt_midpoint,
+          qvel_old_arr,
+          qvel_new_arr,
+        ],
+        outputs=[d.qvel, d.qacc],
+      )
+    else:
+      _advance(m, d, qacc)
   else:
     _advance(m, d, d.qacc)
 

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -351,6 +351,7 @@ def _midpoint(
   w_mid = w_inertial
   tol = 1e-6
 
+  # TODO(team): investigate alternatives, e.g., parallel linesearch
   converged = bool(False)
   for niter in range(10):
     Iw = wp.vec3(inertia[0] * w_mid[0], inertia[1] * w_mid[1], inertia[2] * w_mid[2])

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -494,11 +494,7 @@ class ForwardTest(parameterized.TestCase):
     integrator=(IntegratorType.EULER, IntegratorType.IMPLICITFAST, IntegratorType.RK4),
   )
   def test_step2(self, xml, integrator):
-    # TODO(team): remove enableflags override when mujoco warp feature matches mujoco
-    enableflags = EnableBit.INVDISCRETE if integrator == IntegratorType.IMPLICITFAST else 0
-    mjm, mjd, m, _ = test_data.fixture(
-      xml, qvel_noise=0.01, ctrl_noise=0.1, overrides={"opt.integrator": integrator, "opt.enableflags": enableflags}
-    )
+    mjm, mjd, m, _ = test_data.fixture(xml, qvel_noise=0.01, ctrl_noise=0.1, overrides={"opt.integrator": integrator})
 
     # some of the fields updated by step2
     step2_field = [
@@ -661,6 +657,231 @@ class ForwardTest(parameterized.TestCase):
     _, _, m, d = test_data.fixture("flex/multiflex.xml")
 
     mjw.forward(m, d)
+
+  @parameterized.parameters(1, 2)
+  def test_step2_midpoint(self, xml_idx):
+    # aligned: CoM at joint origin
+    xml1 = """
+    <mujoco>
+      <option integrator="implicitfast" timestep="0.01">
+        <flag gravity="disable"/>
+      </option>
+      <worldbody>
+        <body>
+          <freejoint/>
+          <geom type="box" size=".1 .2 .3" mass="1" euler="10 20 30"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+
+    # non-aligned: CoM offset from joint origin
+    xml2 = """
+    <mujoco>
+      <option integrator="implicitfast" timestep="0.01">
+        <flag gravity="disable"/>
+      </option>
+      <worldbody>
+        <body>
+          <freejoint/>
+          <geom type="box" size=".1 .2 .3" mass="1" euler="10 20 30" pos=".03 .02 .01"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+
+    xmls = [xml1, xml2]
+    xml = xmls[xml_idx - 1]
+
+    mjm, mjd, m, _ = test_data.fixture(xml=xml, overrides={"opt.integrator": IntegratorType.IMPLICITFAST})
+
+    step2_field = [
+      "qfrc_smooth",
+      "qacc",
+      "qacc_warmstart",
+      "qvel",
+      "qpos",
+    ]
+
+    # set initial angular velocity
+    mjd.qvel[3:6] = [1.0, 2.0, 3.0]
+    mujoco.mj_forward(mjm, mjd)
+    mujoco.mj_step1(mjm, mjd)
+
+    d = mjw.put_data(mjm, mjd)
+
+    for arr in step2_field:
+      if arr in ["qpos", "qvel"]:
+        continue
+      attr = getattr(d, arr)
+      if attr.dtype == float:
+        attr.fill_(wp.nan)
+
+    mujoco.mj_step2(mjm, mjd)
+    mjw.step2(m, d)
+
+    for arr in step2_field:
+      d_arr = getattr(d, arr).numpy()[0]
+      _assert_eq(d_arr, getattr(mjd, arr), arr)
+
+  @parameterized.parameters(1, 2, 3)
+  def test_conservation_midpoint(self, xml_idx):
+    # aligned: CoM at joint origin
+    xml1 = """
+    <mujoco>
+      <option integrator="implicitfast" timestep="0.01">
+        <flag energy="enable" gravity="disable"/>
+      </option>
+      <worldbody>
+        <body>
+          <freejoint/>
+          <geom type="box" size=".1 .2 .3" mass="1" euler="10 20 30"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+
+    # auto-aligned: CoM at joint origin
+    xml2 = """
+    <mujoco>
+      <option integrator="implicitfast" timestep="0.01">
+        <flag energy="enable" gravity="disable"/>
+      </option>
+      <worldbody>
+        <body>
+          <freejoint align="true"/>
+          <geom type="box" size=".1 .2 .3" mass="1" euler="10 20 30" pos=".03 .02 .01"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+
+    # non-aligned: CoM offset from joint origin
+    xml3 = """
+    <mujoco>
+      <option integrator="implicitfast" timestep="0.01">
+        <flag energy="enable" gravity="disable"/>
+      </option>
+      <worldbody>
+        <body>
+          <freejoint/>
+          <geom type="box" size=".1 .2 .3" mass="1" euler="10 20 30" pos=".03 .02 .01"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+
+    xmls = [xml1, xml2, xml3]
+    xml = xmls[xml_idx - 1]
+
+    nstep = 10
+
+    mjm, mjd, m, d = test_data.fixture(xml=xml, overrides={"opt.integrator": IntegratorType.IMPLICITFAST})
+
+    # set initial velocity
+    d.qvel.zero_()
+    qvel_init = np.zeros(6)
+    qvel_init[3] = 1.0
+    qvel_init[4] = 2.0
+    qvel_init[5] = 3.0
+    d.qvel.assign(qvel_init.reshape(1, 6))
+
+    mjw.forward(m, d)
+    initial_energy = d.energy.numpy()[0, 1]  # kinetic energy
+
+    # compute subtree angmom
+    mjw.subtree_vel(m, d)
+    initial_angmom = d.subtree_angmom.numpy()[0, 0].copy()  # body 0 is root
+
+    for _ in range(nstep):
+      mjw.step(m, d)
+
+    energy_drift = abs(d.energy.numpy()[0, 1] - initial_energy)
+
+    mjw.subtree_vel(m, d)
+    angmom_err = d.subtree_angmom.numpy()[0, 0] - initial_angmom
+    angmom_drift = np.linalg.norm(angmom_err)
+
+    self.assertLess(angmom_drift, 1e-2)
+    self.assertLess(energy_drift, 1e-2)
+
+  @parameterized.parameters(1, 2)
+  def test_midpoint_convergence_order(self, xml_idx):
+    # aligned: CoM at joint origin
+    xml1 = """
+    <mujoco>
+      <option integrator="implicitfast">
+        <flag gravity="disable"/>
+      </option>
+      <worldbody>
+        <body>
+          <freejoint/>
+          <geom type="box" size=".1 .2 .3" mass="1" euler="10 20 30"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+
+    # non-aligned: CoM offset from joint origin
+    xml2 = """
+    <mujoco>
+      <option integrator="implicitfast">
+        <flag gravity="disable"/>
+      </option>
+      <worldbody>
+        <body>
+          <freejoint/>
+          <geom type="box" size=".1 .2 .3" mass="1" euler="10 20 30" pos=".05 .03 .02"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+
+    xmls = [xml1, xml2]
+    xml = xmls[xml_idx - 1]
+
+    qvel_init = np.zeros(6)
+    qvel_init[3] = 1.0
+    qvel_init[4] = 2.0
+    qvel_init[5] = 3.0
+
+    # coarse: 2 steps at h=0.04, T=0.08
+    _, _, m, d = test_data.fixture(xml=xml, overrides={"opt.integrator": IntegratorType.IMPLICITFAST})
+    m.opt.timestep.assign(np.array([0.04], dtype=np.float32))
+    d.qvel.assign(qvel_init.reshape(1, 6))
+    for _ in range(2):
+      mjw.step(m, d)
+    quat_coarse = d.qpos.numpy()[0, 3:7].copy()
+
+    # fine: 4 steps at h=0.02, T=0.08
+    _, _, m, d = test_data.fixture(xml=xml, overrides={"opt.integrator": IntegratorType.IMPLICITFAST})
+    m.opt.timestep.assign(np.array([0.02], dtype=np.float32))
+    d.qvel.assign(qvel_init.reshape(1, 6))
+    for _ in range(4):
+      mjw.step(m, d)
+    quat_fine = d.qpos.numpy()[0, 3:7].copy()
+
+    # reference: 8 steps at h=0.01, T=0.08
+    _, _, m, d = test_data.fixture(xml=xml, overrides={"opt.integrator": IntegratorType.IMPLICITFAST})
+    m.opt.timestep.assign(np.array([0.01], dtype=np.float32))
+    d.qvel.assign(qvel_init.reshape(1, 6))
+    for _ in range(8):
+      mjw.step(m, d)
+    quat_ref = d.qpos.numpy()[0, 3:7].copy()
+
+    # quaternion distance
+    def quat_dist(a, b):
+      pos = np.sum((a - b) ** 2)
+      neg = np.sum((a + b) ** 2)
+      return np.sqrt(min(pos, neg))
+
+    err_coarse = quat_dist(quat_coarse, quat_ref)
+    err_fine = quat_dist(quat_fine, quat_ref)
+
+    ratio = err_coarse / err_fine
+    # second-order: error ratio should be ~4 when halving timestep
+    self.assertGreater(ratio, 3.0)
+    self.assertLess(ratio, 5.0)
 
 
 class DCMotorTest(parameterized.TestCase):

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -273,6 +273,18 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.jnt_limited_ball_adr = np.nonzero(mjm.jnt_limited & (mjm.jnt_type == mujoco.mjtJoint.mjJNT_BALL))[0]
   m.dof_tri_row, m.dof_tri_col = np.tril_indices(mjm.nv)
 
+  # precompute midpoint eligibility for free joints
+  jnt_midpoint = np.zeros(mjm.njnt, dtype=bool)
+  for j in range(mjm.njnt):
+    if mjm.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+      body = mjm.jnt_bodyid[j]
+      dofadr = mjm.jnt_dofadr[j]
+      treeid = mjm.dof_treeid[dofadr]
+      if mjm.tree_dofnum[treeid] == 6 and mjm.body_subtreemass[body] == mjm.body_mass[body]:
+        jnt_midpoint[j] = True
+  jnt_midpoint_indices = np.where(jnt_midpoint)[0].astype(np.int32)
+  m.jnt_midpoint = wp.array(jnt_midpoint_indices, dtype=wp.int32)
+
   # precalculated geom pairs
   filterparent = not (mjm.opt.disableflags & types.DisableBit.FILTERPARENT)
 
@@ -648,6 +660,8 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   # place m on device
   sizes = dict({"*": 1}, **{f.name: getattr(m, f.name) for f in dataclasses.fields(types.Model) if f.type is int})
   for f in dataclasses.fields(types.Model):
+    if f.name == "jnt_midpoint":
+      continue
     if _is_array_spec(f.type):
       setattr(m, f.name, _create_array(getattr(m, f.name), f.type, sizes))
 

--- a/mujoco_warp/_src/math.py
+++ b/mujoco_warp/_src/math.py
@@ -331,3 +331,36 @@ def upper_trid_index(n: int, i: int, j: int) -> int:
   if j < i:
     i, j = j, i
   return (i * (2 * n - i - 1)) // 2 + j
+
+
+@wp.func
+def solve3(A: wp.mat33, b: wp.vec3) -> wp.vec3:
+  """Solve 3x3 linear system A*x = b using Cramer's rule."""
+  detA = (
+    A[0, 0] * (A[1, 1] * A[2, 2] - A[1, 2] * A[2, 1])
+    - A[0, 1] * (A[1, 0] * A[2, 2] - A[1, 2] * A[2, 0])
+    + A[0, 2] * (A[1, 0] * A[2, 1] - A[1, 1] * A[2, 0])
+  )
+
+  # replace col 0 with b
+  detA0 = (
+    b[0] * (A[1, 1] * A[2, 2] - A[1, 2] * A[2, 1])
+    - A[0, 1] * (b[1] * A[2, 2] - A[1, 2] * b[2])
+    + A[0, 2] * (b[1] * A[2, 1] - A[1, 1] * b[2])
+  )
+
+  # replace col 1 with b
+  detA1 = (
+    A[0, 0] * (b[1] * A[2, 2] - A[1, 2] * b[2])
+    - b[0] * (A[1, 0] * A[2, 2] - A[1, 2] * A[2, 0])
+    + A[0, 2] * (A[1, 0] * b[2] - b[1] * A[2, 0])
+  )
+
+  # replace col 2 with b
+  detA2 = (
+    A[0, 0] * (A[1, 1] * b[2] - b[1] * A[2, 1])
+    - A[0, 1] * (A[1, 0] * b[2] - b[1] * A[2, 0])
+    + b[0] * (A[1, 0] * A[2, 1] - A[1, 1] * A[2, 0])
+  )
+
+  return wp.vec3(detA0 / detA, detA1 / detA, detA2 / detA)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1176,6 +1176,7 @@ class Model:
     body_fluid_ellipsoid: does body use ellipsoid fluid      (nbody,)
     jnt_limited_slide_hinge_adr: limited/slide/hinge jntadr
     jnt_limited_ball_adr: limited/ball jntadr
+    jnt_midpoint: whether joint is eligible for midpoint integration (njnt,)
     dof_tri_row: dof lower triangle row (used in solver)
     dof_tri_col: dof lower triangle col (used in solver)
     nxn_geom_pair: collision pair geom ids [-2, ngeom-1]
@@ -1572,6 +1573,7 @@ class Model:
   body_fluid_ellipsoid: array("nbody", bool)
   jnt_limited_slide_hinge_adr: wp.array[int]
   jnt_limited_ball_adr: wp.array[int]
+  jnt_midpoint: wp.array[int]
   dof_tri_row: wp.array[int]
   dof_tri_col: wp.array[int]
   nxn_geom_pair: wp.array[wp.vec2i]


### PR DESCRIPTION
midpoint integrator for free bodies https://github.com/google-deepmind/mujoco/commit/0c337799bd9f293485bb13d409ff8335d722a2c2

---

# Testspeed Comparison: Midpoint Integrator vs Baseline

**GPU:** NVIDIA RTX 6000 Ada Generation | **Config:** `--nworld=8192`, 1000 steps, dt = 0.01, integrator = `implicitfast`

| Label | Commit | Description |
|-------|--------|-------------|
| **Baseline** | `ebcb4932` (upstream/main) | No midpoint integrator |
| **Midpoint** | `9e9ff2b7` (HEAD) | Midpoint integrator |

---

## Scene 1: Single Rigid Body

```xml
<mujoco model="rigid_body">
  <option timestep="0.01" integrator="implicitfast">
    <flag contact="disable"/>
  </option>

  <worldbody>
    <body pos="0 0 1">
      <freejoint/>
      <geom type="box" size="0.1 0.2 0.3" mass="1"/>
    </body>
  </worldbody>

  <keyframe>
    <key name="spinning"
         qpos="0 0 1 1 0 0 0"
         qvel="0 0 0 0.1 0.2 0.3"/>
  </keyframe>
</mujoco>
```

### Baseline Output (no midpoint integrator)

```
Loading model from: rigid_body.xml...
Model
  nq: 7 nv: 6 nbody: 2 ngeom: 1
Option
  integrator: IMPLICITFAST
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: False
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 393216 njmax: 64
Rolling out 1000 steps at dt = 0.010...
Summary for 8192 parallel rollouts

Total simulation time: 0.23 s
Total steps per second: 35,064,373
Total realtime factor: 350,643.73 x
Total time per step: 28.52 ns
Total converged worlds: 8192 / 8192
```

### Midpoint Integrator Output

```
Loading model from: rigid_body.xml...
Model
  nq: 7 nv: 6 nbody: 2 ngeom: 1
Option
  integrator: IMPLICITFAST
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: False
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 393216 njmax: 64
Rolling out 1000 steps at dt = 0.010...
Summary for 8192 parallel rollouts

Total simulation time: 0.24 s
Total steps per second: 33,443,796
Total realtime factor: 334,437.96 x
Total time per step: 29.90 ns
Total converged worlds: 8192 / 8192
```

### Scene 1 Comparison

| Metric | Baseline | Midpoint | Δ |
|--------|----------|----------|----|
| Steps/s | 35,064,373 | 33,443,796 | −4.62% |
| Time/step | 28.52 ns | 29.90 ns | +4.84% |

---

## Scene 2: Eight Rigid Bodies

```xml
<mujoco model="rigid_bodies_8">
  <option timestep="0.01" integrator="implicitfast">
    <flag contact="disable"/>
  </option>

  <worldbody>
    <body pos="0 0 1">
      <freejoint/>
      <geom type="box" size="0.1 0.2 0.3" mass="1"/>
    </body>
    <body pos="3 0 1">
      <freejoint/>
      <geom type="box" size="0.15 0.1 0.25" mass="1"/>
    </body>
    <body pos="6 0 1">
      <freejoint/>
      <geom type="box" size="0.2 0.15 0.1" mass="1"/>
    </body>
    <body pos="9 0 1">
      <freejoint/>
      <geom type="box" size="0.1 0.1 0.1" mass="1"/>
    </body>
    <body pos="0 3 1">
      <freejoint/>
      <geom type="box" size="0.25 0.2 0.15" mass="1"/>
    </body>
    <body pos="3 3 1">
      <freejoint/>
      <geom type="box" size="0.1 0.3 0.2" mass="1"/>
    </body>
    <body pos="6 3 1">
      <freejoint/>
      <geom type="box" size="0.3 0.1 0.1" mass="1"/>
    </body>
    <body pos="9 3 1">
      <freejoint/>
      <geom type="box" size="0.15 0.25 0.3" mass="1"/>
    </body>
  </worldbody>

  <keyframe>
    <key name="spinning"
         qpos="0 0 1 1 0 0 0
               3 0 1 1 0 0 0
               6 0 1 1 0 0 0
               9 0 1 1 0 0 0
               0 3 1 1 0 0 0
               3 3 1 1 0 0 0
               6 3 1 1 0 0 0
               9 3 1 1 0 0 0"
         qvel="0 0 0  0.1  0.2  0.3
               0 0 0  0.15 0.25 0.35
               0 0 0  0.2  0.3  0.1
               0 0 0  0.25 0.1  0.15
               0 0 0  0.3  0.15 0.25
               0 0 0  0.35 0.2  0.1
               0 0 0  0.1  0.35 0.2
               0 0 0  0.05 0.15 0.35"/>
  </keyframe>
</mujoco>
```

### Baseline Output (no midpoint integrator)

```
Loading model from: rigid_bodies_8.xml...
Model
  nq: 56 nv: 48 nbody: 9 ngeom: 8
Option
  integrator: IMPLICITFAST
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: True
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 393216 njmax: 64
Rolling out 1000 steps at dt = 0.010...
Summary for 8192 parallel rollouts

Total simulation time: 1.05 s
Total steps per second: 7,792,689
Total realtime factor: 77,926.89 x
Total time per step: 128.33 ns
Total converged worlds: 8192 / 8192
```

### Midpoint Integrator Output

```
Loading model from: rigid_bodies_8.xml...
Model
  nq: 56 nv: 48 nbody: 9 ngeom: 8
Option
  integrator: IMPLICITFAST
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: True
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 393216 njmax: 64
Rolling out 1000 steps at dt = 0.010...
Summary for 8192 parallel rollouts

Total simulation time: 1.04 s
Total steps per second: 7,849,850
Total realtime factor: 78,498.50 x
Total time per step: 127.39 ns
Total converged worlds: 8192 / 8192
```

### Scene 2 Comparison

| Metric | Baseline | Midpoint | Δ |
|--------|----------|----------|----|
| Steps/s | 7,792,689 | 7,849,850 | +0.73% |
| Time/step | 128.33 ns | 127.39 ns | −0.73% |

---

## Summary

| Scene | Bodies | Baseline (steps/s) | Midpoint (steps/s) | Runtime Δ |
|-------|--------|--------------------|--------------------|-----------|
| rigid_body.xml | 1 | 35,064,373 | 33,443,796 | −4.62% |
| rigid_bodies_8.xml | 8 | 7,792,689 | 7,849,850 | +0.73% |

- **Single body:** midpoint integrator shows ~5% slowdown, likely within run-to-run variance for this tiny workload.
- **Eight bodies:** performance is within noise (+0.73%).
- All runs achieve full convergence (8192/8192 worlds).

