### PR TITLE
Speed up SDF octree leaf test

### DIFF
--- a/mujoco_warp/_src/collision_sdf.py
+++ b/mujoco_warp/_src/collision_sdf.py
@@ -352,16 +352,17 @@ def find_oct(
     # check if the node is a leaf
     # child indices are relative to root (mesh_octadr offset)
     child0 = oct_child[node][0]
+    # Evaluate this hot leaf predicate eagerly to avoid branch-heavy codegen.
     if (
-      child0 == -1
-      and oct_child[node][1] == -1
-      and oct_child[node][2] == -1
-      and oct_child[node][3] == -1
-      and oct_child[node][4] == -1
-      and oct_child[node][5] == -1
-      and oct_child[node][6] == -1
-      and oct_child[node][7] == -1
-    ):
+      int(child0 == -1)
+      & int(oct_child[node][1] == -1)
+      & int(oct_child[node][2] == -1)
+      & int(oct_child[node][3] == -1)
+      & int(oct_child[node][4] == -1)
+      & int(oct_child[node][5] == -1)
+      & int(oct_child[node][6] == -1)
+      & int(oct_child[node][7] == -1)
+    ) != 0:
       for j in range(8):
         if not grad:
           rx[j] = (


### PR DESCRIPTION
## Summary

This PR restores most of the aloha_sdf performance lost from Warp short-circuit codegen by keeping one hot SDF octree leaf predicate eager in find_oct.

The change is intentionally narrow: it only rewrites the all-children-are-empty leaf test. The broader audit of other possible eager predicates should be handled separately.

## Benchmark

Command:
uv run benchmarks/run.py -f ^aloha_sdf$ --clear_warp_cache=false --assets_root=/tmp/mjwarp_bench_assets

Warm-cache comparison, nworld=8192:
- pre-Warp-update reference: run_time 17.3561 s, step 2111.46 us, sdf_narrowphase 1642.87 us
- upstream/main: run_time 18.9197 s, step 2299.21 us, sdf_narrowphase 1830.90 us
- this PR: run_time 17.8355 s, step 2167.42 us, sdf_narrowphase 1684.55 us
- upstream/main vs pre-update: run_time +9.0%, step +8.9%, sdf_narrowphase +11.4%
- this PR vs upstream/main: run_time -5.7%, step -5.7%, sdf_narrowphase -8.0%
- this PR vs pre-update: run_time +2.8%, step +2.7%, sdf_narrowphase +2.5%

The pre-Warp-update reference was regenerated at 092f3bae, the parent of #1355, using warp-lang 1.13.0.dev20260227. The upstream/main and PR numbers use warp-lang 1.13.0.

Earlier single-site ablation on the sdf_narrowphase kernel also found that this find_oct leaf predicate accounts for most of the broader eager-workaround speedup.

## Checks

- uv run --no-sync python -m py_compile mujoco_warp/_src/collision_sdf.py
- uv run --extra dev ruff check mujoco_warp/_src/collision_sdf.py
- uv run --extra dev python -m pytest mujoco_warp/_src/io_test.py::IOTest::test_sdf -q
- aloha_sdf benchmark above
