### PR TITLE
Fuse blocked Cholesky factorization and solve

### DIFF
--- a/mujoco_warp/_src/block_cholesky.py
+++ b/mujoco_warp/_src/block_cholesky.py
@@ -19,48 +19,77 @@ import warp as wp
 
 
 @lru_cache(maxsize=None)
-def create_blocked_cholesky_func(block_size: int):
+def create_blocked_cholesky_factorize_solve_func(block_size: int, matrix_size_static: int):
   @wp.func
-  def blocked_cholesky_func(
+  def blocked_cholesky_factorize_solve_func(
     # In:
     A: wp.array2d[float],
+    b: wp.array2d[float],
     matrix_size: int,
     # Out:
     U: wp.array2d[float],
+    x: wp.array2d[float],
   ):
-    """Computes the Cholesky factorization of a symmetric positive definite matrix A in blocks.
+    """Block Cholesky factorization and solve while keeping the forward RHS live."""
+    rhs_tile = wp.tile_load(b, shape=(matrix_size_static, 1), offset=(0, 0), storage="shared", bounds_check=False)
 
-    It returns an upper-triangular matrix U such that A = U^T U.
-    """
-    # Process the matrix in blocks along its leading dimension.
     for k in range(0, matrix_size, block_size):
       end = k + block_size
+      rhs_view = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(k, 0))
 
-      # Load current diagonal block A[k:end, k:end]
-      # and update with contributions from previously computed blocks.
-      A_kk_tile = wp.tile_load(A, shape=(block_size, block_size), offset=(k, k), storage="shared")
+      A_kk_tile = wp.tile_load(
+        A, shape=(block_size, block_size), offset=(k, k), storage="shared", bounds_check=False, aligned=True
+      )
 
       for j in range(0, k, block_size):
-        U_block = wp.tile_load(U, shape=(block_size, block_size), offset=(j, k), storage="shared")
+        U_block = wp.tile_load(
+          U, shape=(block_size, block_size), offset=(j, k), storage="shared", bounds_check=False, aligned=True
+        )
         wp.tile_matmul(wp.tile_transpose(U_block), U_block, A_kk_tile, alpha=-1.0)
 
-      # Compute the Cholesky factorization for the block
-      wp.tile_cholesky_inplace(A_kk_tile, fill_mode="upper")
-      wp.tile_store(U, A_kk_tile, offset=(k, k))
+        y_block = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(j, 0))
+        wp.tile_matmul(wp.tile_transpose(U_block), y_block, rhs_view, alpha=-1.0)
 
-      # Process the blocks to the right of the current block
+      wp.tile_cholesky_inplace(A_kk_tile, fill_mode="upper")
+      wp.tile_store(U, A_kk_tile, offset=(k, k), bounds_check=False, aligned=True)
+
+      wp.tile_lower_solve_inplace(wp.tile_transpose(A_kk_tile), rhs_view)
+
       for i in range(end, matrix_size, block_size):
-        A_ki_tile = wp.tile_load(A, shape=(block_size, block_size), offset=(k, i), storage="shared")
+        A_ki_tile = wp.tile_load(
+          A, shape=(block_size, block_size), offset=(k, i), storage="shared", bounds_check=False, aligned=True
+        )
 
         for j in range(0, k, block_size):
-          U_jk_tile = wp.tile_load(U, shape=(block_size, block_size), offset=(j, k), storage="shared")
-          U_ji_tile = wp.tile_load(U, shape=(block_size, block_size), offset=(j, i), storage="shared")
+          U_jk_tile = wp.tile_load(
+            U, shape=(block_size, block_size), offset=(j, k), storage="shared", bounds_check=False, aligned=True
+          )
+          U_ji_tile = wp.tile_load(
+            U, shape=(block_size, block_size), offset=(j, i), storage="shared", bounds_check=False, aligned=True
+          )
           wp.tile_matmul(wp.tile_transpose(U_jk_tile), U_ji_tile, A_ki_tile, alpha=-1.0)
 
         wp.tile_lower_solve_inplace(wp.tile_transpose(A_kk_tile), A_ki_tile)
-        wp.tile_store(U, A_ki_tile, offset=(k, i))
+        wp.tile_store(U, A_ki_tile, offset=(k, i), bounds_check=False, aligned=True)
 
