### PR TITLE
pgs solver

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -201,6 +201,9 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     opt.contact_sensor_maxmatch = mjm.numeric_data[mjm.numeric_adr[contact_sensor_maxmatch_id]]
   else:
     opt.contact_sensor_maxmatch = 64
+  opt.pgs_max_colors = 32
+  opt.pgs_mode = 0  # 0 = Gauss-Seidel, 1 = Jacobi
+  opt.pgs_sor_omega = 0.5  # SOR relaxation (1.0 = pure Jacobi, <1.0 = under-relaxation)
 
   # place opt on device
   for f in dataclasses.fields(types.Option):
@@ -2555,6 +2558,9 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
     "opt.ls_parallel",
     "opt.graph_conditional",
     "opt.contact_sensor_maxmatch",
+    "opt.pgs_max_colors",
+    "opt.pgs_mode",
+    "opt.pgs_sor_omega",
   }
   mj_only_fields = {"opt.jacobian"}
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -23,8 +23,10 @@ from mujoco_warp._src import math
 from mujoco_warp._src import smooth
 from mujoco_warp._src import support
 from mujoco_warp._src import types
+from mujoco_warp._src import util_solve
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_func
+from mujoco_warp._src.types import MJ_MINVAL
 from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 from mujoco_warp._src.warp_util import scoped_mathdx_gemm_disabled
@@ -566,16 +568,15 @@ def _linesearch_parallel(m: types.Model, d: types.Data, ctx: SolverContext, cost
   )
 
 
-# kernel_analyzer: off
 @wp.func
