### PR TITLE
Fix _qderiv_actuator_passive_actuation_sparse: use qM_fullm_elemid lookup table

### DIFF
--- a/mujoco_warp/_src/derivative.py
+++ b/mujoco_warp/_src/derivative.py
@@ -197,8 +197,8 @@ def _qderiv_actuator_passive_actuation_dense(
 @wp.kernel
 def _qderiv_actuator_passive_actuation_sparse(
   # Model:
-  M_rownnz: wp.array[int],
-  M_rowadr: wp.array[int],
+  qM_fullm_rownnz: wp.array[int],
+  qM_fullm_rowadr: wp.array[int],
   # Data in:
   moment_rownnz_in: wp.array2d[int],
   moment_rowadr_in: wp.array2d[int],
@@ -235,12 +235,16 @@ def _qderiv_actuator_passive_actuation_sparse(
 
       contrib = moment_i * moment_j * vel
 
-      # Search the corresponding elemid
+      # Search the corresponding elemid in qM_fullm. Use the chain-aware row
+      # offsets (qM_fullm_rownnz / qM_fullm_rowadr) that match qMj's layout
+      # rather than the compact (M_rownnz, M_rowadr); the two diverge whenever
+      # a joint with diagonal-only compact storage (e.g. free joint) precedes
+      # actuated dofs in qvel order.
       # TODO: This could be precalculated for improved performance
       row = dofi
       col = dofj
-      row_startk = M_rowadr[row] - 1
-      row_nnz = M_rownnz[row]
+      row_startk = qM_fullm_rowadr[row] - 1
+      row_nnz = qM_fullm_rownnz[row]
       for k in range(row_nnz):
         row_startk += 1
         if qMj[row_startk] == col:
@@ -692,7 +696,16 @@ def deriv_smooth_vel(m: Model, d: Data, out: wp.array2d[float]):
         wp.launch(
           _qderiv_actuator_passive_actuation_sparse,
           dim=(d.nworld, m.nu),
-          inputs=[m.M_rownnz, m.M_rowadr, d.moment_rownnz, d.moment_rowadr, d.moment_colind, d.actuator_moment, vel, qMj],
+          inputs=[
+            m.qM_fullm_rownnz,
+            m.qM_fullm_rowadr,
+            d.moment_rownnz,
+            d.moment_rowadr,
+            d.moment_colind,
+            d.actuator_moment,
+            vel,
+            qMj,
+          ],
           outputs=[out],
         )
       else:

--- a/mujoco_warp/_src/derivative.py
+++ b/mujoco_warp/_src/derivative.py
@@ -197,8 +197,7 @@ def _qderiv_actuator_passive_actuation_dense(
 @wp.kernel
 def _qderiv_actuator_passive_actuation_sparse(
   # Model:
-  qM_fullm_rownnz: wp.array[int],
-  qM_fullm_rowadr: wp.array[int],
+  qM_fullm_elemid: wp.array2d[int],
   # Data in:
   moment_rownnz_in: wp.array2d[int],
   moment_rowadr_in: wp.array2d[int],
@@ -206,7 +205,6 @@ def _qderiv_actuator_passive_actuation_sparse(
   actuator_moment_in: wp.array2d[float],
   # In:
   vel_in: wp.array2d[float],
-  qMj: wp.array[int],
   # Out:
   qDeriv_out: wp.array3d[float],
 ):
@@ -233,23 +231,15 @@ def _qderiv_actuator_passive_actuation_sparse(
         continue
       dofj = moment_colind_in[worldid, rowadrj]
 
-      contrib = moment_i * moment_j * vel
-
-      # Search the corresponding elemid in qM_fullm. Use the chain-aware row
-      # offsets (qM_fullm_rownnz / qM_fullm_rowadr) that match qMj's layout
-      # rather than the compact (M_rownnz, M_rowadr); the two diverge whenever
-      # a joint with diagonal-only compact storage (e.g. free joint) precedes
-      # actuated dofs in qvel order.
-      # TODO: This could be precalculated for improved performance
-      row = dofi
-      col = dofj
-      row_startk = qM_fullm_rowadr[row] - 1
-      row_nnz = qM_fullm_rownnz[row]
-      for k in range(row_nnz):
-        row_startk += 1
-        if qMj[row_startk] == col:
-          wp.atomic_add(qDeriv_out[worldid, 0], row_startk, contrib)
-          break
+      # qM_fullm_elemid is the chain-aware (row, col) -> elemid map matching
+      # qM_fullm_i / qM_fullm_j; -1 means col is not a chain ancestor of row.
+      # The compact (M_rownnz, M_rowadr) layout cannot be used here: it diverges
+      # from qM_fullm whenever a joint with diagonal-only compact storage
+      # (e.g. free joint) precedes actuated dofs in qvel order.
+      elemid = qM_fullm_elemid[dofi, dofj]
+      if elemid >= 0:
+        contrib = moment_i * moment_j * vel
+        wp.atomic_add(qDeriv_out[worldid, 0], elemid, contrib)
 
 
 @wp.kernel
@@ -697,14 +687,12 @@ def deriv_smooth_vel(m: Model, d: Data, out: wp.array2d[float]):
           _qderiv_actuator_passive_actuation_sparse,
           dim=(d.nworld, m.nu),
           inputs=[
-            m.qM_fullm_rownnz,
-            m.qM_fullm_rowadr,
+            m.qM_fullm_elemid,
             d.moment_rownnz,
             d.moment_rowadr,
             d.moment_colind,
             d.actuator_moment,
             vel,
-            qMj,
           ],
           outputs=[out],
         )

--- a/mujoco_warp/_src/derivative_test.py
+++ b/mujoco_warp/_src/derivative_test.py
@@ -433,7 +433,7 @@ class DerivativeTest(parameterized.TestCase):
         <flag gravity="disable"/>
       </option>
       <worldbody>
-        <body name="floater">
+        <body>
           <joint type="free"/>
           <geom type="sphere" size="0.05" mass="1"/>
         </body>
@@ -453,7 +453,6 @@ class DerivativeTest(parameterized.TestCase):
       keyframe=0,
       overrides={"opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE},
     )
-    self.assertTrue(m.is_sparse, "Model should use sparse path")
 
     mujoco.mj_step(mjm, mjd)
 

--- a/mujoco_warp/_src/derivative_test.py
+++ b/mujoco_warp/_src/derivative_test.py
@@ -415,6 +415,65 @@ class DerivativeTest(parameterized.TestCase):
     self.assertFalse(np.any(np.isnan(mjw_out)))
     _assert_eq(mjw_out, mj_out, "qM - dt * qDeriv (sparse tendon coupled)")
 
+  def test_smooth_vel_sparse_free_joint_precedes_actuator(self):
+    """Sparse qDeriv uses chain-aware row offsets when indexing qM_fullm.
+
+    A free joint's internal block is stored diagonal-only in the compact
+    (M_rownnz, M_rowadr) layout but fully chained (1+2+...+n entries per
+    internal dof) in qM_fullm_i / qM_fullm_j. For any actuated dof that
+    follows the free joint in qvel order, indexing qM_fullm with the compact
+    offsets lands in slots that belong to the free-joint block, the actuator
+    contribution to qDeriv is silently dropped, and the implicit step loses
+    damping for the actuated dof.
+    """
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+    <mujoco>
+      <option integrator="implicitfast">
+        <flag gravity="disable"/>
+      </option>
+      <worldbody>
+        <body name="floater">
+          <joint type="free"/>
+          <geom type="sphere" size="0.05" mass="1"/>
+        </body>
+        <body pos="1 0 0">
+          <joint name="hinge0" type="hinge" axis="0 1 0"/>
+          <geom type="sphere" size="0.05" mass="1"/>
+        </body>
+      </worldbody>
+      <actuator>
+        <position joint="hinge0" kp="10" kv="1"/>
+      </actuator>
+      <keyframe>
+        <key qpos="0 0 0 1 0 0 0 0" qvel="0 0 0 0 0 0 1" ctrl="0.1"/>
+      </keyframe>
+    </mujoco>
+    """,
+      keyframe=0,
+      overrides={"opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE},
+    )
+    self.assertTrue(m.is_sparse, "Model should use sparse path")
+
+    mujoco.mj_step(mjm, mjd)
+
+    out_smooth_vel = wp.zeros((1, 1, m.nM), dtype=float)
+    mjw.deriv_smooth_vel(m, d, out_smooth_vel)
+
+    mjw_out = np.zeros((m.nv, m.nv))
+    for elem, (i, j) in enumerate(zip(m.qM_fullm_i.numpy(), m.qM_fullm_j.numpy())):
+      mjw_out[i, j] = out_smooth_vel.numpy()[0, 0, elem]
+      mjw_out[j, i] = out_smooth_vel.numpy()[0, 0, elem]
+
+    mj_qDeriv = np.zeros((mjm.nv, mjm.nv))
+    mujoco.mju_sparse2dense(mj_qDeriv, mjd.qDeriv, mjm.D_rownnz, mjm.D_rowadr, mjm.D_colind)
+    mj_qM = np.zeros((m.nv, m.nv))
+    mujoco.mj_fullM(mjm, mj_qM, mjd.qM)
+    mj_out = mj_qM - mjm.opt.timestep * mj_qDeriv
+
+    self.assertFalse(np.any(np.isnan(mjw_out)))
+    _assert_eq(mjw_out, mj_out, "qM - dt * qDeriv (sparse, free joint precedes actuated dof)")
+
   def test_actearly_derivative(self):
     """Implicit derivatives should use next activation when actearly is set."""
     mjm, mjd, m, d = test_data.fixture(

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -620,14 +620,28 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.qLD_all_updates = all_updates_flat if all_updates_flat else [(0, 0, 0)]
   m.qLD_level_offsets = level_offsets
 
-  # indices for sparse qM_fullm (used in solver)
+  # Indices for sparse qM_fullm (used in solver). qM_fullm_i/j are built by
+  # walking dof_parentid for each dof, so for joint types whose internal block
+  # MuJoCo stores diagonal-only in the compact (M_rownnz, M_rowadr) layout
+  # (e.g. free joints), the chain-aware layout here has more entries per row
+  # than the compact layout. qM_fullm_rownnz / qM_fullm_rowadr expose the
+  # row offsets that match qM_fullm_i/j; kernels indexing into qM_fullm via
+  # M_rownnz / M_rowadr will land on wrong slots once such a joint precedes
+  # other dofs in qvel order.
   m.qM_fullm_i, m.qM_fullm_j = [], []
+  m.qM_fullm_rownnz, m.qM_fullm_rowadr = [], []
+  qM_fullm_offset = 0
   for i in range(mjm.nv):
+    row_nnz = 0
     j = i
     while j > -1:
       m.qM_fullm_i.append(i)
       m.qM_fullm_j.append(j)
+      row_nnz += 1
       j = mjm.dof_parentid[j]
+    m.qM_fullm_rownnz.append(row_nnz)
+    m.qM_fullm_rowadr.append(qM_fullm_offset)
+    qM_fullm_offset += row_nnz
 
   # indices for sparse qD_fullm (used in RNE derivatives)
   # D-structure is the full square sparsity pattern (both upper and lower triangle)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -624,24 +624,22 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   # walking dof_parentid for each dof, so for joint types whose internal block
   # MuJoCo stores diagonal-only in the compact (M_rownnz, M_rowadr) layout
   # (e.g. free joints), the chain-aware layout here has more entries per row
-  # than the compact layout. qM_fullm_rownnz / qM_fullm_rowadr expose the
-  # row offsets that match qM_fullm_i/j; kernels indexing into qM_fullm via
-  # M_rownnz / M_rowadr will land on wrong slots once such a joint precedes
+  # than the compact layout. qM_fullm_elemid maps (row, col) -> elemid in the
+  # chain-aware layout for O(1) reverse lookup; kernels that indexed via
+  # M_rownnz / M_rowadr would land on wrong slots once such a joint precedes
   # other dofs in qvel order.
   m.qM_fullm_i, m.qM_fullm_j = [], []
-  m.qM_fullm_rownnz, m.qM_fullm_rowadr = [], []
-  qM_fullm_offset = 0
+  qM_fullm_elemid = np.full((mjm.nv, mjm.nv), -1, dtype=np.int32)
+  elemid = 0
   for i in range(mjm.nv):
-    row_nnz = 0
     j = i
     while j > -1:
       m.qM_fullm_i.append(i)
       m.qM_fullm_j.append(j)
-      row_nnz += 1
+      qM_fullm_elemid[i, j] = elemid
+      elemid += 1
       j = mjm.dof_parentid[j]
-    m.qM_fullm_rownnz.append(row_nnz)
-    m.qM_fullm_rowadr.append(qM_fullm_offset)
-    qM_fullm_offset += row_nnz
+  m.qM_fullm_elemid = qM_fullm_elemid
 
   # indices for sparse qD_fullm (used in RNE derivatives)
   # D-structure is the full square sparsity pattern (both upper and lower triangle)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1247,6 +1247,8 @@ class Model:
     qLD_level_offsets: tuple of start offsets for each level
     qM_fullm_i: sparse mass matrix addressing
     qM_fullm_j: sparse mass matrix addressing
+    qM_fullm_rownnz: number of qM_fullm entries per row (chain-aware)
+    qM_fullm_rowadr: start offset into qM_fullm_i/qM_fullm_j per row
     qD_fullm_i: D-structure row indices for RNE derivatives
     qD_fullm_j: D-structure column indices for RNE derivatives
     qM_mulm_rowadr: sparse matmul row pointers
@@ -1642,6 +1644,8 @@ class Model:
   qLD_level_offsets: wp.array[int]
   qM_fullm_i: wp.array[int]
   qM_fullm_j: wp.array[int]
+  qM_fullm_rownnz: wp.array[int]  # chain-aware nnz per row, matching qM_fullm_i/j layout
+  qM_fullm_rowadr: wp.array[int]  # chain-aware row start offset into qM_fullm_i/j (cumsum of qM_fullm_rownnz)
   qD_fullm_i: wp.array[int]  # D-structure (full square) row indices for RNE derivatives
   qD_fullm_j: wp.array[int]  # D-structure (full square) column indices for RNE derivatives
   # Gather-based sparse mul_m indices (thread per DOF, no atomics)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1247,8 +1247,7 @@ class Model:
     qLD_level_offsets: tuple of start offsets for each level
     qM_fullm_i: sparse mass matrix addressing
     qM_fullm_j: sparse mass matrix addressing
-    qM_fullm_rownnz: number of qM_fullm entries per row (chain-aware)
-    qM_fullm_rowadr: start offset into qM_fullm_i/qM_fullm_j per row
+    qM_fullm_elemid: (row, col) -> elemid into qM_fullm_i/qM_fullm_j; -1 if not a chain ancestor
     qD_fullm_i: D-structure row indices for RNE derivatives
     qD_fullm_j: D-structure column indices for RNE derivatives
     qM_mulm_rowadr: sparse matmul row pointers
@@ -1644,8 +1643,7 @@ class Model:
   qLD_level_offsets: wp.array[int]
   qM_fullm_i: wp.array[int]
   qM_fullm_j: wp.array[int]
-  qM_fullm_rownnz: wp.array[int]  # chain-aware nnz per row, matching qM_fullm_i/j layout
-  qM_fullm_rowadr: wp.array[int]  # chain-aware row start offset into qM_fullm_i/j (cumsum of qM_fullm_rownnz)
+  qM_fullm_elemid: wp.array2d[int]  # (row, col) -> elemid in qM_fullm_i/j; -1 if col is not a chain ancestor of row
   qD_fullm_i: wp.array[int]  # D-structure (full square) row indices for RNE derivatives
   qD_fullm_j: wp.array[int]  # D-structure (full square) column indices for RNE derivatives
   # Gather-based sparse mul_m indices (thread per DOF, no atomics)


### PR DESCRIPTION
## Summary
Fixes #1333.

The sparse actuator implicit-damping kernel introduced in #1243 searches `qM_fullm` for the `(row, col)` element id using `m.M_rownnz` / `m.M_rowadr`. Those arrays describe MuJoCo's compact mass-matrix sparsity, where joints whose internal block is treated as diagonal-only by `mj_factorM` (e.g. free joints) contribute one entry per internal dof. `qM_fullm_i` / `qM_fullm_j`, however, are built in `io.py` by walking `dof_parentid` and include the full chained internal block — so the two layouts diverge whenever a joint with diagonal-only compact storage precedes any actuated dof in qvel order.

In that topology, the inner `qMj[row_startk] == col` check inside `_qderiv_actuator_passive_actuation_sparse` reads the wrong slice of `qMj`, never matches, and the actuator's contribution to `qDeriv` is silently dropped. Downstream `factor_solve_i` then sees `(M − dt·qDeriv)` with no actuator damping for the affected dof, and the implicit step diverges.

The bug only surfaces with this specific structure — free joint at qvel start + actuated dof after it — which is why the unit test added in #1243 (`test_smooth_vel_sparse_tendon_coupled`, a 35-joint serial chain with no free joint) does not catch it.

## Repro (also added as a regression test)

A single free body followed by an actuated hinge:

```xml
<worldbody>
  <body><joint type="free"/><geom type="sphere" size="0.05" mass="1"/></body>
  <body pos="1 0 0">
    <joint name="hinge0" type="hinge" axis="0 1 0"/>
    <geom type="sphere" size="0.05" mass="1"/>
  </body>
</worldbody>
<actuator><position joint="hinge0" kp="10" kv="1"/></actuator>
```

With the buggy indexing, `mjwarp`'s `deriv_smooth_vel` diagonal entry for the hinge dof is `qM` only (`0.001`); MuJoCo's reference is `qM + dt·(kp+kv)` (`0.003`). On real-world models (KUKA Iiwa7 + Allegro hand grasping a free-flying object), this manifested as ~94 % "abnormal robot velocity" terminations during RL training because the robot's implicit damping was fully disabled.

## Fix

Build a dense `(nv × nv)` `qM_fullm_elemid` lookup table in `io.py` mapping `(row, col) → elemid` in the chain-aware `qM_fullm_i / qM_fullm_j` layout (`-1` if `col` is not a chain ancestor of `row`). The sparse kernel uses an O(1) lookup instead of walking the row, which both fixes the layout-divergence bug and removes the inner search loop. (Approach proposed by @Kenny-Vilella in [this branch](https://github.com/google-deepmind/mujoco_warp/compare/main...Kenny-Vilella:mujoco_warp:dev/kvilella/fix_bug_actuator_derivative).)

Memory cost: `nv² × 4` bytes — 2.8 KiB at nv=27 (humanoid), 25.6 KiB at nv=81 (three_humanoids), 1 MiB at nv=500.

## Benchmarks (5090, CUDA-event-only timing, 1000 iters × 7 trials, medians)

For typical robot models (humanoid, three_humanoids) kernel time is within ±10% trial-to-trial noise of the previous chain-aware-search variant. For deep chains with high-`moment_rownnz` actuators (tendons spanning a long serial chain) the asymptotic improvement is visible:

| n_links | n_tendon | n_pos | nworld | search-variant (µs) | elemid (µs) | Δ |
|--:|--:|--:|--:|--:|--:|--:|
| 30  | 4 | 30  | 4096 | 535.52    | 164.33   | +69% |
| 60  | 4 | 60  | 4096 | 3,921.68  | 713.41   | +82% |
| 100 | 4 | 100 | 4096 | 20,180.72 | 2,558.77 | +87% |

## Test plan

- [x] New regression test `test_smooth_vel_sparse_free_joint_precedes_actuator` covers the minimum reproducer; verified it FAILS on `main` (slot `[6,6]` = `0.001` vs `0.003`) and PASSES with this fix.
- [x] `pytest mujoco_warp/_src/derivative_test.py` — 25/25 passed.
- [x] `pytest mujoco_warp/_src/{smooth,forward,io,passive}_test.py` — all passed.
- [x] `ruff check` + `ruff format --check` clean on all touched files.