### PR TITLE
testspeed benchmarking with multiple functions

### DIFF
--- a/benchmarks/cloth/__init__.py
+++ b/benchmarks/cloth/__init__.py
@@ -9,7 +9,7 @@ BENCHMARKS = [
   {
     "name": "cloth_render",
     "mjcf": "scene.xml",
-    "function": "render",
+    "function": ["refit_bvh", "render"],
     "nworld": 32,
     "nconmax": 2200,
     "njmax": 8000,

--- a/benchmarks/render/__init__.py
+++ b/benchmarks/render/__init__.py
@@ -9,7 +9,7 @@ BENCHMARKS = [
   {
     "name": "primitives",
     "mjcf": "primitives.xml",
-    "function": "render",
+    "function": ["refit_bvh", "render"],
     "nworld": 8192,
     "nconmax": 100,
     "njmax": 256,
@@ -18,7 +18,7 @@ BENCHMARKS = [
   {
     "name": "mug",
     "mjcf": "mug.xml",
-    "function": "render",
+    "function": ["refit_bvh", "render"],
     "nworld": 8192,
     "nstep": 100,
     "render_width": 64,

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -142,7 +142,12 @@ def _run_benchmark(bm: dict, input_dir: Path) -> dict:
     if field == "replay":
       cmd.append(f"--replay={(benchmark_root / bm['replay'])}")
     elif field not in ("name", "assets", "mjcf", "_dir"):
-      cmd.append(f"--{field}={bm[field]}")
+      val = bm[field]
+      if isinstance(val, list):
+        for v in val:
+          cmd.append(f"--{field}={v}")
+      else:
+        cmd.append(f"--{field}={val}")
 
   result = _uv_run(*cmd, cwd=input_dir)
 

--- a/benchmarks/sweep.py
+++ b/benchmarks/sweep.py
@@ -166,7 +166,12 @@ def _run_benchmark(bm: dict, input_dir: Path, *, mock: bool) -> dict:
     elif field == "nstep":
       cmd.append(f"--nstep={10 if mock else bm['nstep']}")
     elif field not in ("name", "assets", "mjcf", "_dir"):
-      cmd.append(f"--{field}={bm[field]}")
+      val = bm[field]
+      if isinstance(val, list):
+        for v in val:
+          cmd.append(f"--{field}={v}")
+      else:
+        cmd.append(f"--{field}={val}")
 
   return json.loads(_uv_run(*cmd, cwd=input_dir).stdout)
 

--- a/benchmarks/unitree_g1/__init__.py
+++ b/benchmarks/unitree_g1/__init__.py
@@ -27,7 +27,7 @@ BENCHMARKS = [
   {
     "name": "unitree_g1_hfield_render",
     "mjcf": "scene_hfield.xml",
-    "function": "render",
+    "function": ["refit_bvh", "render"],
     "nworld": 8192,
     "nconmax": 48,
     "njmax": 192,

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -26,7 +26,7 @@ import inspect
 import json
 import shutil
 import sys
-from typing import Sequence
+from typing import Sequence, get_type_hints
 
 import numpy as np
 import warp as wp
@@ -48,7 +48,7 @@ _FUNCS = {
   if inspect.signature(f).parameters.keys() == {"m", "d"} or inspect.signature(f).parameters.keys() == {"m", "d", "rc"}
 }
 
-_FUNCTION = flags.DEFINE_enum("function", "step", _FUNCS.keys(), "the function to benchmark")
+_FUNCTIONS = flags.DEFINE_multi_enum("function", ["step"], list(_FUNCS.keys()), "the function(s) to benchmark")
 _CLEAR_WARP_CACHE = flags.DEFINE_bool("clear_warp_cache", False, "clear warp caches (kernel, LTO, CUDA compute)")
 _MEASURE_ALLOC = flags.DEFINE_bool("measure_alloc", False, "print a report of contacts and constraints per step")
 _MEASURE_SOLVER = flags.DEFINE_bool("measure_solver", False, "print a report of solver iterations per step")
@@ -144,8 +144,10 @@ def _main(argv: Sequence[str]):
   elif len(argv) > 2:
     raise app.UsageError("Too many command-line arguments.")
 
-  if _FUNCTION.value not in _FUNCS:
-    raise ValueError(f"Unknown function: {_FUNCTION.value}")
+  fn_names = _FUNCTIONS.value
+  for fn_name in fn_names:
+    if fn_name not in _FUNCS:
+      raise ValueError(f"Unknown function: {fn_name}")
 
   wp.config.quiet = flags.FLAGS["verbosity"].value < 1
   wp.init()
@@ -168,7 +170,26 @@ def _main(argv: Sequence[str]):
 
   mjm = cli.load_model(path)
   free_mem_at_init = wp.get_device(device).free_memory
-  m, d, rc, ctrls = cli.init_structs(_FUNCS[_FUNCTION.value], mjm)
+  if len(fn_names) == 1:
+    composite_fn = _FUNCS[fn_names[0]]
+  else:
+    # Pre-resolve functions and whether they need rc
+    funcs_to_run = [(_FUNCS[name], mjw.RenderContext in get_type_hints(_FUNCS[name]).values()) for name in fn_names]
+    needs_rc = any(takes_rc for _, takes_rc in funcs_to_run)
+
+    if needs_rc:
+
+      def composite_fn(m: mjw.Model, d: mjw.Data, rc: mjw.RenderContext):
+        for fn, takes_rc in funcs_to_run:
+          fn(m, d, rc) if takes_rc else fn(m, d)
+
+    else:
+
+      def composite_fn(m: mjw.Model, d: mjw.Data):
+        for fn, _ in funcs_to_run:
+          fn(m, d)
+
+  m, d, rc, ctrls = cli.init_structs(composite_fn, mjm)
   m.opt.warn_overflow = _OVERFLOW_BEHAVIOR.value == "continue"
   timestep = m.opt.timestep.numpy()[0]
 
@@ -247,9 +268,8 @@ def _main(argv: Sequence[str]):
       )
 
     print(f"Data\n  nworld: {d.nworld} naconmax: {d.naconmax} njmax: {d.njmax}")
-    print(
-      f"Rolling out {cli.NSTEP.value} {_FUNCTION.value}s at dt = {f'{timestep:g}' if timestep < 0.001 else f'{timestep:.3f}'}..."
-    )
+    funcs_str = "+".join(fn_names)
+    print(f"Rolling out {cli.NSTEP.value} {funcs_str} at dt = {f'{timestep:g}' if timestep < 0.001 else f'{timestep:.3f}'}...")
 
   nacon, nefc, solver_niter = [], [], []
   runtime = 0.0
@@ -277,24 +297,20 @@ def _main(argv: Sequence[str]):
           print(f"  ... and {n_worlds - 10} more worlds (reporting truncated to first 10)")
         sys.exit(1)
 
-  if _FUNCTION.value == "render":
+  if "step" not in fn_names:
     with wp.ScopedCapture() as step_capture:
       mjw.step(m, d)
 
-    def render_callback(step, step_trace, latency):
+    def step_callback(step, step_trace, latency):
       callback(step, step_trace, latency)
       wp.capture_launch(step_capture.graph)
       wp.synchronize()
 
-    # TODO(team): Support specifying multiple functions to benchmark them together,
-    # e.g., `mjwarp-testspeed --function=refit_bvh --function=render`
-    def refit_and_render(m, d, rc):
-      mjw.refit_bvh(m, d, rc)
-      mjw.render(m, d, rc)
-
-    jit_duration = cli.unroll(refit_and_render, m, d, rc, render_callback, ctrls)
+    active_callback = step_callback
   else:
-    jit_duration = cli.unroll(_FUNCS[_FUNCTION.value], m, d, rc, callback, ctrls)
+    active_callback = callback
+
+  jit_duration = cli.unroll(composite_fn, m, d, rc, active_callback, ctrls)
 
   nconverged = np.sum(~np.any(np.isnan(d.qpos.numpy()), axis=1))
   steps = cli.NWORLD.value * cli.NSTEP.value
@@ -303,14 +319,15 @@ def _main(argv: Sequence[str]):
   total_mem = free_mem_at_init - wp.get_device(device).free_memory
 
   if _FORMAT.value == "human":
+    funcs_str = "+".join(fn_names)
     print(f"""
 Summary for {d.nworld} parallel rollouts
 
 Total JIT time: {jit_duration:.2f} s
 Total simulation time: {runtime:.2f} s
-Total steps per second: {steps / runtime:,.0f}
+Total {funcs_str} per second: {steps / runtime:,.0f}
 Total realtime factor: {steps * timestep / runtime:,.2f} x
-Total time per step: {1e9 * runtime / steps:.2f} ns
+Total time per {funcs_str}: {1e9 * runtime / steps:.2f} ns
 Total converged worlds: {nconverged} / {d.nworld}""")
 
     if trace:


### PR DESCRIPTION
provide multiple `--function` flags to benchmark a set of functions.

when `step` is not provided as one of the function flags the callback will step the simulation but this will not be included in the timing results

```
mjwarp-testspeed benchmarks/humanoid/humanoid.xml \
--nworld=8192 --nconmax=24 --njmax=64 \
--function=refit_bvh \
--function=render
```

```
Loading model from: benchmarks/humanoid/humanoid.xml...

Model
  nq: 28 nv: 27 nu: 21 nbody: 17 ngeom: 20
RenderContext
  shadows: False textures: True nlight: 2 bvh_ngeom: 20
  ncam: 3 cam_res: [(64, 64), (64, 64), (64, 64)]
Option
  integrator: EULER
  cone: PYRAMIDAL
  solver: NEWTON iterations: 100 ls_iterations: 50
  is_sparse: False
  ls_parallel: False
  broadphase: NXN broadphase_filter: PLANE|SPHERE|OBB
Data
  nworld: 8192 naconmax: 196608 njmax: 64
Rolling out 1000 refit_bvh+render at dt = 0.005...

Summary for 8192 parallel rollouts

Total JIT time: 0.02 s
Total simulation time: 34.47 s
Total refit_bvh+render per second: 237,670
Total realtime factor: 1,188.35 x
Total time per refit_bvh+render: 4207.51 ns
Total converged worlds: 8192 / 8192
```