-def _compute_efc_eval_pt_pyramidal(
+def _compute_efc_eval_pt_pyramidal(  # kernel_analyzer: ignore
+  # In:
   efcid: int,
   alpha: float,
-  ne: int,
-  nf: int,
-  # Per-row data:
-  efc_D: float,
-  efc_frictionloss: wp.array[float],
+  ne: int,  # kernel_analyzer: ignore
+  nf: int,  # kernel_analyzer: ignore
+  efc_D: float,  # kernel_analyzer: ignore
+  efc_frictionloss: wp.array[float],  # kernel_analyzer: ignore
   ctx_Jaref: float,
   ctx_jv: float,
 ) -> wp.vec3:
@@ -599,21 +600,20 @@ def _compute_efc_eval_pt_pyramidal(
 
 
 @wp.func
-def _compute_efc_eval_pt_elliptic(
+def _compute_efc_eval_pt_elliptic(  # kernel_analyzer: ignore
+  # In:
   efcid: int,
   alpha: float,
-  ne: int,
-  nf: int,
+  ne: int,  # kernel_analyzer: ignore
+  nf: int,  # kernel_analyzer: ignore
   impratio_invsqrt: float,
-  # Per-row data (arrays for deferred load):
-  efc_type: int,
-  efc_D_in: wp.array[float],
-  efc_frictionloss: wp.array[float],
+  efc_type: int,  # kernel_analyzer: ignore
+  efc_D_in: wp.array[float],  # kernel_analyzer: ignore
+  efc_frictionloss: wp.array[float],  # kernel_analyzer: ignore
   ctx_Jaref: float,
   ctx_jv: float,
   ctx_quad: wp.vec3,
-  # Contact data (for elliptic):
-  contact_friction: types.vec5,
+  contact_friction: types.vec5,  # kernel_analyzer: ignore
   efc_address0: int,
   quad1: wp.vec3,
   quad2: wp.vec3,
@@ -646,13 +646,13 @@ def _compute_efc_eval_pt_elliptic(
 
 
 @wp.func
-def _compute_efc_eval_pt_alpha_zero_pyramidal(
+def _compute_efc_eval_pt_alpha_zero_pyramidal(  # kernel_analyzer: ignore
+  # In:
   efcid: int,
-  ne: int,
-  nf: int,
-  # Per-row data:
-  efc_D: float,
-  efc_frictionloss: wp.array[float],
+  ne: int,  # kernel_analyzer: ignore
+  nf: int,  # kernel_analyzer: ignore
+  efc_D: float,  # kernel_analyzer: ignore
+  efc_frictionloss: wp.array[float],  # kernel_analyzer: ignore
   ctx_Jaref: float,
   ctx_jv: float,
 ) -> wp.vec3:
@@ -674,20 +674,19 @@ def _compute_efc_eval_pt_alpha_zero_pyramidal(
 
 
 @wp.func
-def _compute_efc_eval_pt_alpha_zero_elliptic(
+def _compute_efc_eval_pt_alpha_zero_elliptic(  # kernel_analyzer: ignore
+  # In:
   efcid: int,
-  ne: int,
-  nf: int,
+  ne: int,  # kernel_analyzer: ignore
+  nf: int,  # kernel_analyzer: ignore
   impratio_invsqrt: float,
-  # Per-row data (arrays for deferred load):
-  efc_type: int,
-  efc_D_in: wp.array[float],
-  efc_frictionloss: wp.array[float],
+  efc_type: int,  # kernel_analyzer: ignore
+  efc_D_in: wp.array[float],  # kernel_analyzer: ignore
+  efc_frictionloss: wp.array[float],  # kernel_analyzer: ignore
   ctx_Jaref: float,
   ctx_jv: float,
   ctx_quad: wp.vec3,
-  # Contact data (for elliptic):
-  contact_friction: types.vec5,
+  contact_friction: types.vec5,  # kernel_analyzer: ignore
   efc_address0: int,
   quad1: wp.vec3,
   quad2: wp.vec3,
@@ -718,16 +717,16 @@ def _compute_efc_eval_pt_alpha_zero_elliptic(
 
 
 @wp.func
-def _compute_efc_eval_pt_3alphas_pyramidal(
+def _compute_efc_eval_pt_3alphas_pyramidal(  # kernel_analyzer: ignore
+  # In:
   efcid: int,
   lo_alpha: float,
   hi_alpha: float,
   mid_alpha: float,
-  ne: int,
-  nf: int,
-  # Per-row data:
-  efc_D: float,
-  efc_frictionloss: wp.array[float],
+  ne: int,  # kernel_analyzer: ignore
+  nf: int,  # kernel_analyzer: ignore
+  efc_D: float,  # kernel_analyzer: ignore
+  efc_frictionloss: wp.array[float],  # kernel_analyzer: ignore
   ctx_Jaref: float,
   ctx_jv: float,
 ) -> tuple[wp.vec3, wp.vec3, wp.vec3]:
@@ -761,23 +760,22 @@ def _compute_efc_eval_pt_3alphas_pyramidal(
 
 
 @wp.func
-def _compute_efc_eval_pt_3alphas_elliptic(
+def _compute_efc_eval_pt_3alphas_elliptic(  # kernel_analyzer: ignore
+  # In:
   efcid: int,
   lo_alpha: float,
   hi_alpha: float,
   mid_alpha: float,
-  ne: int,
-  nf: int,
+  ne: int,  # kernel_analyzer: ignore
+  nf: int,  # kernel_analyzer: ignore
   impratio_invsqrt: float,
-  # Per-row data (arrays for deferred load):
-  efc_type: int,
-  efc_D_in: wp.array[float],
-  efc_frictionloss: wp.array[float],
+  efc_type: int,  # kernel_analyzer: ignore
+  efc_D_in: wp.array[float],  # kernel_analyzer: ignore
+  efc_frictionloss: wp.array[float],  # kernel_analyzer: ignore
   ctx_Jaref: float,
   ctx_jv: float,
   ctx_quad: wp.vec3,
-  # Contact data (for elliptic):
-  contact_friction: types.vec5,
+  contact_friction: types.vec5,  # kernel_analyzer: ignore
   efc_address0: int,
   quad1: wp.vec3,
   quad2: wp.vec3,
@@ -822,8 +820,6 @@ def _compute_efc_eval_pt_3alphas_elliptic(
   # Equality constraint — direct eval (no quad read)
   return _eval_pt_direct_3alphas(ctx_Jaref, ctx_jv, efc_D_in[efcid], lo_alpha, hi_alpha, mid_alpha)
 
-
-# kernel_analyzer: on
 
 # =============================================================================
 # Iterative Linesearch
@@ -3310,12 +3306,7 @@ def init_context(m: types.Model, d: types.Data, ctx: SolverContext | InverseCont
   # if we are only using 1 thread, it makes sense to do more dofs as we can also skip the
   # init kernel. For more than 1 thread, dofs_per_thread is lower for better load balancing.
 
-  if m.nv > 50:
-    dofs_per_thread = 20
-  else:
-    dofs_per_thread = 50
-
-  threads_per_efc = ceil(m.nv / dofs_per_thread)
+  dofs_per_thread, threads_per_efc = _compute_jaref_threading(m.nv)
   # we need to clear the jaref array if we're doing atomic adds.
   if threads_per_efc > 1:
     ctx.Jaref.zero_()
@@ -3336,11 +3327,32 @@ def init_context(m: types.Model, d: types.Data, ctx: SolverContext | InverseCont
     _update_gradient(m, d, ctx)
 
 
+def _warmstart_qacc_init(m: types.Model, d: types.Data):
+  """Copy qacc_warmstart or qacc_smooth into qacc based on WARMSTART flag."""
+  if not (m.opt.disableflags & types.DisableBit.WARMSTART):
+    wp.copy(d.qacc, d.qacc_warmstart)
+  else:
+    wp.copy(d.qacc, d.qacc_smooth)
+
+
+def _compute_jaref_threading(nv: int) -> tuple[int, int]:
+  """Compute jaref parallelization parameters.
+
+  Returns (dofs_per_thread, threads_per_efc).
+  """
+  dofs_per_thread = 20 if nv > 50 else 50
+  threads_per_efc = ceil(nv / dofs_per_thread)
+  return dofs_per_thread, threads_per_efc
+
+
 @event_scope
 def solve(m: types.Model, d: types.Data):
   if d.njmax == 0 or m.nv == 0:
     wp.copy(d.qacc, d.qacc_smooth)
     d.solver_niter.fill_(0)
+  elif m.opt.solver == types.SolverType.PGS:
+    ctx = _create_pgs_context(m, d)
+    _solve_pgs(m, d, ctx)
   else:
     ctx = create_solver_context(m, d)
     _solve(m, d, ctx)
@@ -3348,10 +3360,7 @@ def solve(m: types.Model, d: types.Data):
 
 def _solve(m: types.Model, d: types.Data, ctx: SolverContext):
   """Finds forces that satisfy constraints."""
-  if not (m.opt.disableflags & types.DisableBit.WARMSTART):
-    wp.copy(d.qacc, d.qacc_warmstart)
-  else:
-    wp.copy(d.qacc, d.qacc_smooth)
+  _warmstart_qacc_init(m, d)
 
   #  context
   init_context(m, d, ctx, grad=True)
@@ -3384,3 +3393,3569 @@ def _solve(m: types.Model, d: types.Data, ctx: SolverContext):
     # It should be removed when JAX becomes compatible.
     for _ in range(m.opt.iterations):
       _solver_iteration(m, d, ctx, step_size_cost, nsolving)
+
+
+@wp.kernel
+def _pgs_build_constraint_groups(
+  # Data in:
+  nefc_in: wp.array[int],
+  contact_dim_in: wp.array[int],
+  contact_efc_address_in: wp.array2d[int],
+  efc_type_in: wp.array2d[int],
+  efc_id_in: wp.array2d[int],
+  # Out:
+  group_efc_start_out: wp.array2d[int],
+  group_efc_count_out: wp.array2d[int],
+  ngroups_out: wp.array[int],
+):
+  """Identify constraint groups for coloring.
+
+  Multi-row constraints (connect, weld, contacts) become single groups.
+  Single-row constraints (limits, friction, etc.) are individual groups.
+  """
+  worldid = wp.tid()
+  nefc = nefc_in[worldid]
+  ng = int(0)
+  i = int(0)
+
+  while i < nefc:
+    typ = efc_type_in[worldid, i]
+
+    if typ == types.ConstraintType.CONTACT_PYRAMIDAL:
+      # Contiguous block: group all pyramidal faces for this contact
+      con_id = efc_id_in[worldid, i]
+      dim = contact_dim_in[con_id]
+      count = int(0)
+      if dim > 1:
+        count = 2 * (dim - 1)
+      else:
+        count = 1
+      # Only create group if this is the first row (idx0)
+      idx0 = contact_efc_address_in[con_id, 0]
+      if i == idx0:
+        group_efc_start_out[worldid, ng] = i
+        group_efc_count_out[worldid, ng] = count
+        ng += 1
+      i += 1
+
+    elif typ == types.ConstraintType.CONTACT_ELLIPTIC:
+      # Contiguous block: group all dim rows for this elliptic contact
+      con_id = efc_id_in[worldid, i]
+      idx0 = contact_efc_address_in[con_id, 0]
+      if i == idx0:
+        dim = contact_dim_in[con_id]
+        group_efc_start_out[worldid, ng] = i
+        group_efc_count_out[worldid, ng] = dim
+        ng += 1
+      i += 1
+
+    elif typ == types.ConstraintType.EQUALITY:
+      # Consecutive EQUALITY rows with same efc_id form one group
+      # (connect = 3 rows, weld = 6 rows, joint/tendon = 1 row)
+      eq_id = efc_id_in[worldid, i]
+      count = int(1)
+      done = int(0)
+      while i + count < nefc and done == 0:
+        if efc_type_in[worldid, i + count] != types.ConstraintType.EQUALITY:
+          done = 1
+        elif efc_id_in[worldid, i + count] != eq_id:
+          done = 1
+        else:
+          count += 1
+
+      group_efc_start_out[worldid, ng] = i
+      group_efc_count_out[worldid, ng] = count
+      ng += 1
+      i += count
+
+    else:
+      # Single-row constraint (limit, friction, frictionless contact)
+      group_efc_start_out[worldid, ng] = i
+      group_efc_count_out[worldid, ng] = 1
+      ng += 1
+      i += 1
+
+  ngroups_out[worldid] = ng
+
+
+def _pgs_color_groups(nv: int, is_sparse: bool):
+  """Factory for greedy coloring kernel using per-tree color lists.
+
+  Combines sparse and dense Jacobian paths via compile-time branching.
+  Conflict detection operates at tree granularity because the BT matrix
+  (M⁻¹Jᵀ) couples all DOFs within a kinematic tree. Two constraints that
+  touch any DOFs in the same tree must not be assigned the same color.
+
+  Uses per-tree integer color lists to support any number of colors
+  (up to pgs_max_colors). Groups that cannot be assigned a color (overflow)
+  are marked with color = -1 for sequential processing.
+  """
+  NV = nv
+  IS_SPARSE = is_sparse
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    dof_treeid: wp.array[int],
+    # Data in:
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    efc_J_in: wp.array3d[float],
+    # In:
+    ngroups_in: wp.array[int],
+    group_efc_start_in: wp.array2d[int],
+    group_efc_count_in: wp.array2d[int],
+    max_colors: int,
+    # In/Out:
+    tree_color_list_inout: wp.array3d[int],  # (nworld, ntree, max_alloc)
+    tree_color_count_inout: wp.array2d[int],  # (nworld, ntree)
+    color_used_inout: wp.array2d[int],  # (nworld, max_colors)
+    tree_update_inout: wp.array2d[int],  # (nworld, ntree)
+    # Out:
+    node_color_out: wp.array2d[int],  # kernel_analyzer: ignore
+    ncolors_out: wp.array[int],
+  ):
+    """Greedy coloring via per-tree integer color lists.
+
+    For each group (sequentially within each world):
+      1. Gather colors used by neighboring groups via tree color lists.
+      2. Pick the smallest unused color.
+      3. Update tree color lists for all touched trees.
+      4. If no free color is found, mark the group with color = -1.
+
+    Complexity: O(ngroups * avg_nnz_per_group * avg_colors_per_tree) per world.
+    Each world runs as one thread; with thousands of worlds, GPU occupancy
+    comes from inter-world parallelism.
+    """
+    worldid = wp.tid()
+    ng = ngroups_in[worldid]
+    max_color_so_far = int(-1)
+
+    for group in range(ng):
+      efc_start = group_efc_start_in[worldid, group]
+      efc_count = group_efc_count_in[worldid, group]
+
+      # Clear scratch up to max_color_so_far + 2
+      for c in range(max_color_so_far + 2):
+        color_used_inout[worldid, c] = 0  # kernel_analyzer: ignore
+
+      # Gather used colors from all trees touched by this group
+      for r in range(efc_count):
+        efcid = efc_start + r
+        if wp.static(IS_SPARSE):
+          nnz = efc_J_rownnz_in[worldid, efcid]
+          adr = efc_J_rowadr_in[worldid, efcid]
+          for k in range(nnz):
+            dof = efc_J_colind_in[worldid, 0, adr + k]
+            treeid = dof_treeid[dof]
+            for i in range(tree_color_count_inout[worldid, treeid]):
+              c = tree_color_list_inout[worldid, treeid, i]
+              color_used_inout[worldid, c] = 1  # kernel_analyzer: ignore
+        else:
+          for dof in range(NV):
+            if efc_J_in[worldid, efcid, dof] != 0.0:
+              treeid = dof_treeid[dof]
+              for i in range(tree_color_count_inout[worldid, treeid]):
+                c = tree_color_list_inout[worldid, treeid, i]
+                color_used_inout[worldid, c] = 1  # kernel_analyzer: ignore
+
+      # Find smallest unused color
+      color = int(-1)
+      for c in range(max_colors):
+        if color < 0 and color_used_inout[worldid, c] == 0:
+          color = c
+
+      node_color_out[worldid, group] = color
+
+      # Update tree color lists with this group's assigned color
+      if color >= 0:
+        if color > max_color_so_far:
+          max_color_so_far = color
+        for r in range(efc_count):
+          efcid = efc_start + r
+          if wp.static(IS_SPARSE):
+            nnz = efc_J_rownnz_in[worldid, efcid]
+            adr = efc_J_rowadr_in[worldid, efcid]
+            for k in range(nnz):
+              dof = efc_J_colind_in[worldid, 0, adr + k]
+              treeid = dof_treeid[dof]
+              if tree_update_inout[worldid, treeid] != group:
+                tree_update_inout[worldid, treeid] = group  # kernel_analyzer: ignore
+                idx = tree_color_count_inout[worldid, treeid]
+                tree_color_list_inout[worldid, treeid, idx] = color  # kernel_analyzer: ignore
+                tree_color_count_inout[worldid, treeid] = idx + 1  # kernel_analyzer: ignore
+          else:
+            for dof in range(NV):
+              if efc_J_in[worldid, efcid, dof] != 0.0:
+                treeid = dof_treeid[dof]
+                if tree_update_inout[worldid, treeid] != group:
+                  tree_update_inout[worldid, treeid] = group  # kernel_analyzer: ignore
+                  idx = tree_color_count_inout[worldid, treeid]
+                  tree_color_list_inout[worldid, treeid, idx] = color  # kernel_analyzer: ignore
+                  tree_color_count_inout[worldid, treeid] = idx + 1  # kernel_analyzer: ignore
+
+    ncolors_out[worldid] = max_color_so_far + 1
+
+  return kernel
+
+
+@wp.kernel
+def _pgs_build_flat_schedule(
+  # In:
+  ngroups_in: wp.array[int],
+  node_color_in: wp.array2d[int],
+  ncolors_in: wp.array[int],
+  max_ncolors: int,
+  # Out:
+  schedule_offsets_out: wp.array2d[int],  # (nworld, max_colors + 1)
+  schedule_groups_out: wp.array2d[int],  # (nworld, njmax)
+):
+  """Build flat CSR schedule via counting sort by color.
+
+  Groups for color c in world w are at:
+    schedule_groups[w, offsets[w,c] : offsets[w,c+1]]
+
+  Offsets for colors beyond this world's ncolors are filled with the
+  final slot value so the sweep kernel sees empty ranges.
+  """
+  worldid = wp.tid()
+  ng = ngroups_in[worldid]
+  nc = ncolors_in[worldid]
+
+  # Iterate colors in order, placing groups into the flat schedule
+  slot = int(0)
+  for c in range(nc):
+    schedule_offsets_out[worldid, c] = slot
+    for g in range(ng):
+      if node_color_in[worldid, g] == c:
+        schedule_groups_out[worldid, slot] = g
+        slot += 1
+
+  # Fill remaining offsets up to max_ncolors with final slot value
+  for c in range(nc, max_ncolors + 1):
+    schedule_offsets_out[worldid, c] = slot
+
+
+@wp.kernel
+def _pgs_build_overflow_list(
+  # In:
+  ngroups_in: wp.array[int],
+  node_color_in: wp.array2d[int],
+  # Out:
+  overflow_list_out: wp.array2d[int],
+  n_overflow_out: wp.array[int],
+):
+  """Build list of overflow (uncolored) groups.
+
+  Groups with node_color == -1 could not be assigned a color and must be
+  processed sequentially to avoid data races.
+  """
+  worldid, group_id = wp.tid()
+  ng = ngroups_in[worldid]
+  if group_id >= ng:
+    return
+
+  if node_color_in[worldid, group_id] < 0:
+    slot = wp.atomic_add(n_overflow_out, worldid, 1)
+    overflow_list_out[worldid, slot] = group_id
+
+
+@event_scope
+def _pgs_coloring(
+  m: types.Model,
+  d: types.Data,
+  ctx,
+):
+  """Compute constraint coloring for parallel PGS sweep.
+
+  Supports both sparse and dense Jacobians.
+
+  Conflict detection operates at tree granularity: constraints that touch
+  any DOFs in the same kinematic tree are assigned different colors. This
+  is necessary because the BT matrix (M⁻¹Jᵀ) couples all DOFs within a tree.
+
+  Groups that cannot be assigned a color (when ngroups > max_colors for
+  single-tree models) are tracked in overflow_list for sequential processing.
+  """
+  max_colors = m.opt.pgs_max_colors
+
+  # Step 1: Build constraint groups (GPU)
+  wp.launch(
+    _pgs_build_constraint_groups,
+    dim=(d.nworld,),
+    inputs=[
+      d.nefc,
+      d.contact.dim,
+      d.contact.efc_address,
+      d.efc.type,
+      d.efc.id,
+    ],
+    outputs=[ctx.group_efc_start, ctx.group_efc_count, ctx.ngroups],
+  )
+
+  # Step 2: Greedy coloring via per-tree integer color lists (GPU)
+  ctx.tree_color_count.zero_()
+  ctx.tree_update_inout.fill_(-1)
+  ctx.node_color.fill_(-1)
+  wp.launch(
+    _pgs_color_groups(m.nv, m.is_sparse),
+    dim=(d.nworld,),
+    inputs=[
+      m.dof_treeid,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      d.efc.J,
+      ctx.ngroups,
+      ctx.group_efc_start,
+      ctx.group_efc_count,
+      max_colors,
+    ],
+    outputs=[
+      ctx.tree_color_list,
+      ctx.tree_color_count,
+      ctx.color_used_inout,
+      ctx.tree_update_inout,
+      ctx.node_color,
+      ctx.ncolors,
+    ],
+  )
+
+  # Step 3: Build flat CSR schedule (GPU)
+  wp.launch(
+    _pgs_build_flat_schedule,
+    dim=(d.nworld,),
+    inputs=[ctx.ngroups, ctx.node_color, ctx.ncolors, max_colors],
+    outputs=[ctx.schedule_offsets, ctx.schedule_groups],
+  )
+
+  # Step 5: Build overflow list for uncolored groups (GPU)
+  ctx.n_overflow.zero_()
+  wp.launch(
+    _pgs_build_overflow_list,
+    dim=(d.nworld, d.njmax),
+    inputs=[ctx.ngroups, ctx.node_color],
+    outputs=[ctx.overflow_list, ctx.n_overflow],
+  )
+
+
+@dataclasses.dataclass
+class PGSContext:
+  """Workspace arrays for the PGS (Projected Gauss-Seidel) dual solver."""
+
+  BT: wp.array3d[float]  # M⁻¹·Jᵀ, shape (nworld, njmax, nv)
+  AR_diag_inv: wp.array2d[float]  # 1/AR[i,i], shape (nworld, njmax)
+  AR_elliptic: wp.array3d[float]  # upper-tri AR sub-block, shape (nworld, njmax, 21)
+  done: wp.array[bool]  # convergence flag per world
+  warmstart_cost: wp.array[float]  # warmstart cost, shape (nworld,)
+  nsolving: wp.array[int]  # number of worlds still solving, shape (1,)
+  # --- Sparse BT index (ntree > 1) ---
+  BT_rownnz: wp.array2d[int]  # (nworld, njmax) nnz per BT row
+  BT_rowadr: wp.array2d[int]  # (nworld, njmax) start addr in BT_colind
+  BT_colind: wp.array3d[int]  # (nworld, 1, bt_nnz_max) column indices
+  # --- Coloring workspace ---
+  group_efc_start: wp.array2d  # (nworld, njmax) first efc row per group
+  group_efc_count: wp.array2d  # (nworld, njmax) efc rows per group
+  ngroups: wp.array  # (nworld,) groups per world
+  tree_color_list: wp.array3d  # (nworld, ntree, max_alloc) color ints per tree
+  tree_color_count: wp.array2d  # (nworld, ntree) colors assigned per tree
+  color_used_inout: wp.array2d  # (nworld, max_colors) scratch for coloring
+  tree_update_inout: wp.array2d  # (nworld, ntree) dedup scratch for coloring
+  node_color: wp.array2d  # (nworld, njmax) color per group
+  schedule_groups: wp.array2d  # (nworld, njmax) flat sorted group IDs
+  schedule_offsets: wp.array2d  # (nworld, max_colors + 1) CSR offsets
+  ncolors: wp.array  # (nworld,) actual colors used per world
+  improvement: wp.array  # (nworld,) atomic convergence accumulator
+  # --- Overflow (uncolored groups) ---
+  overflow_list: wp.array2d  # (nworld, njmax) overflow group IDs
+  n_overflow: wp.array  # (nworld,) count of overflow groups per world
+
+
+def _create_pgs_context(m: types.Model, d: types.Data) -> PGSContext:
+  """Create PGSContext with allocated workspace arrays."""
+  nworld = d.nworld
+  njmax = d.njmax
+  max_colors = m.opt.pgs_max_colors
+  max_colors_alloc = min(max_colors, njmax) if max_colors > 0 else 1
+  use_sparse_bt = m.ntree > 1 and m.is_sparse
+  bt_nnz_max = njmax * m.nv if use_sparse_bt else 0
+
+  return PGSContext(
+    BT=wp.zeros((nworld, njmax, m.nv), dtype=float),
+    AR_diag_inv=wp.empty((nworld, njmax), dtype=float),
+    AR_elliptic=wp.empty((nworld, njmax, 21), dtype=float),
+    done=wp.empty((nworld,), dtype=bool),
+    warmstart_cost=wp.empty((nworld,), dtype=float),
+    nsolving=wp.empty((1,), dtype=int),
+    BT_rownnz=wp.zeros((nworld, njmax), dtype=wp.int32) if use_sparse_bt else None,
+    BT_rowadr=wp.zeros((nworld, njmax), dtype=wp.int32) if use_sparse_bt else None,
+    BT_colind=wp.zeros((nworld, 1, bt_nnz_max), dtype=wp.int32) if use_sparse_bt else None,
+    group_efc_start=wp.empty((nworld, njmax), dtype=wp.int32),
+    group_efc_count=wp.empty((nworld, njmax), dtype=wp.int32),
+    ngroups=wp.empty(nworld, dtype=wp.int32),
+    tree_color_list=wp.empty((nworld, max(m.ntree, 1), max_colors_alloc), dtype=wp.int32),
+    tree_color_count=wp.empty((nworld, max(m.ntree, 1)), dtype=wp.int32),
+    color_used_inout=wp.empty((nworld, max(max_colors, 1)), dtype=wp.int32),
+    tree_update_inout=wp.full((nworld, max(m.ntree, 1)), value=-1, dtype=wp.int32),
+    node_color=wp.full((nworld, njmax), value=-1, dtype=wp.int32),
+    schedule_groups=wp.empty((nworld, njmax), dtype=wp.int32),
+    schedule_offsets=wp.empty((nworld, max(max_colors, 1) + 1), dtype=wp.int32),
+    ncolors=wp.empty(nworld, dtype=wp.int32),
+    improvement=wp.empty(nworld, dtype=float),
+    overflow_list=wp.empty((nworld, njmax), dtype=wp.int32),
+    n_overflow=wp.empty(nworld, dtype=wp.int32),
+  )
+
+
+def _pgs_precompute_AR_diag_inv(nv: int, is_sparse: bool):
+  """Precompute 1/AR[i,i] for all constraints using J and BT (AR-free).
+
+  AR[i,i] = J[i,:] · BT[i,:] + 1/D[i] is constant across iterations.
+  Precomputing avoids an O(nv) dot product per 1D constraint per iteration.
+  """
+  IS_SPARSE = is_sparse
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    nefc_in: wp.array[int],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    efc_J_in: wp.array3d[float],
+    efc_D_in: wp.array2d[float],
+    # In:
+    BT_in: wp.array3d[float],
+    # Out:
+    AR_diag_inv_out: wp.array2d[float],
+  ):
+    worldid, efcid = wp.tid()
+    NV = wp.static(nv)
+    nefc = nefc_in[worldid]
+
+    if efcid >= nefc:
+      return
+
+    # AR[i,i] = J[i,:] · BT[i,:] + 1/D[i]
+    AR_ii = float(0.0)
+    if wp.static(IS_SPARSE):
+      rownnz = efc_J_rownnz_in[worldid, efcid]
+      rowadr = efc_J_rowadr_in[worldid, efcid]
+      for k in range(rownnz):
+        sparseid = rowadr + k
+        col = efc_J_colind_in[worldid, 0, sparseid]
+        AR_ii += efc_J_in[worldid, 0, sparseid] * BT_in[worldid, efcid, col]
+    else:
+      for k in range(NV):
+        AR_ii += efc_J_in[worldid, efcid, k] * BT_in[worldid, efcid, k]
+
+    D_i = efc_D_in[worldid, efcid]
+    if D_i > 0.0:
+      AR_ii += 1.0 / D_i
+
+    if AR_ii > 0.0:
+      AR_diag_inv_out[worldid, efcid] = 1.0 / AR_ii
+    else:
+      AR_diag_inv_out[worldid, efcid] = 0.0
+
+  return kernel
+
+
+def _pgs_precompute_AR_elliptic(nv: int, is_sparse: bool):
+  """Precompute AR sub-block for elliptic contacts.
+
+  AR[di,dj] = J[idx_di,:] · BT[idx_dj,:] + δ(di,dj)/D[idx_di]
+  Stores upper-triangle elements at the contact's normal-row efc index.
+
+  Layout (21 elements max for dim=6):
+    0:AR00 1:AR01 2:AR02 3:AR03 4:AR04 5:AR05
+           6:AR11 7:AR12 8:AR13 9:AR14 10:AR15
+                  11:AR22 12:AR23 13:AR24 14:AR25
+                          15:AR33 16:AR34 17:AR35
+                                  18:AR44 19:AR45
+                                          20:AR55
+  """
+  IS_SPARSE = is_sparse
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    nefc_in: wp.array[int],
+    contact_dim_in: wp.array[int],
+    contact_efc_address_in: wp.array2d[int],
+    efc_type_in: wp.array2d[int],
+    efc_id_in: wp.array2d[int],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    efc_J_in: wp.array3d[float],
+    efc_D_in: wp.array2d[float],
+    # In:
+    BT_in: wp.array3d[float],
+    # Out:
+    AR_elliptic_out: wp.array3d[float],
+  ):
+    worldid, efcid = wp.tid()
+    NV = wp.static(nv)
+    nefc = nefc_in[worldid]
+
+    if efcid >= nefc:
+      return
+
+    # Only process elliptic contact normal rows
+    if efc_type_in[worldid, efcid] != types.ConstraintType.CONTACT_ELLIPTIC:
+      return
+
+    con_id = efc_id_in[worldid, efcid]
+    idx0 = contact_efc_address_in[con_id, 0]
+
+    # Only process from the normal row
+    if efcid != idx0:
+      return
+
+    dim = contact_dim_in[con_id]
+
+    # Look up indices for all dimensions
+    idx1 = contact_efc_address_in[con_id, 1]
+    idx2 = contact_efc_address_in[con_id, 2]
+    idx3 = int(-1)
+    idx4 = int(-1)
+    idx5 = int(-1)
+    if dim >= 4:
+      idx3 = contact_efc_address_in[con_id, 3]
+    if dim >= 6:
+      idx4 = contact_efc_address_in[con_id, 4]
+      idx5 = contact_efc_address_in[con_id, 5]
+
+    # Initialize AR elements
+    AR_00 = float(0.0)
+    AR_01 = float(0.0)
+    AR_02 = float(0.0)
+    AR_03 = float(0.0)
+    AR_04 = float(0.0)
+    AR_05 = float(0.0)
+    AR_11 = float(0.0)
+    AR_12 = float(0.0)
+    AR_13 = float(0.0)
+    AR_14 = float(0.0)
+    AR_15 = float(0.0)
+    AR_22 = float(0.0)
+    AR_23 = float(0.0)
+    AR_24 = float(0.0)
+    AR_25 = float(0.0)
+    AR_33 = float(0.0)
+    AR_34 = float(0.0)
+    AR_35 = float(0.0)
+    AR_44 = float(0.0)
+    AR_45 = float(0.0)
+    AR_55 = float(0.0)
+
+    if wp.static(IS_SPARSE):
+      # Row 0
+      rnnz_0 = efc_J_rownnz_in[worldid, idx0]
+      radr_0 = efc_J_rowadr_in[worldid, idx0]
+      for k in range(rnnz_0):
+        sid = radr_0 + k
+        col = efc_J_colind_in[worldid, 0, sid]
+        jv = efc_J_in[worldid, 0, sid]
+        AR_00 += jv * BT_in[worldid, idx0, col]
+        AR_01 += jv * BT_in[worldid, idx1, col]
+        AR_02 += jv * BT_in[worldid, idx2, col]
+        if dim >= 4:
+          AR_03 += jv * BT_in[worldid, idx3, col]
+        if dim >= 6:
+          AR_04 += jv * BT_in[worldid, idx4, col]
+          AR_05 += jv * BT_in[worldid, idx5, col]
+      # Row 1
+      rnnz_1 = efc_J_rownnz_in[worldid, idx1]
+      radr_1 = efc_J_rowadr_in[worldid, idx1]
+      for k in range(rnnz_1):
+        sid = radr_1 + k
+        col = efc_J_colind_in[worldid, 0, sid]
+        jv = efc_J_in[worldid, 0, sid]
+        AR_11 += jv * BT_in[worldid, idx1, col]
+        AR_12 += jv * BT_in[worldid, idx2, col]
+        if dim >= 4:
+          AR_13 += jv * BT_in[worldid, idx3, col]
+        if dim >= 6:
+          AR_14 += jv * BT_in[worldid, idx4, col]
+          AR_15 += jv * BT_in[worldid, idx5, col]
+      # Row 2
+      rnnz_2 = efc_J_rownnz_in[worldid, idx2]
+      radr_2 = efc_J_rowadr_in[worldid, idx2]
+      for k in range(rnnz_2):
+        sid = radr_2 + k
+        col = efc_J_colind_in[worldid, 0, sid]
+        jv = efc_J_in[worldid, 0, sid]
+        AR_22 += jv * BT_in[worldid, idx2, col]
+        if dim >= 4:
+          AR_23 += jv * BT_in[worldid, idx3, col]
+        if dim >= 6:
+          AR_24 += jv * BT_in[worldid, idx4, col]
+          AR_25 += jv * BT_in[worldid, idx5, col]
+      if dim >= 4:
+        rnnz_3 = efc_J_rownnz_in[worldid, idx3]
+        radr_3 = efc_J_rowadr_in[worldid, idx3]
+        for k in range(rnnz_3):
+          sid = radr_3 + k
+          col = efc_J_colind_in[worldid, 0, sid]
+          jv = efc_J_in[worldid, 0, sid]
+          AR_33 += jv * BT_in[worldid, idx3, col]
+          if dim >= 6:
+            AR_34 += jv * BT_in[worldid, idx4, col]
+            AR_35 += jv * BT_in[worldid, idx5, col]
+      if dim >= 6:
+        rnnz_4 = efc_J_rownnz_in[worldid, idx4]
+        radr_4 = efc_J_rowadr_in[worldid, idx4]
+        for k in range(rnnz_4):
+          sid = radr_4 + k
+          col = efc_J_colind_in[worldid, 0, sid]
+          jv = efc_J_in[worldid, 0, sid]
+          AR_44 += jv * BT_in[worldid, idx4, col]
+          AR_45 += jv * BT_in[worldid, idx5, col]
+        rnnz_5 = efc_J_rownnz_in[worldid, idx5]
+        radr_5 = efc_J_rowadr_in[worldid, idx5]
+        for k in range(rnnz_5):
+          sid = radr_5 + k
+          col = efc_J_colind_in[worldid, 0, sid]
+          jv = efc_J_in[worldid, 0, sid]
+          AR_55 += jv * BT_in[worldid, idx5, col]
+    else:
+      for k in range(NV):
+        j0 = efc_J_in[worldid, idx0, k]
+        AR_00 += j0 * BT_in[worldid, idx0, k]
+        AR_01 += j0 * BT_in[worldid, idx1, k]
+        AR_02 += j0 * BT_in[worldid, idx2, k]
+        if dim >= 4:
+          AR_03 += j0 * BT_in[worldid, idx3, k]
+        if dim >= 6:
+          AR_04 += j0 * BT_in[worldid, idx4, k]
+          AR_05 += j0 * BT_in[worldid, idx5, k]
+      for k in range(NV):
+        j1 = efc_J_in[worldid, idx1, k]
+        AR_11 += j1 * BT_in[worldid, idx1, k]
+        AR_12 += j1 * BT_in[worldid, idx2, k]
+        if dim >= 4:
+          AR_13 += j1 * BT_in[worldid, idx3, k]
+        if dim >= 6:
+          AR_14 += j1 * BT_in[worldid, idx4, k]
+          AR_15 += j1 * BT_in[worldid, idx5, k]
+      for k in range(NV):
+        j2 = efc_J_in[worldid, idx2, k]
+        AR_22 += j2 * BT_in[worldid, idx2, k]
+        if dim >= 4:
+          AR_23 += j2 * BT_in[worldid, idx3, k]
+        if dim >= 6:
+          AR_24 += j2 * BT_in[worldid, idx4, k]
+          AR_25 += j2 * BT_in[worldid, idx5, k]
+      if dim >= 4:
+        for k in range(NV):
+          j3 = efc_J_in[worldid, idx3, k]
+          AR_33 += j3 * BT_in[worldid, idx3, k]
+          if dim >= 6:
+            AR_34 += j3 * BT_in[worldid, idx4, k]
+            AR_35 += j3 * BT_in[worldid, idx5, k]
+      if dim >= 6:
+        for k in range(NV):
+          j4 = efc_J_in[worldid, idx4, k]
+          AR_44 += j4 * BT_in[worldid, idx4, k]
+          AR_45 += j4 * BT_in[worldid, idx5, k]
+        for k in range(NV):
+          AR_55 += efc_J_in[worldid, idx5, k] * BT_in[worldid, idx5, k]
+
+    # Add 1/D to diagonal
+    D_0 = efc_D_in[worldid, idx0]
+    if D_0 > 0.0:
+      AR_00 += 1.0 / D_0
+    D_1 = efc_D_in[worldid, idx1]
+    if D_1 > 0.0:
+      AR_11 += 1.0 / D_1
+    D_2 = efc_D_in[worldid, idx2]
+    if D_2 > 0.0:
+      AR_22 += 1.0 / D_2
+    if dim >= 4:
+      D_3 = efc_D_in[worldid, idx3]
+      if D_3 > 0.0:
+        AR_33 += 1.0 / D_3
+    if dim >= 6:
+      D_4 = efc_D_in[worldid, idx4]
+      if D_4 > 0.0:
+        AR_44 += 1.0 / D_4
+      D_5 = efc_D_in[worldid, idx5]
+      if D_5 > 0.0:
+        AR_55 += 1.0 / D_5
+
+    # Store upper-triangle elements
+    AR_elliptic_out[worldid, idx0, 0] = AR_00
+    AR_elliptic_out[worldid, idx0, 1] = AR_01
+    AR_elliptic_out[worldid, idx0, 2] = AR_02
+    AR_elliptic_out[worldid, idx0, 3] = AR_03
+    AR_elliptic_out[worldid, idx0, 4] = AR_04
+    AR_elliptic_out[worldid, idx0, 5] = AR_05
+    AR_elliptic_out[worldid, idx0, 6] = AR_11
+    AR_elliptic_out[worldid, idx0, 7] = AR_12
+    AR_elliptic_out[worldid, idx0, 8] = AR_13
+    AR_elliptic_out[worldid, idx0, 9] = AR_14
+    AR_elliptic_out[worldid, idx0, 10] = AR_15
+    AR_elliptic_out[worldid, idx0, 11] = AR_22
+    AR_elliptic_out[worldid, idx0, 12] = AR_23
+    AR_elliptic_out[worldid, idx0, 13] = AR_24
+    AR_elliptic_out[worldid, idx0, 14] = AR_25
+    AR_elliptic_out[worldid, idx0, 15] = AR_33
+    AR_elliptic_out[worldid, idx0, 16] = AR_34
+    AR_elliptic_out[worldid, idx0, 17] = AR_35
+    AR_elliptic_out[worldid, idx0, 18] = AR_44
+    AR_elliptic_out[worldid, idx0, 19] = AR_45
+    AR_elliptic_out[worldid, idx0, 20] = AR_55
+
+  return kernel
+
+
+@wp.func
+def _pgs_elliptic_normal_ray(
+  # In:
+  f0: float,
+  f1: float,
+  f2: float,
+  f3: float,
+  f4: float,
+  f5: float,
+  res0: float,
+  res1: float,
+  res2: float,
+  res3: float,
+  res4: float,
+  res5: float,
+  AR_00: float,
+  AR_01: float,
+  AR_02: float,
+  AR_03: float,
+  AR_04: float,
+  AR_05: float,
+  AR_11: float,
+  AR_12: float,
+  AR_13: float,
+  AR_14: float,
+  AR_15: float,
+  AR_22: float,
+  AR_23: float,
+  AR_24: float,
+  AR_25: float,
+  AR_33: float,
+  AR_34: float,
+  AR_35: float,
+  AR_44: float,
+  AR_45: float,
+  AR_55: float,
+) -> tuple[float, float, float, float, float, float]:
+  """Normal or ray update for elliptic cone constraint.
+
+  If f0 < MJ_MINVAL: simple normal update, zero friction forces.
+  Else: ray update using AR sub-block.
+  Returns updated forces (new0..new5).
+  """
+  if f0 < MJ_MINVAL:
+    new0 = f0 - res0 * (1.0 / AR_00 if AR_00 > 0.0 else 0.0)
+    if new0 < 0.0:
+      new0 = 0.0
+    return new0, 0.0, 0.0, 0.0, 0.0, 0.0
+
+  # AR * f (symmetric matvec)
+  av0 = AR_00 * f0 + AR_01 * f1 + AR_02 * f2 + AR_03 * f3 + AR_04 * f4 + AR_05 * f5
+  av1 = AR_01 * f0 + AR_11 * f1 + AR_12 * f2 + AR_13 * f3 + AR_14 * f4 + AR_15 * f5
+  av2 = AR_02 * f0 + AR_12 * f1 + AR_22 * f2 + AR_23 * f3 + AR_24 * f4 + AR_25 * f5
+  av3 = AR_03 * f0 + AR_13 * f1 + AR_23 * f2 + AR_33 * f3 + AR_34 * f4 + AR_35 * f5
+  av4 = AR_04 * f0 + AR_14 * f1 + AR_24 * f2 + AR_34 * f3 + AR_44 * f4 + AR_45 * f5
+  av5 = AR_05 * f0 + AR_15 * f1 + AR_25 * f2 + AR_35 * f3 + AR_45 * f4 + AR_55 * f5
+
+  denom = f0 * av0 + f1 * av1 + f2 * av2 + f3 * av3 + f4 * av4 + f5 * av5
+  vdotres = f0 * res0 + f1 * res1 + f2 * res2 + f3 * res3 + f4 * res4 + f5 * res5
+
+  new0 = f0
+  new1 = f1
+  new2 = f2
+  new3 = f3
+  new4 = f4
+  new5 = f5
+
+  if denom >= MJ_MINVAL:
+    x = -vdotres / denom
+    if f0 + x * f0 < 0.0:
+      x = -1.0
+    new0 = f0 + x * f0
+    new1 = f1 + x * f1
+    new2 = f2 + x * f2
+    new3 = f3 + x * f3
+    new4 = f4 + x * f4
+    new5 = f5 + x * f5
+
+  return new0, new1, new2, new3, new4, new5
+
+
+@wp.func
+def _pgs_elliptic_friction(
+  # In:
+  dim: int,
+  fn: float,
+  old0: float,
+  old1: float,
+  old2: float,
+  old3: float,
+  old4: float,
+  old5: float,
+  res1: float,
+  res2: float,
+  res3: float,
+  res4: float,
+  res5: float,
+  AR_01: float,
+  AR_02: float,
+  AR_03: float,
+  AR_04: float,
+  AR_05: float,
+  AR_11: float,
+  AR_12: float,
+  AR_13: float,
+  AR_14: float,
+  AR_15: float,
+  AR_22: float,
+  AR_23: float,
+  AR_24: float,
+  AR_25: float,
+  AR_33: float,
+  AR_34: float,
+  AR_35: float,
+  AR_44: float,
+  AR_45: float,
+  AR_55: float,
+  mu: types.vec5,
+) -> tuple[float, float, float, float, float]:
+  """QCQP friction update for elliptic cone constraint.
+
+  Given updated normal force fn, solve for tangential forces.
+  Returns (new1..new5).
+  """
+  if fn < MJ_MINVAL:
+    return 0.0, 0.0, 0.0, 0.0, 0.0
+
+  new1 = float(0.0)
+  new2 = float(0.0)
+  new3 = float(0.0)
+  new4 = float(0.0)
+  new5 = float(0.0)
+
+  if dim == 3:
+    bc0 = res1 - (AR_11 * old1 + AR_12 * old2) + AR_01 * (fn - old0)
+    bc1 = res2 - (AR_12 * old1 + AR_22 * old2) + AR_02 * (fn - old0)
+    v0, v1, active = util_solve.qcqp2(AR_11, AR_12, AR_22, bc0, bc1, mu[0], mu[1], fn)
+    if active:
+      s = v0 * v0 / (mu[0] * mu[0]) + v1 * v1 / (mu[1] * mu[1])
+      s = wp.sqrt(fn * fn / wp.max(MJ_MINVAL, s))
+      v0 *= s
+      v1 *= s
+    new1 = v0
+    new2 = v1
+
+  elif dim == 4:
+    bc0 = res1 - (AR_11 * old1 + AR_12 * old2 + AR_13 * old3) + AR_01 * (fn - old0)
+    bc1 = res2 - (AR_12 * old1 + AR_22 * old2 + AR_23 * old3) + AR_02 * (fn - old0)
+    bc2 = res3 - (AR_13 * old1 + AR_23 * old2 + AR_33 * old3) + AR_03 * (fn - old0)
+    v0, v1, v2, active = util_solve.qcqp3(
+      AR_11,
+      AR_12,
+      AR_13,
+      AR_22,
+      AR_23,
+      AR_33,
+      bc0,
+      bc1,
+      bc2,
+      mu[0],
+      mu[1],
+      mu[2],
+      fn,
+    )
+    if active:
+      s = v0 * v0 / (mu[0] * mu[0]) + v1 * v1 / (mu[1] * mu[1]) + v2 * v2 / (mu[2] * mu[2])
+      s = wp.sqrt(fn * fn / wp.max(MJ_MINVAL, s))
+      v0 *= s
+      v1 *= s
+      v2 *= s
+    new1 = v0
+    new2 = v1
+    new3 = v2
+
+  elif dim == 6:
+    Ac00 = AR_11
+    Ac01 = AR_12
+    Ac02 = AR_13
+    Ac03 = AR_14
+    Ac04 = AR_15
+    Ac11 = AR_22
+    Ac12 = AR_23
+    Ac13 = AR_24
+    Ac14 = AR_25
+    Ac22 = AR_33
+    Ac23 = AR_34
+    Ac24 = AR_35
+    Ac33 = AR_44
+    Ac34 = AR_45
+    Ac44 = AR_55
+    bc0 = res1 - (Ac00 * old1 + Ac01 * old2 + Ac02 * old3 + Ac03 * old4 + Ac04 * old5) + AR_01 * (fn - old0)
+    bc1 = res2 - (Ac01 * old1 + Ac11 * old2 + Ac12 * old3 + Ac13 * old4 + Ac14 * old5) + AR_02 * (fn - old0)
+    bc2 = res3 - (Ac02 * old1 + Ac12 * old2 + Ac22 * old3 + Ac23 * old4 + Ac24 * old5) + AR_03 * (fn - old0)
+    bc3 = res4 - (Ac03 * old1 + Ac13 * old2 + Ac23 * old3 + Ac33 * old4 + Ac34 * old5) + AR_04 * (fn - old0)
+    bc4 = res5 - (Ac04 * old1 + Ac14 * old2 + Ac24 * old3 + Ac34 * old4 + Ac44 * old5) + AR_05 * (fn - old0)
+    v0, v1, v2, v3, v4, active = util_solve.qcqp5(
+      Ac00,
+      Ac01,
+      Ac02,
+      Ac03,
+      Ac04,
+      Ac11,
+      Ac12,
+      Ac13,
+      Ac14,
+      Ac22,
+      Ac23,
+      Ac24,
+      Ac33,
+      Ac34,
+      Ac44,
+      bc0,
+      bc1,
+      bc2,
+      bc3,
+      bc4,
+      mu[0],
+      mu[1],
+      mu[2],
+      mu[3],
+      mu[4],
+      fn,
+    )
+    if active:
+      s = (
+        v0 * v0 / (mu[0] * mu[0])
+        + v1 * v1 / (mu[1] * mu[1])
+        + v2 * v2 / (mu[2] * mu[2])
+        + v3 * v3 / (mu[3] * mu[3])
+        + v4 * v4 / (mu[4] * mu[4])
+      )
+      s = wp.sqrt(fn * fn / wp.max(MJ_MINVAL, s))
+      v0 *= s
+      v1 *= s
+      v2 *= s
+      v3 *= s
+      v4 *= s
+    new1 = v0
+    new2 = v1
+    new3 = v2
+    new4 = v3
+    new5 = v4
+
+  return new1, new2, new3, new4, new5
+
+
+@wp.func
+def _pgs_elliptic_cost_change(
+  # In:
+  d0: float,
+  d1: float,
+  d2: float,
+  d3: float,
+  d4: float,
+  d5: float,
+  res0: float,
+  res1: float,
+  res2: float,
+  res3: float,
+  res4: float,
+  res5: float,
+  AR_00: float,
+  AR_01: float,
+  AR_02: float,
+  AR_03: float,
+  AR_04: float,
+  AR_05: float,
+  AR_11: float,
+  AR_12: float,
+  AR_13: float,
+  AR_14: float,
+  AR_15: float,
+  AR_22: float,
+  AR_23: float,
+  AR_24: float,
+  AR_25: float,
+  AR_33: float,
+  AR_34: float,
+  AR_35: float,
+  AR_44: float,
+  AR_45: float,
+  AR_55: float,
+) -> float:
+  """Compute elliptic cost change = 0.5 * d' * AR * d + d' * res."""
+  ad0 = AR_00 * d0 + AR_01 * d1 + AR_02 * d2 + AR_03 * d3 + AR_04 * d4 + AR_05 * d5
+  ad1 = AR_01 * d0 + AR_11 * d1 + AR_12 * d2 + AR_13 * d3 + AR_14 * d4 + AR_15 * d5
+  ad2 = AR_02 * d0 + AR_12 * d1 + AR_22 * d2 + AR_23 * d3 + AR_24 * d4 + AR_25 * d5
+  ad3 = AR_03 * d0 + AR_13 * d1 + AR_23 * d2 + AR_33 * d3 + AR_34 * d4 + AR_35 * d5
+  ad4 = AR_04 * d0 + AR_14 * d1 + AR_24 * d2 + AR_34 * d3 + AR_44 * d4 + AR_45 * d5
+  ad5 = AR_05 * d0 + AR_15 * d1 + AR_25 * d2 + AR_35 * d3 + AR_45 * d4 + AR_55 * d5
+  return (
+    0.5 * (d0 * ad0 + d1 * ad1 + d2 * ad2 + d3 * ad3 + d4 * ad4 + d5 * ad5)
+    + d0 * res0
+    + d1 * res1
+    + d2 * res2
+    + d3 * res3
+    + d4 * res4
+    + d5 * res5
+  )
+
+
+# kernel_analyzer: off
+@wp.func
+def _pgs_solve_elliptic_cone(
+  # Constraint info:
+  dim: int,
+  # Old forces:
+  old0: float,
+  old1: float,
+  old2: float,
+  old3: float,
+  old4: float,
+  old5: float,
+  # Residuals:
+  res0: float,
+  res1: float,
+  res2: float,
+  res3: float,
+  res4: float,
+  res5: float,
+  # Precomputed AR sub-block array:
+  AR_elliptic_in: wp.array3d[float],
+  worldid: int,
+  idx0: int,
+  # Friction coefficients:
+  mu: types.vec5,
+  # SOR omega (1.0 for GS modes):
+  sor_omega: float,
+) -> tuple[float, float, float, float, float, float, float]:
+  """Shared elliptic QCQP solve: load AR, normal/ray update, friction, SOR, cost change.
+
+  Returns (new0, new1, new2, new3, new4, new5, cost_change).
+  """
+  # ---- Load precomputed AR sub-block (21 elements, upper triangle) ----
+  AR_00 = AR_elliptic_in[worldid, idx0, 0]
+  AR_01 = AR_elliptic_in[worldid, idx0, 1]
+  AR_02 = AR_elliptic_in[worldid, idx0, 2]
+  AR_03 = AR_elliptic_in[worldid, idx0, 3]
+  AR_04 = AR_elliptic_in[worldid, idx0, 4]
+  AR_05 = AR_elliptic_in[worldid, idx0, 5]
+  AR_11 = AR_elliptic_in[worldid, idx0, 6]
+  AR_12 = AR_elliptic_in[worldid, idx0, 7]
+  AR_13 = AR_elliptic_in[worldid, idx0, 8]
+  AR_14 = AR_elliptic_in[worldid, idx0, 9]
+  AR_15 = AR_elliptic_in[worldid, idx0, 10]
+  AR_22 = AR_elliptic_in[worldid, idx0, 11]
+  AR_23 = AR_elliptic_in[worldid, idx0, 12]
+  AR_24 = AR_elliptic_in[worldid, idx0, 13]
+  AR_25 = AR_elliptic_in[worldid, idx0, 14]
+  AR_33 = AR_elliptic_in[worldid, idx0, 15]
+  AR_34 = AR_elliptic_in[worldid, idx0, 16]
+  AR_35 = AR_elliptic_in[worldid, idx0, 17]
+  AR_44 = AR_elliptic_in[worldid, idx0, 18]
+  AR_45 = AR_elliptic_in[worldid, idx0, 19]
+  AR_55 = AR_elliptic_in[worldid, idx0, 20]
+
+  # ---- Normal/ray update ----
+  new0, new1, new2, new3, new4, new5 = _pgs_elliptic_normal_ray(
+    old0,
+    old1,
+    old2,
+    old3,
+    old4,
+    old5,
+    res0,
+    res1,
+    res2,
+    res3,
+    res4,
+    res5,
+    AR_00,
+    AR_01,
+    AR_02,
+    AR_03,
+    AR_04,
+    AR_05,
+    AR_11,
+    AR_12,
+    AR_13,
+    AR_14,
+    AR_15,
+    AR_22,
+    AR_23,
+    AR_24,
+    AR_25,
+    AR_33,
+    AR_34,
+    AR_35,
+    AR_44,
+    AR_45,
+    AR_55,
+  )
+
+  # ---- Friction update (QCQP) ----
+  if old0 >= MJ_MINVAL:
+    new1, new2, new3, new4, new5 = _pgs_elliptic_friction(
+      dim,
+      new0,
+      old0,
+      old1,
+      old2,
+      old3,
+      old4,
+      old5,
+      res1,
+      res2,
+      res3,
+      res4,
+      res5,
+      AR_01,
+      AR_02,
+      AR_03,
+      AR_04,
+      AR_05,
+      AR_11,
+      AR_12,
+      AR_13,
+      AR_14,
+      AR_15,
+      AR_22,
+      AR_23,
+      AR_24,
+      AR_25,
+      AR_33,
+      AR_34,
+      AR_35,
+      AR_44,
+      AR_45,
+      AR_55,
+      mu,
+    )
+
+  # ---- SOR blend (sor_omega=1.0 is identity for GS modes) ----
+  new0 = (1.0 - sor_omega) * old0 + sor_omega * new0
+  new1 = (1.0 - sor_omega) * old1 + sor_omega * new1
+  new2 = (1.0 - sor_omega) * old2 + sor_omega * new2
+  new3 = (1.0 - sor_omega) * old3 + sor_omega * new3
+  new4 = (1.0 - sor_omega) * old4 + sor_omega * new4
+  new5 = (1.0 - sor_omega) * old5 + sor_omega * new5
+
+  # ---- Cost change ----
+  d0 = new0 - old0
+  d1 = new1 - old1
+  d2 = new2 - old2
+  d3 = new3 - old3
+  d4 = new4 - old4
+  d5 = new5 - old5
+  change = _pgs_elliptic_cost_change(
+    d0,
+    d1,
+    d2,
+    d3,
+    d4,
+    d5,
+    res0,
+    res1,
+    res2,
+    res3,
+    res4,
+    res5,
+    AR_00,
+    AR_01,
+    AR_02,
+    AR_03,
+    AR_04,
+    AR_05,
+    AR_11,
+    AR_12,
+    AR_13,
+    AR_14,
+    AR_15,
+    AR_22,
+    AR_23,
+    AR_24,
+    AR_25,
+    AR_33,
+    AR_34,
+    AR_35,
+    AR_44,
+    AR_45,
+    AR_55,
+  )
+
+  return new0, new1, new2, new3, new4, new5, change
+
+
+# kernel_analyzer: on
+
+
+def _pgs_update_qacc_delta_func(nv: int, use_sparse_bt: bool):
+  """Factory returning a @wp.func that applies a single-row qacc delta.
+
+  qacc[worldid, :] += delta * BT[worldid, efcid, :]
+
+  Uses sparse or dense BT based on use_sparse_bt (compile-time constant).
+  """
+  NV = nv
+  USE_SPARSE_BT = use_sparse_bt
+
+  # kernel_analyzer: off
+  @wp.func
+  def update_qacc_delta(
+    worldid: int,
+    efcid: int,
+    delta: float,
+    BT_in: wp.array3d[float],
+    BT_rownnz_in: wp.array2d[int],
+    BT_rowadr_in: wp.array2d[int],
+    BT_colind_in: wp.array3d[int],
+    qacc_inout: wp.array2d[float],
+  ):
+    if wp.static(USE_SPARSE_BT):
+      bt_nnz = BT_rownnz_in[worldid, efcid]
+      bt_adr = BT_rowadr_in[worldid, efcid]
+      for k in range(bt_nnz):
+        col = BT_colind_in[worldid, 0, bt_adr + k]
+        qacc_inout[worldid, col] += delta * BT_in[worldid, efcid, col]  # kernel_analyzer: ignore
+    else:
+      for k in range(wp.static(NV)):
+        qacc_inout[worldid, k] += delta * BT_in[worldid, efcid, k]  # kernel_analyzer: ignore
+
+  return update_qacc_delta
+  # kernel_analyzer: on
+
+
+def _pgs_sweep_kernel(nv: int, is_sparse: bool, use_sparse_bt: bool):
+  """One PGS Gauss-Seidel sweep over all constraints (AR-free).
+
+  Sequential per world — processes constraints one at a time,
+  following MuJoCo C's mj_solPGS implementation.
+
+  Uses on-the-fly J·BT products instead of materialized AR matrix.
+  Maintains qacc incrementally: qacc += delta · BT[i,:] after each update.
+
+  For 1D constraints, uses precomputed 1/AR[i,i] to avoid redundant O(nv)
+  dot products each iteration (AR diagonal is constant across iterations).
+
+  Handles:
+  - Equality constraints (no projection)
+  - Friction constraints (interval [-floss, floss])
+  - Limit and contact constraints (non-negativity [0, inf))
+  - Elliptic cone constraints (QCQP sub-problems for dim 3, 4, 6)
+  """
+  IS_SPARSE = is_sparse
+  USE_SPARSE_BT = use_sparse_bt
+  update_qacc = _pgs_update_qacc_delta_func(nv, use_sparse_bt)
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(  # kernel_analyzer: ignore
+    # Data in:
+    ne_in: wp.array[int],
+    nf_in: wp.array[int],
+    nefc_in: wp.array[int],
+    efc_type_in: wp.array2d[int],
+    efc_frictionloss_in: wp.array2d[float],
+    efc_id_in: wp.array2d[int],
+    contact_dim_in: wp.array[int],
+    contact_friction_in: wp.array[types.vec5],
+    contact_efc_address_in: wp.array2d[int],
+    # J (dense or sparse format):
+    efc_J_in: wp.array3d[float],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    # In:
+    BT_in: wp.array3d[float],
+    # Sparse BT index (ntree > 1):
+    BT_rownnz_in: wp.array2d[int],
+    BT_rowadr_in: wp.array2d[int],
+    BT_colind_in: wp.array3d[int],
+    # Precomputed 1/AR[i,i] for 1D constraints:
+    AR_diag_inv_in: wp.array2d[float],
+    # Precomputed AR sub-block for elliptic contacts:
+    AR_elliptic_in: wp.array3d[float],
+    # Constraint params:
+    efc_D_in: wp.array2d[float],
+    efc_aref_in: wp.array2d[float],
+    # Model:
+    opt_tolerance: wp.array[float],
+    stat_meaninertia: wp.array[float],
+    maxiter: int,
+    # Data in/out:
+    efc_force_inout: wp.array2d[float],
+    qacc_inout: wp.array2d[float],
+    done_inout: wp.array[bool],
+    solver_niter_inout: wp.array[int],
+    nsolving_inout: wp.array[int],
+    # Data out:
+    efc_state_out: wp.array2d[int],
+  ):
+    worldid = wp.tid()
+
+    if done_inout[worldid]:
+      return
+
+    nefc = nefc_in[worldid]
+    ne = ne_in[worldid]
+    nf = nf_in[worldid]
+    NV = wp.static(nv)
+    tolerance = opt_tolerance[worldid % opt_tolerance.shape[0]]
+
+    improvement = float(0.0)
+
+    i = int(0)
+    while i < nefc:
+      # Get constraint dimensionality
+      dim = int(1)
+      if efc_type_in[worldid, i] == types.ConstraintType.CONTACT_ELLIPTIC:
+        con_id = efc_id_in[worldid, i]
+        dim = contact_dim_in[con_id]
+
+      # ---- Simple (1D) constraint ----
+      if dim == 1:
+        # Compute residual: res = J[i,:] · qacc - aref[i] + f[i]/D[i]
+        res = float(0.0)
+        if wp.static(IS_SPARSE):
+          rownnz_i = efc_J_rownnz_in[worldid, i]
+          rowadr_i = efc_J_rowadr_in[worldid, i]
+          for k in range(rownnz_i):
+            sparseid = rowadr_i + k
+            col = efc_J_colind_in[worldid, 0, sparseid]
+            res += efc_J_in[worldid, 0, sparseid] * qacc_inout[worldid, col]
+        else:
+          for k in range(NV):
+            res += efc_J_in[worldid, i, k] * qacc_inout[worldid, k]
+        res -= efc_aref_in[worldid, i]
+        D_i = efc_D_in[worldid, i]
+        if D_i > 0.0:
+          res += efc_force_inout[worldid, i] / D_i
+
+        # Use precomputed 1/AR[i,i] — avoids O(nv) dot product each iteration
+        old_force = efc_force_inout[worldid, i]
+        AR_diag_inv = AR_diag_inv_in[worldid, i]
+        new_force = old_force - res * AR_diag_inv
+
+        # Project onto constraint bounds
+        if i >= ne and i < ne + nf:
+          floss = efc_frictionloss_in[worldid, i]
+          if new_force < -floss:
+            new_force = -floss
+          elif new_force > floss:
+            new_force = floss
+        elif i >= ne + nf:
+          if new_force < 0.0:
+            new_force = 0.0
+
+        # Cost change: 0.5 * delta * AR[i,i] * delta + delta * res
+        delta = new_force - old_force
+        AR_ii = 1.0 / AR_diag_inv if AR_diag_inv > 0.0 else 0.0
+        change = 0.5 * delta * delta * AR_ii + delta * res
+
+        if change > tolerance:
+          new_force = old_force
+        else:
+          improvement -= change
+          # Update qacc incrementally
+          actual_delta = new_force - old_force
+          update_qacc(worldid, i, actual_delta, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+
+        efc_force_inout[worldid, i] = new_force  # kernel_analyzer: ignore
+        i += 1
+
+      # ---- Elliptic cone constraint (multi-dim) ----
+      else:
+        con_id = efc_id_in[worldid, i]
+        mu = contact_friction_in[con_id]
+
+        # Indirect indexing: look up actual efcid for each dimension
+        # Rows are contiguous (base_efcid + dim) due to block allocation
+        idx0 = contact_efc_address_in[con_id, 0]
+        idx1 = int(-1)
+        idx2 = int(-1)
+        idx3 = int(-1)
+        idx4 = int(-1)
+        idx5 = int(-1)
+        if dim >= 3:
+          idx1 = contact_efc_address_in[con_id, 1]
+          idx2 = contact_efc_address_in[con_id, 2]
+        if dim >= 4:
+          idx3 = contact_efc_address_in[con_id, 3]
+        if dim >= 6:
+          idx4 = contact_efc_address_in[con_id, 4]
+          idx5 = contact_efc_address_in[con_id, 5]
+
+        # Skip non-normal rows — only process from the first (normal) row
+        if i != idx0:
+          i += dim  # skip entire block
+          continue
+
+        # ---- Compute residuals for all dim rows ----
+        # res_d = J[idx_d,:] · qacc - aref[idx_d] + f[idx_d]/D[idx_d]
+        res0 = float(0.0)
+        res1 = float(0.0)
+        res2 = float(0.0)
+        res3 = float(0.0)
+        res4 = float(0.0)
+        res5 = float(0.0)
+
+        # Row 0 (normal)
+        if wp.static(IS_SPARSE):
+          rnnz0 = efc_J_rownnz_in[worldid, idx0]
+          radr0 = efc_J_rowadr_in[worldid, idx0]
+          for k in range(rnnz0):
+            sid = radr0 + k
+            col = efc_J_colind_in[worldid, 0, sid]
+            res0 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+        else:
+          for k in range(NV):
+            res0 += efc_J_in[worldid, idx0, k] * qacc_inout[worldid, k]
+        res0 -= efc_aref_in[worldid, idx0]
+        D_0 = efc_D_in[worldid, idx0]
+        if D_0 > 0.0:
+          res0 += efc_force_inout[worldid, idx0] / D_0
+
+        if dim >= 3:
+          if wp.static(IS_SPARSE):
+            rnnz1 = efc_J_rownnz_in[worldid, idx1]
+            radr1 = efc_J_rowadr_in[worldid, idx1]
+            for k in range(rnnz1):
+              sid = radr1 + k
+              col = efc_J_colind_in[worldid, 0, sid]
+              res1 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+          else:
+            for k in range(NV):
+              res1 += efc_J_in[worldid, idx1, k] * qacc_inout[worldid, k]
+          res1 -= efc_aref_in[worldid, idx1]
+          D_1 = efc_D_in[worldid, idx1]
+          if D_1 > 0.0:
+            res1 += efc_force_inout[worldid, idx1] / D_1
+
+          if wp.static(IS_SPARSE):
+            rnnz2 = efc_J_rownnz_in[worldid, idx2]
+            radr2 = efc_J_rowadr_in[worldid, idx2]
+            for k in range(rnnz2):
+              sid = radr2 + k
+              col = efc_J_colind_in[worldid, 0, sid]
+              res2 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+          else:
+            for k in range(NV):
+              res2 += efc_J_in[worldid, idx2, k] * qacc_inout[worldid, k]
+          res2 -= efc_aref_in[worldid, idx2]
+          D_2 = efc_D_in[worldid, idx2]
+          if D_2 > 0.0:
+            res2 += efc_force_inout[worldid, idx2] / D_2
+
+        if dim >= 4:
+          if wp.static(IS_SPARSE):
+            rnnz3 = efc_J_rownnz_in[worldid, idx3]
+            radr3 = efc_J_rowadr_in[worldid, idx3]
+            for k in range(rnnz3):
+              sid = radr3 + k
+              col = efc_J_colind_in[worldid, 0, sid]
+              res3 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+          else:
+            for k in range(NV):
+              res3 += efc_J_in[worldid, idx3, k] * qacc_inout[worldid, k]
+          res3 -= efc_aref_in[worldid, idx3]
+          D_3 = efc_D_in[worldid, idx3]
+          if D_3 > 0.0:
+            res3 += efc_force_inout[worldid, idx3] / D_3
+
+        if dim >= 6:
+          if wp.static(IS_SPARSE):
+            rnnz4 = efc_J_rownnz_in[worldid, idx4]
+            radr4 = efc_J_rowadr_in[worldid, idx4]
+            for k in range(rnnz4):
+              sid = radr4 + k
+              col = efc_J_colind_in[worldid, 0, sid]
+              res4 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+          else:
+            for k in range(NV):
+              res4 += efc_J_in[worldid, idx4, k] * qacc_inout[worldid, k]
+          res4 -= efc_aref_in[worldid, idx4]
+          D_4 = efc_D_in[worldid, idx4]
+          if D_4 > 0.0:
+            res4 += efc_force_inout[worldid, idx4] / D_4
+
+          if wp.static(IS_SPARSE):
+            rnnz5 = efc_J_rownnz_in[worldid, idx5]
+            radr5 = efc_J_rowadr_in[worldid, idx5]
+            for k in range(rnnz5):
+              sid = radr5 + k
+              col = efc_J_colind_in[worldid, 0, sid]
+              res5 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+          else:
+            for k in range(NV):
+              res5 += efc_J_in[worldid, idx5, k] * qacc_inout[worldid, k]
+          res5 -= efc_aref_in[worldid, idx5]
+          D_5 = efc_D_in[worldid, idx5]
+          if D_5 > 0.0:
+            res5 += efc_force_inout[worldid, idx5] / D_5
+
+        # ---- Save old forces ----
+        old0 = efc_force_inout[worldid, idx0]
+        old1 = float(0.0)
+        old2 = float(0.0)
+        old3 = float(0.0)
+        old4 = float(0.0)
+        old5 = float(0.0)
+        if dim >= 3:
+          old1 = efc_force_inout[worldid, idx1]
+          old2 = efc_force_inout[worldid, idx2]
+        if dim >= 4:
+          old3 = efc_force_inout[worldid, idx3]
+        if dim >= 6:
+          old4 = efc_force_inout[worldid, idx4]
+          old5 = efc_force_inout[worldid, idx5]
+
+        # ---- Solve elliptic QCQP (shared) ----
+        new0, new1, new2, new3, new4, new5, change = _pgs_solve_elliptic_cone(
+          dim,
+          old0,
+          old1,
+          old2,
+          old3,
+          old4,
+          old5,
+          res0,
+          res1,
+          res2,
+          res3,
+          res4,
+          res5,
+          AR_elliptic_in,
+          worldid,
+          idx0,
+          mu,
+          1.0,
+        )
+
+        # ---- Accept or reject ----
+        if change <= tolerance:
+          improvement -= change
+          d0 = new0 - old0
+          d1 = new1 - old1
+          d2 = new2 - old2
+          d3 = new3 - old3
+          d4 = new4 - old4
+          d5 = new5 - old5
+          efc_force_inout[worldid, idx0] = new0  # kernel_analyzer: ignore
+          if dim >= 3:
+            efc_force_inout[worldid, idx1] = new1  # kernel_analyzer: ignore
+            efc_force_inout[worldid, idx2] = new2  # kernel_analyzer: ignore
+          if dim >= 4:
+            efc_force_inout[worldid, idx3] = new3  # kernel_analyzer: ignore
+          if dim >= 6:
+            efc_force_inout[worldid, idx4] = new4  # kernel_analyzer: ignore
+            efc_force_inout[worldid, idx5] = new5  # kernel_analyzer: ignore
+          # Update qacc
+          if d0 != 0.0:
+            update_qacc(worldid, idx0, d0, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+          if dim >= 3:
+            if d1 != 0.0:
+              update_qacc(worldid, idx1, d1, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+            if d2 != 0.0:
+              update_qacc(worldid, idx2, d2, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+          if dim >= 4:
+            if d3 != 0.0:
+              update_qacc(worldid, idx3, d3, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+          if dim >= 6:
+            if d4 != 0.0:
+              update_qacc(worldid, idx4, d4, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+            if d5 != 0.0:
+              update_qacc(worldid, idx5, d5, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+
+        i += dim
+
+    # ---- Inline dual state ----
+    for efcid in range(nefc):
+      force = efc_force_inout[worldid, efcid]
+      if efcid < ne:
+        efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC.value
+      elif efcid < ne + nf:
+        floss = efc_frictionloss_in[worldid, efcid]
+        if force <= -floss:
+          efc_state_out[worldid, efcid] = types.ConstraintState.LINEARPOS.value
+        elif force >= floss:
+          efc_state_out[worldid, efcid] = types.ConstraintState.LINEARNEG.value
+        else:
+          efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC.value
+      elif efc_type_in[worldid, efcid] != types.ConstraintType.CONTACT_ELLIPTIC:
+        if force <= 0.0:
+          efc_state_out[worldid, efcid] = types.ConstraintState.SATISFIED.value
+        else:
+          efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC.value
+      else:
+        efc_state_out[worldid, efcid] = types.ConstraintState.SATISFIED.value
+
+    # ---- Inline convergence check ----
+    NV_ = wp.static(nv)
+    tolerance = opt_tolerance[worldid % opt_tolerance.shape[0]]
+    meaninertia = stat_meaninertia[worldid % stat_meaninertia.shape[0]]
+    scale = 1.0 / (meaninertia * float(wp.max(1, NV_)))
+    scaled_improvement = improvement * scale
+
+    solver_niter_inout[worldid] += 1  # kernel_analyzer: ignore
+
+    if scaled_improvement < tolerance or solver_niter_inout[worldid] >= maxiter:
+      done_inout[worldid] = True  # kernel_analyzer: ignore
+      wp.atomic_add(nsolving_inout, 0, -1)
+
+  return kernel
+
+
+def _pgs_process_group_func(nv: int, is_sparse: bool, use_sparse_bt: bool):
+  """Factory returning a shared @wp.func for processing one constraint group.
+
+  Handles both 1D constraints (pyramidal contacts, limits, friction, equality)
+  and elliptic QCQP contacts (dim 3, 4, 6). Used by both the color-parallel
+  sweep and the sequential overflow sweep.
+
+  Returns improvement via atomic accumulation.
+  """
+  IS_SPARSE = is_sparse
+  update_qacc = _pgs_update_qacc_delta_func(nv, use_sparse_bt)
+
+  # kernel_analyzer: off
+  @wp.func
+  def process_group(
+    worldid: int,
+    efc_start: int,
+    efc_count: int,
+    ne: int,
+    nf: int,
+    tolerance: float,
+    # Data arrays:
+    efc_type_in: wp.array2d[int],
+    efc_frictionloss_in: wp.array2d[float],
+    efc_id_in: wp.array2d[int],
+    contact_dim_in: wp.array[int],
+    contact_friction_in: wp.array[types.vec5],
+    contact_efc_address_in: wp.array2d[int],
+    efc_J_in: wp.array3d[float],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    BT_in: wp.array3d[float],
+    BT_rownnz_in: wp.array2d[int],
+    BT_rowadr_in: wp.array2d[int],
+    BT_colind_in: wp.array3d[int],
+    AR_diag_inv_in: wp.array2d[float],
+    AR_elliptic_in: wp.array3d[float],
+    efc_D_in: wp.array2d[float],
+    efc_aref_in: wp.array2d[float],
+    # In/Out:
+    efc_force_inout: wp.array2d[float],
+    qacc_inout: wp.array2d[float],
+    improvement_out: wp.array[float],
+  ):
+    NV = wp.static(nv)
+
+    # Check if this group is an elliptic contact (multi-dim QCQP)
+    is_elliptic = int(0)
+    dim = int(1)
+    if efc_type_in[worldid, efc_start] == types.ConstraintType.CONTACT_ELLIPTIC:
+      con_id = efc_id_in[worldid, efc_start]
+      dim = contact_dim_in[con_id]
+      if dim > 1:
+        is_elliptic = 1
+
+    if is_elliptic == 0:
+      # ---- 1D or multi-row sequential (pyramidal/connect/weld) ----
+      for row_offset in range(efc_count):
+        i = efc_start + row_offset
+
+        # Compute residual
+        res = float(0.0)
+        if wp.static(IS_SPARSE):
+          rownnz_i = efc_J_rownnz_in[worldid, i]
+          rowadr_i = efc_J_rowadr_in[worldid, i]
+          for k in range(rownnz_i):
+            sparseid = rowadr_i + k
+            col = efc_J_colind_in[worldid, 0, sparseid]
+            res += efc_J_in[worldid, 0, sparseid] * qacc_inout[worldid, col]
+        else:
+          for k in range(NV):
+            res += efc_J_in[worldid, i, k] * qacc_inout[worldid, k]
+        res -= efc_aref_in[worldid, i]
+        D_i = efc_D_in[worldid, i]
+        if D_i > 0.0:
+          res += efc_force_inout[worldid, i] / D_i
+
+        old_force = efc_force_inout[worldid, i]
+        AR_diag_inv = AR_diag_inv_in[worldid, i]
+        new_force = old_force - res * AR_diag_inv
+
+        # Project
+        if i >= ne and i < ne + nf:
+          floss = efc_frictionloss_in[worldid, i]
+          if new_force < -floss:
+            new_force = -floss
+          elif new_force > floss:
+            new_force = floss
+        elif i >= ne + nf:
+          if new_force < 0.0:
+            new_force = 0.0
+
+        # Cost change
+        delta = new_force - old_force
+        AR_ii = 1.0 / AR_diag_inv if AR_diag_inv > 0.0 else 0.0
+        change = 0.5 * delta * delta * AR_ii + delta * res
+
+        if change > tolerance:
+          new_force = old_force
+        else:
+          wp.atomic_add(improvement_out, worldid, -change)
+          actual_delta = new_force - old_force
+          update_qacc(worldid, i, actual_delta, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+
+        efc_force_inout[worldid, i] = new_force  # kernel_analyzer: ignore
+
+    else:
+      # ---- Elliptic cone constraint (multi-dim QCQP) ----
+      # Contiguous rows: idx_d = efc_start + d
+      con_id = efc_id_in[worldid, efc_start]
+      mu = contact_friction_in[con_id]
+
+      idx0 = efc_start
+      idx1 = efc_start + 1
+      idx2 = efc_start + 2
+      idx3 = int(-1)
+      idx4 = int(-1)
+      idx5 = int(-1)
+      if dim >= 4:
+        idx3 = efc_start + 3
+      if dim >= 6:
+        idx4 = efc_start + 4
+        idx5 = efc_start + 5
+
+      # ---- Compute residuals for all dim rows ----
+      res0 = float(0.0)
+      res1 = float(0.0)
+      res2 = float(0.0)
+      res3 = float(0.0)
+      res4 = float(0.0)
+      res5 = float(0.0)
+
+      # Row 0 (normal)
+      if wp.static(IS_SPARSE):
+        rnnz0 = efc_J_rownnz_in[worldid, idx0]
+        radr0 = efc_J_rowadr_in[worldid, idx0]
+        for k in range(rnnz0):
+          sid = radr0 + k
+          col = efc_J_colind_in[worldid, 0, sid]
+          res0 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+      else:
+        for k in range(NV):
+          res0 += efc_J_in[worldid, idx0, k] * qacc_inout[worldid, k]
+      res0 -= efc_aref_in[worldid, idx0]
+      D_0 = efc_D_in[worldid, idx0]
+      if D_0 > 0.0:
+        res0 += efc_force_inout[worldid, idx0] / D_0
+
+      # Rows 1,2
+      if wp.static(IS_SPARSE):
+        rnnz1 = efc_J_rownnz_in[worldid, idx1]
+        radr1 = efc_J_rowadr_in[worldid, idx1]
+        for k in range(rnnz1):
+          sid = radr1 + k
+          col = efc_J_colind_in[worldid, 0, sid]
+          res1 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+      else:
+        for k in range(NV):
+          res1 += efc_J_in[worldid, idx1, k] * qacc_inout[worldid, k]
+      res1 -= efc_aref_in[worldid, idx1]
+      D_1 = efc_D_in[worldid, idx1]
+      if D_1 > 0.0:
+        res1 += efc_force_inout[worldid, idx1] / D_1
+
+      if wp.static(IS_SPARSE):
+        rnnz2 = efc_J_rownnz_in[worldid, idx2]
+        radr2 = efc_J_rowadr_in[worldid, idx2]
+        for k in range(rnnz2):
+          sid = radr2 + k
+          col = efc_J_colind_in[worldid, 0, sid]
+          res2 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+      else:
+        for k in range(NV):
+          res2 += efc_J_in[worldid, idx2, k] * qacc_inout[worldid, k]
+      res2 -= efc_aref_in[worldid, idx2]
+      D_2 = efc_D_in[worldid, idx2]
+      if D_2 > 0.0:
+        res2 += efc_force_inout[worldid, idx2] / D_2
+
+      if dim >= 4:
+        if wp.static(IS_SPARSE):
+          rnnz3 = efc_J_rownnz_in[worldid, idx3]
+          radr3 = efc_J_rowadr_in[worldid, idx3]
+          for k in range(rnnz3):
+            sid = radr3 + k
+            col = efc_J_colind_in[worldid, 0, sid]
+            res3 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+        else:
+          for k in range(NV):
+            res3 += efc_J_in[worldid, idx3, k] * qacc_inout[worldid, k]
+        res3 -= efc_aref_in[worldid, idx3]
+        D_3 = efc_D_in[worldid, idx3]
+        if D_3 > 0.0:
+          res3 += efc_force_inout[worldid, idx3] / D_3
+
+      if dim >= 6:
+        if wp.static(IS_SPARSE):
+          rnnz4 = efc_J_rownnz_in[worldid, idx4]
+          radr4 = efc_J_rowadr_in[worldid, idx4]
+          for k in range(rnnz4):
+            sid = radr4 + k
+            col = efc_J_colind_in[worldid, 0, sid]
+            res4 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+        else:
+          for k in range(NV):
+            res4 += efc_J_in[worldid, idx4, k] * qacc_inout[worldid, k]
+        res4 -= efc_aref_in[worldid, idx4]
+        D_4 = efc_D_in[worldid, idx4]
+        if D_4 > 0.0:
+          res4 += efc_force_inout[worldid, idx4] / D_4
+
+        if wp.static(IS_SPARSE):
+          rnnz5 = efc_J_rownnz_in[worldid, idx5]
+          radr5 = efc_J_rowadr_in[worldid, idx5]
+          for k in range(rnnz5):
+            sid = radr5 + k
+            col = efc_J_colind_in[worldid, 0, sid]
+            res5 += efc_J_in[worldid, 0, sid] * qacc_inout[worldid, col]
+        else:
+          for k in range(NV):
+            res5 += efc_J_in[worldid, idx5, k] * qacc_inout[worldid, k]
+        res5 -= efc_aref_in[worldid, idx5]
+        D_5 = efc_D_in[worldid, idx5]
+        if D_5 > 0.0:
+          res5 += efc_force_inout[worldid, idx5] / D_5
+
+      # ---- Save old forces ----
+      old0 = efc_force_inout[worldid, idx0]
+      old1 = efc_force_inout[worldid, idx1]
+      old2 = efc_force_inout[worldid, idx2]
+      old3 = float(0.0)
+      old4 = float(0.0)
+      old5 = float(0.0)
+      if dim >= 4:
+        old3 = efc_force_inout[worldid, idx3]
+      if dim >= 6:
+        old4 = efc_force_inout[worldid, idx4]
+        old5 = efc_force_inout[worldid, idx5]
+
+      # ---- Solve elliptic QCQP (shared) ----
+      new0, new1, new2, new3, new4, new5, change = _pgs_solve_elliptic_cone(
+        dim,
+        old0,
+        old1,
+        old2,
+        old3,
+        old4,
+        old5,
+        res0,
+        res1,
+        res2,
+        res3,
+        res4,
+        res5,
+        AR_elliptic_in,
+        worldid,
+        idx0,
+        mu,
+        1.0,
+      )
+
+      # ---- Accept or reject ----
+      if change <= tolerance:
+        wp.atomic_add(improvement_out, worldid, -change)
+        d0 = new0 - old0
+        d1 = new1 - old1
+        d2 = new2 - old2
+        d3 = new3 - old3
+        d4 = new4 - old4
+        d5 = new5 - old5
+        efc_force_inout[worldid, idx0] = new0  # kernel_analyzer: ignore
+        efc_force_inout[worldid, idx1] = new1  # kernel_analyzer: ignore
+        efc_force_inout[worldid, idx2] = new2  # kernel_analyzer: ignore
+        if dim >= 4:
+          efc_force_inout[worldid, idx3] = new3  # kernel_analyzer: ignore
+        if dim >= 6:
+          efc_force_inout[worldid, idx4] = new4  # kernel_analyzer: ignore
+          efc_force_inout[worldid, idx5] = new5  # kernel_analyzer: ignore
+        # Update qacc
+        if d0 != 0.0:
+          update_qacc(worldid, idx0, d0, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+        if d1 != 0.0:
+          update_qacc(worldid, idx1, d1, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+        if d2 != 0.0:
+          update_qacc(worldid, idx2, d2, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+        if dim >= 4:
+          if d3 != 0.0:
+            update_qacc(worldid, idx3, d3, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+        if dim >= 6:
+          if d4 != 0.0:
+            update_qacc(worldid, idx4, d4, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+          if d5 != 0.0:
+            update_qacc(worldid, idx5, d5, BT_in, BT_rownnz_in, BT_rowadr_in, BT_colind_in, qacc_inout)
+
+  return process_group
+  # kernel_analyzer: on
+
+
+def _pgs_color_sweep_kernel(nv: int, is_sparse: bool, use_sparse_bt: bool):
+  """Color-parallel PGS sweep: each thread processes one constraint group.
+
+  Handles 1D constraints (pyramidal contacts, limits, friction, equality),
+  and elliptic QCQP contacts (dim 3, 4, 6). qacc updates need no atomics
+  since constraints within a color don't share DOFs.
+
+  Contact efc rows are contiguous (efc_start + dimid).
+  """
+  process_group = _pgs_process_group_func(nv, is_sparse, use_sparse_bt)
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(  # kernel_analyzer: ignore
+    # In:
+    schedule_groups_in: wp.array2d[int],
+    schedule_offsets_in: wp.array2d[int],
+    color_idx: int,
+    group_efc_start_in: wp.array2d[int],
+    group_efc_count_in: wp.array2d[int],
+    # Data in:
+    ne_in: wp.array[int],
+    nf_in: wp.array[int],
+    nefc_in: wp.array[int],
+    efc_type_in: wp.array2d[int],
+    efc_frictionloss_in: wp.array2d[float],
+    efc_id_in: wp.array2d[int],
+    contact_dim_in: wp.array[int],
+    contact_friction_in: wp.array[types.vec5],
+    contact_efc_address_in: wp.array2d[int],
+    efc_J_in: wp.array3d[float],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    BT_in: wp.array3d[float],
+    # Sparse BT index (ntree > 1):
+    BT_rownnz_in: wp.array2d[int],
+    BT_rowadr_in: wp.array2d[int],
+    BT_colind_in: wp.array3d[int],
+    AR_diag_inv_in: wp.array2d[float],
+    AR_elliptic_in: wp.array3d[float],
+    efc_D_in: wp.array2d[float],
+    efc_aref_in: wp.array2d[float],
+    # Model:
+    opt_tolerance: wp.array[float],
+    done_in: wp.array[bool],
+    # Out:
+    efc_force_inout: wp.array2d[float],
+    qacc_inout: wp.array2d[float],
+    improvement_out: wp.array[float],  # kernel_analyzer: ignore
+  ):
+    worldid, batch_idx = wp.tid()
+
+    if done_in[worldid]:
+      return
+
+    sched_start = schedule_offsets_in[worldid, color_idx]
+    sched_end = schedule_offsets_in[worldid, color_idx + 1]
+    if batch_idx >= (sched_end - sched_start):
+      return
+
+    group_id = schedule_groups_in[worldid, sched_start + batch_idx]
+    if group_id < 0:
+      return
+
+    efc_start = group_efc_start_in[worldid, group_id]
+    efc_count = group_efc_count_in[worldid, group_id]
+    ne = ne_in[worldid]
+    nf = nf_in[worldid]
+    tolerance = opt_tolerance[worldid % opt_tolerance.shape[0]]
+
+    process_group(
+      worldid,
+      efc_start,
+      efc_count,
+      ne,
+      nf,
+      tolerance,
+      efc_type_in,
+      efc_frictionloss_in,
+      efc_id_in,
+      contact_dim_in,
+      contact_friction_in,
+      contact_efc_address_in,
+      efc_J_in,
+      efc_J_rownnz_in,
+      efc_J_rowadr_in,
+      efc_J_colind_in,
+      BT_in,
+      BT_rownnz_in,
+      BT_rowadr_in,
+      BT_colind_in,
+      AR_diag_inv_in,
+      AR_elliptic_in,
+      efc_D_in,
+      efc_aref_in,
+      efc_force_inout,
+      qacc_inout,
+      improvement_out,
+    )
+
+  return kernel
+
+
+def _pgs_overflow_sweep_kernel(nv: int, is_sparse: bool, use_sparse_bt: bool):
+  """Sequential sweep over overflow (uncolored) constraint groups.
+
+  Processes groups that could not be assigned a color during graph coloring
+  (typically when ngroups > max_colors on single-tree models). Runs with
+  dim=(nworld,) — one thread per world, iterating over the overflow list
+  sequentially to avoid data races.
+  """
+  process_group = _pgs_process_group_func(nv, is_sparse, use_sparse_bt)
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(  # kernel_analyzer: ignore
+    # In:
+    overflow_list_in: wp.array2d[int],
+    n_overflow_in: wp.array[int],
+    # Group info:
+    group_efc_start_in: wp.array2d[int],
+    group_efc_count_in: wp.array2d[int],
+    # Data in:
+    ne_in: wp.array[int],
+    nf_in: wp.array[int],
+    nefc_in: wp.array[int],
+    efc_type_in: wp.array2d[int],
+    efc_frictionloss_in: wp.array2d[float],
+    efc_id_in: wp.array2d[int],
+    contact_dim_in: wp.array[int],
+    contact_friction_in: wp.array[types.vec5],
+    contact_efc_address_in: wp.array2d[int],
+    efc_J_in: wp.array3d[float],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    BT_in: wp.array3d[float],
+    # Sparse BT index (ntree > 1):
+    BT_rownnz_in: wp.array2d[int],
+    BT_rowadr_in: wp.array2d[int],
+    BT_colind_in: wp.array3d[int],
+    AR_diag_inv_in: wp.array2d[float],
+    AR_elliptic_in: wp.array3d[float],
+    efc_D_in: wp.array2d[float],
+    efc_aref_in: wp.array2d[float],
+    # Model:
+    opt_tolerance: wp.array[float],
+    done_in: wp.array[bool],
+    # Out:
+    efc_force_inout: wp.array2d[float],
+    qacc_inout: wp.array2d[float],
+    improvement_out: wp.array[float],  # kernel_analyzer: ignore
+  ):
+    worldid = wp.tid()
+
+    if done_in[worldid]:
+      return
+
+    n_ov = n_overflow_in[worldid]
+    ne = ne_in[worldid]
+    nf = nf_in[worldid]
+    tolerance = opt_tolerance[worldid % opt_tolerance.shape[0]]
+
+    for ov_idx in range(n_ov):
+      group_id = overflow_list_in[worldid, ov_idx]
+      efc_start = group_efc_start_in[worldid, group_id]
+      efc_count = group_efc_count_in[worldid, group_id]
+
+      process_group(
+        worldid,
+        efc_start,
+        efc_count,
+        ne,
+        nf,
+        tolerance,
+        efc_type_in,
+        efc_frictionloss_in,
+        efc_id_in,
+        contact_dim_in,
+        contact_friction_in,
+        contact_efc_address_in,
+        efc_J_in,
+        efc_J_rownnz_in,
+        efc_J_rowadr_in,
+        efc_J_colind_in,
+        BT_in,
+        BT_rownnz_in,
+        BT_rowadr_in,
+        BT_colind_in,
+        AR_diag_inv_in,
+        AR_elliptic_in,
+        efc_D_in,
+        efc_aref_in,
+        efc_force_inout,
+        qacc_inout,
+        improvement_out,
+      )
+
+  return kernel
+
+
+@wp.kernel
+def _pgs_dual_state(
+  # Data in:
+  ne_in: wp.array[int],
+  nf_in: wp.array[int],
+  nefc_in: wp.array[int],
+  efc_type_in: wp.array2d[int],
+  efc_frictionloss_in: wp.array2d[float],
+  efc_force_in: wp.array2d[float],
+  # Data out:
+  efc_state_out: wp.array2d[int],
+):
+  """Compute dual state for all constraint rows."""
+  worldid, efcid = wp.tid()
+  nefc = nefc_in[worldid]
+  if efcid >= nefc:
+    return
+
+  ne = ne_in[worldid]
+  nf = nf_in[worldid]
+  force = efc_force_in[worldid, efcid]
+
+  if efcid < ne:
+    efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC.value
+  elif efcid < ne + nf:
+    floss = efc_frictionloss_in[worldid, efcid]
+    if force <= -floss:
+      efc_state_out[worldid, efcid] = types.ConstraintState.LINEARPOS.value
+    elif force >= floss:
+      efc_state_out[worldid, efcid] = types.ConstraintState.LINEARNEG.value
+    else:
+      efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC.value
+  elif efc_type_in[worldid, efcid] != types.ConstraintType.CONTACT_ELLIPTIC:
+    if force <= 0.0:
+      efc_state_out[worldid, efcid] = types.ConstraintState.SATISFIED.value
+    else:
+      efc_state_out[worldid, efcid] = types.ConstraintState.QUADRATIC.value
+  else:
+    efc_state_out[worldid, efcid] = types.ConstraintState.SATISFIED.value
+
+
+@wp.kernel
+def _pgs_convergence_check(
+  # Model:
+  opt_tolerance: wp.array[float],
+  stat_meaninertia: wp.array[float],
+  # In:
+  improvement_in: wp.array[float],
+  nv_val: int,
+  maxiter: int,
+  # Out:
+  done_inout: wp.array[bool],
+  solver_niter_inout: wp.array[int],
+  nsolving_inout: wp.array[int],
+):
+  """Check convergence after one colored sweep."""
+  worldid = wp.tid()
+  if done_inout[worldid]:
+    return
+
+  tolerance = opt_tolerance[worldid % opt_tolerance.shape[0]]
+  meaninertia = stat_meaninertia[worldid % stat_meaninertia.shape[0]]
+  scale = 1.0 / (meaninertia * float(wp.max(1, nv_val)))
+  scaled_improvement = improvement_in[worldid] * scale
+
+  solver_niter_inout[worldid] += 1  # kernel_analyzer: ignore
+
+  if scaled_improvement < tolerance or solver_niter_inout[worldid] >= maxiter:
+    done_inout[worldid] = True  # kernel_analyzer: ignore
+    wp.atomic_add(nsolving_inout, 0, -1)
+
+
+@wp.kernel
+def _pgs_warmstart_cost_dense(
+  # Data in:
+  nefc_in: wp.array[int],
+  qacc_in: wp.array2d[float],
+  qacc_smooth_in: wp.array2d[float],
+  efc_J_in: wp.array3d[float],
+  efc_D_in: wp.array2d[float],
+  efc_aref_in: wp.array2d[float],
+  efc_force_in: wp.array2d[float],
+  # Out:
+  warmstart_cost_out: wp.array[float],
+):
+  """Compute warmstart cost = f·b + 0.5·f·AR·f (AR-free, dense J).
+
+  cost = 0.5 · Σ_i f[i] · (J[i,:]·(qacc + qacc_smooth) - 2·aref[i] + f[i]/D[i])
+  """
+  worldid = wp.tid()
+  nefc = nefc_in[worldid]
+  nv_dim = qacc_in.shape[1]
+
+  cost = float(0.0)
+  for i in range(nefc):
+    fi = efc_force_in[worldid, i]
+    if fi == 0.0:
+      continue
+
+    # J[i,:] · (qacc + qacc_smooth)
+    j_sum_qacc = float(0.0)
+    for k in range(nv_dim):
+      j_sum_qacc += efc_J_in[worldid, i, k] * (qacc_in[worldid, k] + qacc_smooth_in[worldid, k])
+
+    # cost_i = f[i] * (j_sum_qacc - 2*aref[i] + f[i]/D[i])
+    D_i = efc_D_in[worldid, i]
+    R_fi = fi / D_i if D_i > 0.0 else 0.0
+    cost += fi * (j_sum_qacc - 2.0 * efc_aref_in[worldid, i] + R_fi)
+
+  warmstart_cost_out[worldid] = 0.5 * cost
+
+
+@wp.kernel
+def _pgs_warmstart_cost_sparse(
+  # Data in:
+  nefc_in: wp.array[int],
+  qacc_in: wp.array2d[float],
+  qacc_smooth_in: wp.array2d[float],
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
+  efc_J_in: wp.array3d[float],
+  efc_D_in: wp.array2d[float],
+  efc_aref_in: wp.array2d[float],
+  efc_force_in: wp.array2d[float],
+  # Out:
+  warmstart_cost_out: wp.array[float],
+):
+  """Compute warmstart cost = f·b + 0.5·f·AR·f (AR-free, sparse J)."""
+  worldid = wp.tid()
+  nefc = nefc_in[worldid]
+
+  cost = float(0.0)
+  for i in range(nefc):
+    fi = efc_force_in[worldid, i]
+    if fi == 0.0:
+      continue
+
+    # J[i,:] · (qacc + qacc_smooth) — sparse dot
+    j_sum_qacc = float(0.0)
+    rownnz = efc_J_rownnz_in[worldid, i]
+    rowadr = efc_J_rowadr_in[worldid, i]
+    for k in range(rownnz):
+      sparseid = rowadr + k
+      col = efc_J_colind_in[worldid, 0, sparseid]
+      j_sum_qacc += efc_J_in[worldid, 0, sparseid] * (qacc_in[worldid, col] + qacc_smooth_in[worldid, col])
+
+    D_i = efc_D_in[worldid, i]
+    R_fi = fi / D_i if D_i > 0.0 else 0.0
+    cost += fi * (j_sum_qacc - 2.0 * efc_aref_in[worldid, i] + R_fi)
+
+  warmstart_cost_out[worldid] = 0.5 * cost
+
+
+@wp.kernel
+def _pgs_warmstart_forces(
+  # Data in:
+  ne_in: wp.array[int],
+  nf_in: wp.array[int],
+  nefc_in: wp.array[int],
+  contact_friction_in: wp.array[types.vec5],
+  contact_dim_in: wp.array[int],
+  contact_efc_address_in: wp.array2d[int],
+  efc_type_in: wp.array2d[int],
+  efc_id_in: wp.array2d[int],
+  efc_D_in: wp.array2d[float],
+  efc_frictionloss_in: wp.array2d[float],
+  # In:
+  impratio_invsqrt_in: wp.array[float],
+  jar_in: wp.array2d[float],  # J @ qacc_warmstart - aref
+  # Data out:
+  efc_force_out: wp.array2d[float],
+):
+  """Compute warmstart forces: force = -D * jar with projection.
+
+  Follows MuJoCo C's mj_constraintUpdate logic:
+  - Equality: force = -D * jar (unconstrained)
+  - Friction: clamp to [-floss, floss]
+  - Limit/contact (non-negative): clamp to [0, inf)
+  - Elliptic: three-zone dual cone projection
+  """
+  worldid, efcid = wp.tid()
+  nefc = nefc_in[worldid]
+
+  if efcid >= nefc:
+    return
+
+  ne = ne_in[worldid]
+  nf = nf_in[worldid]
+
+  # Skip friction rows of elliptic contacts (handled by normal row)
+  if efcid >= ne + nf and efc_type_in[worldid, efcid] == types.ConstraintType.CONTACT_ELLIPTIC:
+    con_id = efc_id_in[worldid, efcid]
+    dim = contact_dim_in[con_id]
+    friction = contact_friction_in[con_id]
+
+    # Use indirect indexing: only process from the normal row (dimid=0)
+    idx0 = contact_efc_address_in[con_id, 0]
+    if efcid != idx0:
+      return
+
+    # Look up indirect indices for all dimensions
+    idx1 = int(-1)
+    idx2 = int(-1)
+    idx3 = int(-1)
+    idx4 = int(-1)
+    idx5 = int(-1)
+    if dim >= 3:
+      idx1 = contact_efc_address_in[con_id, 1]
+      idx2 = contact_efc_address_in[con_id, 2]
+    if dim >= 4:
+      idx3 = contact_efc_address_in[con_id, 3]
+    if dim >= 6:
+      idx4 = contact_efc_address_in[con_id, 4]
+      idx5 = contact_efc_address_in[con_id, 5]
+
+    # Compute mu = friction[0] / sqrt(impratio)
+    mu_cone = friction[0] * impratio_invsqrt_in[0]
+
+    # Map jar to regular dual cone space using indirect indices
+    U0 = jar_in[worldid, idx0] * mu_cone
+    N = U0
+    T_sq = float(0.0)
+    if dim >= 3:
+      U1 = jar_in[worldid, idx1] * friction[0]
+      U2 = jar_in[worldid, idx2] * friction[1]
+      T_sq += U1 * U1 + U2 * U2
+    if dim >= 4:
+      U3 = jar_in[worldid, idx3] * friction[2]
+      T_sq += U3 * U3
+    if dim >= 6:
+      U4 = jar_in[worldid, idx4] * friction[3]
+      U5 = jar_in[worldid, idx5] * friction[4]
+      T_sq += U4 * U4 + U5 * U5
+    T = wp.sqrt(T_sq)
+
+    # Three zones
+    # Top zone: N >= mu*T || (T <= 0 && N >= 0) -> force = 0
+    if N >= mu_cone * T or (T <= 0.0 and N >= 0.0):
+      efc_force_out[worldid, idx0] = 0.0
+      if dim >= 3:
+        efc_force_out[worldid, idx1] = 0.0
+        efc_force_out[worldid, idx2] = 0.0
+      if dim >= 4:
+        efc_force_out[worldid, idx3] = 0.0
+      if dim >= 6:
+        efc_force_out[worldid, idx4] = 0.0
+        efc_force_out[worldid, idx5] = 0.0
+
+    # Bottom zone: mu*N + T <= 0 || (T <= 0 && N < 0) -> force = -D*jar (quadratic)
+    elif mu_cone * N + T <= 0.0 or (T <= 0.0 and N < 0.0):
+      efc_force_out[worldid, idx0] = -efc_D_in[worldid, idx0] * jar_in[worldid, idx0]
+      if dim >= 3:
+        efc_force_out[worldid, idx1] = -efc_D_in[worldid, idx1] * jar_in[worldid, idx1]
+        efc_force_out[worldid, idx2] = -efc_D_in[worldid, idx2] * jar_in[worldid, idx2]
+      if dim >= 4:
+        efc_force_out[worldid, idx3] = -efc_D_in[worldid, idx3] * jar_in[worldid, idx3]
+      if dim >= 6:
+        efc_force_out[worldid, idx4] = -efc_D_in[worldid, idx4] * jar_in[worldid, idx4]
+        efc_force_out[worldid, idx5] = -efc_D_in[worldid, idx5] * jar_in[worldid, idx5]
+
+    # Middle zone: cone projection
+    else:
+      Dm = efc_D_in[worldid, idx0] / (mu_cone * mu_cone * (1.0 + mu_cone * mu_cone))
+      NmT = N - mu_cone * T
+      f0 = -Dm * NmT * mu_cone
+      efc_force_out[worldid, idx0] = f0
+
+      if T > MJ_MINVAL:
+        if dim >= 3:
+          U1_ = jar_in[worldid, idx1] * friction[0]
+          efc_force_out[worldid, idx1] = -f0 / T * U1_ * friction[0]
+          U2_ = jar_in[worldid, idx2] * friction[1]
+          efc_force_out[worldid, idx2] = -f0 / T * U2_ * friction[1]
+        if dim >= 4:
+          U3_ = jar_in[worldid, idx3] * friction[2]
+          efc_force_out[worldid, idx3] = -f0 / T * U3_ * friction[2]
+        if dim >= 6:
+          U4_ = jar_in[worldid, idx4] * friction[3]
+          efc_force_out[worldid, idx4] = -f0 / T * U4_ * friction[3]
+          U5_ = jar_in[worldid, idx5] * friction[4]
+          efc_force_out[worldid, idx5] = -f0 / T * U5_ * friction[4]
+      else:
+        if dim >= 3:
+          efc_force_out[worldid, idx1] = 0.0
+          efc_force_out[worldid, idx2] = 0.0
+        if dim >= 4:
+          efc_force_out[worldid, idx3] = 0.0
+        if dim >= 6:
+          efc_force_out[worldid, idx4] = 0.0
+          efc_force_out[worldid, idx5] = 0.0
+
+    return
+
+  jar = jar_in[worldid, efcid]
+  D = efc_D_in[worldid, efcid]
+
+  force = -D * jar
+
+  # Friction: clamp to [-floss, floss]
+  if efcid >= ne and efcid < ne + nf:
+    floss = efc_frictionloss_in[worldid, efcid]
+    if force < -floss:
+      force = -floss
+    elif force > floss:
+      force = floss
+
+  # Limit/contact (non-elliptic): force >= 0
+  elif efcid >= ne + nf:
+    if jar >= 0.0:
+      force = 0.0
+
+  efc_force_out[worldid, efcid] = force
+
+
+@wp.kernel
+def _pgs_warmstart_select(
+  # Data in:
+  nefc_in: wp.array[int],
+  qacc_smooth_in: wp.array2d[float],
+  # In:
+  warmstart_cost_in: wp.array[float],
+  nv_val: int,
+  # Data in/out:
+  efc_force_inout: wp.array2d[float],
+  qfrc_constraint_inout: wp.array2d[float],
+  qacc_inout: wp.array2d[float],
+):
+  """If warmstart cost > 0 or NaN, use zero forces and reset qacc."""
+  worldid = wp.tid()
+
+  cost = warmstart_cost_in[worldid]
+  # NaN check: cost != cost is true for NaN
+  if cost > 0.0 or cost != cost:
+    nefc = nefc_in[worldid]
+    for i in range(nefc):
+      efc_force_inout[worldid, i] = 0.0  # kernel_analyzer: ignore
+    for i in range(nv_val):
+      qfrc_constraint_inout[worldid, i] = 0.0  # kernel_analyzer: ignore
+      qacc_inout[worldid, i] = qacc_smooth_in[worldid, i]  # kernel_analyzer: ignore
+
+
+@wp.kernel
+def _pgs_update_qacc(
+  # Data in:
+  nefc_in: wp.array[int],
+  efc_force_in: wp.array2d[float],
+  # In:
+  BT_in: wp.array3d[float],
+  # Data in/out:
+  qacc_inout: wp.array2d[float],
+):
+  """Update qacc += BT^T · f, i.e., qacc[k] += Σ_j f[j] · BT[j, k]."""
+  worldid, dofid = wp.tid()
+  nefc = nefc_in[worldid]
+
+  val = float(0.0)
+  for j in range(nefc):
+    val += efc_force_in[worldid, j] * BT_in[worldid, j, dofid]
+  qacc_inout[worldid, dofid] += val  # kernel_analyzer: ignore
+
+
+@wp.kernel
+def _pgs_copy_j_rows_sparse(
+  # Data in:
+  nefc_in: wp.array[int],
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
+  efc_J_in: wp.array3d[float],
+  # Out:
+  BT_out: wp.array3d[float],
+):
+  """Copy all sparse J rows into BT buffer."""
+  worldid, efcid = wp.tid()
+  nefc = nefc_in[worldid]
+
+  if efcid >= nefc:
+    return
+
+  rownnz = efc_J_rownnz_in[worldid, efcid]
+  rowadr = efc_J_rowadr_in[worldid, efcid]
+  for k in range(rownnz):
+    colind = efc_J_colind_in[worldid, 0, rowadr + k]
+    BT_out[worldid, efcid, colind] = efc_J_in[worldid, 0, rowadr + k]
+
+
+@wp.kernel
+def _pgs_copy_j_rows_dense(
+  # Data in:
+  nefc_in: wp.array[int],
+  efc_J_in: wp.array3d[float],
+  # Out:
+  BT_out: wp.array3d[float],
+):
+  """Copy all dense J rows into BT buffer."""
+  worldid, efcid, dofid = wp.tid()
+  nefc = nefc_in[worldid]
+
+  if efcid >= nefc:
+    return
+
+  BT_out[worldid, efcid, dofid] = efc_J_in[worldid, efcid, dofid]
+
+
+def _pgs_solve_m_batched_sparse(nv: int, nlevels: int):
+  """Batched sparse backsubstitution: BT[w,e,:] = M⁻¹ @ BT[w,e,:].
+
+  Each (worldid, efcid) thread does a sequential LDL backsubstitution
+  using the pre-computed factorization. All efcid are independent and
+  run in parallel.
+  """
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    nefc_in: wp.array[int],
+    # In:
+    L: wp.array3d[float],
+    D: wp.array2d[float],
+    all_updates: wp.array[wp.vec3i],
+    level_offsets: wp.array[int],
+    # In/Out:
+    BT_inout: wp.array3d[float],
+  ):
+    worldid, efcid = wp.tid()
+    NV = wp.static(nv)
+    NLEVELS = wp.static(nlevels)
+
+    nefc = nefc_in[worldid]
+    if efcid >= nefc:
+      return
+
+    # Forward substitution: x <- L^{-T} x
+    for level in range(NLEVELS):
+      level_idx = NLEVELS - 1 - level
+      level_offset = level_offsets[level_idx]
+      level_size = level_offsets[level_idx + 1] - level_offset
+
+      for u in range(level_size):
+        update = all_updates[level_offset + u]
+        i, k, Madr_ki = update[0], update[1], update[2]
+        BT_inout[worldid, efcid, i] -= L[worldid, 0, Madr_ki] * BT_inout[worldid, efcid, k]  # kernel_analyzer: ignore
+
+    # Diagonal: x <- D^{-1} x
+    for dofid in range(NV):
+      BT_inout[worldid, efcid, dofid] *= D[worldid, dofid]  # kernel_analyzer: ignore
+
+    # Backward substitution: x <- L^{-1} x
+    for level in range(NLEVELS):
+      level_idx = level
+      level_offset = level_offsets[level_idx]
+      level_size = level_offsets[level_idx + 1] - level_offset
+
+      for u in range(level_size):
+        update = all_updates[level_offset + u]
+        i, k, Madr_ki = update[0], update[1], update[2]
+        BT_inout[worldid, efcid, k] -= L[worldid, 0, Madr_ki] * BT_inout[worldid, efcid, i]  # kernel_analyzer: ignore
+
+  return kernel
+
+
+def _pgs_solve_m_batched_dense(tile):
+  """Batched dense Cholesky backsubstitution for one tile."""
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    nefc_in: wp.array[int],
+    # In:
+    L: wp.array3d[float],
+    adr: wp.array[int],
+    # In/Out:
+    BT_inout: wp.array3d[float],
+  ):
+    worldid, efcid, nodeid = wp.tid()
+    TILE_SIZE = wp.static(tile.size)
+
+    nefc = nefc_in[worldid]
+    if efcid >= nefc:
+      return
+
+    dofid = adr[nodeid]
+
+    # Load L tile and y slice
+    L_tile = wp.tile_load(L[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid))
+    y_slice = wp.tile_load(BT_inout[worldid, efcid], shape=(TILE_SIZE,), offset=(dofid,))
+    x_slice = wp.tile_cholesky_solve(L_tile, y_slice)
+    wp.tile_store(BT_inout[worldid, efcid], x_slice, offset=(dofid,))
+
+  return kernel
+
+
+@wp.kernel
+def _pgs_bt_rownnz(
+  # Model:
+  dof_treeid: wp.array[int],
+  tree_dofnum: wp.array[int],
+  # Data in:
+  nefc_in: wp.array[int],
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
+  # Out:
+  BT_rownnz_out: wp.array2d[int],
+):
+  """Compute BT row nnz from J's sparsity and tree structure.
+
+  BT has non-zeros at all DOFs of every tree that J touches.
+  Unique trees are detected by scanning previously visited J columns,
+  which works for any number of trees without overflow.
+  """
+  worldid, efcid = wp.tid()
+  nefc = nefc_in[worldid]
+  if efcid >= nefc:
+    return
+
+  nnz_j = efc_J_rownnz_in[worldid, efcid]
+  rowadr = efc_J_rowadr_in[worldid, efcid]
+  nnz = int(0)
+  for k in range(nnz_j):
+    col = efc_J_colind_in[worldid, 0, rowadr + k]
+    tid = dof_treeid[col]
+    # Check if this tree was already seen by scanning previous columns
+    n_prev_matches = int(0)
+    for prev in range(k):
+      prev_col = efc_J_colind_in[worldid, 0, rowadr + prev]
+      if dof_treeid[prev_col] == tid:
+        n_prev_matches += 1
+    if n_prev_matches == 0:
+      nnz += tree_dofnum[tid]
+  BT_rownnz_out[worldid, efcid] = nnz
+
+
+@wp.kernel
+def _pgs_bt_rowadr(
+  # Data in:
+  nefc_in: wp.array[int],
+  # In:
+  BT_rownnz_in: wp.array2d[int],
+  # Out:
+  BT_rowadr_out: wp.array2d[int],
+):
+  """Compute BT row start addresses via sequential prefix sum per world."""
+  worldid = wp.tid()
+  nefc = nefc_in[worldid]
+  adr = int(0)
+  for i in range(nefc):
+    BT_rowadr_out[worldid, i] = adr
+    adr += BT_rownnz_in[worldid, i]
+
+
+@wp.kernel
+def _pgs_bt_colind(
+  # Model:
+  dof_treeid: wp.array[int],
+  tree_dofadr: wp.array[int],
+  tree_dofnum: wp.array[int],
+  # Data in:
+  nefc_in: wp.array[int],
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
+  # In:
+  BT_rowadr_in: wp.array2d[int],
+  # Out:
+  BT_colind_out: wp.array3d[int],
+):
+  """Fill BT column indices: all DOFs of every tree that J touches."""
+  worldid, efcid = wp.tid()
+  nefc = nefc_in[worldid]
+  if efcid >= nefc:
+    return
+
+  nnz_j = efc_J_rownnz_in[worldid, efcid]
+  rowadr_j = efc_J_rowadr_in[worldid, efcid]
+  rowadr_bt = BT_rowadr_in[worldid, efcid]
+  offset = int(0)
+  for k in range(nnz_j):
+    col = efc_J_colind_in[worldid, 0, rowadr_j + k]
+    tid = dof_treeid[col]
+    # Check if this tree was already seen by scanning previous columns
+    n_prev_matches = int(0)
+    for prev in range(k):
+      prev_col = efc_J_colind_in[worldid, 0, rowadr_j + prev]
+      if dof_treeid[prev_col] == tid:
+        n_prev_matches += 1
+    if n_prev_matches == 0:
+      dofadr = tree_dofadr[tid]
+      dofnum = tree_dofnum[tid]
+      for d in range(dofnum):
+        BT_colind_out[worldid, 0, rowadr_bt + offset] = dofadr + d
+        offset += 1
+
+
+@event_scope
+def _pgs_compute_bt_sparsity(m: types.Model, d: types.Data, ctx: PGSContext):
+  """Compute sparse BT index from J's sparsity and tree structure."""
+  # Pass 1: compute nnz per BT row
+  wp.launch(
+    _pgs_bt_rownnz,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.dof_treeid,
+      m.tree_dofnum,
+      d.nefc,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+    ],
+    outputs=[ctx.BT_rownnz],
+  )
+
+  # Pass 2: prefix sum for row addresses
+  wp.launch(
+    _pgs_bt_rowadr,
+    dim=(d.nworld,),
+    inputs=[d.nefc, ctx.BT_rownnz],
+    outputs=[ctx.BT_rowadr],
+  )
+
+  # Pass 3: fill column indices
+  wp.launch(
+    _pgs_bt_colind,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.dof_treeid,
+      m.tree_dofadr,
+      m.tree_dofnum,
+      d.nefc,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      ctx.BT_rowadr,
+    ],
+    outputs=[ctx.BT_colind],
+  )
+
+
+def _pgs_jacobi_update_forces_kernel(nv: int, is_sparse: bool):
+  """Jacobi force update: compute residuals and update all forces in parallel.
+
+  For each constraint i (in parallel):
+    1. Compute residual: res = J[i,:] · qacc - aref[i] + f[i]/D[i]
+    2. Compute new force: f_new = f_old - res / AR[i,i]
+    3. Project onto constraint bounds
+    4. SOR blend: f_final = (1-ω) * f_old + ω * f_new
+    5. Accept/reject based on cost change vs tolerance
+    6. Atomic-add improvement for convergence check
+
+  For elliptic contacts (dim > 1): only the normal row (idx0) processes
+  the full QCQP sub-problem; sub-rows skip (handled by the normal row).
+  """
+  IS_SPARSE = is_sparse
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    opt_tolerance: wp.array[float],
+    # Data in:
+    ne_in: wp.array[int],
+    nf_in: wp.array[int],
+    nefc_in: wp.array[int],
+    qacc_in: wp.array2d[float],
+    contact_friction_in: wp.array[types.vec5],
+    contact_dim_in: wp.array[int],
+    contact_efc_address_in: wp.array2d[int],
+    efc_type_in: wp.array2d[int],
+    efc_id_in: wp.array2d[int],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    efc_J_in: wp.array3d[float],
+    efc_D_in: wp.array2d[float],
+    efc_aref_in: wp.array2d[float],
+    efc_frictionloss_in: wp.array2d[float],
+    # In:
+    AR_diag_inv_in: wp.array2d[float],
+    AR_elliptic_in: wp.array3d[float],
+    sor_omega: float,
+    done_in: wp.array[bool],
+    # Data in/out:
+    efc_force_inout: wp.array2d[float],
+    # Out:
+    improvement_out: wp.array[float],
+  ):
+    worldid, efcid = wp.tid()
+
+    if done_in[worldid]:
+      return
+
+    nefc = nefc_in[worldid]
+    if efcid >= nefc:
+      return
+
+    ne = ne_in[worldid]
+    nf = nf_in[worldid]
+    NV = wp.static(nv)
+    tolerance = opt_tolerance[worldid % opt_tolerance.shape[0]]
+
+    # Check if this is an elliptic contact sub-row (not the normal row)
+    efc_type = efc_type_in[worldid, efcid]
+    if efc_type == types.ConstraintType.CONTACT_ELLIPTIC:
+      con_id = efc_id_in[worldid, efcid]
+      dim = contact_dim_in[con_id]
+      idx0 = contact_efc_address_in[con_id, 0]
+      if efcid != idx0:
+        # Sub-row: handled by normal row processing
+        return
+
+      if dim > 1:
+        # ---- Elliptic contact: QCQP sub-problem ----
+        mu = contact_friction_in[con_id]
+
+        idx1 = contact_efc_address_in[con_id, 1]
+        idx2 = contact_efc_address_in[con_id, 2]
+        idx3 = int(-1)
+        idx4 = int(-1)
+        idx5 = int(-1)
+        if dim >= 4:
+          idx3 = contact_efc_address_in[con_id, 3]
+        if dim >= 6:
+          idx4 = contact_efc_address_in[con_id, 4]
+          idx5 = contact_efc_address_in[con_id, 5]
+
+        # Compute residuals for all dim rows
+        res0 = float(0.0)
+        res1 = float(0.0)
+        res2 = float(0.0)
+        res3 = float(0.0)
+        res4 = float(0.0)
+        res5 = float(0.0)
+
+        if wp.static(IS_SPARSE):
+          rnnz0 = efc_J_rownnz_in[worldid, idx0]
+          radr0 = efc_J_rowadr_in[worldid, idx0]
+          for k in range(rnnz0):
+            sid = radr0 + k
+            col = efc_J_colind_in[worldid, 0, sid]
+            res0 += efc_J_in[worldid, 0, sid] * qacc_in[worldid, col]
+        else:
+          for k in range(NV):
+            res0 += efc_J_in[worldid, idx0, k] * qacc_in[worldid, k]
+        res0 -= efc_aref_in[worldid, idx0]
+        D_0 = efc_D_in[worldid, idx0]
+        if D_0 > 0.0:
+          res0 += efc_force_inout[worldid, idx0] / D_0
+
+        # Rows 1,2
+        if wp.static(IS_SPARSE):
+          rnnz1 = efc_J_rownnz_in[worldid, idx1]
+          radr1 = efc_J_rowadr_in[worldid, idx1]
+          for k in range(rnnz1):
+            sid = radr1 + k
+            col = efc_J_colind_in[worldid, 0, sid]
+            res1 += efc_J_in[worldid, 0, sid] * qacc_in[worldid, col]
+        else:
+          for k in range(NV):
+            res1 += efc_J_in[worldid, idx1, k] * qacc_in[worldid, k]
+        res1 -= efc_aref_in[worldid, idx1]
+        D_1 = efc_D_in[worldid, idx1]
+        if D_1 > 0.0:
+          res1 += efc_force_inout[worldid, idx1] / D_1
+
+        if wp.static(IS_SPARSE):
+          rnnz2 = efc_J_rownnz_in[worldid, idx2]
+          radr2 = efc_J_rowadr_in[worldid, idx2]
+          for k in range(rnnz2):
+            sid = radr2 + k
+            col = efc_J_colind_in[worldid, 0, sid]
+            res2 += efc_J_in[worldid, 0, sid] * qacc_in[worldid, col]
+        else:
+          for k in range(NV):
+            res2 += efc_J_in[worldid, idx2, k] * qacc_in[worldid, k]
+        res2 -= efc_aref_in[worldid, idx2]
+        D_2 = efc_D_in[worldid, idx2]
+        if D_2 > 0.0:
+          res2 += efc_force_inout[worldid, idx2] / D_2
+
+        if dim >= 4:
+          if wp.static(IS_SPARSE):
+            rnnz3 = efc_J_rownnz_in[worldid, idx3]
+            radr3 = efc_J_rowadr_in[worldid, idx3]
+            for k in range(rnnz3):
+              sid = radr3 + k
+              col = efc_J_colind_in[worldid, 0, sid]
+              res3 += efc_J_in[worldid, 0, sid] * qacc_in[worldid, col]
+          else:
+            for k in range(NV):
+              res3 += efc_J_in[worldid, idx3, k] * qacc_in[worldid, k]
+          res3 -= efc_aref_in[worldid, idx3]
+          D_3 = efc_D_in[worldid, idx3]
+          if D_3 > 0.0:
+            res3 += efc_force_inout[worldid, idx3] / D_3
+
+        if dim >= 6:
+          if wp.static(IS_SPARSE):
+            rnnz4 = efc_J_rownnz_in[worldid, idx4]
+            radr4 = efc_J_rowadr_in[worldid, idx4]
+            for k in range(rnnz4):
+              sid = radr4 + k
+              col = efc_J_colind_in[worldid, 0, sid]
+              res4 += efc_J_in[worldid, 0, sid] * qacc_in[worldid, col]
+          else:
+            for k in range(NV):
+              res4 += efc_J_in[worldid, idx4, k] * qacc_in[worldid, k]
+          res4 -= efc_aref_in[worldid, idx4]
+          D_4 = efc_D_in[worldid, idx4]
+          if D_4 > 0.0:
+            res4 += efc_force_inout[worldid, idx4] / D_4
+
+          if wp.static(IS_SPARSE):
+            rnnz5 = efc_J_rownnz_in[worldid, idx5]
+            radr5 = efc_J_rowadr_in[worldid, idx5]
+            for k in range(rnnz5):
+              sid = radr5 + k
+              col = efc_J_colind_in[worldid, 0, sid]
+              res5 += efc_J_in[worldid, 0, sid] * qacc_in[worldid, col]
+          else:
+            for k in range(NV):
+              res5 += efc_J_in[worldid, idx5, k] * qacc_in[worldid, k]
+          res5 -= efc_aref_in[worldid, idx5]
+          D_5 = efc_D_in[worldid, idx5]
+          if D_5 > 0.0:
+            res5 += efc_force_inout[worldid, idx5] / D_5
+
+        # Save old forces
+        old0 = efc_force_inout[worldid, idx0]
+        old1 = efc_force_inout[worldid, idx1]
+        old2 = efc_force_inout[worldid, idx2]
+        old3 = float(0.0)
+        old4 = float(0.0)
+        old5 = float(0.0)
+        if dim >= 4:
+          old3 = efc_force_inout[worldid, idx3]
+        if dim >= 6:
+          old4 = efc_force_inout[worldid, idx4]
+          old5 = efc_force_inout[worldid, idx5]
+
+        # ---- Solve elliptic QCQP (shared, with SOR blend) ----
+        new0, new1, new2, new3, new4, new5, change = _pgs_solve_elliptic_cone(
+          dim,
+          old0,
+          old1,
+          old2,
+          old3,
+          old4,
+          old5,
+          res0,
+          res1,
+          res2,
+          res3,
+          res4,
+          res5,
+          AR_elliptic_in,
+          worldid,
+          idx0,
+          mu,
+          sor_omega,
+        )
+
+        # In Jacobi mode, always accept projected forces (no per-constraint
+        # cost change rejection — the estimate is invalid when all forces
+        # update simultaneously).
+        wp.atomic_add(improvement_out, worldid, -change)
+
+        efc_force_inout[worldid, idx0] = new0  # kernel_analyzer: ignore
+        efc_force_inout[worldid, idx1] = new1  # kernel_analyzer: ignore
+        efc_force_inout[worldid, idx2] = new2  # kernel_analyzer: ignore
+        if dim >= 4:
+          efc_force_inout[worldid, idx3] = new3  # kernel_analyzer: ignore
+        if dim >= 6:
+          efc_force_inout[worldid, idx4] = new4  # kernel_analyzer: ignore
+          efc_force_inout[worldid, idx5] = new5  # kernel_analyzer: ignore
+
+        return  # Done with elliptic contact
+
+    # ---- 1D constraint (equality, friction, limit, frictionless contact) ----
+    # Compute residual: res = J[i,:] · qacc - aref[i] + f[i]/D[i]
+    res = float(0.0)
+    if wp.static(IS_SPARSE):
+      rownnz_i = efc_J_rownnz_in[worldid, efcid]
+      rowadr_i = efc_J_rowadr_in[worldid, efcid]
+      for k in range(rownnz_i):
+        sparseid = rowadr_i + k
+        col = efc_J_colind_in[worldid, 0, sparseid]
+        res += efc_J_in[worldid, 0, sparseid] * qacc_in[worldid, col]
+    else:
+      for k in range(NV):
+        res += efc_J_in[worldid, efcid, k] * qacc_in[worldid, k]
+    res -= efc_aref_in[worldid, efcid]
+    D_i = efc_D_in[worldid, efcid]
+    if D_i > 0.0:
+      res += efc_force_inout[worldid, efcid] / D_i
+
+    # Use precomputed 1/AR[i,i]
+    old_force = efc_force_inout[worldid, efcid]
+    AR_diag_inv = AR_diag_inv_in[worldid, efcid]
+    new_force = old_force - res * AR_diag_inv
+
+    # Project onto constraint bounds
+    if efcid >= ne and efcid < ne + nf:
+      floss = efc_frictionloss_in[worldid, efcid]
+      if new_force < -floss:
+        new_force = -floss
+      elif new_force > floss:
+        new_force = floss
+    elif efcid >= ne + nf:
+      if new_force < 0.0:
+        new_force = 0.0
+
+    # SOR blend
+    new_force = (1.0 - sor_omega) * old_force + sor_omega * new_force
+
+    # In Jacobi mode, always accept projected forces. The per-constraint
+    # cost change is invalid when all forces update simultaneously.
+    delta = new_force - old_force
+    AR_ii = 1.0 / AR_diag_inv if AR_diag_inv > 0.0 else 0.0
+    change = 0.5 * delta * delta * AR_ii + delta * res
+    wp.atomic_add(improvement_out, worldid, -change)
+
+    efc_force_inout[worldid, efcid] = new_force  # kernel_analyzer: ignore
+
+  return kernel
+
+
+def _pgs_jacobi_recompute_qacc_kernel():
+  """Factory for qacc recomputation kernel (deferred compilation)."""
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    nefc_in: wp.array[int],
+    qacc_smooth_in: wp.array2d[float],
+    efc_force_in: wp.array2d[float],
+    # In:
+    BT_in: wp.array3d[float],
+    done_in: wp.array[bool],
+    # Data out:
+    qacc_out: wp.array2d[float],
+  ):
+    """Recompute qacc = qacc_smooth + BT^T · f (parallel over DOFs).
+
+    In Jacobi iteration, qacc is recomputed from scratch each iteration
+    instead of being updated incrementally. This removes inter-constraint
+    dependencies, enabling fully parallel force updates.
+    """
+    worldid, dofid = wp.tid()
+
+    if done_in[worldid]:
+      return
+
+    nefc = nefc_in[worldid]
+
+    val = qacc_smooth_in[worldid, dofid]
+    for j in range(nefc):
+      val += efc_force_in[worldid, j] * BT_in[worldid, j, dofid]
+    qacc_out[worldid, dofid] = val
+
+  return kernel
+
+
+@event_scope
+def _pgs_iteration_jacobi(
+  m: types.Model,
+  d: types.Data,
+  ctx: PGSContext,
+  nsolving: wp.array,
+):
+  """One Projected Jacobi PGS iteration: parallel force update + qacc recompute + convergence.
+
+  Unlike GS which updates forces and qacc sequentially (constraint by constraint),
+  Jacobi updates all forces in parallel using the current qacc, then recomputes
+  qacc from scratch. This enables dim=(nworld, nefc) parallelism instead of
+  dim=(nworld,).
+  """
+  ctx.improvement.zero_()
+
+  # Step 1: Update all forces in parallel
+  wp.launch(
+    _pgs_jacobi_update_forces_kernel(m.nv, m.is_sparse),
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.opt.tolerance,
+      d.ne,
+      d.nf,
+      d.nefc,
+      d.qacc,
+      d.contact.friction,
+      d.contact.dim,
+      d.contact.efc_address,
+      d.efc.type,
+      d.efc.id,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      d.efc.J,
+      d.efc.D,
+      d.efc.aref,
+      d.efc.frictionloss,
+      ctx.AR_diag_inv,
+      ctx.AR_elliptic,
+      m.opt.pgs_sor_omega,
+      ctx.done,
+    ],
+    outputs=[d.efc.force, ctx.improvement],
+  )
+
+  # Step 2: Recompute qacc = qacc_smooth + BT^T · f
+  wp.launch(
+    _pgs_jacobi_recompute_qacc_kernel(),
+    dim=(d.nworld, m.nv),
+    inputs=[d.nefc, d.qacc_smooth, d.efc.force, ctx.BT, ctx.done],
+    outputs=[d.qacc],
+  )
+
+  # Step 3: Convergence check
+  wp.launch(
+    _pgs_convergence_check,
+    dim=(d.nworld,),
+    inputs=[
+      m.opt.tolerance,
+      m.stat.meaninertia,
+      ctx.improvement,
+      m.nv,
+      m.opt.iterations,
+    ],
+    outputs=[ctx.done, d.solver_niter, nsolving],
+  )
+
+
+@event_scope
+def _pgs_iteration_sequential(
+  m: types.Model,
+  d: types.Data,
+  ctx: PGSContext,
+  nsolving: wp.array,
+):
+  """One PGS iteration: fused sweep + dual state + convergence check."""
+  use_sparse_bt = m.ntree > 1 and m.is_sparse
+  wp.launch(
+    _pgs_sweep_kernel(m.nv, m.is_sparse, use_sparse_bt),
+    dim=(d.nworld,),
+    inputs=[
+      d.ne,
+      d.nf,
+      d.nefc,
+      d.efc.type,
+      d.efc.frictionloss,
+      d.efc.id,
+      d.contact.dim,
+      d.contact.friction,
+      d.contact.efc_address,
+      d.efc.J,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      ctx.BT,
+      ctx.BT_rownnz,
+      ctx.BT_rowadr,
+      ctx.BT_colind,
+      ctx.AR_diag_inv,
+      ctx.AR_elliptic,
+      d.efc.D,
+      d.efc.aref,
+      m.opt.tolerance,
+      m.stat.meaninertia,
+      m.opt.iterations,
+    ],
+    outputs=[d.efc.force, d.qacc, ctx.done, d.solver_niter, nsolving, d.efc.state],
+  )
+
+
+@event_scope
+def _pgs_iteration_color(
+  m: types.Model,
+  d: types.Data,
+  ctx: PGSContext,
+  nsolving: wp.array,
+):
+  """One colored PGS iteration: parallel sweep per color + convergence."""
+  use_sparse_bt = m.ntree > 1 and m.is_sparse
+  ctx.improvement.zero_()
+
+  # Parallel color passes
+  for c in range(m.opt.pgs_max_colors):
+    wp.launch(
+      _pgs_color_sweep_kernel(m.nv, m.is_sparse, use_sparse_bt),
+      dim=(d.nworld, d.njmax),
+      inputs=[
+        ctx.schedule_groups,
+        ctx.schedule_offsets,
+        c,
+        ctx.group_efc_start,
+        ctx.group_efc_count,
+        d.ne,
+        d.nf,
+        d.nefc,
+        d.efc.type,
+        d.efc.frictionloss,
+        d.efc.id,
+        d.contact.dim,
+        d.contact.friction,
+        d.contact.efc_address,
+        d.efc.J,
+        d.efc.J_rownnz,
+        d.efc.J_rowadr,
+        d.efc.J_colind,
+        ctx.BT,
+        ctx.BT_rownnz,
+        ctx.BT_rowadr,
+        ctx.BT_colind,
+        ctx.AR_diag_inv,
+        ctx.AR_elliptic,
+        d.efc.D,
+        d.efc.aref,
+        m.opt.tolerance,
+        ctx.done,
+      ],
+      outputs=[d.efc.force, d.qacc, ctx.improvement],
+    )
+
+  # Sequential overflow pass for uncolored groups
+  wp.launch(
+    _pgs_overflow_sweep_kernel(m.nv, m.is_sparse, use_sparse_bt),
+    dim=(d.nworld,),
+    inputs=[
+      ctx.overflow_list,
+      ctx.n_overflow,
+      ctx.group_efc_start,
+      ctx.group_efc_count,
+      d.ne,
+      d.nf,
+      d.nefc,
+      d.efc.type,
+      d.efc.frictionloss,
+      d.efc.id,
+      d.contact.dim,
+      d.contact.friction,
+      d.contact.efc_address,
+      d.efc.J,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      ctx.BT,
+      ctx.BT_rownnz,
+      ctx.BT_rowadr,
+      ctx.BT_colind,
+      ctx.AR_diag_inv,
+      ctx.AR_elliptic,
+      d.efc.D,
+      d.efc.aref,
+      m.opt.tolerance,
+      ctx.done,
+    ],
+    outputs=[d.efc.force, d.qacc, ctx.improvement],
+  )
+
+  # Convergence check
+  wp.launch(
+    _pgs_convergence_check,
+    dim=(d.nworld,),
+    inputs=[
+      m.opt.tolerance,
+      m.stat.meaninertia,
+      ctx.improvement,
+      m.nv,
+      m.opt.iterations,
+    ],
+    outputs=[ctx.done, d.solver_niter, nsolving],
+  )
+
+
+@event_scope
+def _pgs_compute_BT(m: types.Model, d: types.Data, ctx: PGSContext):
+  """Phase 1: Compute BT[i,:] = M⁻¹ @ J[i,:] for all constraint rows."""
+  if m.is_sparse:
+    # Copy all sparse J rows into BT in one launch
+    wp.launch(
+      _pgs_copy_j_rows_sparse,
+      dim=(d.nworld, d.njmax),
+      inputs=[d.nefc, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind, d.efc.J],
+      outputs=[ctx.BT],
+    )
+
+    # Batched backsubstitution: BT[w,e,:] = M⁻¹ @ BT[w,e,:] for all (w,e)
+    nlevels = len(m.qLD_updates)
+    wp.launch(
+      _pgs_solve_m_batched_sparse(m.nv, nlevels),
+      dim=(d.nworld, d.njmax),
+      inputs=[
+        d.nefc,
+        d.qLD,
+        d.qLDiagInv,
+        m.qLD_all_updates,
+        m.qLD_level_offsets,
+      ],
+      outputs=[ctx.BT],
+    )
+  else:
+    # Copy all dense J rows into BT in one launch
+    wp.launch(
+      _pgs_copy_j_rows_dense,
+      dim=(d.nworld, d.njmax, m.nv),
+      inputs=[d.nefc, d.efc.J],
+      outputs=[ctx.BT],
+    )
+
+    # Batched backsubstitution using tile Cholesky
+    for tile in m.qM_tiles:
+      wp.launch_tiled(
+        _pgs_solve_m_batched_dense(tile),
+        dim=(d.nworld, d.njmax, tile.adr.size),
+        inputs=[d.nefc, d.qLD, tile.adr],
+        outputs=[ctx.BT],
+        block_dim=m.block_dim.cholesky_solve,
+      )
+
+  # Compute sparse BT index for multi-tree models
+  if m.ntree > 1 and m.is_sparse:
+    _pgs_compute_bt_sparsity(m, d, ctx)
+
+
+@event_scope
+def _pgs_precompute_AR(m: types.Model, d: types.Data, ctx: PGSContext):
+  """Precompute 1/AR[i,i] for 1D constraints and AR sub-blocks for elliptic."""
+  wp.launch(
+    _pgs_precompute_AR_diag_inv(m.nv, m.is_sparse),
+    dim=(d.nworld, d.njmax),
+    inputs=[d.nefc, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind, d.efc.J, d.efc.D, ctx.BT],
+    outputs=[ctx.AR_diag_inv],
+  )
+  wp.launch(
+    _pgs_precompute_AR_elliptic(m.nv, m.is_sparse),
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      d.nefc,
+      d.contact.dim,
+      d.contact.efc_address,
+      d.efc.type,
+      d.efc.id,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      d.efc.J,
+      d.efc.D,
+      ctx.BT,
+    ],
+    outputs=[ctx.AR_elliptic],
+  )
+
+
+@event_scope
+def _pgs_warmstart(m: types.Model, d: types.Data, ctx: PGSContext):
+  """Warmstart: compute initial forces from qacc_warmstart."""
+  wp.copy(d.qacc, d.qacc_smooth)
+
+  if not (m.opt.disableflags & types.DisableBit.WARMSTART):
+    # Compute jar = J @ qacc_warmstart - aref (reuse shared Jaref kernel)
+    jar = wp.zeros((d.nworld, d.njmax), dtype=float)
+    dofs_per_thread, threads_per_efc = _compute_jaref_threading(m.nv)
+    wp.launch(
+      solve_init_jaref(m.is_sparse, m.nv, dofs_per_thread),
+      dim=(d.nworld, d.njmax, threads_per_efc),
+      inputs=[d.nefc, d.qacc_warmstart, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind, d.efc.J, d.efc.aref],
+      outputs=[jar],
+    )
+
+    # Compute initial forces: force = -D * jar with projection
+    wp.launch(
+      _pgs_warmstart_forces,
+      dim=(d.nworld, d.njmax),
+      inputs=[
+        d.ne,
+        d.nf,
+        d.nefc,
+        d.contact.friction,
+        d.contact.dim,
+        d.contact.efc_address,
+        d.efc.type,
+        d.efc.id,
+        d.efc.D,
+        d.efc.frictionloss,
+        m.opt.impratio_invsqrt,
+        jar,
+      ],
+      outputs=[d.efc.force],
+    )
+
+    # Update qacc for warmstart forces: qacc += BT^T · f
+    wp.launch(
+      _pgs_update_qacc,
+      dim=(d.nworld, m.nv),
+      inputs=[d.nefc, d.efc.force, ctx.BT],
+      outputs=[d.qacc],
+    )
+
+    # Evaluate warmstart cost (AR-free)
+    # warmstart_cost is pre-allocated in PGSContext
+    if m.is_sparse:
+      wp.launch(
+        _pgs_warmstart_cost_sparse,
+        dim=(d.nworld,),
+        inputs=[
+          d.nefc,
+          d.qacc,
+          d.qacc_smooth,
+          d.efc.J_rownnz,
+          d.efc.J_rowadr,
+          d.efc.J_colind,
+          d.efc.J,
+          d.efc.D,
+          d.efc.aref,
+          d.efc.force,
+        ],
+        outputs=[ctx.warmstart_cost],
+      )
+    else:
+      wp.launch(
+        _pgs_warmstart_cost_dense,
+        dim=(d.nworld,),
+        inputs=[d.nefc, d.qacc, d.qacc_smooth, d.efc.J, d.efc.D, d.efc.aref, d.efc.force],
+        outputs=[ctx.warmstart_cost],
+      )
+
+    # If cost > 0 or NaN, zero out forces and reset qacc
+    wp.launch(
+      _pgs_warmstart_select,
+      dim=(d.nworld,),
+      inputs=[d.nefc, d.qacc_smooth, ctx.warmstart_cost, m.nv],
+      outputs=[d.efc.force, d.qfrc_constraint, d.qacc],
+    )
+  else:
+    # Coldstart: zero forces
+    d.efc.force.zero_()
+
+
+@event_scope
+def _pgs_iterations(m: types.Model, d: types.Data, ctx: PGSContext, use_coloring: bool):
+  """Main PGS iteration loop."""
+  d.solver_niter.zero_()
+  ctx.done.zero_()
+
+  nsolving = wp.full(shape=(1,), value=d.nworld, dtype=int)
+
+  # Jacobi mode: fully parallel, no coloring needed
+  if m.opt.pgs_mode == 1:
+    if m.opt.iterations != 0 and m.opt.graph_conditional:
+      wp.capture_while(
+        nsolving,
+        while_body=_pgs_iteration_jacobi,
+        m=m,
+        d=d,
+        ctx=ctx,
+        nsolving=nsolving,
+      )
+    else:
+      for _ in range(m.opt.iterations):
+        _pgs_iteration_jacobi(m, d, ctx, nsolving)
+  # GS mode: sequential or colored
+  elif use_coloring:
+    if m.opt.iterations != 0 and m.opt.graph_conditional:
+      wp.capture_while(
+        nsolving,
+        while_body=_pgs_iteration_color,
+        m=m,
+        d=d,
+        ctx=ctx,
+        nsolving=nsolving,
+      )
+    else:
+      for _ in range(m.opt.iterations):
+        _pgs_iteration_color(m, d, ctx, nsolving)
+  elif m.opt.iterations != 0 and m.opt.graph_conditional:
+    wp.capture_while(
+      nsolving,
+      while_body=_pgs_iteration_sequential,
+      m=m,
+      d=d,
+      ctx=ctx,
+      nsolving=nsolving,
+    )
+  else:
+    for _ in range(m.opt.iterations):
+      _pgs_iteration_sequential(m, d, ctx, nsolving)
+
+
+@event_scope
+def _pgs_dual_finish(m: types.Model, d: types.Data, ctx: PGSContext, use_coloring: bool):
+  """Compute dual state and map to joint space (qfrc_constraint)."""
+  # Compute dual state (split out from sweep for colored and Jacobi paths)
+  if use_coloring or m.opt.pgs_mode == 1:
+    wp.launch(
+      _pgs_dual_state,
+      dim=(d.nworld, d.njmax),
+      inputs=[d.ne, d.nf, d.nefc, d.efc.type, d.efc.frictionloss, d.efc.force],
+      outputs=[d.efc.state],
+    )
+
+  # Map to joint space (dualFinish)
+  # qfrc_constraint = J^T @ efc_force
+  # Must process ALL worlds (including converged ones)
+  ctx.done.zero_()
+  d.qfrc_constraint.zero_()
+  if m.is_sparse:
+    wp.launch(
+      update_constraint_init_qfrc_constraint_sparse,
+      dim=(d.nworld, d.njmax),
+      inputs=[d.nefc, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind, d.efc.J, d.efc.force, ctx.done],
+      outputs=[d.qfrc_constraint],
+    )
+  else:
+    wp.launch(
+      update_constraint_init_qfrc_constraint_dense,
+      dim=(d.nworld, m.nv),
+      inputs=[d.nefc, d.efc.J, d.efc.force, d.njmax, ctx.done],
+      outputs=[d.qfrc_constraint],
+    )
+
+
+@event_scope
+def _solve_pgs(m: types.Model, d: types.Data, ctx: PGSContext):
+  """PGS (Projected Gauss-Seidel) constraint solver.
+
+  Operates in dual (constraint force) space following MuJoCo C's mj_solPGS.
+  Uses AR-free formulation: maintains qacc incrementally and computes
+  residuals on-the-fly via J and BT = M⁻¹·Jᵀ.
+
+  When sparse Jacobians are available, uses constraint coloring for
+  parallel execution of independent constraints within each color.
+
+  TODO(team): Add island support.
+  TODO(team): Add noslip post-processing solver.
+  """
+  _pgs_compute_BT(m, d, ctx)
+  _pgs_precompute_AR(m, d, ctx)
+  _pgs_warmstart(m, d, ctx)
+
+  use_coloring = m.opt.pgs_max_colors > 0
+  if use_coloring:
+    _pgs_coloring(m, d, ctx)
+
+  _pgs_iterations(m, d, ctx, use_coloring)
+  _pgs_dual_finish(m, d, ctx, use_coloring)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -23,6 +23,7 @@ from absl.testing import parameterized
 
 import mujoco_warp as mjw
 from mujoco_warp import ConeType
+from mujoco_warp import DisableBit
 from mujoco_warp import SolverType
 from mujoco_warp import test_data
 from mujoco_warp._src import solver
@@ -41,7 +42,7 @@ def _assert_eq(a, b, name):
 class SolverTest(parameterized.TestCase):
   @parameterized.product(
     cone=tuple(ConeType),
-    solver_=tuple(SolverType),
+    solver_=(SolverType.CG, SolverType.NEWTON),
     jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
   )
   def test_constraint_update(self, cone, solver_, jacobian):
@@ -655,6 +656,279 @@ class SolverTest(parameterized.TestCase):
       _assert_eq(qacc_inc, qacc_full, f"qacc keyframe={keyframe}")
 
     self.assertTrue(total_any_changes, "no state changes detected across any keyframe")
+
+
+class PGSSolverTest(parameterized.TestCase):
+  """Tests specific to the PGS (Projected Gauss-Seidel) solver."""
+
+  def _apply_pgs_mode(self, m, pgs_mode):
+    """Apply PGS mode overrides to the model after put_model."""
+    if pgs_mode == "gs_sequential":
+      m.opt.pgs_max_colors = 0
+    elif pgs_mode == "gs_color":
+      pass  # default pgs_max_colors=32
+    elif pgs_mode == "jacobi":
+      m.opt.pgs_mode = 1
+      m.opt.pgs_sor_omega = 0.3
+    else:
+      raise ValueError(f"Unknown pgs_mode: {pgs_mode}")
+
+  @parameterized.parameters(
+    ("gs_sequential", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("gs_sequential", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("gs_sequential", ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("gs_sequential", ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("gs_color", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("gs_color", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("gs_color", ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("gs_color", ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("jacobi", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("jacobi", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("jacobi", ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("jacobi", ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_pgs_solve(self, pgs_mode, cone, jacobian):
+    """Tests PGS solver across all modes and Jacobian formats."""
+    for keyframe in range(3):
+      mjm, mjd, m, d = test_data.fixture(
+        "constraints.xml",
+        keyframe=keyframe,
+        overrides={
+          "opt.solver": mujoco.mjtSolver.mjSOL_PGS,
+          "opt.cone": cone,
+          "opt.jacobian": jacobian,
+          "opt.iterations": 50,
+        },
+      )
+
+      mujoco.mj_forward(mjm, mjd)
+
+      self._apply_pgs_mode(m, pgs_mode)
+      mjw.solve(m, d)
+
+      def cost(qacc):
+        jaref = np.zeros(mjd.nefc, dtype=float)
+        cost_out = np.zeros(1)
+        mujoco.mj_mulJacVec(mjm, mjd, jaref, qacc)
+        mujoco.mj_constraintUpdate(mjm, mjd, jaref - mjd.efc_aref, cost_out, 0)
+        return cost_out[0]
+
+      mj_cost = cost(mjd.qacc)
+      mjwarp_cost = cost(d.qacc.numpy()[0])
+
+      if pgs_mode == "jacobi":
+        # Jacobi converges slower; with ω=0.5 and 50 iters, cost within 1.5×
+        self.assertLessEqual(
+          mjwarp_cost,
+          mj_cost * 1.5,
+          f"Jacobi cost too high: {mjwarp_cost:.1f} vs {mj_cost:.1f} "
+          f"(mode={pgs_mode}, cone={cone}, jac={jacobian}, kf={keyframe})",
+        )
+      else:
+        # GS modes should match MuJoCo C cost closely
+        self.assertLessEqual(mjwarp_cost, mj_cost * 1.025)
+
+  @parameterized.parameters(
+    (ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+  )
+  def test_pgs_cost_decreasing(self, cone, jacobian):
+    """Tests that PGS cost monotonically decreases."""
+    mjm, mjd, m, d = test_data.fixture(
+      "constraints.xml",
+      keyframe=0,
+      overrides={
+        "opt.solver": mujoco.mjtSolver.mjSOL_PGS,
+        "opt.cone": cone,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 50,
+      },
+    )
+
+    mujoco.mj_forward(mjm, mjd)
+
+    def cost(qacc):
+      jaref = np.zeros(mjd.nefc, dtype=float)
+      cost_out = np.zeros(1)
+      mujoco.mj_mulJacVec(mjm, mjd, jaref, qacc)
+      mujoco.mj_constraintUpdate(mjm, mjd, jaref - mjd.efc_aref, cost_out, 0)
+      return cost_out[0]
+
+    mj_cost = cost(mjd.qacc)
+    mjwarp_cost = cost(d.qacc.numpy()[0])
+
+    # PGS cost should be within a reasonable factor of MuJoCo C
+    self.assertLessEqual(mjwarp_cost, mj_cost * 1.1)
+
+  @parameterized.parameters(
+    (ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+  )
+  def test_pgs_step(self, cone, jacobian):
+    """Tests full mj_step with PGS solver matches MuJoCo C."""
+    mjm, mjd, m, d = test_data.fixture(
+      "constraints.xml",
+      keyframe=0,
+      overrides={
+        "opt.solver": mujoco.mjtSolver.mjSOL_PGS,
+        "opt.cone": cone,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 50,
+      },
+    )
+
+    # Run forward (not step) to compare solver output directly
+    mujoco.mj_forward(mjm, mjd)
+    mjw.step(m, d)
+
+    # After step, qacc is from the NEXT forward pass.
+    # Compare qvel which reflects integration of the solver's qacc.
+    _assert_eq(d.qvel.numpy()[0], mjd.qvel, "qvel")
+
+  @parameterized.parameters(
+    ("gs_sequential", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("gs_sequential", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("gs_color", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("gs_color", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("gs_color", ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("gs_color", ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("jacobi", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("jacobi", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_pgs_solve_humanoid(self, pgs_mode, cone, jacobian):
+    """Tests PGS solver on humanoid model across all modes."""
+    mjm, mjd, m, d = test_data.fixture(
+      "humanoid/humanoid.xml",
+      keyframe=0,
+      overrides={
+        "opt.solver": mujoco.mjtSolver.mjSOL_PGS,
+        "opt.cone": cone,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 50,
+      },
+    )
+
+    mujoco.mj_forward(mjm, mjd)
+
+    self._apply_pgs_mode(m, pgs_mode)
+    mjw.solve(m, d)
+
+    if pgs_mode == "jacobi":
+
+      def cost(qacc):
+        jaref = np.zeros(mjd.nefc, dtype=float)
+        cost_out = np.zeros(1)
+        mujoco.mj_mulJacVec(mjm, mjd, jaref, qacc)
+        mujoco.mj_constraintUpdate(mjm, mjd, jaref - mjd.efc_aref, cost_out, 0)
+        return cost_out[0]
+
+      mj_cost = cost(mjd.qacc)
+      mjwarp_cost = cost(d.qacc.numpy()[0])
+      self.assertLessEqual(mjwarp_cost, mj_cost * 1.5)
+    else:
+
+      def cost(qacc):
+        jaref = np.zeros(mjd.nefc, dtype=float)
+        cost_out = np.zeros(1)
+        mujoco.mj_mulJacVec(mjm, mjd, jaref, qacc)
+        mujoco.mj_constraintUpdate(mjm, mjd, jaref - mjd.efc_aref, cost_out, 0)
+        return cost_out[0]
+
+      mj_cost = cost(mjd.qacc)
+      mjwarp_cost = cost(d.qacc.numpy()[0])
+      self.assertLessEqual(mjwarp_cost, mj_cost * 1.025)
+
+  @parameterized.parameters(
+    ("gs_sequential", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("gs_sequential", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("gs_color", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("gs_color", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+    ("jacobi", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    ("jacobi", ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_pgs_deterministic_no_warmstart(self, pgs_mode, cone, jacobian):
+    """Tests PGS is deterministic and idempotent without warmstarts.
+
+    Mirrors MuJoCo C's DeterministicNoWarmstart pipeline test.
+    """
+    mjm, mjd, m, d = test_data.fixture(
+      "constraints.xml",
+      keyframe=0,
+      overrides={
+        "opt.solver": mujoco.mjtSolver.mjSOL_PGS,
+        "opt.cone": cone,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 50,
+        "opt.disableflags": DisableBit.WARMSTART,
+      },
+    )
+
+    self._apply_pgs_mode(m, pgs_mode)
+
+    # First forward pass
+    mujoco.mj_forward(mjm, mjd)
+    mjw.forward(m, d)
+    qacc_first = d.qacc.numpy()[0].copy()
+
+    # Second forward pass (should be idempotent without warmstart)
+    mjw.forward(m, d)
+    qacc_second = d.qacc.numpy()[0].copy()
+
+    np.testing.assert_array_equal(qacc_first, qacc_second)
+
+  @parameterized.parameters(
+    (ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_DENSE),
+    (ConeType.PYRAMIDAL, mujoco.mjtJacobian.mjJAC_SPARSE),
+    (ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_DENSE),
+    (ConeType.ELLIPTIC, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_pgs_solvers_equivalent(self, cone, jacobian):
+    """Tests PGS produces similar qfrc_constraint as Newton ground truth.
+
+    Mirrors MuJoCo C's SolversEquivalent test: uses Newton Dense as ground
+    truth and checks PGS output is within a tolerance of it.
+    """
+    # Ground truth: Newton Dense with high iterations, no warmstart
+    mjm, mjd_truth, m_truth, d_truth = test_data.fixture(
+      "constraints.xml",
+      keyframe=0,
+      overrides={
+        "opt.solver": mujoco.mjtSolver.mjSOL_NEWTON,
+        "opt.cone": cone,
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_DENSE,
+        "opt.iterations": 500,
+        "opt.disableflags": DisableBit.WARMSTART,
+      },
+    )
+    mujoco.mj_forward(mjm, mjd_truth)
+    mjw.forward(m_truth, d_truth)
+    truth_qfrc = d_truth.qfrc_constraint.numpy()[0]
+
+    # PGS solution
+    _, _, m, d = test_data.fixture(
+      "constraints.xml",
+      keyframe=0,
+      overrides={
+        "opt.solver": mujoco.mjtSolver.mjSOL_PGS,
+        "opt.cone": cone,
+        "opt.jacobian": jacobian,
+        "opt.iterations": 500,
+        "opt.disableflags": DisableBit.WARMSTART,
+      },
+    )
+    mjw.forward(m, d)
+    pgs_qfrc = d.qfrc_constraint.numpy()[0]
+
+    # PGS should produce similar constraint forces to Newton
+    scale = np.linalg.norm(truth_qfrc)
+    if scale > 1e-10:
+      # Relative tolerance: PGS is approximate, allow generous margin
+      rtol = 0.5 if cone == ConeType.ELLIPTIC else 0.1
+      np.testing.assert_allclose(
+        pgs_qfrc,
+        truth_qfrc,
+        atol=scale * rtol,
+        rtol=rtol,
+        err_msg=f"PGS vs Newton qfrc_constraint (cone={cone}, jacobian={jacobian})",
+      )
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -390,13 +390,14 @@ class SolverType(enum.IntEnum):
   """Constraint solver algorithm.
 
   Attributes:
+    PGS: Projected Gauss-Seidel (dual)
     CG: Conjugate gradient (primal)
     NEWTON: Newton (primal)
   """
 
+  PGS = mujoco.mjtSolver.mjSOL_PGS
   CG = mujoco.mjtSolver.mjSOL_CG
   NEWTON = mujoco.mjtSolver.mjSOL_NEWTON
-  # unsupported: PGS
 
 
 class ConstraintState(enum.IntEnum):
@@ -753,6 +754,9 @@ class Option:
       zeros out the contacts at each step)
     contact_sensor_maxmatch: max number of contacts considered by contact sensor matching criteria
                              contacts matched after this value is exceded will be ignored
+    pgs_max_colors: maximum number of colors for constraint graph coloring in PGS solver
+    pgs_mode: PGS iteration mode (0 = Gauss-Seidel, 1 = Jacobi)
+    pgs_sor_omega: SOR relaxation parameter for Jacobi PGS (0 < omega <= 1.0, default 0.5)
   """
 
   timestep: array("*", float)
@@ -783,6 +787,9 @@ class Option:
   graph_conditional: bool
   run_collision_detection: bool
   contact_sensor_maxmatch: int
+  pgs_max_colors: int
+  pgs_mode: int
+  pgs_sor_omega: float
 
 
 @dataclasses.dataclass

--- a/mujoco_warp/_src/util_solve.py
+++ b/mujoco_warp/_src/util_solve.py
@@ -1,0 +1,342 @@
+# Copyright 2026 The Newton Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Solver utility functions.
+
+Mirrors MuJoCo C's engine_util_solve: QCQP solvers for elliptic friction cone
+projection.
+"""
+
+import warp as wp
+
+
+@wp.func
+def qcqp2(
+  # In:
+  A00: float,
+  A01: float,
+  A11: float,
+  b0: float,
+  b1: float,
+  d0: float,
+  d1: float,
+  r: float,
+):
+  """Solve 2D QCQP: min 0.5*x'*A*x + x'*b s.t. sum(xi/di)^2 <= r^2.
+
+  Returns (v0, v1, active) where active=1 if constraint is active.
+  """
+  # Scale A,b so constraint becomes x'*x <= r*r
+  sb0 = b0 * d0
+  sb1 = b1 * d1
+  sA00 = A00 * d0 * d0
+  sA11 = A11 * d1 * d1
+  sA01 = A01 * d0 * d1
+
+  # Newton iteration on dual variable lambda
+  la = float(0.0)
+  v0 = float(0.0)
+  v1 = float(0.0)
+
+  for _iter in range(20):
+    # det(A + la*I)
+    det = (sA00 + la) * (sA11 + la) - sA01 * sA01
+
+    if det < 1e-10:
+      return v0, v1, 0
+
+    detinv = 1.0 / det
+    P00 = (sA11 + la) * detinv
+    P11 = (sA00 + la) * detinv
+    P01 = -sA01 * detinv
+
+    # v = -P*b
+    v0 = -P00 * sb0 - P01 * sb1
+    v1 = -P01 * sb0 - P11 * sb1
+
+    # val = v'*v - r*r
+    val = v0 * v0 + v1 * v1 - r * r
+
+    if val < 1e-10:
+      break
+
+    # deriv = -2 * v' * P * v
+    deriv = -2.0 * (P00 * v0 * v0 + 2.0 * P01 * v0 * v1 + P11 * v1 * v1)
+
+    delta = -val / deriv
+    if delta < 1e-10:
+      break
+
+    la += delta
+
+  # Undo scaling
+  v0 = v0 * d0
+  v1 = v1 * d1
+
+  active = 0
+  if la != 0.0:
+    active = 1
+  return v0, v1, active
+
+
+@wp.func
+def qcqp3(
+  # In:
+  A00: float,
+  A01: float,
+  A02: float,
+  A11: float,
+  A12: float,
+  A22: float,
+  b0: float,
+  b1: float,
+  b2: float,
+  d0: float,
+  d1: float,
+  d2: float,
+  r: float,
+):
+  """Solve 3D QCQP: min 0.5*x'*A*x + x'*b s.t. sum(xi/di)^2 <= r^2.
+
+  Returns (v0, v1, v2, active).
+  """
+  # Scale A,b
+  sb0 = b0 * d0
+  sb1 = b1 * d1
+  sb2 = b2 * d2
+  sA00 = A00 * d0 * d0
+  sA11 = A11 * d1 * d1
+  sA22 = A22 * d2 * d2
+  sA01 = A01 * d0 * d1
+  sA02 = A02 * d0 * d2
+  sA12 = A12 * d1 * d2
+
+  la = float(0.0)
+  v0 = float(0.0)
+  v1 = float(0.0)
+  v2 = float(0.0)
+
+  for _iter in range(20):
+    # Cofactors (unscaled P)
+    P00 = (sA11 + la) * (sA22 + la) - sA12 * sA12
+    P11 = (sA00 + la) * (sA22 + la) - sA02 * sA02
+    P22 = (sA00 + la) * (sA11 + la) - sA01 * sA01
+    P01 = sA02 * sA12 - sA01 * (sA22 + la)
+    P02 = sA01 * sA12 - sA02 * (sA11 + la)
+    P12 = sA01 * sA02 - sA12 * (sA00 + la)
+
+    det = (sA00 + la) * P00 + sA01 * P01 + sA02 * P02
+
+    if det < 1e-10:
+      return v0, v1, v2, 0
+
+    detinv = 1.0 / det
+    P00 *= detinv
+    P11 *= detinv
+    P22 *= detinv
+    P01 *= detinv
+    P02 *= detinv
+    P12 *= detinv
+
+    v0 = -P00 * sb0 - P01 * sb1 - P02 * sb2
+    v1 = -P01 * sb0 - P11 * sb1 - P12 * sb2
+    v2 = -P02 * sb0 - P12 * sb1 - P22 * sb2
+
+    val = v0 * v0 + v1 * v1 + v2 * v2 - r * r
+
+    if val < 1e-10:
+      break
+
+    deriv = -2.0 * (P00 * v0 * v0 + P11 * v1 * v1 + P22 * v2 * v2) - 4.0 * (P01 * v0 * v1 + P02 * v0 * v2 + P12 * v1 * v2)
+
+    delta = -val / deriv
+    if delta < 1e-10:
+      break
+
+    la += delta
+
+  v0 = v0 * d0
+  v1 = v1 * d1
+  v2 = v2 * d2
+
+  active = 0
+  if la != 0.0:
+    active = 1
+  return v0, v1, v2, active
+
+
+@wp.func
+def qcqp5(
+  # In:
+  A00: float,
+  A01: float,
+  A02: float,
+  A03: float,
+  A04: float,
+  A11: float,
+  A12: float,
+  A13: float,
+  A14: float,
+  A22: float,
+  A23: float,
+  A24: float,
+  A33: float,
+  A34: float,
+  A44: float,
+  # 5-vector
+  b0: float,
+  b1: float,
+  b2: float,
+  b3: float,
+  b4: float,
+  # 5 scaling values
+  d0: float,
+  d1: float,
+  d2: float,
+  d3: float,
+  d4: float,
+  # constraint radius
+  r: float,
+):
+  """Solve 5D QCQP via Newton on dual variable with explicit Cholesky."""
+  # Scale A, b
+  sb0 = b0 * d0
+  sb1 = b1 * d1
+  sb2 = b2 * d2
+  sb3 = b3 * d3
+  sb4 = b4 * d4
+  sA00 = A00 * d0 * d0
+  sA01 = A01 * d0 * d1
+  sA02 = A02 * d0 * d2
+  sA03 = A03 * d0 * d3
+  sA04 = A04 * d0 * d4
+  sA11 = A11 * d1 * d1
+  sA12 = A12 * d1 * d2
+  sA13 = A13 * d1 * d3
+  sA14 = A14 * d1 * d4
+  sA22 = A22 * d2 * d2
+  sA23 = A23 * d2 * d3
+  sA24 = A24 * d2 * d4
+  sA33 = A33 * d3 * d3
+  sA34 = A34 * d3 * d4
+  sA44 = A44 * d4 * d4
+
+  la = float(0.0)
+  v0_out = float(0.0)
+  v1_out = float(0.0)
+  v2_out = float(0.0)
+  v3_out = float(0.0)
+  v4_out = float(0.0)
+
+  for _iter in range(20):
+    # M = sA + la*I
+    M00 = sA00 + la
+    M11 = sA11 + la
+    M22 = sA22 + la
+    M33 = sA33 + la
+    M44 = sA44 + la
+
+    # Cholesky: L*L' = M (lower triangle)
+    # Row 0
+    if M00 < 1e-10:
+      return v0_out, v1_out, v2_out, v3_out, v4_out, 0
+    L00 = wp.sqrt(M00)
+    L10 = sA01 / L00
+    L20 = sA02 / L00
+    L30 = sA03 / L00
+    L40 = sA04 / L00
+
+    # Row 1
+    s1 = M11 - L10 * L10
+    if s1 < 1e-10:
+      return v0_out, v1_out, v2_out, v3_out, v4_out, 0
+    L11 = wp.sqrt(s1)
+    L21 = (sA12 - L20 * L10) / L11
+    L31 = (sA13 - L30 * L10) / L11
+    L41 = (sA14 - L40 * L10) / L11
+
+    # Row 2
+    s2 = M22 - L20 * L20 - L21 * L21
+    if s2 < 1e-10:
+      return v0_out, v1_out, v2_out, v3_out, v4_out, 0
+    L22 = wp.sqrt(s2)
+    L32 = (sA23 - L30 * L20 - L31 * L21) / L22
+    L42 = (sA24 - L40 * L20 - L41 * L21) / L22
+
+    # Row 3
+    s3 = M33 - L30 * L30 - L31 * L31 - L32 * L32
+    if s3 < 1e-10:
+      return v0_out, v1_out, v2_out, v3_out, v4_out, 0
+    L33 = wp.sqrt(s3)
+    L43 = (sA34 - L40 * L30 - L41 * L31 - L42 * L32) / L33
+
+    # Row 4
+    s4 = M44 - L40 * L40 - L41 * L41 - L42 * L42 - L43 * L43
+    if s4 < 1e-10:
+      return v0_out, v1_out, v2_out, v3_out, v4_out, 0
+    L44 = wp.sqrt(s4)
+
+    # Forward solve: L * y = -sb
+    y0 = -sb0 / L00
+    y1 = (-sb1 - L10 * y0) / L11
+    y2 = (-sb2 - L20 * y0 - L21 * y1) / L22
+    y3 = (-sb3 - L30 * y0 - L31 * y1 - L32 * y2) / L33
+    y4 = (-sb4 - L40 * y0 - L41 * y1 - L42 * y2 - L43 * y3) / L44
+
+    # Back solve: L' * v = y
+    v4_out = y4 / L44
+    v3_out = (y3 - L43 * v4_out) / L33
+    v2_out = (y2 - L32 * v3_out - L42 * v4_out) / L22
+    v1_out = (y1 - L21 * v2_out - L31 * v3_out - L41 * v4_out) / L11
+    v0_out = (y0 - L10 * v1_out - L20 * v2_out - L30 * v3_out - L40 * v4_out) / L00
+
+    # val = v'*v - r*r
+    val = v0_out * v0_out + v1_out * v1_out + v2_out * v2_out + v3_out * v3_out + v4_out * v4_out - r * r
+
+    if val < 1e-10:
+      break
+
+    # For derivative: solve L L' tmp = v
+    t0 = v0_out / L00
+    t1 = (v1_out - L10 * t0) / L11
+    t2 = (v2_out - L20 * t0 - L21 * t1) / L22
+    t3 = (v3_out - L30 * t0 - L31 * t1 - L32 * t2) / L33
+    t4 = (v4_out - L40 * t0 - L41 * t1 - L42 * t2 - L43 * t3) / L44
+
+    u4 = t4 / L44
+    u3 = (t3 - L43 * u4) / L33
+    u2 = (t2 - L32 * u3 - L42 * u4) / L22
+    u1 = (t1 - L21 * u2 - L31 * u3 - L41 * u4) / L11
+    u0 = (t0 - L10 * u1 - L20 * u2 - L30 * u3 - L40 * u4) / L00
+
+    # deriv = -2 * v' * u
+    deriv = -2.0 * (v0_out * u0 + v1_out * u1 + v2_out * u2 + v3_out * u3 + v4_out * u4)
+
+    delta = -val / deriv
+    if delta < 1e-10:
+      break
+
+    la += delta
+
+  # Undo scaling
+  v0_out *= d0
+  v1_out *= d1
+  v2_out *= d2
+  v3_out *= d3
+  v4_out *= d4
+
+  active = 0
+  if la != 0.0:
+    active = 1
+  return v0_out, v1_out, v2_out, v3_out, v4_out, active


### PR DESCRIPTION
experimenting with pgs solver variations

implementation includes:
- pgs sequential: based on mujoco implementation ([algorithms](https://mujoco.readthedocs.io/en/latest/computation/index.html#algorithms))
- pgs color: pgs with graph coloring
- jacobi method: basically pgs with parallel constraint updates

---

## Three Humanoids Solver Benchmark

**Scene**: `benchmarks/humanoid/three_humanoids.xml`
**GPU**: NVIDIA RTX 6000 Ada Generation (48 GB)
**Config**: `--nworld=8192 --nconmax=100 --njmax=192 --nstep=1000`

### Results

| Solver | Steps/s | Runtime (s) | Solver Iters (mean) | Converged |
|---|---:|---:|---:|---:|
| Newton | 709,321 | 11.5 | 2.8 | 8192/8192 |
| CG | 241,013 | 34.0 | 24.9 | 8192/8192 |
| PGS Jacobi (ω=0.3) | 164,797 | 49.7 | 29.3 | 8192/8192 |
| PGS Sequential | 102,649 | 79.8 | 21.6 | 8192/8192 |
| PGS Jacobi (ω=0.5) | 89,154 | 91.9 | 100.0 | 8192/8192 |
| PGS Color (2) | 87,987 | 93.1 | 21.6 | 8192/8192 |
| PGS Color (4) | 76,561 | 107.0 | 21.6 | 8192/8192 |
| PGS Color (32) | 50,770 | 161.4 | 21.6 | 8192/8192 |
| PGS Color (64) | 40,976 | 199.9 | 21.6 | 8192/8192 |
| PGS Color (128) | 29,210 | 280.5 | 21.6 | 8192/8192 |

### Key Observations

- **Newton** is the fastest overall at 709K steps/s — the factorization cost is amortized across 8192 worlds and the solver converges in ~3 iterations.
- **PGS Jacobi ω=0.3** is the fastest PGS variant at 165K steps/s — the lower relaxation parameter enables convergence in ~29 iterations (vs ω=0.5 which saturates at 100 and never converges).
- **PGS Sequential** is faster than all Color GS variants due to kernel launch overhead — color GS launches one kernel per color per iteration
- **PGS Color GS** performance degrades linearly with `max_colors`: each additional color adds ~7.5K steps/s of overhead from empty kernel launches.

---

## Cloth Benchmark

**Scene**: `cloth/scene.xml` (30×30 flexcomp towel, nq=2707, nv=2706, nu=0, nbody=918, ngeom=21)
**Config**: 64 worlds, 100 steps, dt=0.005, pyramidal cone, sparse Jacobian, nconmax=4000, njmax=32000
**GPU**: NVIDIA RTX 6000 Ada Generation (48 GiB)
| Solver | Steps/s | Sim Time (s) | Avg Iters | Converged |
|--------|---------|--------------|-----------|-----------|
| CG | 1,616 | 3.96 | 2.6–39.6 | 64/64 |
| PGS Color (2) | 386 | 16.57 | 12.8–25.4 | 64/64 |
| PGS Color (4) | 383 | 16.70 | 12.7–25.6 | 64/64 |
| PGS Color (32) | 335 | 19.12 | 12.3–25.5 | 64/64 |
| PGS Sequential | 257 | 24.94 | 12.8–25.6 | 64/64 |
| PGS Color (64) | 226 | 28.32 | 13.2–25.5 | 64/64 |
| PGS Color (128) | 199 | 32.24 | 12.6–25.6 | 64/64 |
| PGS Jacobi (ω=0.3) | 172 | 37.31 | 100 (max) | 64/64 |
| PGS Jacobi (ω=0.5) | 171 | 37.51 | 100 (max) | 64/64 |
| Newton | 48 | 133.50 | 1.1–4.6 | 64/64 |

> **CG dominates** on this high-DOF deformable model at 1,616 steps/s — 4.2× faster than PGS Color and 34× faster than Newton. Newton's Cholesky factorization is prohibitively expensive for a single 2706-DOF kinematic tree.

> **PGS Color (2–4) outperforms Sequential** by 1.50× (386 vs 257 steps/s). The cloth constraint graph benefits from colored parallelism due to its regular structure and single kinematic tree. Performance degrades with higher color counts due to kernel launch overhead.

> **Jacobi PGS fails to converge** on cloth — both ω=0.3 and ω=0.5 hit the maximum 100 iterations every step. The dense constraint coupling in deformable models prevents Jacobi convergence at these relaxation factors.

> **PGS memory bottleneck**: The dense BT matrix `(nworld × njmax × nv)` limits PGS to nworld=64 on 48 GiB GPU (BT alone ≈ 44 GiB). CG and Newton scale to nworld=4096+ since they don't allocate BT.