### PR TITLE
Warp Renderer OpenGL Lighting Parity

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2951,10 +2951,14 @@ def create_render_context(
   use_ambient_lighting: bool = True,
   enabled_geom_groups: list[int] = [0, 1, 2],
   cam_active: list[bool] | None = None,
+  background_color: tuple[float, float, float, float] = (0.1, 0.1, 0.2, 1.0),
   flex_render_smooth: bool = True,
   use_precomputed_rays: bool = True,
   render_skybox: bool = False,
   enable_backface_culling: bool = True,
+  enable_specular: bool = True,
+  enable_emission: bool = True,
+  enable_per_light_ambient: bool = True,
 ) -> types.RenderContext:
   """Creates a render context on device.
 
@@ -2969,8 +2973,9 @@ def create_render_context(
       If None, uses the MuJoCo model values.
     use_textures: Whether to use textures.
     use_shadows: Whether to use shadows.
-    use_ambient_lighting: Whether to add the renderer's hemispheric ambient
-      lighting term before applying model lights.
+    use_ambient_lighting: Top-level ambient switch. When False, skips all
+                          ambient contributions, including headlight ambient,
+                          the no-light fallback, and per-light ambient.
     enabled_geom_groups: The geom groups to render.
     cam_active: List of booleans indicating which cameras to include in rendering.
                 If None, all cameras are included.
@@ -2983,6 +2988,19 @@ def create_render_context(
                              the ray (ray origin inside the geom). Matches MuJoCo's
                              mesh-ray rule. Default True. Disable for a small
                              performance gain when no camera is ever inside a geom.
+    background_color: The color to use for background pixels when no skybox is rendered.
+    enable_specular: Evaluate specular highlights per light. When False the
+                     half-vector normalize and shininess `pow` are dropped at
+                     compile time. Disable for performance when no specular is present.
+    enable_emission: Add `mat_emission * base_color` per shaded pixel. When
+                     False the term is dropped at compile time. Disable for performance
+                     when no emission is present.
+    enable_per_light_ambient: When ambient lighting is enabled, sum each
+                              light's `ambient` color into shaded pixels
+                              even outside its cone or in shadow. When False
+                              the per-light ambient pass is removed at compile
+                              time. Disable for performance when model lights
+                              do not use ambient colors.
 
   Returns:
     The render context containing rendering fields and output arrays on device.
@@ -3163,6 +3181,13 @@ def create_render_context(
   if len(flex_geom_flexid) > 0:
     geom_ray_types.add(int(types.GeomType.FLEX))
   geom_ray_types = tuple(sorted(geom_ray_types))
+  if mjm.nlight == 0:
+    light_attenuation_is_default = True
+    has_spot_lights = False
+  else:
+    atten = np.asarray(mjm.light_attenuation, dtype=np.float32).reshape(-1, 3)
+    light_attenuation_is_default = bool(np.allclose(atten, np.array([1.0, 0.0, 0.0], dtype=np.float32)))
+    has_spot_lights = bool((np.asarray(mjm.light_type) == int(mujoco.mjtLightType.mjLIGHT_SPOT)).any())
 
   rc = types.RenderContext(
     nrender=ncam,
@@ -3171,11 +3196,17 @@ def create_render_context(
     use_textures=use_textures,
     use_shadows=use_shadows,
     use_ambient_lighting=use_ambient_lighting,
-    background_color=render_util.pack_rgba_to_uint32(0.1 * 255.0, 0.1 * 255.0, 0.2 * 255.0, 1.0 * 255.0),
+    background_color=render_util.pack_rgba_to_uint32(
+      background_color[0] * 255.0, background_color[1] * 255.0, background_color[2] * 255.0, background_color[3] * 255.0
+    ),
     use_precomputed_rays=use_precomputed_rays,
     render_skybox=render_skybox,
     skybox_tex_id=skybox_tex_id,
     skybox_face_width=skybox_face_width,
+    headlight_active=bool(mjm.vis.headlight.active),
+    headlight_ambient=wp.vec3(mjm.vis.headlight.ambient),
+    headlight_diffuse=wp.vec3(mjm.vis.headlight.diffuse),
+    headlight_specular=wp.vec3(mjm.vis.headlight.specular),
     bvh_ngeom=bvh_ngeom,
     enabled_geom_ids=wp.array(geom_enabled_idx, dtype=int),
     mesh_registry=mesh_registry,
@@ -3218,6 +3249,11 @@ def create_render_context(
     total_rays=int(total),
     enable_backface_culling=enable_backface_culling,
     geom_ray_types=geom_ray_types,
+    enable_specular=enable_specular,
+    enable_emission=enable_emission,
+    enable_per_light_ambient=enable_per_light_ambient,
+    light_attenuation_is_default=light_attenuation_is_default,
+    has_spot_lights=has_spot_lights,
   )
 
   bvh.build_scene_bvh(mjm, mjd, rc, nworld)

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1995,6 +1995,42 @@ class IOTest(parameterized.TestCase):
     self.assertTrue(rc.use_textures, "use_textures")
     self.assertEqual(rc.textures.shape, (mjm.ntex,), "textures")
 
+  def test_render_context_lighting_flags(self):
+    mjm, _, _, _ = test_data.fixture(
+      xml="""
+      <mujoco>
+        <visual>
+          <headlight active="0" ambient="0.2 0.3 0.4" diffuse="0.5 0.6 0.7" specular="0.8 0.9 1.0"/>
+        </visual>
+        <worldbody>
+          <light pos="0 0 3" dir="0 0 -1" attenuation="1 0.1 0.05" cutoff="25"/>
+          <geom type="sphere" size="0.3"/>
+        </worldbody>
+      </mujoco>
+      """
+    )
+    rc = mjwarp.create_render_context(
+      mjm,
+      cam_res=(32, 32),
+      render_rgb=True,
+      use_shadows=False,
+      use_ambient_lighting=False,
+      enable_specular=False,
+      enable_emission=False,
+      enable_per_light_ambient=False,
+    )
+    self.assertFalse(rc.use_shadows)
+    self.assertFalse(rc.use_ambient_lighting)
+    self.assertFalse(rc.enable_specular)
+    self.assertFalse(rc.enable_emission)
+    self.assertFalse(rc.enable_per_light_ambient)
+    self.assertFalse(rc.headlight_active)
+    self.assertFalse(rc.light_attenuation_is_default)
+    self.assertTrue(rc.has_spot_lights)
+    _assert_eq(np.asarray(rc.headlight_ambient), mjm.vis.headlight.ambient, "headlight_ambient")
+    _assert_eq(np.asarray(rc.headlight_diffuse), mjm.vis.headlight.diffuse, "headlight_diffuse")
+    _assert_eq(np.asarray(rc.headlight_specular), mjm.vis.headlight.specular, "headlight_specular")
+
   def test_check_toolkit_driver_warns(self):
     """Tests that check_toolkit_driver warns."""
     mock_device = mock.MagicMock()

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -529,8 +529,9 @@ def _make_compute_lighting(cast_ray_first_hit: wp.Function) -> wp.Function:
         spec_rgb = lightspec * (mat_spec * wp.pow(ndoth, mat_shin_exp) * weight)
 
     return diff_rgb, spec_rgb
-  
+
   return compute_lighting
+
 
 @event_scope
 def render(m: Model, d: Data, rc: RenderContext):

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -779,7 +779,7 @@ def render(m: Model, d: Data, rc: RenderContext):
         if mat_id_for_spec >= 0:
           if wp.static(rc.enable_specular):
             mat_spec = mat_specular[worldid % mat_specular.shape[0], mat_id_for_spec]
-            mat_shin_exp = mat_shininess[worldid % mat_shininess.shape[0], mat_id_for_spec] * 128.0
+            mat_shin_exp = mat_shininess[worldid % mat_shininess.shape[0], mat_id_for_spec] * MAX_SHININESS
           if wp.static(rc.enable_emission):
             mat_emis = mat_emission[worldid % mat_emission.shape[0], mat_id_for_spec]
 

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -40,6 +40,21 @@ from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"enable_backward": False})
 
+# Default value for mat_shininess in MuJoCo is 0.5
+# With an 8 bit image format, the maximum value is 255.0
+# So max shininess value for the Phong lighting model is 128.0
+MAX_SHININESS = 128.0
+# The exponent value for mat_shininess is 0.5 times the max shininess value
+DEFAULT_MAT_SHININESS_EXPONENT = 0.5 * MAX_SHININESS
+
+# Default value for mat_specular in MuJoCo is 0.5
+DEFAULT_MAT_SPECULAR = 0.5
+
+# Default value for mat_emission in MuJoCo is 0.0
+DEFAULT_MAT_EMISSION = 0.0
+
+NO_LIGHT_AMBIENT_FALLBACK = 0.3
+
 
 @wp.func
 def sample_texture(
@@ -416,37 +431,54 @@ def _make_compute_lighting(cast_ray_first_hit: wp.Function) -> wp.Function:
     lightcastshadow: bool,
     lightpos: wp.vec3,
     lightdir: wp.vec3,
+    lightattenuation: wp.vec3,
+    lightcutoff_rad: float,
+    lightexp: float,
+    lightdiff: wp.vec3,
+    lightspec: wp.vec3,
     normal: wp.vec3,
     hitpoint: wp.vec3,
+    view_dir: wp.vec3,
+    mat_spec: float,
+    mat_shin_exp: float,
     cull_backfaces: bool,
-  ) -> float:
-    light_contribution = float(0.0)
+    enable_specular: bool,
+    default_attenuation: bool,
+    has_spot: bool,
+  ) -> Tuple[wp.vec3, wp.vec3]:
+    diff_rgb = wp.vec3(0.0)
+    spec_rgb = wp.vec3(0.0)
 
     # TODO: We should probably only be looping over active lights
     # in the first place with a static loop of enabled light idx?
     if not lightactive:
-      return light_contribution
+      return diff_rgb, spec_rgb
 
-    L = wp.vec3(0.0, 0.0, 0.0)
+    L = wp.vec3(0.0)
     dist_to_light = float(MJ_MAXVAL)
-    attenuation = float(1.0)
+    attenuation = 1.0
 
     if lighttype == 1:  # directional light
-      L = wp.normalize(-lightdir)
+      # MuJoCo guarantees `lightdir` is unit length.
+      L = -lightdir
     else:
       L, dist_to_light = math.normalize_with_norm(lightpos - hitpoint)
-      attenuation = 1.0 / (1.0 + 0.02 * dist_to_light * dist_to_light)
-      if lighttype == 0:  # spot light
-        spot_dir = wp.normalize(lightdir)
-        cos_theta = wp.dot(-L, spot_dir)
-        spot_factor = wp.min(1.0, wp.max(0.0, (cos_theta - 0.85) * 10.0))
-        attenuation = attenuation * spot_factor
+      if not default_attenuation:
+        light_attenuation_factor = wp.vec3(1.0, dist_to_light, dist_to_light * dist_to_light)
+        attenuation = math.safe_div(1.0, wp.dot(light_attenuation_factor, lightattenuation))
+      if has_spot:
+        if lighttype == 0:  # spot light
+          cos_theta = wp.dot(-L, lightdir)
+          cos_cutoff = wp.cos(lightcutoff_rad)
+          if cos_theta < cos_cutoff:
+            return diff_rgb, spec_rgb
+          attenuation = attenuation * wp.pow(wp.max(cos_theta, 0.0), lightexp)
 
     ndotl = wp.max(0.0, wp.dot(normal, L))
     if ndotl == 0.0:
-      return light_contribution
+      return diff_rgb, spec_rgb
 
-    visible = float(1.0)
+    visible = 1.0
 
     if use_shadows and lightcastshadow:
       # Nudge the origin slightly along the surface normal to avoid
@@ -486,12 +518,19 @@ def _make_compute_lighting(cast_ray_first_hit: wp.Function) -> wp.Function:
       )
 
       if shadow_geom_id != -1:
-        visible = 0.3
+        visible = NO_LIGHT_AMBIENT_FALLBACK
 
-    return ndotl * attenuation * visible
+    weight = attenuation * visible
+    diff_rgb = lightdiff * (ndotl * weight)
+    if enable_specular:
+      if mat_spec > 0.0 and mat_shin_exp > 0.0:
+        H = wp.normalize(L + view_dir)
+        ndoth = wp.max(0.0, wp.dot(normal, H))
+        spec_rgb = lightspec * (mat_spec * wp.pow(ndoth, mat_shin_exp) * weight)
 
+    return diff_rgb, spec_rgb
+  
   return compute_lighting
-
 
 @event_scope
 def render(m: Model, d: Data, rc: RenderContext):
@@ -530,12 +569,21 @@ def render(m: Model, d: Data, rc: RenderContext):
     light_type: wp.array2d[int],
     light_castshadow: wp.array2d[bool],
     light_active: wp.array2d[bool],
+    light_attenuation: wp.array2d[wp.vec3],
+    light_cutoff: wp.array2d[float],
+    light_exponent: wp.array2d[float],
+    light_ambient: wp.array2d[wp.vec3],
+    light_diffuse: wp.array2d[wp.vec3],
+    light_specular: wp.array2d[wp.vec3],
     flex_vertadr: wp.array[int],
     flex_edge: wp.array[wp.vec2i],
     flex_radius: wp.array[float],
     mesh_faceadr: wp.array[int],
     mat_texid: wp.array3d[int],
     mat_texrepeat: wp.array2d[wp.vec2],
+    mat_emission: wp.array2d[float],
+    mat_specular: wp.array2d[float],
+    mat_shininess: wp.array2d[float],
     mat_rgba: wp.array2d[wp.vec4],
     # Data in:
     geom_xpos_in: wp.array2d[wp.vec3],
@@ -619,8 +667,9 @@ def render(m: Model, d: Data, rc: RenderContext):
         wp.static(rc.znear),
       )
 
-    ray_dir_world = cam_xmat_in[worldid, mujoco_cam_id] @ ray_dir_local_cam
     ray_origin_world = cam_xpos_in[worldid, mujoco_cam_id]
+    cam_mat_world = cam_xmat_in[worldid, mujoco_cam_id]
+    ray_dir_world = cam_mat_world @ ray_dir_local_cam
 
     geom_id, dist, normal, u, v, f, mesh_id = cast_ray(
       geom_type,
@@ -694,7 +743,6 @@ def render(m: Model, d: Data, rc: RenderContext):
       color = mat_rgba[worldid % mat_rgba.shape[0], geom_matid[worldid % geom_matid.shape[0], geom_id]]
 
     base_color = wp.vec3(color[0], color[1], color[2])
-    hit_color = base_color
 
     if wp.static(rc.use_textures):
       if geom_id != -2:
@@ -721,18 +769,48 @@ def render(m: Model, d: Data, rc: RenderContext):
             )
             base_color = wp.cw_mul(base_color, tex_color)
 
-    result = wp.vec3(0.0, 0.0, 0.0)
-    if wp.static(rc.use_ambient_lighting):
-      len_n = wp.length(normal)
-      n = normal if len_n > 0.0 else wp.vec3(0.0, 0.0, 1.0)
-      n = wp.normalize(n)
-      hemispheric = 0.5 * (n[2] + 1.0)
-      ambient_color = wp.vec3(0.4, 0.4, 0.45) * hemispheric + wp.vec3(0.1, 0.1, 0.12) * (1.0 - hemispheric)
-      result = 0.5 * wp.cw_mul(base_color, ambient_color)
+    mat_spec = DEFAULT_MAT_SPECULAR
+    mat_shin_exp = DEFAULT_MAT_SHININESS_EXPONENT
+    mat_emis = DEFAULT_MAT_EMISSION
+    if wp.static(rc.enable_specular or rc.enable_emission):
+      if geom_id != -2:
+        mat_id_for_spec = geom_matid[worldid % geom_matid.shape[0], geom_id]
+        if mat_id_for_spec >= 0:
+          if wp.static(rc.enable_specular):
+            mat_spec = mat_specular[worldid % mat_specular.shape[0], mat_id_for_spec]
+            mat_shin_exp = mat_shininess[worldid % mat_shininess.shape[0], mat_id_for_spec] * 128.0
+          if wp.static(rc.enable_emission):
+            mat_emis = mat_emission[worldid % mat_emission.shape[0], mat_id_for_spec]
 
-    # Apply lighting and shadows
-    for l in range(wp.static(m.nlight)):
-      light_contribution = compute_lighting(
+    result = wp.vec3(0.0)
+    if wp.static(rc.enable_emission):
+      result = base_color * mat_emis
+
+    if wp.static(rc.use_ambient_lighting):
+      if wp.static(rc.headlight_active):
+        result = result + wp.cw_mul(base_color, wp.static(rc.headlight_ambient))
+      elif wp.static(m.nlight == 0):
+        result = result + base_color * NO_LIGHT_AMBIENT_FALLBACK
+      if wp.static(rc.enable_per_light_ambient):
+        for light_index in range(wp.static(m.nlight)):
+          if light_active[worldid % light_active.shape[0], light_index]:
+            result = result + wp.cw_mul(base_color, light_ambient[worldid % light_ambient.shape[0], light_index])
+
+    view_dir = -ray_dir_world
+
+    light_cutoff_worldid = light_cutoff[worldid % light_cutoff.shape[0]]
+    light_active_worldid = light_active[worldid % light_active.shape[0]]
+    light_type_worldid = light_type[worldid % light_type.shape[0]]
+    light_castshadow_worldid = light_castshadow[worldid % light_castshadow.shape[0]]
+    light_xpos_in_worldid = light_xpos_in[worldid]
+    light_xdir_in_worldid = light_xdir_in[worldid]
+    light_attenuation_worldid = light_attenuation[worldid % light_attenuation.shape[0]]
+    light_exponent_worldid = light_exponent[worldid % light_exponent.shape[0]]
+    light_diffuse_worldid = light_diffuse[worldid % light_diffuse.shape[0]]
+    light_specular_worldid = light_specular[worldid % light_specular.shape[0]]
+    # Apply Lighting for each light
+    for light_index in range(wp.static(m.nlight)):
+      diff_rgb, spec_rgb = compute_lighting(
         geom_type,
         geom_dataid,
         geom_size,
@@ -755,16 +833,76 @@ def render(m: Model, d: Data, rc: RenderContext):
         flex_geom_edgeid,
         flex_bvh_id,
         flex_group_root,
-        light_active[worldid % light_active.shape[0], l],
-        light_type[worldid % light_type.shape[0], l],
-        light_castshadow[worldid % light_castshadow.shape[0], l],
-        light_xpos_in[worldid, l],
-        light_xdir_in[worldid, l],
+        light_active_worldid[light_index],
+        light_type_worldid[light_index],
+        light_castshadow_worldid[light_index],
+        light_xpos_in_worldid[light_index],
+        light_xdir_in_worldid[light_index],
+        light_attenuation_worldid[light_index],
+        light_cutoff_worldid[light_index] * wp.static(wp.pi / 180.0),
+        light_exponent_worldid[light_index],
+        light_diffuse_worldid[light_index],
+        light_specular_worldid[light_index],
         normal,
         hit_point,
+        view_dir,
+        mat_spec,
+        mat_shin_exp,
         wp.static(rc.enable_backface_culling),
+        wp.static(rc.enable_specular),
+        wp.static(rc.light_attenuation_is_default),
+        wp.static(rc.has_spot_lights),
       )
-      result = result + base_color * light_contribution
+      result = result + wp.cw_mul(base_color, diff_rgb) + spec_rgb
+
+    # Apply Headlight
+    if wp.static(rc.headlight_active):
+      cam_pos = ray_origin_world
+      cam_fwd = -cam_mat_world[:, 2]
+      hl_diff, hl_spec = compute_lighting(
+        geom_type,
+        geom_dataid,
+        geom_size,
+        flex_vertadr,
+        flex_edge,
+        flex_radius,
+        geom_xpos_in,
+        geom_xmat_in,
+        flexvert_xpos_in,
+        use_shadows,
+        bvh_id,
+        group_root[worldid],
+        bvh_ngeom,
+        bvh_nflexgeom,
+        enabled_geom_ids,
+        worldid,
+        mesh_bvh_id,
+        hfield_bvh_id,
+        flex_geom_flexid,
+        flex_geom_edgeid,
+        flex_bvh_id,
+        flex_group_root,
+        True,
+        1,
+        False,
+        cam_pos,
+        cam_fwd,
+        wp.vec3(1.0, 0.0, 0.0),
+        0.0,
+        0.0,
+        wp.static(rc.headlight_diffuse),
+        wp.static(rc.headlight_specular),
+        normal,
+        hit_point,
+        view_dir,
+        mat_spec,
+        mat_shin_exp,
+        wp.static(rc.enable_backface_culling),
+        wp.static(rc.enable_specular),
+        True,
+        False,
+      )
+      result = result + wp.cw_mul(base_color, hl_diff) + hl_spec
 
     hit_color = wp.min(result, wp.vec3(1.0, 1.0, 1.0))
     hit_color = wp.max(hit_color, wp.vec3(0.0, 0.0, 0.0))
@@ -792,12 +930,21 @@ def render(m: Model, d: Data, rc: RenderContext):
       m.light_type,
       m.light_castshadow,
       m.light_active,
+      m.light_attenuation,
+      m.light_cutoff,
+      m.light_exponent,
+      m.light_ambient,
+      m.light_diffuse,
+      m.light_specular,
       m.flex_vertadr,
       m.flex_edge,
       m.flex_radius,
       m.mesh_faceadr,
       m.mat_texid,
       m.mat_texrepeat,
+      m.mat_emission,
+      m.mat_specular,
+      m.mat_shininess,
       m.mat_rgba,
       d.geom_xpos,
       d.geom_xmat,

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -140,6 +140,58 @@ class RenderTest(parameterized.TestCase):
     self.assertGreater(np.count_nonzero(rgb), 0)
     self.assertTrue(np.any(seg[..., 1] == int(mjw.ObjType.GEOM)))
 
+  def test_render_spot_light_with_attenuation(self):
+    """Kernel runs under `has_spot_lights=True` and non-default attenuation."""
+    xml = """
+    <mujoco>
+      <visual>
+        <headlight active="0"/>
+      </visual>
+      <worldbody>
+        <camera pos="0 -2 0.8" xyaxes="1 0 0 0 0.5 1" resolution="32 32"/>
+        <light pos="0 0 2.5" dir="0 0 -1" cutoff="25" exponent="10"
+               attenuation="1 0.1 0.05" diffuse="1 0.9 0.7"/>
+        <geom type="plane" size="2 2 0.1" rgba="0.7 0.7 0.7 1"/>
+        <geom pos="0 0 0.3" size="0.3" rgba="0.8 0.8 0.8 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, _, m, d = test_data.fixture(xml=xml)
+    rc = mjw.create_render_context(mjm, cam_res=(32, 32), render_rgb=True)
+    self.assertTrue(rc.has_spot_lights, "fixture must trigger `has_spot_lights`")
+    self.assertFalse(rc.light_attenuation_is_default, "fixture must trigger non-default attenuation")
+    mjw.render(m, d, rc)
+    rgb = _unpack_rgb(rc.rgb_data.numpy()[0]).reshape(32, 32, 3)
+    self.assertGreater(int(rgb.max()), 10, "spot light should illuminate the floor cone")
+
+  def test_render_with_features_disabled(self):
+    """Kernel compiles + runs with static options disabled."""
+    xml = """
+    <mujoco>
+      <asset>
+        <material name="m" specular="0.7" emission="0.3" rgba="0.4 0.5 0.8 1"/>
+      </asset>
+      <worldbody>
+        <camera pos="0 -2 0.5" xyaxes="1 0 0 0 0.3 1" resolution="32 32"/>
+        <light pos="0 0 3" dir="0 0 -1" directional="true"
+               diffuse="0.6 0.6 0.6" ambient="0.15 0.15 0.15"/>
+        <geom type="sphere" pos="0 0 0.3" size="0.3" material="m"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, _, m, d = test_data.fixture(xml=xml)
+    rc = mjw.create_render_context(
+      mjm,
+      cam_res=(32, 32),
+      render_rgb=True,
+      enable_specular=False,
+      enable_emission=False,
+      enable_per_light_ambient=False,
+    )
+    mjw.render(m, d, rc)
+    rgb = _unpack_rgb(rc.rgb_data.numpy()[0]).reshape(32, 32, 3)
+    self.assertGreater(int(rgb.max()), 10, "directional light + headlight should still light the scene")
+
   def test_disable_ambient_lighting(self):
     xml = """
     <mujoco>

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1032,6 +1032,12 @@ class Model:
     light_poscom0: global position rel. to sub-com in qpos0  (*, nlight, 3)
     light_pos0: global position rel. to body in qpos0        (*, nlight, 3)
     light_dir0: global direction in qpos0                    (*, nlight, 3)
