### PR TITLE
`qM` to `M`

### DIFF
--- a/mujoco_warp/_src/derivative.py
+++ b/mujoco_warp/_src/derivative.py
@@ -153,15 +153,15 @@ def _qderiv_actuator_passive_actuation_dense(
   actuator_moment_in: wp.array2d[float],
   # In:
   vel_in: wp.array2d[float],
-  qMi: wp.array[int],
-  qMj: wp.array[int],
+  Mi: wp.array[int],
+  Mj: wp.array[int],
   # Out:
   qDeriv_out: wp.array3d[float],
 ):
   worldid, elemid = wp.tid()
 
-  dofiid = qMi[elemid]
-  dofjid = qMj[elemid]
+  dofiid = Mi[elemid]
+  dofjid = Mj[elemid]
   qderiv_contrib = float(0.0)
   for actid in range(nu):
     vel = vel_in[worldid, actid]
@@ -197,7 +197,7 @@ def _qderiv_actuator_passive_actuation_dense(
 @wp.kernel
 def _qderiv_actuator_passive_actuation_sparse(
   # Model:
-  qM_fullm_elemid: wp.array2d[int],
+  M_elemid: wp.array2d[int],
   # Data in:
   moment_rownnz_in: wp.array2d[int],
   moment_rowadr_in: wp.array2d[int],
@@ -231,12 +231,7 @@ def _qderiv_actuator_passive_actuation_sparse(
         continue
       dofj = moment_colind_in[worldid, rowadrj]
 
-      # qM_fullm_elemid is the chain-aware (row, col) -> elemid map matching
-      # qM_fullm_i / qM_fullm_j; -1 means col is not a chain ancestor of row.
-      # The compact (M_rownnz, M_rowadr) layout cannot be used here: it diverges
-      # from qM_fullm whenever a joint with diagonal-only compact storage
-      # (e.g. free joint) precedes actuated dofs in qvel order.
-      elemid = qM_fullm_elemid[dofi, dofj]
+      elemid = M_elemid[dofi, dofj]
       if elemid >= 0:
         contrib = moment_i * moment_j * vel
         wp.atomic_add(qDeriv_out[worldid, 0], elemid, contrib)
@@ -250,23 +245,29 @@ def _qderiv_actuator_passive(
   dof_damping: wp.array2d[float],
   dof_dampingpoly: wp.array2d[wp.vec2],
   is_sparse: bool,
+  M_elemid: wp.array2d[int],
   # Data in:
   qvel_in: wp.array2d[float],
-  qM_in: wp.array3d[float],
+  M_in: wp.array3d[float],
   # In:
-  qMi: wp.array[int],
-  qMj: wp.array[int],
+  Mi: wp.array[int],
+  Mj: wp.array[int],
   qDeriv_in: wp.array3d[float],
   # Out:
   qDeriv_out: wp.array3d[float],
 ):
   worldid, elemid = wp.tid()
 
-  dofiid = qMi[elemid]
-  dofjid = qMj[elemid]
+  dofiid = Mi[elemid]
+  dofjid = Mj[elemid]
+
+  madr = M_elemid[dofiid, dofjid]
 
   if is_sparse:
-    qderiv = qDeriv_in[worldid, 0, elemid]
+    if madr >= 0:
+      qderiv = qDeriv_in[worldid, 0, madr]
+    else:
+      qderiv = 0.0
   else:
     qderiv = qDeriv_in[worldid, dofiid, dofjid]
 
@@ -279,12 +280,13 @@ def _qderiv_actuator_passive(
   qderiv *= opt_timestep[worldid % opt_timestep.shape[0]]
 
   if is_sparse:
-    qDeriv_out[worldid, 0, elemid] = qM_in[worldid, 0, elemid] - qderiv
+    if madr >= 0:
+      qDeriv_out[worldid, 0, madr] = M_in[worldid, 0, madr] - qderiv
   else:
-    qM = qM_in[worldid, dofiid, dofjid] - qderiv
-    qDeriv_out[worldid, dofiid, dofjid] = qM
+    M = M_in[worldid, dofiid, dofjid] - qderiv
+    qDeriv_out[worldid, dofiid, dofjid] = M
     if dofiid != dofjid:
-      qDeriv_out[worldid, dofjid, dofiid] = qM
+      qDeriv_out[worldid, dofjid, dofiid] = M
 
 
 # TODO(team): improve performance with tile operations?
@@ -299,18 +301,19 @@ def _qderiv_tendon_damping(
   tendon_damping: wp.array2d[float],
   tendon_dampingpoly: wp.array2d[wp.vec2],
   is_sparse: bool,
+  M_elemid: wp.array2d[int],
   # Data in:
   ten_J_in: wp.array2d[float],
   ten_velocity_in: wp.array2d[float],
   # In:
-  qMi: wp.array[int],
-  qMj: wp.array[int],
+  Mi: wp.array[int],
+  Mj: wp.array[int],
   # Out:
   qDeriv_out: wp.array3d[float],
 ):
   worldid, elemid = wp.tid()
-  dofiid = qMi[elemid]
-  dofjid = qMj[elemid]
+  dofiid = Mi[elemid]
+  dofjid = Mj[elemid]
 
   qderiv = float(0.0)
   tendon_damping_id = worldid % tendon_damping.shape[0]
@@ -339,8 +342,11 @@ def _qderiv_tendon_damping(
 
   qderiv *= opt_timestep[worldid % opt_timestep.shape[0]]
 
+  madr = M_elemid[dofiid, dofjid]
+
   if is_sparse:
-    qDeriv_out[worldid, 0, elemid] -= qderiv
+    if madr >= 0:
+      qDeriv_out[worldid, 0, madr] -= qderiv
   else:
     qDeriv_out[worldid, dofiid, dofjid] -= qderiv
     if dofiid != dofjid:
@@ -516,8 +522,8 @@ def rne_deriv_body2jnt_sparse(
   cdof_in: wp.array2d[wp.spatial_vector],
   # In:
   timestep: wp.array[float],
-  qMi: wp.array[int],
-  qMj: wp.array[int],
+  Di: wp.array[int],
+  Dj: wp.array[int],
   Dcfrcbody_in: wp.array3d[wp.spatial_vector],
   # Out:
   qDeriv_out: wp.array3d[float],
@@ -526,8 +532,8 @@ def rne_deriv_body2jnt_sparse(
   worldid, elemid = wp.tid()
   dt = timestep[worldid % timestep.shape[0]]
 
-  i = qMi[elemid]
-  j = qMj[elemid]
+  i = Di[elemid]
+  j = Dj[elemid]
 
   body_i = dof_bodyid[i]
   dcfrc = Dcfrcbody_in[worldid, body_i, j]
@@ -647,10 +653,10 @@ def deriv_smooth_vel(m: Model, d: Data, out: wp.array2d[float]):
   Args:
     m: The model containing kinematic and dynamic information (device).
     d: The data object containing the current state and output arrays (device).
-    out: qM - dt * qDeriv (derivatives of smooth forces w.r.t velocities).
+    out: M - dt * qDeriv (derivatives of smooth forces w.r.t velocities).
   """
-  qMi = m.qM_fullm_i
-  qMj = m.qM_fullm_j
+  Mi = m.M_fullm_i
+  Mj = m.M_fullm_j
 
   if ~(m.opt.disableflags & (DisableBit.ACTUATION | DisableBit.DAMPER)):
     # TODO(team): only clear elements not set by _qderiv_actuator_passive
@@ -687,7 +693,7 @@ def deriv_smooth_vel(m: Model, d: Data, out: wp.array2d[float]):
           _qderiv_actuator_passive_actuation_sparse,
           dim=(d.nworld, m.nu),
           inputs=[
-            m.qM_fullm_elemid,
+            m.M_elemid,
             d.moment_rownnz,
             d.moment_rowadr,
             d.moment_colind,
@@ -699,35 +705,36 @@ def deriv_smooth_vel(m: Model, d: Data, out: wp.array2d[float]):
       else:
         wp.launch(
           _qderiv_actuator_passive_actuation_dense,
-          dim=(d.nworld, qMi.size),
-          inputs=[m.nu, d.moment_rownnz, d.moment_rowadr, d.moment_colind, d.actuator_moment, vel, qMi, qMj],
+          dim=(d.nworld, Mi.size),
+          inputs=[m.nu, d.moment_rownnz, d.moment_rowadr, d.moment_colind, d.actuator_moment, vel, Mi, Mj],
           outputs=[out],
         )
     wp.launch(
       _qderiv_actuator_passive,
-      dim=(d.nworld, qMi.size),
+      dim=(d.nworld, Mi.size),
       inputs=[
         m.opt.timestep,
         m.opt.disableflags,
         m.dof_damping,
         m.dof_dampingpoly,
         m.is_sparse,
+        m.M_elemid,
         d.qvel,
-        d.qM,
-        qMi,
-        qMj,
+        d.M,
+        Mi,
+        Mj,
         out,
       ],
       outputs=[out],
     )
   else:
-    # TODO(team): directly utilize qM for these settings
-    wp.copy(out, d.qM)
+    # TODO(team): directly utilize M for these settings
+    wp.copy(out, d.M)
 
   if not (m.opt.disableflags & DisableBit.DAMPER):
     wp.launch(
       _qderiv_tendon_damping,
-      dim=(d.nworld, qMi.size),
+      dim=(d.nworld, Mi.size),
       inputs=[
         m.ntendon,
         m.opt.timestep,
@@ -737,10 +744,11 @@ def deriv_smooth_vel(m: Model, d: Data, out: wp.array2d[float]):
         m.tendon_damping,
         m.tendon_dampingpoly,
         m.is_sparse,
+        m.M_elemid,
         d.ten_J,
         d.ten_velocity,
-        qMi,
-        qMj,
+        Mi,
+        Mj,
       ],
       outputs=[out],
     )

--- a/mujoco_warp/_src/derivative_test.py
+++ b/mujoco_warp/_src/derivative_test.py
@@ -100,11 +100,11 @@ class DerivativeTest(parameterized.TestCase):
     mujoco.mj_step(mjm, mjd)
 
     if jacobian == mujoco.mjtJacobian.mjJAC_SPARSE:
-      out_smooth_vel = wp.zeros((1, 1, m.nM), dtype=float)
+      out_smooth_vel = wp.zeros((1, 1, m.nC), dtype=float)
     else:
-      out_smooth_vel = wp.zeros(d.qM.shape, dtype=float)
+      out_smooth_vel = wp.zeros(d.M.shape, dtype=float)
 
-    # Compute kinematics without factorizing qM to allow direct comparison
+    # Compute kinematics without factorizing M to allow direct comparison
     forward.fwd_position(m, d, factorize=False)
     forward.fwd_velocity(m, d)
 
@@ -113,8 +113,18 @@ class DerivativeTest(parameterized.TestCase):
 
     if jacobian == mujoco.mjtJacobian.mjJAC_SPARSE:
       mjw_out = np.zeros((m.nv, m.nv))
-      for elem, (i, j) in enumerate(zip(m.qM_fullm_i.numpy(), m.qM_fullm_j.numpy())):
-        mjw_out[i, j] = out_smooth_vel.numpy()[0, 0, elem]
+      if check_version("mujoco>=3.8.1.dev910242375"):
+        mujoco.mju_sym2dense(
+          mjw_out, out_smooth_vel.numpy().reshape(-1).astype(np.float64), mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind
+        )
+      else:
+        for i in range(m.nv):
+          rowadr = m.M_rowadr.numpy()[i]
+          rownnz = m.M_rownnz.numpy()[i]
+          for k in range(rownnz):
+            madr = rowadr + k
+            col = m.M_colind.numpy()[madr]
+            mjw_out[i, col] = out_smooth_vel.numpy()[0, 0, madr]
     else:
       mjw_out = out_smooth_vel.numpy()[0, : m.nv, : m.nv]
 
@@ -124,14 +134,14 @@ class DerivativeTest(parameterized.TestCase):
     mj_qDeriv = np.zeros((mjm.nv, mjm.nv))
     mujoco.mju_sparse2dense(mj_qDeriv, mjd.qDeriv, mjm.D_rownnz, mjm.D_rowadr, mjm.D_colind)
 
-    mj_qM = np.zeros((m.nv, m.nv))
+    mj_M = np.zeros((m.nv, m.nv))
     if check_version("mujoco>=3.8.1.dev910242375"):
-      mujoco.mju_sym2dense(mj_qM, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
+      mujoco.mju_sym2dense(mj_M, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
     else:
-      mujoco.mj_fullM(mjm, mj_qM, mjd.qM)
-    mj_out = mj_qM - mjm.opt.timestep * mj_qDeriv
+      mujoco.mj_fullM(mjm, mj_M, mjd.qM)
+    mj_out = mj_M - mjm.opt.timestep * mj_qDeriv
 
-    _assert_eq(mjw_out, mj_out, "qM - dt * qDeriv")
+    _assert_eq(mjw_out, mj_out, "M - dt * qDeriv")
 
   _TENDON_SERIAL_CHAIN_XML = """
     <mujoco>
@@ -181,31 +191,41 @@ class DerivativeTest(parameterized.TestCase):
     mujoco.mj_step(mjm, mjd)
 
     if jacobian == mujoco.mjtJacobian.mjJAC_SPARSE:
-      out_smooth_vel = wp.zeros((1, 1, m.nM), dtype=float)
+      out_smooth_vel = wp.zeros((1, 1, m.nC), dtype=float)
     else:
-      out_smooth_vel = wp.zeros(d.qM.shape, dtype=float)
+      out_smooth_vel = wp.zeros(d.M.shape, dtype=float)
 
     mjw.deriv_smooth_vel(m, d, out_smooth_vel)
 
     if jacobian == mujoco.mjtJacobian.mjJAC_SPARSE:
       mjw_out = np.zeros((m.nv, m.nv))
-      for elem, (i, j) in enumerate(zip(m.qM_fullm_i.numpy(), m.qM_fullm_j.numpy())):
-        mjw_out[i, j] = out_smooth_vel.numpy()[0, 0, elem]
+      if check_version("mujoco>=3.8.1.dev910242375"):
+        mujoco.mju_sym2dense(
+          mjw_out, out_smooth_vel.numpy().reshape(-1).astype(np.float64), mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind
+        )
+      else:
+        for i in range(m.nv):
+          rowadr = m.M_rowadr.numpy()[i]
+          rownnz = m.M_rownnz.numpy()[i]
+          for k in range(rownnz):
+            madr = rowadr + k
+            col = m.M_colind.numpy()[madr]
+            mjw_out[i, col] = out_smooth_vel.numpy()[0, 0, madr]
     else:
       mjw_out = out_smooth_vel.numpy()[0, : m.nv, : m.nv]
 
-    # Final comparison against new ground truth: qM - dt * qDeriv
+    # Final comparison against new ground truth: M - dt * qDeriv
     mj_qDeriv = np.zeros((mjm.nv, mjm.nv))
     mujoco.mju_sparse2dense(mj_qDeriv, mjd.qDeriv, mjm.D_rownnz, mjm.D_rowadr, mjm.D_colind)
-    mj_qM = np.zeros((m.nv, m.nv))
+    mj_M = np.zeros((m.nv, m.nv))
     if check_version("mujoco>=3.8.1.dev910242375"):
-      mujoco.mju_sym2dense(mj_qM, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
+      mujoco.mju_sym2dense(mj_M, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
     else:
-      mujoco.mj_fullM(mjm, mj_qM, mjd.qM)
-    mj_out = mj_qM - mjm.opt.timestep * mj_qDeriv
+      mujoco.mj_fullM(mjm, mj_M, mjd.qM)
+    mj_out = mj_M - mjm.opt.timestep * mj_qDeriv
 
     self.assertFalse(np.any(np.isnan(mjw_out)))
-    _assert_eq(mjw_out, mj_out, "qM - dt * qDeriv (tendon serial chain)")
+    _assert_eq(mjw_out, mj_out, "M - dt * qDeriv (tendon serial chain)")
 
   def test_step_tendon_serial_chain_no_nan(self):
     """Regression: implicitfast + tendon on serial chain must not NaN."""
@@ -404,34 +424,44 @@ class DerivativeTest(parameterized.TestCase):
 
     mujoco.mj_step(mjm, mjd)
 
-    out_smooth_vel = wp.zeros((1, 1, m.nM), dtype=float)
+    out_smooth_vel = wp.zeros((1, 1, m.nC), dtype=float)
     mjw.deriv_smooth_vel(m, d, out_smooth_vel)
 
     mjw_out = np.zeros((m.nv, m.nv))
-    for elem, (i, j) in enumerate(zip(m.qM_fullm_i.numpy(), m.qM_fullm_j.numpy())):
-      mjw_out[i, j] = out_smooth_vel.numpy()[0, 0, elem]
-      mjw_out[j, i] = out_smooth_vel.numpy()[0, 0, elem]
+    if check_version("mujoco>=3.8.1.dev910242375"):
+      mujoco.mju_sym2dense(
+        mjw_out, out_smooth_vel.numpy().reshape(-1).astype(np.float64), mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind
+      )
+    else:
+      for i in range(m.nv):
+        rowadr = m.M_rowadr.numpy()[i]
+        rownnz = m.M_rownnz.numpy()[i]
+        for k in range(rownnz):
+          madr = rowadr + k
+          col = m.M_colind.numpy()[madr]
+          mjw_out[i, col] = out_smooth_vel.numpy()[0, 0, madr]
+          mjw_out[col, i] = out_smooth_vel.numpy()[0, 0, madr]
 
     mj_qDeriv = np.zeros((mjm.nv, mjm.nv))
     mujoco.mju_sparse2dense(mj_qDeriv, mjd.qDeriv, mjm.D_rownnz, mjm.D_rowadr, mjm.D_colind)
 
-    mj_qM = np.zeros((m.nv, m.nv))
+    mj_M = np.zeros((m.nv, m.nv))
     if check_version("mujoco>=3.8.1.dev910242375"):
-      mujoco.mju_sym2dense(mj_qM, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
+      mujoco.mju_sym2dense(mj_M, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
     else:
-      mujoco.mj_fullM(mjm, mj_qM, mjd.qM)
-    mj_out = mj_qM - mjm.opt.timestep * mj_qDeriv
+      mujoco.mj_fullM(mjm, mj_M, mjd.qM)
+    mj_out = mj_M - mjm.opt.timestep * mj_qDeriv
 
     self.assertFalse(np.any(np.isnan(mjw_out)))
-    _assert_eq(mjw_out, mj_out, "qM - dt * qDeriv (sparse tendon coupled)")
+    _assert_eq(mjw_out, mj_out, "M - dt * qDeriv (sparse tendon coupled)")
 
   def test_smooth_vel_sparse_free_joint_precedes_actuator(self):
-    """Sparse qDeriv uses chain-aware row offsets when indexing qM_fullm.
+    """Sparse qDeriv uses chain-aware row offsets when indexing M_fullm.
 
     A free joint's internal block is stored diagonal-only in the compact
     (M_rownnz, M_rowadr) layout but fully chained (1+2+...+n entries per
-    internal dof) in qM_fullm_i / qM_fullm_j. For any actuated dof that
-    follows the free joint in qvel order, indexing qM_fullm with the compact
+    internal dof) in M_fullm_i / M_fullm_j. For any actuated dof that
+    follows the free joint in qvel order, indexing M_fullm with the compact
     offsets lands in slots that belong to the free-joint block, the actuator
     contribution to qDeriv is silently dropped, and the implicit step loses
     damping for the actuated dof.
@@ -466,22 +496,32 @@ class DerivativeTest(parameterized.TestCase):
 
     mujoco.mj_step(mjm, mjd)
 
-    out_smooth_vel = wp.zeros((1, 1, m.nM), dtype=float)
+    out_smooth_vel = wp.zeros((1, 1, m.nC), dtype=float)
     mjw.deriv_smooth_vel(m, d, out_smooth_vel)
 
     mjw_out = np.zeros((m.nv, m.nv))
-    for elem, (i, j) in enumerate(zip(m.qM_fullm_i.numpy(), m.qM_fullm_j.numpy())):
-      mjw_out[i, j] = out_smooth_vel.numpy()[0, 0, elem]
-      mjw_out[j, i] = out_smooth_vel.numpy()[0, 0, elem]
+    if check_version("mujoco>=3.8.1.dev910242375"):
+      mujoco.mju_sym2dense(
+        mjw_out, out_smooth_vel.numpy().reshape(-1).astype(np.float64), mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind
+      )
+    else:
+      for i in range(m.nv):
+        rowadr = m.M_rowadr.numpy()[i]
+        rownnz = m.M_rownnz.numpy()[i]
+        for k in range(rownnz):
+          madr = rowadr + k
+          col = m.M_colind.numpy()[madr]
+          mjw_out[i, col] = out_smooth_vel.numpy()[0, 0, madr]
+          mjw_out[col, i] = out_smooth_vel.numpy()[0, 0, madr]
 
     mj_qDeriv = np.zeros((mjm.nv, mjm.nv))
     mujoco.mju_sparse2dense(mj_qDeriv, mjd.qDeriv, mjm.D_rownnz, mjm.D_rowadr, mjm.D_colind)
-    mj_qM = np.zeros((m.nv, m.nv))
-    mujoco.mj_fullM(mjm, mj_qM, mjd.qM)
-    mj_out = mj_qM - mjm.opt.timestep * mj_qDeriv
+    mj_M = np.zeros((m.nv, m.nv))
+    mujoco.mj_fullM(mjm, mj_M, mjd.qM)
+    mj_out = mj_M - mjm.opt.timestep * mj_qDeriv
 
     self.assertFalse(np.any(np.isnan(mjw_out)))
-    _assert_eq(mjw_out, mj_out, "qM - dt * qDeriv (sparse, free joint precedes actuated dof)")
+    _assert_eq(mjw_out, mj_out, "M - dt * qDeriv (sparse, free joint precedes actuated dof)")
 
   def test_actearly_derivative(self):
     """Implicit derivatives should use next activation when actearly is set."""
@@ -517,7 +557,7 @@ class DerivativeTest(parameterized.TestCase):
     _assert_eq(d.act_dot.numpy()[0, 0], d.act_dot.numpy()[0, 1], "act_dot")
 
     # compute qDeriv using deriv_smooth_vel
-    out_smooth_vel = wp.zeros(d.qM.shape, dtype=float)
+    out_smooth_vel = wp.zeros(d.M.shape, dtype=float)
     mjw.deriv_smooth_vel(m, d, out_smooth_vel)
     mjw_out = out_smooth_vel.numpy()[0, : m.nv, : m.nv]
 
@@ -525,8 +565,8 @@ class DerivativeTest(parameterized.TestCase):
     # because actearly uses next activation: act + act_dot*dt
     # for our model: next_act = 0 + 1*1 = 1, current_act = 0
     # derivative adds gain_vel * act to qDeriv diagonal
-    # qDeriv = qM - dt * actuator_vel_derivative
-    # for independent bodies with mass=1: qM diagonal = 1.0
+    # qDeriv = M - dt * actuator_vel_derivative
+    # for independent bodies with mass=1: M diagonal = 1.0
     # actearly=true: vel = gain_vel * next_act = 1 * 1 = 1, out = 1 - 1*1 = 0
     # actearly=false: vel = gain_vel * current_act = 1 * 0 = 0, out = 1 - 1*0 = 1
     self.assertNotAlmostEqual(
@@ -534,8 +574,8 @@ class DerivativeTest(parameterized.TestCase):
       mjw_out[1, 1],
       msg="actearly=true should use next activation in derivative",
     )
-    _assert_eq(mjw_out[0, 0], 0.0, "actearly=true: qM - dt*gain_vel*next_act = 1 - 1*1 = 0")
-    _assert_eq(mjw_out[1, 1], 1.0, "actearly=false: qM - dt*gain_vel*current_act = 1 - 1*0 = 1")
+    _assert_eq(mjw_out[0, 0], 0.0, "actearly=true: M - dt*gain_vel*next_act = 1 - 1*1 = 0")
+    _assert_eq(mjw_out[1, 1], 1.0, "actearly=false: M - dt*gain_vel*current_act = 1 - 1*0 = 1")
 
   def test_forcerange_clamped_derivative(self):
     """Implicit integration is more accurate than Euler with active forcerange clamping."""
@@ -828,7 +868,7 @@ class DerivativeTest(parameterized.TestCase):
     if jacobian == mujoco.mjtJacobian.mjJAC_SPARSE:
       out_rne = wp.zeros((1, 1, m.nD), dtype=float)
     else:
-      out_rne = wp.zeros(d.qM.shape, dtype=float)
+      out_rne = wp.zeros(d.M.shape, dtype=float)
 
     derivative.rne_vel_deriv(m, d, out_rne)
 

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -346,17 +346,18 @@ def _compute_damping_deriv(
 def _euler_damp_qfrc_sparse(
   # Model:
   opt_timestep: wp.array[float],
-  dof_Madr: wp.array[int],
+  M_rownnz: wp.array[int],
+  M_rowadr: wp.array[int],
   # In:
   damp_deriv: wp.array2d[float],
   # Out:
-  qM_integration_out: wp.array3d[float],
+  M_integration_out: wp.array3d[float],
 ):
   worldid, tid = wp.tid()
   timestep = opt_timestep[worldid % opt_timestep.shape[0]]
 
-  adr = dof_Madr[tid]
-  qM_integration_out[worldid, 0, adr] += timestep * damp_deriv[worldid, tid]
+  adr = M_rowadr[tid] + M_rownnz[tid] - 1
+  M_integration_out[worldid, 0, adr] += timestep * damp_deriv[worldid, tid]
 
 
 @cache_kernel
@@ -366,7 +367,7 @@ def _tile_euler_dense(tile: TileSet):
     # Model:
     opt_timestep: wp.array[float],
     # Data in:
-    qM_in: wp.array3d[float],
+    M_in: wp.array3d[float],
     efc_Ma_in: wp.array2d[float],
     # In:
     damp_deriv: wp.array2d[float],
@@ -379,7 +380,7 @@ def _tile_euler_dense(tile: TileSet):
     TILE_SIZE = wp.static(tile.size)
 
     dofid = adr_in[nodeid]
-    M_tile = wp.tile_load(qM_in[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid))
+    M_tile = wp.tile_load(M_in[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid))
     damping_tile = wp.tile_load(damp_deriv[worldid], shape=(TILE_SIZE,), offset=(dofid,))
     damping_scaled = damping_tile * timestep
     qm_integration_tile = wp.tile_diag_add(M_tile, damping_scaled)
@@ -409,22 +410,22 @@ def euler(m: Model, d: Data):
     )
 
     if m.is_sparse:
-      qM = wp.clone(d.qM)
+      M = wp.clone(d.M)
       qLD = wp.empty((d.nworld, 1, m.nC), dtype=float)
       qLDiagInv = wp.empty((d.nworld, m.nv), dtype=float)
       wp.launch(
         _euler_damp_qfrc_sparse,
         dim=(d.nworld, m.nv),
-        inputs=[m.opt.timestep, m.dof_Madr, damp_deriv],
-        outputs=[qM],
+        inputs=[m.opt.timestep, m.M_rownnz, m.M_rowadr, damp_deriv],
+        outputs=[M],
       )
-      smooth.factor_solve_i(m, d, qM, qLD, qLDiagInv, qacc, d.efc.Ma)
+      smooth.factor_solve_i(m, d, M, qLD, qLDiagInv, qacc, d.efc.Ma)
     else:
-      for tile in m.qM_tiles:
+      for tile in m.M_tiles:
         wp.launch_tiled(
           _tile_euler_dense(tile),
           dim=(d.nworld, tile.adr.size),
-          inputs=[m.opt.timestep, d.qM, d.efc.Ma, damp_deriv, tile.adr],
+          inputs=[m.opt.timestep, d.M, d.efc.Ma, damp_deriv, tile.adr],
           outputs=[qacc],
           block_dim=m.block_dim.euler_dense,
         )
@@ -578,11 +579,11 @@ def implicit(m: Model, d: Data):
   """Integrates fully implicit in velocity."""
   if ~(m.opt.disableflags | ~(DisableBit.ACTUATION | DisableBit.SPRING | DisableBit.DAMPER)):
     if m.is_sparse:
-      qDeriv = wp.empty((d.nworld, 1, m.nM), dtype=float)
+      qDeriv = wp.empty((d.nworld, 1, m.nC), dtype=float)
       qLD = wp.empty((d.nworld, 1, m.nC), dtype=float)
     else:
-      qDeriv = wp.empty(d.qM.shape, dtype=float)
-      qLD = wp.empty(d.qM.shape, dtype=float)
+      qDeriv = wp.empty(d.M.shape, dtype=float)
+      qLD = wp.empty(d.M.shape, dtype=float)
     qLDiagInv = wp.empty((d.nworld, m.nv), dtype=float)
     derivative.deriv_smooth_vel(m, d, qDeriv)
     qacc = wp.empty((d.nworld, m.nv), dtype=float)
@@ -1221,7 +1222,7 @@ def fwd_acceleration(m: Model, d: Data, factorize: bool = False):
   xfrc_accumulate(m, d, d.qfrc_smooth)
 
   if factorize:
-    smooth.factor_solve_i(m, d, d.qM, d.qLD, d.qLDiagInv, d.qacc_smooth, d.qfrc_smooth)
+    smooth.factor_solve_i(m, d, d.M, d.qLD, d.qLDiagInv, d.qacc_smooth, d.qfrc_smooth)
   else:
     smooth.solve_m(m, d, d.qacc_smooth, d.qfrc_smooth)
 

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -344,7 +344,7 @@ class ForwardTest(parameterized.TestCase):
       "ten_wrapnum",
       "wrap_obj",
       "wrap_xpos",
-      "qM",
+      "M",
       "qLD",
       "nefc",
       "efc_type",
@@ -436,7 +436,7 @@ class ForwardTest(parameterized.TestCase):
       if arr in ["xmat", "ximat", "geom_xmat", "site_xmat", "cam_xmat"]:
         mjd_arr = mjd_arr.reshape(-1)
         d_arr = d_arr.reshape(-1)
-      elif arr == "qM":
+      elif arr == "M":
         mjd_arr = np.zeros((mjm.nv, mjm.nv))
         if check_version("mujoco>=3.8.1.dev910242375"):
           mujoco.mju_sym2dense(mjd_arr, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)

--- a/mujoco_warp/_src/inverse.py
+++ b/mujoco_warp/_src/inverse.py
@@ -95,9 +95,9 @@ def discrete_acc(m: Model, d: Data, qacc: wp.array2d[float]):
 
     # TODO(team): qacc = d.qacc if (m.dof_damping == 0.0).all()
 
-    # set qfrc = (d.qM + m.opt.timestep * diag(m.dof_damping)) * d.qacc
+    # set qfrc = (d.M + m.opt.timestep * diag(m.dof_damping)) * d.qacc
 
-    # d.qM @ d.qacc
+    # d.M @ d.qacc
     support.mul_m(m, d, qfrc, d.qacc)
 
     # qfrc += m.opt.timestep * damp_deriv * d.qacc
@@ -109,16 +109,16 @@ def discrete_acc(m: Model, d: Data, qacc: wp.array2d[float]):
     )
   elif m.opt.integrator == IntegratorType.IMPLICITFAST:
     if m.is_sparse:
-      qDeriv = wp.empty((d.nworld, 1, m.nM), dtype=float)
+      qDeriv = wp.empty((d.nworld, 1, m.nC), dtype=float)
     else:
       qDeriv = wp.empty((d.nworld, m.nv, m.nv), dtype=float)
     derivative.deriv_smooth_vel(m, d, qDeriv)
     mul_m(m, d, qfrc, d.qacc, M=qDeriv)
-    smooth.factor_solve_i(m, d, d.qM, d.qLD, d.qLDiagInv, qacc, qfrc)
+    smooth.factor_solve_i(m, d, d.M, d.qLD, d.qLDiagInv, qacc, qfrc)
   else:
     raise NotImplementedError(f"integrator {m.opt.integrator} not implemented.")
 
-  # solve for qacc: qfrc = d.qM @ d.qacc
+  # solve for qacc: qfrc = d.M @ d.qacc
   smooth.solve_m(m, d, qacc, qfrc)
 
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -585,14 +585,14 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
     for j in range(mjm.mesh_vertnum[mjm.sensor_objid[i]])
   ]
 
-  # qM_tiles records the block diagonal structure of qM
+  # M_tiles records the block diagonal structure of M
   tile_corners = [i for i in range(mjm.nv) if mjm.dof_parentid[i] == -1]
   tiles = {}
   for i in range(len(tile_corners)):
     tile_beg = tile_corners[i]
     tile_end = mjm.nv if i == len(tile_corners) - 1 else tile_corners[i + 1]
     tiles.setdefault(tile_end - tile_beg, []).append(tile_beg)
-  m.qM_tiles = tuple(types.TileSet(adr=wp.array(tiles[sz], dtype=int), size=sz) for sz in sorted(tiles.keys()))
+  m.M_tiles = tuple(types.TileSet(adr=wp.array(tiles[sz], dtype=int), size=sz) for sz in sorted(tiles.keys()))
 
   # qLD_updates has dof tree ordering of qLD updates for sparse factor m
   qLD_updates, dof_depth = {}, np.zeros(mjm.nv, dtype=int) - 1
@@ -620,32 +620,35 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.qLD_all_updates = all_updates_flat if all_updates_flat else [(0, 0, 0)]
   m.qLD_level_offsets = level_offsets
 
-  # Indices for sparse qM_fullm (used in solver). qM_fullm_i/j are built by
+  # Indices for sparse M_fullm (used in solver). M_fullm_i/j are built by
   # walking dof_parentid for each dof, so for joint types whose internal block
   # MuJoCo stores diagonal-only in the compact (M_rownnz, M_rowadr) layout
   # (e.g. free joints), the chain-aware layout here has more entries per row
-  # than the compact layout. qM_fullm_elemid maps (row, col) -> elemid in the
-  # chain-aware layout for O(1) reverse lookup; kernels that indexed via
-  # M_rownnz / M_rowadr would land on wrong slots once such a joint precedes
-  # other dofs in qvel order.
-  m.qM_fullm_i, m.qM_fullm_j = [], []
-  qM_fullm_elemid = np.full((mjm.nv, mjm.nv), -1, dtype=np.int32)
-  elemid = 0
+  # than the compact layout.
+  m.M_fullm_i, m.M_fullm_j = [], []
   for i in range(mjm.nv):
     j = i
     while j > -1:
-      m.qM_fullm_i.append(i)
-      m.qM_fullm_j.append(j)
-      qM_fullm_elemid[i, j] = elemid
-      elemid += 1
+      m.M_fullm_i.append(i)
+      m.M_fullm_j.append(j)
       j = mjm.dof_parentid[j]
-  m.qM_fullm_elemid = qM_fullm_elemid
+  # M_elemid maps (row, col) -> madr index in the native CSR M layout
+  M_elemid = np.full((mjm.nv, mjm.nv), -1, dtype=np.int32)
+  for i in range(mjm.nv):
+    rowadr = mjm.M_rowadr[i]
+    rownnz = mjm.M_rownnz[i]
+    for k in range(rownnz):
+      madr = rowadr + k
+      col = int(mjm.M_colind[madr])
+      M_elemid[i, col] = madr
+  m.M_elemid = M_elemid
+
   upper_j, upper_i = np.triu_indices(mjm.nv)
-  upper_elemid = qM_fullm_elemid[upper_i, upper_j]
+  upper_elemid = M_elemid[upper_i, upper_j]
   valid_mask = upper_elemid != -1
-  m.qM_fullm_upper_i = upper_j[valid_mask].tolist()
-  m.qM_fullm_upper_j = upper_i[valid_mask].tolist()
-  m.qM_fullm_upper_elemid = upper_elemid[valid_mask].tolist()
+  m.M_fullm_upper_i = upper_j[valid_mask].tolist()
+  m.M_fullm_upper_j = upper_i[valid_mask].tolist()
+  m.M_fullm_upper_elemid = upper_elemid[valid_mask].tolist()
 
   # indices for sparse qD_fullm (used in RNE derivatives)
   # D-structure is the full square sparsity pattern (both upper and lower triangle)
@@ -661,29 +664,25 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   # Gather-based sparse mul_m: for each row, all (col, madr) including diagonal
   row_elements = [[] for _ in range(mjm.nv)]
 
-  # Add diagonal
   for i in range(mjm.nv):
-    row_elements[i].append((i, mjm.dof_Madr[i]))
-
-  # Add off-diagonals: ancestors (lower) and descendants (upper)
-  for i in range(mjm.nv):
-    madr_ij, j = mjm.dof_Madr[i], i
-    while True:
-      madr_ij, j = madr_ij + 1, mjm.dof_parentid[j]
-      if j == -1:
-        break
-      row_elements[i].append((j, madr_ij))  # row i gathers M[i,j] * vec[j]
-      row_elements[j].append((i, madr_ij))  # row j gathers M[j,i] * vec[i]
+    rowadr = mjm.M_rowadr[i]
+    rownnz = mjm.M_rownnz[i]
+    for k in range(rownnz):
+      madr = rowadr + k
+      col = int(mjm.M_colind[madr])
+      row_elements[i].append((col, madr))  # row i gathers M[i,col] * vec[col]
+      if i != col:
+        row_elements[col].append((i, madr))  # row col gathers M[i,col] * vec[i]
 
   # Flatten into CSR-like arrays
-  m.qM_mulm_rowadr = [0]
-  m.qM_mulm_col = []
-  m.qM_mulm_madr = []
+  m.M_mulm_rowadr = [0]
+  m.M_mulm_col = []
+  m.M_mulm_madr = []
   for i in range(mjm.nv):
     for col, madr in row_elements[i]:
-      m.qM_mulm_col.append(col)
-      m.qM_mulm_madr.append(madr)
-    m.qM_mulm_rowadr.append(len(m.qM_mulm_col))
+      m.M_mulm_col.append(col)
+      m.M_mulm_madr.append(madr)
+    m.M_mulm_rowadr.append(len(m.M_mulm_col))
 
   m.flexedge_J_rownnz = mjm.flexedge_J_rownnz
   m.flexedge_J_rowadr = mjm.flexedge_J_rowadr
@@ -1034,7 +1033,7 @@ def make_data(
     "njmax": njmax,
     "njmax_pad": sizes["njmax_pad"],
     "njmax_nnz": njmax_nnz,
-    "qM": None,
+    "M": None,
     "qLD": None,
     # world body
     "xquat": wp.array(np.tile(mjd.xquat, (nworld, 1)), shape=(nworld, mjm.nbody), dtype=wp.quat),
@@ -1062,10 +1061,10 @@ def make_data(
   d = types.Data(**d_kwargs)
 
   if is_sparse(mjm):
-    d.qM = wp.zeros((nworld, 1, mjm.nM), dtype=float)
+    d.M = wp.zeros((nworld, 1, mjm.nC), dtype=float)
     d.qLD = wp.zeros((nworld, 1, mjm.nC), dtype=float)
   else:
-    d.qM = wp.zeros((nworld, sizes["nv_pad"], sizes["nv_pad"]), dtype=float)
+    d.M = wp.zeros((nworld, sizes["nv_pad"], sizes["nv_pad"]), dtype=float)
     d.qLD = wp.zeros((nworld, mjm.nv, mjm.nv), dtype=float)
 
   # island discovery arrays
@@ -1265,7 +1264,7 @@ def put_data(
     "njmax_nnz": njmax_nnz,
     # fields set after initialization:
     "solver_niter": None,
-    "qM": None,
+    "M": None,
     "qLD": None,
     "nacon": None,
     # island arrays
@@ -1286,23 +1285,21 @@ def put_data(
 
   if is_sparse(mjm):
     if check_version("mujoco>=3.8.1.dev910242375"):
-      qM_legacy = np.zeros(mjm.nM)
-      qM_legacy[mjm.mapM2M] = mjd.M
-      d.qM = wp.array(np.full((nworld, 1, mjm.nM), qM_legacy), dtype=float)
+      d.M = wp.array(np.full((nworld, 1, mjm.nC), mjd.M), dtype=float)
     else:
-      d.qM = wp.array(np.full((nworld, 1, mjm.nM), mjd.qM), dtype=float)
+      d.M = wp.array(np.full((nworld, 1, mjm.nC), mjd.qM[mjm.mapM2M]), dtype=float)
     d.qLD = wp.array(np.full((nworld, 1, mjm.nC), mjd.qLD), dtype=float)
   else:
-    qM = np.zeros((mjm.nv, mjm.nv))
+    M = np.zeros((mjm.nv, mjm.nv))
     if check_version("mujoco>=3.8.1.dev910242375"):
-      mujoco.mju_sym2dense(qM, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
-      qLD = np.linalg.cholesky(qM).T if (mjd.M != 0.0).any() and (mjd.qLD != 0.0).any() else np.zeros((mjm.nv, mjm.nv))
+      mujoco.mju_sym2dense(M, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
+      qLD = np.linalg.cholesky(M).T if (mjd.M != 0.0).any() and (mjd.qLD != 0.0).any() else np.zeros((mjm.nv, mjm.nv))
     else:
-      mujoco.mj_fullM(mjm, qM, mjd.qM)
-      qLD = np.linalg.cholesky(qM).T if (mjd.qM != 0.0).any() and (mjd.qLD != 0.0).any() else np.zeros((mjm.nv, mjm.nv))
+      mujoco.mj_fullM(mjm, M, mjd.qM)
+      qLD = np.linalg.cholesky(M).T if (mjd.qM != 0.0).any() and (mjd.qLD != 0.0).any() else np.zeros((mjm.nv, mjm.nv))
     padding = sizes["nv_pad"] - mjm.nv
-    qM_padded = np.pad(qM, ((0, padding), (0, padding)), mode="constant", constant_values=0.0)
-    d.qM = wp.array(np.full((nworld, sizes["nv_pad"], sizes["nv_pad"]), qM_padded), dtype=float)
+    M_padded = np.pad(M, ((0, padding), (0, padding)), mode="constant", constant_values=0.0)
+    d.M = wp.array(np.full((nworld, sizes["nv_pad"], sizes["nv_pad"]), M_padded), dtype=float)
     d.qLD = wp.array(np.full((nworld, mjm.nv, mjm.nv), qLD), dtype=float)
 
   # island arrays
@@ -1456,25 +1453,24 @@ def get_data_into(
 
   if is_sparse(mjm):
     if check_version("mujoco>=3.8.1.dev910242375"):
-      warp_qM = d.qM.numpy()[world_id, 0]
-      result.M[:] = warp_qM[mjm.mapM2M]
+      result.M[:] = d.M.numpy()[world_id, 0]
     else:
-      result.qM[:] = d.qM.numpy()[world_id, 0]
+      result.qM[mjm.mapM2M] = d.M.numpy()[world_id, 0]
     result.qLD[:] = d.qLD.numpy()[world_id, 0]
   else:
-    qM = d.qM.numpy()[world_id]
+    M = d.M.numpy()[world_id]
     if check_version("mujoco>=3.8.1.dev910242375"):
       for i in range(mjm.nv):
         adr = mjm.M_rowadr[i]
         for k in range(mjm.M_rownnz[i]):
           col = mjm.M_colind[adr + k]
-          result.M[adr + k] = qM[i, col]
+          result.M[adr + k] = M[i, col]
     else:
       adr = 0
       for i in range(mjm.nv):
         j = i
         while j >= 0:
-          result.qM[adr] = qM[i, j]
+          result.qM[adr] = M[i, j]
           j = mjm.dof_parentid[j]
           adr += 1
     mujoco.mj_factorM(mjm, result)
@@ -1560,14 +1556,14 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     xfrc_applied_out[worldid, bodyid][elemid] = 0.0
 
   @wp.kernel(module="unique", enable_backward=False)
-  def reset_qM(reset_in: wp.array[bool], qM_out: wp.array3d[float]):
+  def reset_M(reset_in: wp.array[bool], M_out: wp.array3d[float]):
     worldid, elemid1, elemid2 = wp.tid()
 
     if wp.static(reset is not None):
       if not reset_in[worldid]:
         return
 
-    qM_out[worldid, elemid1, elemid2] = 0.0
+    M_out[worldid, elemid1, elemid2] = 0.0
 
   @wp.kernel(module="unique", enable_backward=False)
   def reset_nworld(
@@ -1719,10 +1715,10 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
 
   wp.launch(reset_xfrc_applied, dim=(d.nworld, m.nbody, 6), inputs=[reset_input], outputs=[d.xfrc_applied])
   wp.launch(
-    reset_qM,
-    dim=(d.nworld, d.qM.shape[1], d.qM.shape[2]),
+    reset_M,
+    dim=(d.nworld, d.M.shape[1], d.M.shape[2]),
     inputs=[reset_input],
-    outputs=[d.qM],
+    outputs=[d.M],
   )
 
   # set mocap_pos/quat = body_pos/quat for mocap bodies
@@ -1835,11 +1831,12 @@ def _copy_tendon_length0(
 def _compute_meaninertia(
   nv: int,
   is_sparse: bool,
-  dof_Madr_in: wp.array[int],
-  qM_in: wp.array3d[float],
+  M_rownnz_in: wp.array[int],
+  M_rowadr_in: wp.array[int],
+  M_in: wp.array3d[float],
   meaninertia_out: wp.array[float],
 ):
-  """Compute mean diagonal inertia from qM at qpos0."""
+  """Compute mean diagonal inertia from M at qpos0."""
   worldid = wp.tid()
 
   if nv == 0:
@@ -1849,12 +1846,12 @@ def _compute_meaninertia(
   total = float(0.0)
   for i in range(nv):
     if is_sparse:
-      # Sparse: qM is flattened lower triangular, diagonal at dof_Madr[i]
-      madr = dof_Madr_in[i]
-      total += qM_in[worldid, 0, madr]
+      # Sparse: M is in CSR format, diagonal at M_rowadr_in[i] + M_rownnz_in[i] - 1
+      madr = M_rowadr_in[i] + M_rownnz_in[i] - 1
+      total += M_in[worldid, 0, madr]
     else:
-      # Dense: qM is 2D matrix, diagonal at [i,i]
-      total += qM_in[worldid, i, i]
+      # Dense: M is 2D matrix, diagonal at [i,i]
+      total += M_in[worldid, i, i]
 
   meaninertia_out[worldid % meaninertia_out.shape[0]] = total / float(nv)
 
@@ -2337,11 +2334,11 @@ def set_const_0(m: types.Model, d: types.Data):
   smooth.factor_m(m, d)
   smooth.transmission(m, d)
 
-  # Compute meaninertia from qM diagonal at qpos0
+  # Compute meaninertia from M diagonal at qpos0
   wp.launch(
     _compute_meaninertia,
     dim=d.nworld,
-    inputs=[m.nv, m.is_sparse, m.dof_Madr, d.qM],
+    inputs=[m.nv, m.is_sparse, m.M_rownnz, m.M_rowadr, d.M],
     outputs=[m.stat.meaninertia],
   )
 

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -910,7 +910,7 @@ class IOTest(parameterized.TestCase):
       "sensordata",
       "mocap_pos",
       "mocap_quat",
-      "qM",
+      "M",
     ]
 
     mjm, mjd, m, d = test_data.fixture(xml)
@@ -941,8 +941,8 @@ class IOTest(parameterized.TestCase):
       d_arr = getattr(d, arr).numpy()
       for i in range(d_arr.shape[0]):
         di_arr = d_arr[i]
-        if arr == "qM":
-          di_arr = di_arr.reshape(-1)[: mjd.qM.size]
+        if arr == "M":
+          di_arr = di_arr.reshape(-1)[: mjd.M.size]
         _assert_eq(di_arr, getattr(mjd, arr), arr)
 
     _assert_eq(d.nacon.numpy(), 0, "nacon")

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -823,37 +823,38 @@ def _crb_accumulate(
 
 
 @wp.kernel
-def _qM_sparse(
+def _M_sparse(
   # Model:
   dof_bodyid: wp.array[int],
   dof_parentid: wp.array[int],
-  dof_Madr: wp.array[int],
   dof_armature: wp.array2d[float],
+  M_rownnz: wp.array[int],
+  M_rowadr: wp.array[int],
   # Data in:
   cdof_in: wp.array2d[wp.spatial_vector],
   crb_in: wp.array2d[vec10],
   # Data out:
-  qM_out: wp.array3d[float],
+  M_out: wp.array3d[float],
 ):
   worldid, dofid = wp.tid()
-  madr_ij = dof_Madr[dofid]  # dof_Madr is not batched
   bodyid = dof_bodyid[dofid]
+  madr_ij = M_rowadr[dofid] + M_rownnz[dofid] - 1
 
   # init M(i,i) with armature inertia
-  qM_out[worldid, 0, madr_ij] = dof_armature[worldid % dof_armature.shape[0], dofid]
+  M_out[worldid, 0, madr_ij] = dof_armature[worldid % dof_armature.shape[0], dofid]
 
   # precompute buf = crb_body_i * cdof_i
   buf = math.inert_vec(crb_in[worldid, bodyid], cdof_in[worldid, dofid])
 
   # sparse backward pass over ancestors
   while dofid >= 0:
-    qM_out[worldid, 0, madr_ij] += wp.dot(cdof_in[worldid, dofid], buf)
-    madr_ij += 1
+    M_out[worldid, 0, madr_ij] += wp.dot(cdof_in[worldid, dofid], buf)
+    madr_ij -= 1
     dofid = dof_parentid[dofid]
 
 
 @wp.kernel
-def _qM_dense(
+def _M_dense(
   # Model:
   dof_bodyid: wp.array[int],
   dof_parentid: wp.array[int],
@@ -862,7 +863,7 @@ def _qM_dense(
   cdof_in: wp.array2d[wp.spatial_vector],
   crb_in: wp.array2d[vec10],
   # Data out:
-  qM_out: wp.array3d[float],
+  M_out: wp.array3d[float],
 ):
   worldid, dofid = wp.tid()
   bodyid = dof_bodyid[dofid]
@@ -873,15 +874,15 @@ def _qM_dense(
   buf = math.inert_vec(crb_in[worldid, bodyid], cdof_in[worldid, dofid])
   M += wp.dot(cdof_in[worldid, dofid], buf)
 
-  qM_out[worldid, dofid, dofid] = M
+  M_out[worldid, dofid, dofid] = M
 
   # sparse backward pass over ancestors
   dofidi = dofid
   dofid = dof_parentid[dofid]
   while dofid >= 0:
-    qMij = wp.dot(cdof_in[worldid, dofid], buf)
-    qM_out[worldid, dofidi, dofid] += qMij
-    qM_out[worldid, dofid, dofidi] += qMij
+    Mij = wp.dot(cdof_in[worldid, dofid], buf)
+    M_out[worldid, dofidi, dofid] += Mij
+    M_out[worldid, dofid, dofidi] += Mij
     dofid = dof_parentid[dofid]
 
 
@@ -898,17 +899,17 @@ def crb(m: Model, d: Data):
     body_tree = m.body_tree[i]
     wp.launch(_crb_accumulate, dim=(d.nworld, body_tree.size), inputs=[m.body_parentid, d.crb, body_tree], outputs=[d.crb])
 
-  d.qM.zero_()
+  d.M.zero_()
   if m.is_sparse:
     wp.launch(
-      _qM_sparse,
+      _M_sparse,
       dim=(d.nworld, m.nv),
-      inputs=[m.dof_bodyid, m.dof_parentid, m.dof_Madr, m.dof_armature, d.cdof, d.crb],
-      outputs=[d.qM],
+      inputs=[m.dof_bodyid, m.dof_parentid, m.dof_armature, m.M_rownnz, m.M_rowadr, d.cdof, d.crb],
+      outputs=[d.M],
     )
   else:
     wp.launch(
-      _qM_dense, dim=(d.nworld, m.nv), inputs=[m.dof_bodyid, m.dof_parentid, m.dof_armature, d.cdof, d.crb], outputs=[d.qM]
+      _M_dense, dim=(d.nworld, m.nv), inputs=[m.dof_bodyid, m.dof_parentid, m.dof_armature, d.cdof, d.crb], outputs=[d.M]
     )
 
 
@@ -916,16 +917,17 @@ def crb(m: Model, d: Data):
 def _tendon_armature(
   # Model:
   dof_parentid: wp.array[int],
-  dof_Madr: wp.array[int],
   ten_J_rownnz: wp.array[int],
   ten_J_rowadr: wp.array[int],
   ten_J_colind: wp.array[int],
   tendon_armature: wp.array2d[float],
+  M_rownnz: wp.array[int],
+  M_rowadr: wp.array[int],
   is_sparse: bool,
   # Data in:
   ten_J_in: wp.array2d[float],
   # Data out:
-  qM_out: wp.array3d[float],
+  M_out: wp.array3d[float],
 ):
   worldid, tenid, dofid = wp.tid()
 
@@ -947,7 +949,7 @@ def _tendon_armature(
     return
 
   if is_sparse:
-    madr_ij = dof_Madr[dofid]
+    madr_ij = M_rowadr[dofid] + M_rownnz[dofid] - 2
 
   # sparse backward pass over ancestors
   dofidi = dofid
@@ -967,50 +969,38 @@ def _tendon_armature(
       else:
         ten_Jj = float(0.0)
 
-    qMij = armature * ten_Jj * ten_Ji
+    Mij = armature * ten_Jj * ten_Ji
 
     if is_sparse:
-      wp.atomic_add(qM_out[worldid, 0], madr_ij, qMij)
-      madr_ij += 1
+      wp.atomic_add(M_out[worldid, 0], madr_ij, Mij)
+      madr_ij -= 1
     else:
-      wp.atomic_add(qM_out[worldid, dofidi], dofid, qMij)
+      wp.atomic_add(M_out[worldid, dofidi], dofid, Mij)
       if dofidi != dofid:
-        wp.atomic_add(qM_out[worldid, dofid], dofidi, qMij)
+        wp.atomic_add(M_out[worldid, dofid], dofidi, Mij)
 
     dofid = dof_parentid[dofid]
 
 
 @event_scope
 def tendon_armature(m: Model, d: Data):
-  """Add tendon armature to qM."""
+  """Add tendon armature to M."""
   wp.launch(
     _tendon_armature,
     dim=(d.nworld, m.ntendon, m.max_ten_J_rownnz),
     inputs=[
       m.dof_parentid,
-      m.dof_Madr,
       m.ten_J_rownnz,
       m.ten_J_rowadr,
       m.ten_J_colind,
       m.tendon_armature,
+      m.M_rownnz,
+      m.M_rowadr,
       m.is_sparse,
       d.ten_J,
     ],
-    outputs=[d.qM],
+    outputs=[d.M],
   )
-
-
-@wp.kernel
-def _copy_CSR(
-  # Model:
-  mapM2M: wp.array[int],
-  # In:
-  M_in: wp.array3d[float],
-  # Out:
-  L_out: wp.array3d[float],
-):
-  worldid, ind = wp.tid()
-  L_out[worldid, 0, ind] = M_in[worldid, 0, mapM2M[ind]]
 
 
 @wp.kernel
@@ -1055,7 +1045,7 @@ def _qLDiag_div(
 
 def _factor_i_sparse(m: Model, d: Data, M: wp.array3d[float], L: wp.array3d[float], D: wp.array2d[float]):
   """Sparse L'*D*L factorization of inertia-like matrix M, assumed spd."""
-  wp.launch(_copy_CSR, dim=(d.nworld, m.nC), inputs=[m.mapM2M, M], outputs=[L])
+  wp.copy(L, M)
 
   for i in reversed(range(len(m.qLD_updates))):
     qLD_updates = m.qLD_updates[i]
@@ -1071,7 +1061,7 @@ def _tile_cholesky_factorize(tile: TileSet):
   @wp.kernel(module="unique", enable_backward=False)
   def cholesky_factorize(
     # Data in:
-    qM_in: wp.array3d[float],
+    M_in: wp.array3d[float],
     # In:
     adr: wp.array[int],
     # Out:
@@ -1081,7 +1071,7 @@ def _tile_cholesky_factorize(tile: TileSet):
     TILE_SIZE = wp.static(tile.size)
 
     dofid = adr[nodeid]
-    M_tile = wp.tile_load(qM_in[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid))
+    M_tile = wp.tile_load(M_in[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid))
     L_tile = wp.tile_cholesky(M_tile, fill_mode="upper")
     wp.tile_store(L_out[worldid], L_tile, offset=(dofid, dofid))
 
@@ -1090,7 +1080,7 @@ def _tile_cholesky_factorize(tile: TileSet):
 
 def _factor_i_dense(m: Model, d: Data, M: wp.array, L: wp.array):
   """Dense Cholesky factorization of inertia-like matrix M, assumed spd."""
-  for tile in m.qM_tiles:
+  for tile in m.M_tiles:
     wp.launch_tiled(
       _tile_cholesky_factorize(tile),
       dim=(d.nworld, tile.adr.size),
@@ -1104,9 +1094,9 @@ def _factor_i_dense(m: Model, d: Data, M: wp.array, L: wp.array):
 def factor_m(m: Model, d: Data):
   """Factorization of inertia-like matrix M, assumed spd."""
   if m.is_sparse:
-    _factor_i_sparse(m, d, d.qM, d.qLD, d.qLDiagInv)
+    _factor_i_sparse(m, d, d.M, d.qLD, d.qLDiagInv)
   else:
-    _factor_i_dense(m, d, d.qM, d.qLD)
+    _factor_i_dense(m, d, d.M, d.qLD)
 
 
 @wp.kernel
@@ -2850,7 +2840,7 @@ def _tile_cholesky_solve(tile: TileSet):
 
 def _solve_LD_dense(m: Model, d: Data, L: wp.array3d[float], x: wp.array2d[float], y: wp.array2d[float]):
   """Computes dense backsubstitution: x = inv(U.T @ U) * y."""
-  for tile in m.qM_tiles:
+  for tile in m.M_tiles:
     wp.launch_tiled(
       _tile_cholesky_solve(tile),
       dim=(d.nworld, tile.adr.size),
@@ -2907,8 +2897,9 @@ def _tile_cholesky_factorize_solve(tile: TileSet):
 
   @wp.kernel(module="unique", enable_backward=False)
   def cholesky_factorize_solve(
+    # Data in:
+    M_in: wp.array3d[float],
     # In:
-    M: wp.array3d[float],
     y: wp.array2d[float],
     adr: wp.array[int],
     # Out:
@@ -2919,7 +2910,7 @@ def _tile_cholesky_factorize_solve(tile: TileSet):
     TILE_SIZE = wp.static(tile.size)
 
     dofid = adr[nodeid]
-    M_tile = wp.tile_load(M[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid))
+    M_tile = wp.tile_load(M_in[worldid], shape=(TILE_SIZE, TILE_SIZE), offset=(dofid, dofid))
     y_slice = wp.tile_load(y[worldid], shape=(TILE_SIZE,), offset=(dofid,))
 
     L_tile = wp.tile_cholesky(M_tile, fill_mode="upper")
@@ -2938,7 +2929,7 @@ def _factor_solve_i_dense(
   y: wp.array2d[float],
   L: wp.array3d[float],
 ):
-  for tile in m.qM_tiles:
+  for tile in m.M_tiles:
     wp.launch_tiled(
       _tile_cholesky_factorize_solve(tile),
       dim=(d.nworld, tile.adr.size),

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -196,18 +196,16 @@ class SmoothTest(parameterized.TestCase):
 
     if jacobian == mujoco.mjtJacobian.mjJAC_SPARSE:
       if check_version("mujoco>=3.8.1.dev910242375"):
-        mjd_qM = np.zeros(mjm.nM)
-        mjd_qM[mjm.mapM2M] = mjd.M
-        _assert_eq(d.qM.numpy()[0, 0], mjd_qM, "qM")
+        _assert_eq(d.M.numpy()[0, 0], mjd.M, "M")
       else:
-        _assert_eq(d.qM.numpy()[0, 0], mjd.qM, "qM")
+        _assert_eq(d.M.numpy()[0, 0], mjd.qM[mjm.mapM2M], "M")
     else:
-      qM = np.zeros((mjm.nv, mjm.nv))
+      M = np.zeros((mjm.nv, mjm.nv))
       if check_version("mujoco>=3.8.1.dev910242375"):
-        mujoco.mju_sym2dense(qM, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
+        mujoco.mju_sym2dense(M, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
       else:
-        mujoco.mj_fullM(mjm, qM, mjd.qM)
-      _assert_eq(d.qM.numpy()[0, : mjm.nv, : mjm.nv], qM, "qM")
+        mujoco.mj_fullM(mjm, M, mjd.qM)
+      _assert_eq(d.M.numpy()[0, : mjm.nv, : mjm.nv], M, "M")
 
   @parameterized.parameters(mujoco.mjtJacobian.mjJAC_SPARSE, mujoco.mjtJacobian.mjJAC_DENSE)
   def test_factor_m(self, jacobian):
@@ -504,9 +502,9 @@ class SmoothTest(parameterized.TestCase):
     res = wp.zeros((1, mjm.nv), dtype=float)
     vec = wp.ones((1, mjm.nv), dtype=float)
 
-    mjw._src.smooth.factor_solve_i(m, d, d.qM, d.qLD, d.qLDiagInv, res, vec)
+    mjw._src.smooth.factor_solve_i(m, d, d.M, d.qLD, d.qLDiagInv, res, vec)
 
-    _assert_eq(res.numpy()[0], np.linalg.solve(qM, vec.numpy()[0]), "qM \\ 1")
+    _assert_eq(res.numpy()[0], np.linalg.solve(qM, vec.numpy()[0]), "M \\ 1")
 
     if sparse:
       _assert_eq(d.qLD.numpy()[0].reshape(-1), mjd.qLD, "qLD")
@@ -518,18 +516,18 @@ class SmoothTest(parameterized.TestCase):
   def test_tendon_armature(self):
     mjm, mjd, m, d = test_data.fixture("tendon/armature.xml", keyframe=0)
 
-    # qM
-    d.qM.fill_(wp.inf)
+    # M
+    d.M.fill_(wp.inf)
 
     mjw._src.smooth.crb(m, d)
     mjw._src.smooth.tendon_armature(m, d)
 
-    qM = np.zeros((mjm.nv, mjm.nv))
+    M = np.zeros((mjm.nv, mjm.nv))
     if check_version("mujoco>=3.8.1.dev910242375"):
-      mujoco.mju_sym2dense(qM, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
+      mujoco.mju_sym2dense(M, mjd.M, mjm.M_rownnz, mjm.M_rowadr, mjm.M_colind)
     else:
-      mujoco.mj_fullM(mjm, qM, mjd.qM)
-    _assert_eq(d.qM.numpy()[0, : mjm.nv, : mjm.nv], qM, "qM")
+      mujoco.mj_fullM(mjm, M, mjd.qM)
+    _assert_eq(d.M.numpy()[0, : mjm.nv, : mjm.nv], M, "M")
 
     # qfrc_bias
     d.qfrc_bias.fill_(wp.inf)

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1669,7 +1669,7 @@ def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext, cost: wp.arra
     ctx: SolverContext
     cost: Scratch array for storing costs per (world, alpha) - used for parallel mode
   """
-  # mv = qM @ search (common to both parallel and iterative)
+  # mv = M @ search (common to both parallel and iterative)
   support.mul_m(m, d, ctx.mv, ctx.search, skip=ctx.done)
 
   # Fuse jv computation in-kernel for small nv (iterative only, dense only)
@@ -2257,13 +2257,13 @@ def update_gradient_grad(
 
 
 @wp.kernel
-def update_gradient_set_h_qM_upper_sparse(
+def update_gradient_set_h_M_upper_sparse(
   # Model:
-  qM_fullm_upper_i: wp.array[int],
-  qM_fullm_upper_j: wp.array[int],
-  qM_fullm_upper_elemid: wp.array[int],
+  M_fullm_upper_i: wp.array[int],
+  M_fullm_upper_j: wp.array[int],
+  M_fullm_upper_elemid: wp.array[int],
   # Data in:
-  qM_in: wp.array3d[float],
+  M_in: wp.array3d[float],
   # In:
   ctx_done_in: wp.array[bool],
   # Out:
@@ -2274,10 +2274,10 @@ def update_gradient_set_h_qM_upper_sparse(
   if ctx_done_in[worldid]:
     return
 
-  i = qM_fullm_upper_i[elementid]
-  j = qM_fullm_upper_j[elementid]
-  qM_elemid = qM_fullm_upper_elemid[elementid]
-  ctx_h_out[worldid, i, j] += qM_in[worldid, 0, qM_elemid]
+  i = M_fullm_upper_i[elementid]
+  j = M_fullm_upper_j[elementid]
+  madr = M_fullm_upper_elemid[elementid]
+  ctx_h_out[worldid, i, j] += M_in[worldid, 0, madr]
 
 
 @wp.func
@@ -2377,7 +2377,7 @@ def update_gradient_JTDAJ_dense_tiled(nv_pad: int, tile_size: int, njmax: int):
   def kernel(
     # Data in:
     nefc_in: wp.array[int],
-    qM_in: wp.array3d[float],
+    M_in: wp.array3d[float],
     efc_J_in: wp.array3d[float],
     efc_D_in: wp.array2d[float],
     efc_state_in: wp.array2d[int],
@@ -2393,7 +2393,7 @@ def update_gradient_JTDAJ_dense_tiled(nv_pad: int, tile_size: int, njmax: int):
 
     nefc = nefc_in[worldid]
 
-    sum_val = wp.tile_load(qM_in[worldid], shape=(nv_pad, nv_pad), bounds_check=True)
+    sum_val = wp.tile_load(M_in[worldid], shape=(nv_pad, nv_pad), bounds_check=True)
 
     # Each tile processes one output tile by looping over all constraints
     for k in range(0, njmax, TILE_SIZE_K):
@@ -2936,7 +2936,7 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
   if m.opt.solver == types.SolverType.CG:
     smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
   elif m.opt.solver == types.SolverType.NEWTON:
-    # h = qM + (efc_J.T * efc_D * active) @ efc_J
+    # h = M + (efc_J.T * efc_D * active) @ efc_J
     if m.is_sparse:
       ctx.h.zero_()
       wp.launch(
@@ -2947,9 +2947,9 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
       )
 
       wp.launch(
-        update_gradient_set_h_qM_upper_sparse,
-        dim=(d.nworld, m.qM_fullm_upper_i.size),
-        inputs=[m.qM_fullm_upper_i, m.qM_fullm_upper_j, m.qM_fullm_upper_elemid, d.qM, ctx.done],
+        update_gradient_set_h_M_upper_sparse,
+        dim=(d.nworld, m.M_fullm_upper_i.size),
+        inputs=[m.M_fullm_upper_i, m.M_fullm_upper_j, m.M_fullm_upper_elemid, d.M, ctx.done],
         outputs=[ctx.h],
       )
     else:
@@ -2959,7 +2959,7 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
           dim=d.nworld,
           inputs=[
             d.nefc,
-            d.qM,
+            d.M,
             d.efc.J,
             d.efc.D,
             d.efc.state,
@@ -3330,7 +3330,7 @@ def init_context(m: types.Model, d: types.Data, ctx: SolverContext | InverseCont
     outputs=[ctx.Jaref],
   )
 
-  # Ma = qM @ qacc
+  # Ma = M @ qacc
   support.mul_m(m, d, d.efc.Ma, d.qacc, skip=ctx.done)
 
   _update_constraint(m, d, ctx)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -40,15 +40,15 @@ def _assert_eq(a, b, name):
 
 
 class SolverTest(parameterized.TestCase):
-  def test_qM_fullm_upper_indices_are_row_sorted(self):
-    """Sparse qM seeding uses upper-triangle row-sorted writes."""
+  def test_M_fullm_upper_indices_are_row_sorted(self):
+    """Sparse M seeding uses upper-triangle row-sorted writes."""
     _, _, m, _ = test_data.fixture("humanoid/humanoid.xml")
 
-    lower_row = m.qM_fullm_i.numpy()
-    lower_col = m.qM_fullm_j.numpy()
-    upper_row = m.qM_fullm_upper_i.numpy()
-    upper_col = m.qM_fullm_upper_j.numpy()
-    upper_elemid = m.qM_fullm_upper_elemid.numpy()
+    lower_row = np.repeat(np.arange(m.nv), m.M_rownnz.numpy())
+    lower_col = m.M_colind.numpy()
+    upper_row = m.M_fullm_upper_i.numpy()
+    upper_col = m.M_fullm_upper_j.numpy()
+    upper_elemid = m.M_fullm_upper_elemid.numpy()
 
     self.assertEqual(upper_row.size, lower_row.size)
     self.assertTrue(np.all(upper_row <= upper_col))
@@ -391,23 +391,23 @@ class SolverTest(parameterized.TestCase):
       ]
     )
 
-    qM0 = np.zeros((mjm0.nv, mjm0.nv))
-    qM1 = np.zeros((mjm1.nv, mjm1.nv))
-    qM2 = np.zeros((mjm2.nv, mjm2.nv))
+    M0 = np.zeros((mjm0.nv, mjm0.nv))
+    M1 = np.zeros((mjm1.nv, mjm1.nv))
+    M2 = np.zeros((mjm2.nv, mjm2.nv))
     if check_version("mujoco>=3.8.1.dev910242375"):
-      mujoco.mju_sym2dense(qM0, mjd0.M, mjm0.M_rownnz, mjm0.M_rowadr, mjm0.M_colind)
-      mujoco.mju_sym2dense(qM1, mjd1.M, mjm1.M_rownnz, mjm1.M_rowadr, mjm1.M_colind)
-      mujoco.mju_sym2dense(qM2, mjd2.M, mjm2.M_rownnz, mjm2.M_rowadr, mjm2.M_colind)
+      mujoco.mju_sym2dense(M0, mjd0.M, mjm0.M_rownnz, mjm0.M_rowadr, mjm0.M_colind)
+      mujoco.mju_sym2dense(M1, mjd1.M, mjm1.M_rownnz, mjm1.M_rowadr, mjm1.M_colind)
+      mujoco.mju_sym2dense(M2, mjd2.M, mjm2.M_rownnz, mjm2.M_rowadr, mjm2.M_colind)
     else:
-      mujoco.mj_fullM(mjm0, qM0, mjd0.qM)
-      mujoco.mj_fullM(mjm1, qM1, mjd1.qM)
-      mujoco.mj_fullM(mjm2, qM2, mjd2.qM)
+      mujoco.mj_fullM(mjm0, M0, mjd0.qM)
+      mujoco.mj_fullM(mjm1, M1, mjd1.qM)
+      mujoco.mj_fullM(mjm2, M2, mjd2.qM)
 
-    qM = np.vstack(
+    M = np.vstack(
       [
-        np.expand_dims(qM0, axis=0),
-        np.expand_dims(qM1, axis=0),
-        np.expand_dims(qM2, axis=0),
+        np.expand_dims(M0, axis=0),
+        np.expand_dims(M1, axis=0),
+        np.expand_dims(M2, axis=0),
       ]
     )
     qacc_smooth = np.vstack(
@@ -479,7 +479,7 @@ class SolverTest(parameterized.TestCase):
     efc_aref_fill[2, : mjd2.nefc] = efc_aref2
 
     d.qacc_warmstart = wp.from_numpy(qacc_warmstart, dtype=wp.float32)
-    d.qM = wp.from_numpy(qM, dtype=wp.float32)
+    d.M = wp.from_numpy(M, dtype=wp.float32)
     d.qacc_smooth = wp.from_numpy(qacc_smooth, dtype=wp.float32)
     d.qfrc_smooth = wp.from_numpy(qfrc_smooth, dtype=wp.float32)
     d.efc.D = wp.from_numpy(efc_D_fill, dtype=wp.float32)

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -69,11 +69,11 @@ def mul_m_sparse(check_skip: bool):
   @wp.kernel(module="unique")
   def _mul_m_sparse(
     # Model:
-    qM_mulm_rowadr: wp.array[int],
-    qM_mulm_col: wp.array[int],
-    qM_mulm_madr: wp.array[int],
+    M_mulm_rowadr: wp.array[int],
+    M_mulm_col: wp.array[int],
+    M_mulm_madr: wp.array[int],
     # Data in:
-    qM_in: wp.array3d[float],
+    M_in: wp.array3d[float],
     # In:
     vec: wp.array2d[float],
     skip: wp.array[bool],
@@ -89,12 +89,12 @@ def mul_m_sparse(check_skip: bool):
 
     # Gather all contributions (diagonal + off-diagonal)
     acc = float(0.0)
-    start = qM_mulm_rowadr[dofid]
-    end = qM_mulm_rowadr[dofid + 1]
+    start = M_mulm_rowadr[dofid]
+    end = M_mulm_rowadr[dofid + 1]
     for k in range(start, end):
-      col = qM_mulm_col[k]
-      madr = qM_mulm_madr[k]
-      acc += qM_in[worldid, 0, madr] * vec[worldid, col]
+      col = M_mulm_col[k]
+      madr = M_mulm_madr[k]
+      acc += M_in[worldid, 0, madr] * vec[worldid, col]
 
     res[worldid, dofid] = acc
 
@@ -108,7 +108,7 @@ def mul_m_dense(nv: int, check_skip: bool):
   @wp.kernel(module="unique")
   def _mul_m_dense(
     # Data in:
-    qM_in: wp.array3d[float],
+    M_in: wp.array3d[float],
     # In:
     vec: wp.array2d[float],
     skip: wp.array[bool],
@@ -123,7 +123,7 @@ def mul_m_dense(nv: int, check_skip: bool):
 
     acc = float(0.0)
     for j in range(wp.static(nv)):
-      acc += qM_in[worldid, i, j] * vec[worldid, j]
+      acc += M_in[worldid, i, j] * vec[worldid, j]
     res[worldid, i] = acc
 
   return _mul_m_dense
@@ -143,8 +143,8 @@ def mul_m(
   Args:
     m: The model containing kinematic and dynamic information (device).
     d: The data object containing the current state and output arrays (device).
-    res: Result: qM @ vec.
-    vec: Input vector to multiply by qM.
+    res: Result: M @ vec.
+    vec: Input vector to multiply by M.
     skip: Per-world bitmask to skip computing output.
     M: Input matrix: M @ vec.
   """
@@ -152,13 +152,13 @@ def mul_m(
   skip = skip or wp.empty(0, dtype=bool)
 
   if M is None:
-    M = d.qM
+    M = d.M
 
   if m.is_sparse:
     wp.launch(
       mul_m_sparse(check_skip),
       dim=(d.nworld, m.nv),
-      inputs=[m.qM_mulm_rowadr, m.qM_mulm_col, m.qM_mulm_madr, M, vec, skip],
+      inputs=[m.M_mulm_rowadr, m.M_mulm_col, m.M_mulm_madr, M, vec, skip],
       outputs=[res],
     )
 

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1156,9 +1156,9 @@ class Model:
     sensor_cutoff: cutoff for real and positive; 0: ignore   (nsensor,)
     plugin: globally registered plugin slot number           (nplugin,)
     plugin_attr: config attributes of geom plugin            (nplugin, _NPLUGINATTR)
-    M_rownnz: number of non-zeros in each row of qM          (nv,)
-    M_rowadr: index of each row in qM                        (nv,)
-    M_colind: column indices of non-zeros in qM              (nM,)
+    M_rownnz: number of non-zeros in each row of M           (nv,)
+    M_rowadr: index of each row in M                         (nv,)
+    M_colind: column indices of non-zeros in M               (nC,)
     mapM2M: index mapping from M (legacy) to M (CSR)         (nC)
     flex_vertflexid: flex id for each flex vertex            (nflexvert,)
 
@@ -1244,21 +1244,21 @@ class Model:
     sensor_rangefinder_bodyid: bodyid for rangefinder        (nrangefinder,)
     taxel_vertadr: tactile sensor vertex address             (nsensortaxel,)
     taxel_sensorid: address for tactile sensors
-    qM_tiles: tiling configuration
+    M_tiles: tiling configuration
     qLD_updates: tuple of index triples for sparse factorization
     qLD_all_updates: tuple of all levels concatenated
     qLD_level_offsets: tuple of start offsets for each level
-    qM_fullm_i: sparse mass matrix addressing
-    qM_fullm_j: sparse mass matrix addressing
-    qM_fullm_elemid: (row, col) -> elemid into qM_fullm_i/qM_fullm_j; -1 if not a chain ancestor
-    qM_fullm_upper_i: upper-triangle row indices for solver h seeding
-    qM_fullm_upper_j: upper-triangle column indices for solver h seeding
-    qM_fullm_upper_elemid: source elemid into qM_fullm_i/qM_fullm_j
+    M_fullm_i: sparse mass matrix addressing
+    M_fullm_j: sparse mass matrix addressing
+    M_elemid: (row, col) -> CSR madr addresses; -1 if not a chain ancestor
+    M_fullm_upper_i: upper-triangle row indices for solver h seeding
+    M_fullm_upper_j: upper-triangle column indices for solver h seeding
+    M_fullm_upper_elemid: source elemid into M_fullm_i/M_fullm_j
     qD_fullm_i: D-structure row indices for RNE derivatives
     qD_fullm_j: D-structure column indices for RNE derivatives
-    qM_mulm_rowadr: sparse matmul row pointers
-    qM_mulm_col: sparse matmul column indices
-    qM_mulm_madr: sparse matmul matrix addresses
+    M_mulm_rowadr: sparse matmul row pointers
+    M_mulm_col: sparse matmul column indices
+    M_mulm_madr: sparse matmul matrix addresses
   """
 
   nq: int
@@ -1643,22 +1643,24 @@ class Model:
   sensor_rangefinder_bodyid: array("nrangefinder", int)
   taxel_vertadr: array("nsensortaxel", int)
   taxel_sensorid: wp.array[int]
-  qM_tiles: tuple[TileSet, ...]
+  M_tiles: tuple[TileSet, ...]
   qLD_updates: tuple[wp.array[wp.vec3i], ...]
   qLD_all_updates: wp.array[wp.vec3i]
   qLD_level_offsets: wp.array[int]
-  qM_fullm_i: wp.array[int]
-  qM_fullm_j: wp.array[int]
-  qM_fullm_elemid: wp.array2d[int]  # (row, col) -> elemid in qM_fullm_i/j; -1 if col is not a chain ancestor of row
-  qM_fullm_upper_i: wp.array[int]
-  qM_fullm_upper_j: wp.array[int]
-  qM_fullm_upper_elemid: wp.array[int]
+  # TODO(team): Remove M_fullm_i/j and M_elemid by iterating the M CSR layout
+  # directly in the solver/derivative kernels
+  M_fullm_i: wp.array[int]
+  M_fullm_j: wp.array[int]
+  M_elemid: wp.array2d[int]  # (row, col) -> CSR madr address; -1 if col is not a chain ancestor of row
+  M_fullm_upper_i: wp.array[int]
+  M_fullm_upper_j: wp.array[int]
+  M_fullm_upper_elemid: wp.array[int]
   qD_fullm_i: wp.array[int]  # D-structure (full square) row indices for RNE derivatives
   qD_fullm_j: wp.array[int]  # D-structure (full square) column indices for RNE derivatives
   # Gather-based sparse mul_m indices (thread per DOF, no atomics)
-  qM_mulm_rowadr: wp.array[int]  # start address for each row [nv+1]
-  qM_mulm_col: wp.array[int]  # column index to gather from
-  qM_mulm_madr: wp.array[int]  # matrix address to read
+  M_mulm_rowadr: wp.array[int]  # start address for each row [nv+1]
+  M_mulm_col: wp.array[int]  # column index to gather from
+  M_mulm_madr: wp.array[int]  # matrix address to read
 
 
 class ContactType(enum.IntFlag):
@@ -1818,10 +1820,10 @@ class Data:
     moment_colind: column indices in sparse actuator_moment     (nworld, nJmom)
     actuator_moment: actuator moments                           (nworld, nJmom)
     crb: com-based composite inertia and mass                   (nworld, nbody, 10)
-    qM: total inertia                                           (nworld, nv, nv) if dense
-                                                                (nworld, 1, nM) if sparse
-    qLD: upper Cholesky factorization if dense                  (nworld, nv, nv)
-         L'*D*L factorization of M if sparse                    (nworld, 1, nC)
+    M: total inertia                                            (nworld, nv, nv) if dense
+                                                                (nworld, 1, nC) if sparse
+    qLD: upper Cholesky factorization                           (nworld, nv, nv) if dense
+         L'*D*L factorization of M                              (nworld, 1, nC) if sparse
     qLDiagInv: 1/diag(D)                                        (nworld, nv)
     flexedge_velocity: flex edge velocities                     (nworld, nflexedge)
     ten_velocity: tendon velocities                             (nworld, ntendon)
@@ -1916,7 +1918,7 @@ class Data:
   moment_colind: array("nworld", "nJmom", int)
   actuator_moment: array("nworld", "nJmom", float)
   crb: array("nworld", "nbody", vec10)
-  qM: wp.array3d[float]
+  M: wp.array3d[float]
   qLD: wp.array3d[float]
   qLDiagInv: array("nworld", "nv", float)
   flexedge_velocity: array("nworld", "nflexedge", float)


### PR DESCRIPTION
replace inertia matrix legacy representation `qM` with csr representation `M`

---

comparing performance before and after the changes:

- **Current Commit**: `a93ab311285d48207ee093d2f38c14df8fa7379c` (Branch `qMtoM` - message: `qM to M`)
- **Previous Commit**: `092f3baecfc7317b28bd7b28d657aa52c7cc103c` (message: `sdf cylinder (#1358)`)

---

### Steps Per Second Comparison

| Benchmark Scenario | Previous Commit (`092f3ba`) | Current Commit (`a93ab31`) | Relative Change |
| :--- | :---: | :---: | :---: |
| **Humanoid (Dense)** | 4,729,047 | 4,743,228 | +0.30% |
| **Humanoid (Sparse)** | 3,440,224 | 3,449,920 | +0.28% |
| **Three Humanoids (Sparse)** | 704,842 | 710,394 | +0.79% |

### 1. Humanoid (Dense)
```bash
mjwarp-testspeed benchmarks/humanoid/humanoid.xml \
  --nworld=8192 --nconmax=24 --njmax=64 --format=short -o "opt.jacobian=dense"
```

### 2. Humanoid (Sparse)
```bash
mjwarp-testspeed benchmarks/humanoid/humanoid.xml \
  --nworld=8192 --nconmax=24 --njmax=64 --format=short -o "opt.jacobian=sparse"
```

### 3. Three Humanoids (Sparse)
```bash
mjwarp-testspeed benchmarks/humanoid/three_humanoids.xml \
  --nworld=8192 --nconmax=100 --njmax=192 --format=short -o "opt.jacobian=sparse"
```