-  return blocked_cholesky_func
+    for i in range(matrix_size - block_size, -1, -block_size):
+      i_end = i + block_size
+      tmp_tile = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(i, 0))
+      for j in range(i_end, matrix_size, block_size):
+        U_tile = wp.tile_load(
+          U, shape=(block_size, block_size), offset=(i, j), storage="shared", bounds_check=False, aligned=True
+        )
+        x_tile = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(j, 0))
+        wp.tile_matmul(U_tile, x_tile, tmp_tile, alpha=-1.0)
+
+      U_tile = wp.tile_load(
+        U, shape=(block_size, block_size), offset=(i, i), storage="shared", bounds_check=False, aligned=True
+      )
+      wp.tile_upper_solve_inplace(U_tile, tmp_tile)
+
+    wp.tile_store(x, rhs_tile, offset=(0, 0), bounds_check=False)
+
+  return blocked_cholesky_factorize_solve_func
 
 
 @lru_cache(maxsize=None)
@@ -74,7 +103,7 @@ def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int)
     # Out:
     x: wp.array2d[float],
   ):
-    """Block Cholesky factorization and solve.
+    """Block Cholesky solve.
 
     Solves A x = b given the Cholesky factor U (A = U^T U) using blocked forward and backward
     substitution.
@@ -85,11 +114,15 @@ def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int)
     for i in range(0, matrix_size, block_size):
       rhs_view = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(i, 0))
       for j in range(0, i, block_size):
-        U_block = wp.tile_load(U, shape=(block_size, block_size), offset=(j, i), storage="shared")
+        U_block = wp.tile_load(
+          U, shape=(block_size, block_size), offset=(j, i), storage="shared", bounds_check=False, aligned=True
+        )
         y_block = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(j, 0))
         wp.tile_matmul(wp.tile_transpose(U_block), y_block, rhs_view, alpha=-1.0)
 
-      U_tile = wp.tile_load(U, shape=(block_size, block_size), offset=(i, i), storage="shared")
+      U_tile = wp.tile_load(
+        U, shape=(block_size, block_size), offset=(i, i), storage="shared", bounds_check=False, aligned=True
+      )
       wp.tile_lower_solve_inplace(wp.tile_transpose(U_tile), rhs_view)
 
     # Backward substitution: solve U x = y
@@ -97,10 +130,14 @@ def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int)
       i_end = i + block_size
       tmp_tile = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(i, 0))
       for j in range(i_end, matrix_size, block_size):
-        U_tile = wp.tile_load(U, shape=(block_size, block_size), offset=(i, j), storage="shared")
+        U_tile = wp.tile_load(
+          U, shape=(block_size, block_size), offset=(i, j), storage="shared", bounds_check=False, aligned=True
+        )
         x_tile = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(j, 0))
         wp.tile_matmul(U_tile, x_tile, tmp_tile, alpha=-1.0)
-      U_tile = wp.tile_load(U, shape=(block_size, block_size), offset=(i, i), storage="shared")
+      U_tile = wp.tile_load(
+        U, shape=(block_size, block_size), offset=(i, i), storage="shared", bounds_check=False, aligned=True
+      )
 
       wp.tile_upper_solve_inplace(U_tile, tmp_tile)
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -23,7 +23,7 @@ from mujoco_warp._src import math
 from mujoco_warp._src import smooth
 from mujoco_warp._src import support
 from mujoco_warp._src import types
-from mujoco_warp._src.block_cholesky import create_blocked_cholesky_func
+from mujoco_warp._src.block_cholesky import create_blocked_cholesky_factorize_solve_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_func
 from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
@@ -2779,9 +2779,8 @@ def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
     # runtime input is needed for the loop bounds, otherwise warp will unroll
     # unconditionally leading to shared memory capacity issues.
 
-    wp.static(create_blocked_cholesky_func(TILE_SIZE))(ctx_h_in[worldid], matrix_size, ctx_hfactor[worldid])
-    wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
-      ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
+    wp.static(create_blocked_cholesky_factorize_solve_func(TILE_SIZE, matrix_size))(
+      ctx_h_in[worldid], ctx_grad_in[worldid], matrix_size, ctx_hfactor[worldid], ctx_Mgrad_out[worldid]
     )
 
   return kernel
@@ -2809,11 +2808,13 @@ def update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size:
       return
 
     if changed_count_in[worldid] > 0:
-      wp.static(create_blocked_cholesky_func(TILE_SIZE))(ctx_h_in[worldid], matrix_size, ctx_hfactor[worldid])
-
-    wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
-      ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
-    )
+      wp.static(create_blocked_cholesky_factorize_solve_func(TILE_SIZE, matrix_size))(
+        ctx_h_in[worldid], ctx_grad_in[worldid], matrix_size, ctx_hfactor[worldid], ctx_Mgrad_out[worldid]
+      )
+    else:
+      wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
+        ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
+      )
 
   return kernel
 