+    light_attenuation: OpenGL constant/linear/quadratic      (*, nlight, 3)
+    light_cutoff: spotlight half-cone angle in degrees       (*, nlight)
+    light_exponent: spotlight angular falloff exponent       (*, nlight)
+    light_ambient: ambient RGB                               (*, nlight, 3)
+    light_diffuse: diffuse RGB                               (*, nlight, 3)
+    light_specular: specular RGB                             (*, nlight, 3)
     flex_contype: flex contact type                          (nflex,)
     flex_conaffinity: flex contact affinity                  (nflex,)
     flex_condim: contact dimensionality (1, 3, 4, 6)         (nflex,)
@@ -1100,6 +1106,9 @@ class Model:
     hfield_data: elevation data                              (nhfielddata,)
     mat_texid: texture id for rendering                      (*, nmat, mjNTEXROLE)
     mat_texrepeat: texture repeat for rendering              (*, nmat, 2)
+    mat_emission: emission scalar (self-illumination)        (*, nmat)
+    mat_specular: specular reflection scalar                 (*, nmat)
+    mat_shininess: shininess in [0, 1], mapped to GL [0, 128](*, nmat)
     mat_rgba: rgba                                           (*, nmat, 4)
     pair_dim: contact dimensionality                         (npair,)
     pair_geom1: id of geom1                                  (npair,)
