### PR TITLE
testspeed eager mode and cpu

### DIFF
--- a/mujoco_warp/_src/cli.py
+++ b/mujoco_warp/_src/cli.py
@@ -40,6 +40,7 @@ NCCDMAX = flags.DEFINE_integer("nccdmax", None, "override maximum number of CCD 
 OVERRIDE = flags.DEFINE_multi_string("override", [], "Model overrides (notation: foo.bar = baz)", short_name="o")
 KEYFRAME = flags.DEFINE_integer("keyframe", 0, "keyframe to initialize simulation.")
 EVENT_TRACE = flags.DEFINE_bool("event_trace", False, "print an event trace report")
+EAGER = flags.DEFINE_bool("eager", False, "run without CUDA graph capture (eager mode)")
 NOISE_STD = flags.DEFINE_float("noise_std", 0.01, "add noise to ctrl signal (standard deviation)")
 NOISE_RATE = flags.DEFINE_float("noise_rate", 0.1, "add noise to ctrl signal (noise rate)")
 
@@ -185,37 +186,48 @@ def unroll(
     jit_duration: Time to JIT capture the function.
   """
   with wp.ScopedDevice(wp.get_device(DEVICE.value)):
-    with warp_util.EventTracer(enabled=EVENT_TRACE.value) as tracer:
+    is_cuda = wp.get_device().is_cuda
+    use_graph = is_cuda and not EAGER.value
+
+    with warp_util.EventTracer(enabled=EVENT_TRACE.value and is_cuda) as tracer:
+      fn_args = (m, d) if rc is None else (m, d, rc)
+
       jit_beg = time.perf_counter()
-      with wp.ScopedCapture() as capture:
-        fn(*(m, d) if rc is None else (m, d, rc))
+      if use_graph:
+        with wp.ScopedCapture() as capture:
+          fn(*fn_args)
+      else:
+        fn(*fn_args)
+        wp.synchronize()
       jit_end = time.perf_counter()
 
       for i in range(NSTEP.value):
-        with wp.ScopedStream(wp.get_stream()):
-          if ctrls is not None:
-            center = wp.array(ctrls[i], dtype=wp.float32)
-            wp.launch(
-              _ctrl_noise,
-              dim=(d.nworld, m.nu),
-              inputs=[
-                m.opt.timestep,
-                m.actuator_ctrllimited,
-                m.actuator_ctrlrange,
-                d.ctrl,
-                center,
-                i,
-                NOISE_STD.value,
-                NOISE_RATE.value,
-              ],
-              outputs=[d.ctrl],
-            )
-            wp.synchronize()
-
-          run_beg = time.perf_counter()
-          wp.capture_launch(capture.graph)
+        if ctrls is not None:
+          center = wp.array(ctrls[i], dtype=wp.float32)
+          wp.launch(
+            _ctrl_noise,
+            dim=(d.nworld, m.nu),
+            inputs=[
+              m.opt.timestep,
+              m.actuator_ctrllimited,
+              m.actuator_ctrlrange,
+              d.ctrl,
+              center,
+              i,
+              NOISE_STD.value,
+              NOISE_RATE.value,
+            ],
+            outputs=[d.ctrl],
+          )
           wp.synchronize()
-          run_end = time.perf_counter()
+
+        run_beg = time.perf_counter()
+        if use_graph:
+          wp.capture_launch(capture.graph)
+        else:
+          fn(*fn_args)
+        wp.synchronize()
+        run_end = time.perf_counter()
 
         if callback:
           callback(i, tracer.trace(), run_end - run_beg)

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -26,6 +26,7 @@ import inspect
 import json
 import shutil
 import sys
+import warnings
 from typing import Sequence
 
 import numpy as np
@@ -146,8 +147,7 @@ def _main(argv: Sequence[str]):
   wp.config.quiet = flags.FLAGS["verbosity"].value < 1
   wp.init()
   device = wp.get_device(cli.DEVICE.value)
-  if device == "cpu":
-    raise ValueError("testspeed available for gpu only")
+  is_cuda = device.is_cuda
 
   if _CLEAR_WARP_CACHE.value:
     wp.clear_kernel_cache()
@@ -163,7 +163,7 @@ def _main(argv: Sequence[str]):
     print(f"Loading model from: {path}...\n")
 
   mjm = cli.load_model(path)
-  free_mem_at_init = wp.get_device(device).free_memory
+  free_mem_at_init = device.free_memory if is_cuda else 0
   m, d, rc, ctrls = cli.init_structs(_FUNCS[_FUNCTION.value], mjm)
   timestep = m.opt.timestep.numpy()[0]
 
@@ -248,6 +248,9 @@ def _main(argv: Sequence[str]):
       f"Rolling out {cli.NSTEP.value} {_FUNCTION.value}s at dt = {f'{timestep:g}' if timestep < 0.001 else f'{timestep:.3f}'}..."
     )
 
+  if cli.EVENT_TRACE.value and not is_cuda:
+    warnings.warn("--event_trace is not supported on CPU, skipping")
+
   nacon, nefc, solver_niter = [], [], []
   runtime = 0.0
   trace = {}
@@ -307,7 +310,9 @@ Total converged worlds: {nconverged} / {d.nworld}""")
 
       _print_table(matrix, ("mean", "std", "min", "max"), "solver niter")
 
-    if _MEMORY.value:
+    if _MEMORY.value and not is_cuda:
+      warnings.warn("--memory is not supported on CPU, skipping")
+    elif _MEMORY.value:
       total_mem = wp.get_device(device).total_memory
       used_mem = total_mem - wp.get_device(device).free_memory
       other_mem = used_mem
@@ -332,7 +337,13 @@ Total converged worlds: {nconverged} / {d.nworld}""")
       "converged_worlds": int(nconverged),
       "model_memory": sum(c for _, c in model_mem),
       "data_memory": sum(c for _, c in data_mem),
-      "total_memory": free_mem_at_init - wp.get_device(device).free_memory,
+      **(
+        {
+          "total_memory": free_mem_at_init - device.free_memory,
+        }
+        if is_cuda
+        else {}
+      ),
       "ncon_mean": np.mean(nacon) / cli.NWORLD.value,
       "ncon_p95": np.percentile(nacon, 95) / cli.NWORLD.value,
       "nefc_mean": np.mean(nefc),


### PR DESCRIPTION
add testspeed support for eager mode and cpu

## Benchmark Results: Humanoid

**Model:** `benchmarks/humanoid/humanoid.xml`
**Config:** `--nconmax=24 --njmax=64`
**GPU:** NVIDIA RTX 6000 Ada Generation (48 GB)

| Mode | nworld | Steps/sec | Realtime Factor | Time/step | Total Sim Time | JIT Time |
|------|--------|----------:|----------------:|----------:|---------------:|---------:|
| GPU (graph) | 8,192 | 4,734,044 | 23,670× | 211 ns | 1.73s | 0.32s |
| GPU (eager) | 8,192 | 359,861 | 1,799× | 2,779 ns | 22.76s | 0.32s |
| CPU | 1 | 49 | 0.24× | 20.5 ms | 20.52s | 0.26s |

### Key Observations

- **CUDA graph capture** provides a **13.2× speedup** over eager mode on GPU (211 ns vs 2,779 ns per step) by eliminating per-kernel launch overhead.
- **GPU eager mode** is still **~7,400× faster** than CPU single-world execution on a per-step basis, demonstrating massive parallelism benefits even without graph capture.
- **CPU mode** runs at 0.24× realtime for a single humanoid — useful for debugging and validation, not performance.

---

## Code Changes

Two files were modified to support `--eager` mode and `--device=cpu` execution.

### cli.py

#### 1. Added `--eager` flag

```python
EAGER = flags.DEFINE_bool("eager", False, "run without CUDA graph capture (eager mode)")
```

#### 2. Made `unroll()` device-aware

The original `unroll()` unconditionally used CUDA-only APIs (`ScopedCapture`, `capture_launch`, `ScopedStream`, `get_stream`). Changes:

- **Conditional graph capture:** Only uses `wp.ScopedCapture` / `wp.capture_launch` when `use_graph = is_cuda and not EAGER.value`. Otherwise calls `fn()` directly.
- **Removed `ScopedStream`:** The `wp.ScopedStream(wp.get_stream())` wrapper was removed entirely — it called `wp.get_stream()` which raises `RuntimeError` on CPU. The stream pinning wasn't needed for correctness.
- **Guarded `EventTracer`:** Added `and is_cuda` to the tracer enable condition since event tracing is CUDA-only.

---

### testspeed.py

#### 1. Removed GPU-only gate

```diff
-  if device == "cpu":
-    raise ValueError("testspeed available for gpu only")
+  is_cuda = device.is_cuda
```

#### 2. Guarded CUDA-only APIs

- `device.free_memory` → only accessed when `is_cuda`
- `--memory` flag → warns and skips on CPU
- `--event_trace` flag → warns and skips on CPU
- `total_memory` metric → conditionally included in JSON output