### PR TITLE
Support nccdmax in benchmarks.

### DIFF
--- a/benchmarks/aloha/__init__.py
+++ b/benchmarks/aloha/__init__.py
@@ -19,6 +19,7 @@ BENCHMARKS = [
     "mjcf": "scene_pot.xml",
     "nworld": 8192,
     "nconmax": 24,
+    "nccdmax": 12,
     "njmax": 128,
     "replay": "lift_pot.npz",
     "assets": [(ASSETS[0], "aloha")],
@@ -36,6 +37,7 @@ BENCHMARKS = [
     "mjcf": "scene_cloth.xml",
     "nworld": 32,
     "nconmax": 4096,
+    "nccdmax": 12,
     "njmax": 40_000,
     "nstep": 100,
     "assets": [(ASSETS[0], "aloha")],
@@ -45,6 +47,7 @@ BENCHMARKS = [
     "mjcf": "scene_clutter.xml",
     "nworld": 512,
     "nconmax": 512,
+    "nccdmax": 320,
     "njmax": 1024,
     "replay": "pick_clutter.npz",
     "assets": [

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -127,11 +127,10 @@ def _assemble_benchmark(bm: dict):
 
 def _run_benchmark(bm: dict, input_dir: Path) -> dict:
   """Run a single benchmark via uv, returning parsed JSON."""
-  mjcf_path = Path(_ARGS.assets_root) / bm["name"] / bm["mjcf"]
+  benchmark_root = Path(_ARGS.assets_root) / bm["name"]
   cmd = [
     "mjwarp-testspeed",
-    mjcf_path.as_posix(),
-    f"--nworld={bm['nworld']}",
+    (benchmark_root / bm["mjcf"]).as_posix(),
     f"--clear_warp_cache={_ARGS.clear_warp_cache}",
     "--format=short",
     "--event_trace=true",
@@ -139,12 +138,11 @@ def _run_benchmark(bm: dict, input_dir: Path) -> dict:
     "--measure_solver=true",
     "--measure_alloc=true",
   ]
-  for field in ("nconmax", "njmax", "function", "nstep", "render_width", "render_height", "render_rgb", "render_depth"):
-    if field in bm:
+  for field in bm:
+    if field == "replay":
+      cmd.append(f"--replay={(benchmark_root / bm['replay'])}")
+    elif field not in ("name", "assets", "mjcf", "_dir"):
       cmd.append(f"--{field}={bm[field]}")
-  if "replay" in bm:
-    replay_path = Path(_ARGS.assets_root) / bm["name"] / bm["replay"]
-    cmd.append(f"--replay={replay_path.as_posix()}")
 
   result = _uv_run(*cmd, cwd=input_dir)
 
@@ -161,18 +159,17 @@ def _run_benchmark(bm: dict, input_dir: Path) -> dict:
 
 def _view_benchmark(bm: dict, input_dir: Path):
   """Launch mjwarp-viewer for a single benchmark."""
-  mjcf_path = Path(_ARGS.assets_root) / bm["name"] / bm["mjcf"]
+  benchmark_root = Path(_ARGS.assets_root) / bm["name"]
   cmd = [
     "mjwarp-viewer",
-    mjcf_path.as_posix(),
+    (benchmark_root / bm["mjcf"]).as_posix(),
     "--nworld=1",
   ]
-  for field in ("nconmax", "njmax"):
+  for field in ("nconmax", "nccdmax", "njmax"):
     if field in bm:
       cmd.append(f"--{field}={bm[field]}")
   if "replay" in bm:
-    replay_path = Path(_ARGS.assets_root) / bm["name"] / bm["replay"]
-    cmd.append(f"--replay={replay_path.as_posix()}")
+    cmd.append(f"--replay={(benchmark_root / bm['replay'])}")
 
   log.info("Command: uv run %s", " ".join(cmd))
   subprocess.run(("uv", "run") + tuple(cmd), cwd=input_dir, check=True)

--- a/benchmarks/sweep.py
+++ b/benchmarks/sweep.py
@@ -147,11 +147,10 @@ def _assemble_benchmark(bm: dict):
 
 def _run_benchmark(bm: dict, input_dir: Path, *, mock: bool) -> dict:
   """Run a single benchmark via uv, returning parsed JSON."""
-  mjcf_path = Path(_ARGS.assets_root) / bm["name"] / bm["mjcf"]
+  benchmark_root = Path(_ARGS.assets_root) / bm["name"]
   cmd = [
     "mjwarp-testspeed",
-    mjcf_path.as_posix(),
-    f"--nworld={1 if mock else bm['nworld']}",
+    (benchmark_root / bm["mjcf"]).as_posix(),
     f"--clear_warp_cache={not mock}",
     "--format=json",
     "--event_trace=true",
@@ -159,16 +158,15 @@ def _run_benchmark(bm: dict, input_dir: Path, *, mock: bool) -> dict:
     "--measure_solver=true",
     "--measure_alloc=true",
   ]
-  for field in ("nconmax", "njmax", "function", "render_width", "render_height"):
-    if field in bm:
+  for field in bm:
+    if field == "replay":
+      cmd.append(f"--replay={(benchmark_root / bm['replay'])}")
+    elif field == "nworld":
+      cmd.append(f"--nworld={1 if mock else bm['nworld']}")
+    elif field == "nstep":
+      cmd.append(f"--nstep={10 if mock else bm['nstep']}")
+    elif field not in ("name", "assets", "mjcf", "_dir"):
       cmd.append(f"--{field}={bm[field]}")
-  if "replay" in bm:
-    replay_path = Path(_ARGS.assets_root) / bm["name"] / bm["replay"]
-    cmd.append(f"--replay={replay_path.as_posix()}")
-  if mock:
-    cmd.append("--nstep=10")
-  elif "nstep" in bm:
-    cmd.append(f"--nstep={bm['nstep']}")
 
   return json.loads(_uv_run(*cmd, cwd=input_dir).stdout)
 


### PR DESCRIPTION
Significantly lowers device memory usage for benchmarks with convex mesh collisions, for example `aloha_pot` goes from 3528 MB to 1913MB.  Introducing `nccdmax` had no change on `step` performance.