@@ -1456,6 +1465,12 @@ class Model:
   light_poscom0: array("*", "nlight", wp.vec3)
   light_pos0: array("*", "nlight", wp.vec3)
   light_dir0: array("*", "nlight", wp.vec3)
+  light_attenuation: array("*", "nlight", wp.vec3)
+  light_cutoff: array("*", "nlight", float)
+  light_exponent: array("*", "nlight", float)
+  light_ambient: array("*", "nlight", wp.vec3)
+  light_diffuse: array("*", "nlight", wp.vec3)
+  light_specular: array("*", "nlight", wp.vec3)
   flex_contype: array("nflex", int)
   flex_conaffinity: array("nflex", int)
   flex_condim: array("nflex", int)
@@ -1524,6 +1539,9 @@ class Model:
   hfield_data: array("nhfielddata", float)
   mat_texid: array("*", "nmat", 10, int)
   mat_texrepeat: array("*", "nmat", wp.vec2)
+  mat_emission: array("*", "nmat", float)
+  mat_specular: array("*", "nmat", float)
+  mat_shininess: array("*", "nmat", float)
   mat_rgba: array("*", "nmat", wp.vec4)
   pair_dim: array("npair", int)
   pair_geom1: array("npair", int)
@@ -2158,8 +2176,8 @@ class RenderContext:
     cam_id_map: camera id map
     use_textures: whether to use textures
     use_shadows: whether to use shadows
