### PR TITLE
Refresh README, add AGENTS.md, add --view flag to benchmarks/run.py

### DIFF
--- a/.agent/rules/project.md
+++ b/.agent/rules/project.md
@@ -1,0 +1,4 @@
+# MuJoCo Warp Project Rules
+
+For project conventions, coding standards, and architectural context,
+read the file `AGENTS.md` in the repository root before starting work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,13 @@
 
 - Always use `uv run`, not python.
 - Always run `uv run pytest -n 8` before creating a PR.
-- Run `uv run pre-commit install` after cloning to enable pre-commit hooks
-  (ruff, uv-lock, kernel-analyzer).
+- Run `uv run pre-commit install` after cloning to enable pre-commit hooks (ruff, uv-lock, kernel-analyzer).
 - Prefer running individual tests rather than the full test suite to improve iteration speed.
 
 # Commits and PRs
 
-- PR body should be plain, concise prose. No section headers, checklists,
-  or structured templates. Describe the problem, what the change does, and
-  any non-obvious tradeoffs. A good PR description reads like a short
-  paragraph to a colleague, not a form.
-- PR and commit messages are rendered on GitHub, so don't hard-wrap them
-  at 88 columns. Let each sentence flow on one line.
+- PR body should be plain, concise prose. Describe the problem, what the change does, and any non-obvious tradeoffs. Bullet points listing changes are fine, but avoid section headers, structured templates, and emojis. A good PR description reads like a short paragraph to a colleague, not a form.
+- PR and commit messages are rendered on GitHub, so don't hard-wrap them at 88 columns. Let each sentence flow on one line.
 - Push branches to your own fork, not to the google-deepmind/mujoco_warp repo directly.
 - Amending commits is fine before a PR has reviewers looking at it. Once a PR is under review, use new commits so reviewers can see what changed.
 - When responding to PR review comments:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Development Workflow
+
+- Always use `uv run`, not python.
+- Always run `uv run pytest -n 8` before creating a PR.
+- Run `uv run pre-commit install` after cloning to enable pre-commit hooks
+  (ruff, uv-lock, kernel-analyzer).
+- Prefer running individual tests rather than the full test suite to improve iteration speed.
+
+# Commits and PRs
+
+- PR body should be plain, concise prose. No section headers, checklists,
+  or structured templates. Describe the problem, what the change does, and
+  any non-obvious tradeoffs. A good PR description reads like a short
+  paragraph to a colleague, not a form.
+- PR and commit messages are rendered on GitHub, so don't hard-wrap them
+  at 88 columns. Let each sentence flow on one line.
+- Push branches to your own fork, not to the google-deepmind/mujoco_warp repo directly.
+
+# Code Style
+
+- Line length limit is 128 characters. Docstring length limit is 100 characters.
+- Prefer targeted, efficient tests over exhaustive edge-case coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,11 @@
 - PR and commit messages are rendered on GitHub, so don't hard-wrap them
   at 88 columns. Let each sentence flow on one line.
 - Push branches to your own fork, not to the google-deepmind/mujoco_warp repo directly.
