### PR TITLE
Speed up CI: narrow OOB test and fix warp kernel cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/warp
-          key: warp-kernels-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock', 'mujoco_warp/**/*.py') }}
+          key: warp-kernels-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ matrix.dep-type }}-${{ hashFiles('uv.lock', 'mujoco_warp/**/*.py') }}
           restore-keys: |
-            warp-kernels-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-
+            warp-kernels-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ matrix.dep-type }}-
             
       # Install for stable
       - name: Install stable dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Out-of-bounds check for batched model fields
         if: matrix.dep-type == 'stable'
         run: |
-          pytest -k io_test --debug_mode
+          pytest mujoco_warp/_src/io_test.py  -k test_model_batched_fields --debug_mode
 
   kernel_analyzer:
     name: Kernel analyzer


### PR DESCRIPTION
## Summary

Two CI speedups for the stable dependency test matrix.

### Narrow out-of-bounds check

The `--debug_mode` out-of-bounds check was running all of `io_test`, but only `test_model_batched_fields` needs it. Narrow the pytest invocation to just that test.

### Fix warp kernel cache

Add `dep-type` to the warp kernel cache key so that **stable** and **locked uv** dependency tests each get their own kernel cache. Previously both shared the same cache key (keyed on `uv.lock`), which is irrelevant for the stable job (`pip install .`). When Warp versions differed between locked and stable, the shared cache contained incompatible kernels, forcing recompilation.