-    use_ambient_lighting: whether to use ambient lighting
-    background_color: background color
+    use_ambient_lighting: top-level switch for ambient contributions
+    background_color: color used for missed rays when no skybox is rendered
     use_precomputed_rays: whether to use precomputed rays
     bvh_ngeom: number of geometries in the BVH
     enabled_geom_ids: enabled geometry ids
@@ -2204,11 +2222,38 @@ class RenderContext:
     render_skybox: whether to shade missed rays with the MuJoCo skybox texture
     skybox_tex_id: index into textures of the skybox (MuJoCo tex_type == SKYBOX), -1 if none
     skybox_face_width: pixel width of one skybox cube face (0 if no skybox)
+    headlight_active: whether to inject MuJoCo's vis.headlight as a synthetic
+      directional light at the active camera. Read from `mjm.vis.headlight.active`
+      at context creation; users disable the headlight by configuring it on the
+      MuJoCo model (e.g. `<visual><headlight active="0"/></visual>` in XML).
+    headlight_ambient: RGB ambient color of the headlight (from vis.headlight).
+    headlight_diffuse: RGB diffuse color of the headlight.
+    headlight_specular: RGB specular color of the headlight.
     enable_backface_culling: drop primitive ray hits whose normal faces away
       from the ray (i.e. the ray origin is inside the geom). Matches MuJoCo's
       mesh-ray rule. When False, the renderer reports inner-surface hits, which
       is faster but causes a camera placed inside a geom to render that geom's
       back wall.
