### PR TITLE
Add uv run to kernel analyzer in pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
     hooks:
       - id: kernel-analyzer
         name: kernel-analyzer
-        entry: python contrib/kernel_analyzer/kernel_analyzer/cli.py
+        entry: uv run python contrib/kernel_analyzer/kernel_analyzer/cli.py
         language: system
         types: [python]


### PR DESCRIPTION
Otherwise, kernel analyzer fails if user is not inside a venv.