+- Amending commits is fine before a PR has reviewers looking at it. Once a PR is under review, use new commits so reviewers can see what changed.
+- When responding to PR review comments:
+  - Reply to each comment individually confirming what you did (or why you didn't).
+  - Resolve comment threads that are addressed.
+  - Add a summary comment on the PR after responding, covering what was applied and what was intentionally skipped.
 
 # Code Style
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ you open, so it's important to fix any issues it reports.
 For performance profiling MJWarp, use the `--event_trace` flag on `mjwarp-testspeed` to get a full trace on a test scene of your choice:
 
 ```bash
-mjwarp-testspeed benchmarks/humanoid/humanoid.xml --event_trace=True
+mjwarp-testspeed benchmarks/humanoid/humanoid.xml --event_trace
 ```
 
 `mjwarp-testspeed` has many configuration options, see ```mjwarp-testspeed --help``` for details.  For more details and advanced topics on using MJWarp, see the [MuJoCo Warp documentation](https://mujoco.readthedocs.io/en/latest/mjwarp/index.html).
@@ -117,12 +117,12 @@ If you prefer [PyTorch](https://pytorch.org/) for research, consider one of thes
 
 MuJoCo Warp supports the same features as MuJoCo with the following exceptions:
 
-- **Integrator**: `IMPLICIT` not yet supported
+- **Integrator**: `IMPLICIT` not yet supported ([#1339](https://github.com/google-deepmind/mujoco_warp/pull/1339))
 - **Solver**: `PGS` and `noslip` not yet supported
 - **Actuator / Sensors**: `PLUGIN` types not yet supported
-- **Flex**: flex-flex collisions, `selfcollide`, `mjEQ_FLEXVERT`, and `mjEQ_FLEXSTRAIN` not yet supported
-- **Jacobian format**: `DENSE` only (row-sparse, no islanding yet)
-- **Differentiability**: [differentiability via Warp](https://nvidia.github.io/warp/user_guide/differentiability.html) is not yet available
+- **Flex**: experimental — not all features are implemented or optimized yet
+
+[Differentiability via Warp](https://nvidia.github.io/warp/user_guide/differentiability.html) is not yet available. See [#500](https://github.com/google-deepmind/mujoco_warp/issues/500) for progress.
 
 # Batch Rendering
 

--- a/README.md
+++ b/README.md
@@ -5,90 +5,128 @@
 
 # MuJoCo Warp (MJWarp)
 
-MJWarp is a GPU-optimized version of the [MuJoCo](https://github.com/google-deepmind/mujoco) physics simulator, designed for NVIDIA hardware.
+MJWarp is a GPU-accelerated version of the [MuJoCo](https://github.com/google-deepmind/mujoco) physics simulator, designed for NVIDIA hardware. MJWarp delivers high-throughput, accurate simulation for robotics research.
 
-MJWarp uses [NVIDIA Warp](https://github.com/NVIDIA/warp) to circumvent many of the [sharp bits](https://mujoco.readthedocs.io/en/stable/mjx.html#mjx-the-sharp-bits) in [MuJoCo MJX](https://mujoco.readthedocs.io/en/stable/mjx.html#). MJWarp is integrated into both [MJX](https://mujoco.readthedocs.io/en/stable/mjx.html) and [Newton](https://github.com/newton-physics/newton).
-
-MJWarp is maintained by [Google DeepMind](https://deepmind.google/) and [NVIDIA](https://www.nvidia.com/).
+MJWarp is maintained by [Google DeepMind](https://deepmind.google/) and [NVIDIA](https://www.nvidia.com/) as part of the [Newton](https://github.com/newton-physics/newton) project.
 
 # Getting started
 
-There are a few ways to jump into using MuJoCo Warp:
+MuJoCo Warp requires an NVIDIA GPU for fast simulation but supports CPU for development and debugging.
 
-* For a quick overview of MJWarp's API and design, please see [our colab that introduces the basics](https://colab.research.google.com/github/google-deepmind/mujoco_warp/blob/main/notebooks/tutorial.ipynb).
-* For more details and advanced topics on using MJWarp, see the [MuJoCo Warp documentation](https://mujoco.readthedocs.io/en/latest/mjwarp/index.html).
+**Try it now:** view a simulation of a dancing humanoid robot locally on your machine:
 
-If you would like to train robot policies using MJWarp, consider using a robotics research toolkit that integrates it:
+```bash
+git clone https://github.com/google-deepmind/mujoco_warp.git && cd mujoco_warp
+python benchmarks/run.py -f unitree_g1_flat --view
+```
 
-* [MuJoCo Playground](https://github.com/google-deepmind/mujoco_playground) integrates MJWarp via [MJX](https://mujoco.readthedocs.io/en/stable/mjx.html)
-* [Isaac Lab](https://github.com/isaac-sim/IsaacLab/tree/feature/newton) integrates MJWarp via [Newton](https://github.com/newton-physics/newton)
-* [mjlab](https://github.com/mujocolab/mjlab) integrates MJWarp directly
+Or try out [a tutorial in your browser](https://colab.research.google.com/github/google-deepmind/mujoco_warp/blob/main/notebooks/tutorial.ipynb) (no local setup required).
 
-# Installing
-
-**From PyPI:**
+MJWarp is also available via PyPI:
 
 ```bash
 pip install mujoco-warp
 ```
 
-**From source:**
+# Examples
+
+MuJoCo Warp simulates many kinds of physical systems, from rigid bodies with contacts to soft bodies, cloth, signed distance fields, and more. Here are a few examples of what it can do:
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <img width="320" src="benchmarks/unitree_g1/rollout_flat.webp" alt="Unitree G1">
+      <br><b>python benchmarks/run.py -f unitree_g1_flat --view</b>
+    </td>
+    <td align="center" width="33%">
+      <img width="320" src="benchmarks/unitree_g1/rollout_hfield.webp" alt="Unitree G1 Heightfield">
+      <br><b>python benchmarks/run.py -f unitree_g1_hfield --view</b>
+    </td>
+    <td align="center" width="33%">
+      <img width="320" src="benchmarks/myosim/rollout.webp" alt="MyoArm">
+      <br><b>python benchmarks/run.py -f myoarm --view</b>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <img width="320" src="benchmarks/aloha/rollout_clutter.webp" alt="ALOHA Clutter">
+      <br><b>python benchmarks/run.py -f aloha_clutter --view</b>
+    </td>
+    <td align="center" width="33%">
+      <img width="320" src="benchmarks/aloha/rollout_pot.webp" alt="ALOHA Pot">
+      <br><b>python benchmarks/run.py -f aloha_pot --view</b>
+    </td>
+    <td align="center" width="33%">
+      <img width="320" src="benchmarks/aloha/rollout_sdf.webp" alt="ALOHA SDF">
+      <br><b>python benchmarks/run.py -f aloha_sdf --view</b>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <img width="320" src="benchmarks/humanoid/rollout_humanoid.webp" alt="Humanoid">
+      <br><b>python benchmarks/run.py -f humanoid --view</b>
+    </td>
+    <td align="center" width="33%">
+      <img width="320" src="benchmarks/humanoid/rollout_three_humanoids.webp" alt="Three Humanoids">
+      <br><b>python benchmarks/run.py -f three_humanoids --view</b>
+    </td>
+    <td align="center" width="33%">
+      <img width="320" src="benchmarks/cloth/rollout.webp" alt="Cloth">
+      <br><b>python benchmarks/run.py -f cloth --view</b>
+    </td>
+  </tr>
+</table>
+
+Each of these scenes is benchmarked nightly and the [results are published nightly](https://google-deepmind.github.io/mujoco_warp/nightly/).
+
+# Tips for developers
+
+To set up MJWarp for development:
 
 ```bash
-git clone https://github.com/google-deepmind/mujoco_warp.git
-cd mujoco_warp
-uv sync --all-extras
-```
-
-To make sure everything is working:
-
-```bash
-uv run pytest -n 8
+git clone https://github.com/google-deepmind/mujoco_warp.git && cd mujoco_warp
+uv sync --all-extras  # install all optional dependencies for development
+uv run pre-commit install  # enables ruff, uv-lock, and kernel-analyzer checks on commit
+uv run pytest -n 8  # run all tests, verify everything works
 ```
 
 If you plan to write Warp kernels for MJWarp, please use the `kernel_analyzer` vscode plugin located in [`contrib/kernel_analyzer`](https://github.com/google-deepmind/mujoco_warp/tree/main/contrib/kernel_analyzer).
-Please see the [README](https://github.com/google-deepmind/mujoco_warp/blob/main/contrib/kernel_analyzer/README.md) there for details on how to install it and use it.  The same kernel analyzer will be run on any PR
+See the [README](https://github.com/google-deepmind/mujoco_warp/blob/main/contrib/kernel_analyzer/README.md) there for details on how to install it and use it.  The same kernel analyzer will run on any PR
 you open, so it's important to fix any issues it reports.
 
-# Compatibility
-
-The following features are implemented:
-
-| Category           | Feature                                                                                                 |
-| ------------------ | --------------------------------------------------------------------------------------------------------|
-| Dynamics           | Forward, Inverse                                                                                        |
-| Transmission       | All                                                                                                     |
-| Actuator           | All except `PLUGIN`                                                                                     |
-| Geom               | All                                                                                                     |
-| Constraint         | All                                                                                                     |
-| Equality           | All                                                                                                     |
-| Integrator         | All except `IMPLICIT`                                                                                   |
-| Cone               | All                                                                                                     |
-| Condim             | All                                                                                                     |
-| Solver             | All except `PGS`, `noslip`                                                                              |
-| Fluid Model        | All                                                                                                     |
-| Tendon Wrap        | All                                                                                                     |
-| Sensors            | All except `PLUGIN`                                                                                     |
-| Flex               | All except flex-flex collisions, `selfcollide`, `mjEQ_FLEXVERT`, and `mjEQ_FLEXSTRAIN`                  |
-| Mass matrix format | Sparse and Dense                                                                                        |
-| Jacobian format    | `DENSE` only (row-sparse, no islanding yet)                                                             |
-
-[Differentiability via Warp](https://nvidia.github.io/warp/user_guide/differentiability.html) is not currently
-available.
-
-# Viewing simulations
-
-Explore MuJoCo Warp simulations using an interactive viewer:
+For performance profiling MJWarp, use the `--event_trace` flag on `mjwarp-testspeed` to get a full trace on a test scene of your choice:
 
 ```bash
-mjwarp-viewer benchmarks/humanoid/humanoid.xml
+mjwarp-testspeed benchmarks/humanoid/humanoid.xml --event_trace=True
 ```
 
-This will open a window on your local machine that uses the [MuJoCo native visualizer](https://mujoco.readthedocs.io/en/stable/programming/visualization.html).
+`mjwarp-testspeed` has many configuration options, see ```mjwarp-testspeed --help``` for details.  For more details and advanced topics on using MJWarp, see the [MuJoCo Warp documentation](https://mujoco.readthedocs.io/en/latest/mjwarp/index.html).
+
+# Integrating MuJoCo Warp
+
+There are many ways to use MuJoCo Warp in your projects. In many cases, you can directly install and use MJWarp as a drop-in replacement for MuJoCo.
+
+If you prefer the [JAX](https://github.com/jax-ml/jax) ecosystem, you can use MJWarp via [MJX](https://mujoco.readthedocs.io/en/stable/mjx.html).  See [MuJoCo Playground](https://github.com/google-deepmind/mujoco_playground) for robotics machine learning recipes that use [JAX](https://github.com/jax-ml/jax) and MJWarp.
+
+If you prefer [PyTorch](https://pytorch.org/) for research, consider one of these two great options:
+
+* [Isaac Lab](https://github.com/isaac-sim/IsaacLab/tree/feature/newton) integrates MJWarp via [Newton](https://github.com/newton-physics/newton).  This setup enables powerful, highly extensible multi-physics simulation with deep NVIDIA ecosystem integration.
+* [mjlab](https://github.com/mujocolab/mjlab) exposes the [Isaac Lab](https://github.com/isaac-sim/IsaacLab) manager-based API directly on top of MJWarp, providing a focused framework for robotics research with minimal dependencies and direct access to native MuJoCo data structures.
+
+# MuJoCo API Compatibility
+
+MuJoCo Warp supports the same features as MuJoCo with the following exceptions:
+
+- **Integrator**: `IMPLICIT` not yet supported
+- **Solver**: `PGS` and `noslip` not yet supported
+- **Actuator / Sensors**: `PLUGIN` types not yet supported
+- **Flex**: flex-flex collisions, `selfcollide`, `mjEQ_FLEXVERT`, and `mjEQ_FLEXSTRAIN` not yet supported
+- **Jacobian format**: `DENSE` only (row-sparse, no islanding yet)
+- **Differentiability**: [differentiability via Warp](https://nvidia.github.io/warp/user_guide/differentiability.html) is not yet available
 
 # Batch Rendering
 
-MJWarp includes a **high-throughput** GPU batch renderer designed for simultaneous rendering of cameras across many parallel simulation worlds. The renderer uses ray-tracing to render MuJoCo primitives using Warp's BVH API.
+MJWarp includes a **high-throughput** GPU batch renderer designed for simultaneous rendering of cameras across many parallel simulation worlds. The renderer uses ray-tracing to render MuJoCo scenes at millions of frames per second on NVIDIA GPUs.
 
 Key capabilities:
 - Mesh rendering
@@ -98,24 +136,8 @@ Key capabilities:
 - Heterogeneous multi-camera support (different resolutions/FOV/intrinsics for each camera)
 - Lighting and shadow support
 
-# Benchmarking
+See the [announcement PR](https://github.com/google-deepmind/mujoco_warp/pull/1113) for more details.
 
-Benchmark as follows:
+# License
 
-```bash
-mjwarp-testspeed benchmarks/humanoid/humanoid.xml
-```
-
-To get a full trace of the physics steps (e.g. timings of the subcomponents) run the following:
-
-```bash
-mjwarp-testspeed benchmarks/humanoid/humanoid.xml --event_trace=True
-```
-
-`mjwarp-testspeed` has many configuration options, see ```mjwarp-testspeed --help``` for details.
-
-Benchmark rendering with:
-
-```bash
-mjwarp-testspeed benchmarks/primitives.xml --function=render
-```
+MJWarp is released under the Apache 2.0 license. See [LICENSE](LICENSE) for details.

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -21,6 +21,7 @@ Usage: python benchmarks/run.py [flags]
 
 Example:
   python benchmarks/run.py -f humanoid
+  python benchmarks/run.py -f humanoid --view
   python benchmarks/run.py --input git@github.com:google-deepmind/mujoco_warp.git#abc123f
   python benchmarks/run.py --input .
 """
@@ -158,11 +159,31 @@ def _run_benchmark(bm: dict, input_dir: Path) -> dict:
   return data
 
 
+def _view_benchmark(bm: dict, input_dir: Path):
+  """Launch mjwarp-viewer for a single benchmark."""
+  mjcf_path = Path(_ARGS.assets_root) / bm["name"] / bm["mjcf"]
+  cmd = [
+    "mjwarp-viewer",
+    mjcf_path.as_posix(),
+    "--nworld=1",
+  ]
+  for field in ("nconmax", "njmax"):
+    if field in bm:
+      cmd.append(f"--{field}={bm[field]}")
+  if "replay" in bm:
+    replay_path = Path(_ARGS.assets_root) / bm["name"] / bm["replay"]
+    cmd.append(f"--replay={replay_path.as_posix()}")
+
+  log.info("Command: uv run %s", " ".join(cmd))
+  subprocess.run(("uv", "run") + tuple(cmd), cwd=input_dir, check=True)
+
+
 def main():
   global _ARGS
   parser = argparse.ArgumentParser(description="Run MuJoCo Warp benchmarks.")
   parser.add_argument("--input", default=".", help="git uri or path to mujoco_warp repo to benchmark")
   parser.add_argument("-f", "--filter", default=".*", help="filter benchmarks by name (regex)")
+  parser.add_argument("--view", action="store_true", help="open the benchmark in mjwarp-viewer instead of running testspeed")
   parser.add_argument("--assets_root", default="/tmp/benchmark_assets", help="root directory to assemble benchmark assets")
   parser.add_argument(
     "--clear_warp_cache",
@@ -195,14 +216,21 @@ def main():
     log.info("Discovered %d benchmarks: [%s]", len(benchmarks), ", ".join(benchmarks.keys()))
 
     for name, bm in benchmarks.items():
-      log.info("Running benchmark: %s", name)
-      try:
-        data = _run_benchmark(bm, input_dir)
-      except subprocess.CalledProcessError as e:
-        log.error("Benchmark %s failed:\n%s", name, e.stderr)
-        continue
-      for key, value in data.items():
-        print(f"{name}.{key} {value}")
+      if _ARGS.view:
+        log.info("Viewing benchmark: %s", name)
+        try:
+          _view_benchmark(bm, input_dir)
+        except subprocess.CalledProcessError as e:
+          log.error("Viewer for %s failed:\n%s", name, e.stderr)
+      else:
+        log.info("Running benchmark: %s", name)
+        try:
+          data = _run_benchmark(bm, input_dir)
+        except subprocess.CalledProcessError as e:
+          log.error("Benchmark %s failed:\n%s", name, e.stderr)
+          continue
+        for key, value in data.items():
+          print(f"{name}.{key} {value}")
   except Exception:
     log.exception("Run failed — temp dir left for diagnosis: input_dir=%s", input_dir)
     sys.exit(1)

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -217,11 +217,14 @@ def main():
 
     for name, bm in benchmarks.items():
       if _ARGS.view:
+        if len(benchmarks) > 1:
+          log.warning("--view: multiple benchmarks matched, viewing first match: %s", name)
         log.info("Viewing benchmark: %s", name)
         try:
           _view_benchmark(bm, input_dir)
         except subprocess.CalledProcessError as e:
-          log.error("Viewer for %s failed:\n%s", name, e.stderr)
+          log.error("Viewer for %s failed with exit code %d", name, e.returncode)
+        break
       else:
         log.info("Running benchmark: %s", name)
         try:

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -206,37 +206,23 @@ def main():
     return path
 
   input_dir = clone_if_needed(_ARGS.input)
+  benchmarks = list(_discover_benchmarks(input_dir))
 
-  try:
-    benchmarks = {}
-    for bm in _discover_benchmarks(input_dir):
+  if _ARGS.view:
+    if len(benchmarks) > 1:
+      log.warning("--view: multiple benchmarks matched, truncating to first match: %s", benchmarks[0]["name"])
+    elif len(benchmarks) == 0:
+      log.error("--view: no benchmarks matched the regex filter '%s'", _ARGS.filter)
+      sys.exit(1)
+    bm = benchmarks[0]
+    _assemble_benchmark(bm)
+    _view_benchmark(bm, input_dir)
+  else:
+    log.info("Discovered %d benchmarks: [%s]", len(benchmarks), ", ".join(bm["name"] for bm in benchmarks))
+    for bm in benchmarks:
       _assemble_benchmark(bm)
-      benchmarks[bm["name"]] = bm
-
-    log.info("Discovered %d benchmarks: [%s]", len(benchmarks), ", ".join(benchmarks.keys()))
-
-    for name, bm in benchmarks.items():
-      if _ARGS.view:
-        if len(benchmarks) > 1:
-          log.warning("--view: multiple benchmarks matched, viewing first match: %s", name)
-        log.info("Viewing benchmark: %s", name)
-        try:
-          _view_benchmark(bm, input_dir)
-        except subprocess.CalledProcessError as e:
-          log.error("Viewer for %s failed with exit code %d", name, e.returncode)
-        break
-      else:
-        log.info("Running benchmark: %s", name)
-        try:
-          data = _run_benchmark(bm, input_dir)
-        except subprocess.CalledProcessError as e:
-          log.error("Benchmark %s failed:\n%s", name, e.stderr)
-          continue
-        for key, value in data.items():
-          print(f"{name}.{key} {value}")
-  except Exception:
-    log.exception("Run failed — temp dir left for diagnosis: input_dir=%s", input_dir)
-    sys.exit(1)
+      for key, value in _run_benchmark(bm, input_dir).items():
+        print(f"{bm['name']}.{key} {value}")
 
   # clean up cloned temp dir on success
   if ":" in _ARGS.input:


### PR DESCRIPTION
Improves the README and first-time user experience.

- Rewrites the README to lead with a quickstart example and reorganizes sections for clarity.
- Replaces the compatibility table with a concise exceptions list.
- Adds an animated examples gallery showcasing benchmark scenes.
- Adds AGENTS.md with development workflow conventions and a .agent/rules pointer for AI coding assistants.
- Adds a --view flag to benchmarks/run.py that launches mjwarp-viewer on a benchmark scene with nworld=1, so the examples in the README work out of the box.