--- a/mujoco_warp/_src/support_test.py
+++ b/mujoco_warp/_src/support_test.py
@@ -25,8 +25,7 @@ import mujoco_warp as mjwarp
 from mujoco_warp import ConeType
 from mujoco_warp import State
 from mujoco_warp import test_data
-from mujoco_warp._src.block_cholesky import create_blocked_cholesky_func
-from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_func
+from mujoco_warp._src.block_cholesky import create_blocked_cholesky_factorize_solve_func
 
 # tolerance for difference between MuJoCo and MJWarp support calculations - mostly
 # due to float precision
@@ -201,9 +200,8 @@ class SupportTest(parameterized.TestCase):
     nv_pad = m.nv_pad
     nworld = d.nworld
 
-    # Create combined factor and solve kernel as in solver.py
     @wp.kernel(module="unique", enable_backward=False)
-    def combined_cholesky_kernel(
+    def fused_cholesky_kernel(
       grad_in: wp.array3d[float],
       h_in: wp.array3d[float],
       done_in: wp.array[bool],
@@ -216,9 +214,8 @@ class SupportTest(parameterized.TestCase):
       if done_in[worldid]:
         return
 
-      wp.static(create_blocked_cholesky_func(TILE_SIZE))(h_in[worldid], nv_pad, hfactor_in[worldid])
-      wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, nv_pad))(
-        hfactor_in[worldid], grad_in[worldid], nv_pad, Mgrad_out[worldid]
+      wp.static(create_blocked_cholesky_factorize_solve_func(TILE_SIZE, nv_pad))(
+        h_in[worldid], grad_in[worldid], nv_pad, hfactor_in[worldid], Mgrad_out[worldid]
       )
 
     # Create test vector and fill the built-in arrays
@@ -248,25 +245,24 @@ class SupportTest(parameterized.TestCase):
     # Initialize padding region to identity
     L_init[0, nv:, nv:] = np.eye(nv_pad - nv, dtype=np.float32)
 
-    hfactor = wp.array(L_init, dtype=float)
+    hfactor_fused = wp.array(L_init, dtype=float)
 
-    Mgrad = wp.zeros((nworld, nv_pad), dtype=float)
+    Mgrad_fused = wp.zeros((nworld, nv_pad), dtype=float)
 
     # Ensure done is False so kernel executes
     done = wp.zeros((nworld,), dtype=bool)
 
-    # Launch with same dimensions as solver.py, using inline arrays
     wp.launch_tiled(
-      combined_cholesky_kernel,
+      fused_cholesky_kernel,
       dim=nworld,
-      inputs=[grad.reshape(shape=(nworld, nv_pad, 1)), h, done, hfactor],
-      outputs=[Mgrad.reshape(shape=(nworld, nv_pad, 1))],
+      inputs=[grad.reshape(shape=(nworld, nv_pad, 1)), h, done, hfactor_fused],
+      outputs=[Mgrad_fused.reshape(shape=(nworld, nv_pad, 1))],
       block_dim=m.block_dim.update_gradient_cholesky,
     )
     wp.synchronize()
 
-    U_result = hfactor.numpy()[0]
-    x_result = Mgrad.numpy()[0]
+    U_result = hfactor_fused.numpy()[0]
+    x_result = Mgrad_fused.numpy()[0]
 
     # Verify padding outside active region doesn't affect active computation
     # Off-diagonal padding should be zero (active region shouldn't touch padding)


### PR DESCRIPTION
## Summary
- Fuse blocked Cholesky factorization with the forward solve for changed worlds.
- Keep the cached-factor solve path for skip-unchanged worlds.
- Update the existing block Cholesky test to validate the fused helper against NumPy.

## Performance
On three_humanoids, Nsight kernel averages improved:
- update_gradient_cholesky_blocked: 415.29 us -> 379.55 us
- update_gradient_cholesky_blocked_skip_unchanged: 167.51 us -> 157.85 us

## Testing
- uv run ruff check mujoco_warp/_src/block_cholesky.py mujoco_warp/_src/solver.py mujoco_warp/_src/support_test.py
- uv run ruff format --check mujoco_warp/_src/block_cholesky.py mujoco_warp/_src/solver.py mujoco_warp/_src/support_test.py
- uv run python -m pytest mujoco_warp/_src/support_test.py -k block_cholesky -q