+    light_attenuation_is_default: True iff every light in the model has the
+      MuJoCo default `attenuation = (1, 0, 0)`. Computed once at context
+      creation; when True the kernel skips the per-light polynomial
+      attenuation evaluation (a divide + 3 multiplies + an add per
+      non-directional light per pixel) via `wp.static`.
+    has_spot_lights: True iff any light in the model has `type == SPOT`.
+      When False, the kernel skips the spot-cone branch (cos cutoff +
+      pow exponent) per non-directional light per pixel via `wp.static`.
+    enable_specular: when True, evaluate the Phong specular highlight per
+      light per pixel (uses `mat_specular` / `mat_shininess`). When False,
+      the entire specular branch is removed at compile time. Useful for
+      depth/segmentation-only workflows or when materials are matte.
+    enable_emission: when True, add `mat_emission * base_color` to each
+      shaded pixel. When False the term is dropped at compile time.
+    enable_per_light_ambient: when True and `use_ambient_lighting` is also
+      True, sum the per-light `light_ambient` colors into each shaded pixel
+      even when the surface normal is perpendicular to the light direction
+      or the pixel is shadowed. When False the second per-light loop for
+      ambient is removed at compile time. Headlight ambient and the no-light
+      fallback are controlled by `use_ambient_lighting`.
     geom_ray_types: tuple of GeomType int values present in the scene, used to
       statically eliminate unused intersection branches in the ray-cast kernels.
   """
@@ -2224,6 +2269,10 @@ class RenderContext:
   render_skybox: bool
   skybox_tex_id: int
   skybox_face_width: int
+  headlight_active: bool
+  headlight_ambient: wp.vec3
+  headlight_diffuse: wp.vec3
+  headlight_specular: wp.vec3
   bvh_ngeom: int
   enabled_geom_ids: array("*", int)
   mesh_registry: dict
@@ -2265,4 +2314,9 @@ class RenderContext:
   znear: float
   total_rays: int
   enable_backface_culling: bool
+  enable_specular: bool
+  enable_emission: bool
+  enable_per_light_ambient: bool
+  light_attenuation_is_default: bool
+  has_spot_lights: bool
   geom_ray_types: tuple = ()


### PR DESCRIPTION
## PR Description: Renderer OpenGL Lighting Parity

### Summary

This PR brings the MuJoCo Warp RGB renderer much closer to MuJoCo OpenGL lighting behavior. It plumbs missing light and material fields into `types.Model`, rewrites `compute_lighting` around MuJoCo-style diffuse/specular/attenuation/spotlight terms, injects the MuJoCo headlight as a camera-relative light, and adds opt-out flags for the main parity features.

The renderer now handles:

- MuJoCo `vis.headlight` ambient/diffuse/specular contribution.
- Per-light diffuse, specular, ambient, attenuation, cutoff, and exponent.
- Material specular, shininess, and emission.
- Binary shadow visibility that matches OpenGL more closely. (Not sure if this should be configurable)
- Black-background parity in the renderer parity tests.
- Unit tests that look at a simplified SSIM score diff between opengl and warp renders

I realize this is on the longer side and I put this all in a single PR but if need be I can split up into subcomponents to ease the processes.

### Visual Parity

Canonical fixture SSIM against `mujoco.Renderer` improves from roughly `0.3-0.5` before this PR to `0.917-0.994` after this PR.

#### Renderer parity fixtures before/after/reference
The grid below shows each renderer parity test fixture before this PR, after this PR, and against the MuJoCo OpenGL reference.
<img width="664" height="1124" alt="image" src="https://github.com/user-attachments/assets/8dafdcbf-c2f6-4b44-8d0b-c5162d4cc45f" />


#### Feature visual impact by opt-out flag
The visual comparison below shows the effect of disabling each feature independently on a representative lit scene, with shadows disabled to isolate the lighting terms.
<img width="990" height="238" alt="image" src="https://github.com/user-attachments/assets/f585e5f2-ec46-4fa4-90a0-be81acb3dd44" />

### Performance Cost
A reference scene was evaluated for 100 samples where the impact of each feature on SSIM and compute is shown compared to the baseline (origin/main)
<img width="653" height="228" alt="image" src="https://github.com/user-attachments/assets/cdc59198-c5e2-4484-b165-7e036106cf94" />


Reference Scene
```
"""
<mujoco>
  <visual>
    <headlight active="1" ambient="0.2 0.2 0.2" diffuse="0.7 0.7 0.7" specular="0.8 0.8 0.8"/>
  </visual>
  <asset>
    <material name="benchmat" specular="0.8" shininess="0.7" emission="0.1" rgba="0.6 0.7 0.9 1"/>
  </asset>
  <worldbody>
    <camera name="cam" pos="0 -3 0.9" xyaxes="1 0 0 0 0.3 1" resolution="256 256"/>
    <light pos="-1 -1.5 2" dir="0.3 0.2 -1" cutoff="35" exponent="15"
           attenuation="1 0.2 0.12" diffuse="1 1 1" specular="1 1 1" ambient="0.1 0.1 0.1"/>
    <geom type="plane" size="4 4 0.1" rgba="0.8 0.8 0.8 1"/>
    <geom type="box" pos="-0.5 0 0.15" size="0.15 0.15 0.15" material="benchmat"/>
    <geom type="sphere" pos="0.0 0 0.25" size="0.25" material="benchmat"/>
    <geom type="capsule" fromto="0.4 -0.2 0.1 0.8 0.3 0.5" size="0.08" material="benchmat"/>
  </worldbody>
</mujoco>
"""
```
