### PR TITLE
Fix per-step CollisionContext allocation causing OOM in long runs

### DIFF
--- a/mujoco_warp/_src/broadphase_test.py
+++ b/mujoco_warp/_src/broadphase_test.py
@@ -30,7 +30,7 @@ from mujoco_warp._src import collision_driver
 
 def broadphase_caller(m, d):
   """Run broadphase and return the CollisionContext with results."""
-  ctx = collision_driver.create_collision_context(d.naconmax)
+  ctx = d.collision_ctx
   d.ncollision.zero_()
   if m.opt.broadphase == BroadphaseType.NXN:
     collision_driver.nxn_broadphase(m, d, ctx)

--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -17,7 +17,6 @@ from typing import Tuple
 
 import warp as wp
 
-from mujoco_warp._src.collision_core import CollisionContext
 from mujoco_warp._src.collision_core import Geom
 from mujoco_warp._src.collision_core import contact_params
 from mujoco_warp._src.collision_core import geom_collision_pair
@@ -36,6 +35,7 @@ from mujoco_warp._src.types import MJ_MAX_EPAHORIZON
 from mujoco_warp._src.types import MJ_MAXCONPAIR
 from mujoco_warp._src.types import MJ_MAXVAL
 from mujoco_warp._src.types import NEW_GAP_SEMANTICS
+from mujoco_warp._src.types import CollisionContext
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import DisableBit
 from mujoco_warp._src.types import GeomType

--- a/mujoco_warp/_src/collision_core.py
+++ b/mujoco_warp/_src/collision_core.py
@@ -15,7 +15,6 @@
 
 """Core collision types and utilities shared across collision modules."""
 
-import dataclasses
 from typing import Tuple
 
 import warp as wp
@@ -344,27 +343,3 @@ def contact_params(
   )
 
   return geoms, margin, gap, condim, friction, solref, solreffriction, solimp
-
-
-@dataclasses.dataclass
-class CollisionContext:
-  """Collision driver intermediate arrays.
-
-  Attributes:
-    collision_pair: collision pairs from broadphase             (naconmax, 2)
-    collision_pairid: ids from broadphase                       (naconmax, 2)
-    collision_worldid: collision world ids from broadphase      (naconmax,)
-  """
-
-  collision_pair: wp.array
-  collision_pairid: wp.array
-  collision_worldid: wp.array
-
-
-def create_collision_context(naconmax: int) -> CollisionContext:
-  """Create a CollisionContext with allocated arrays."""
-  return CollisionContext(
-    collision_pair=wp.empty(naconmax, dtype=wp.vec2i),
-    collision_pairid=wp.empty(naconmax, dtype=wp.vec2i),
-    collision_worldid=wp.empty(naconmax, dtype=int),
-  )

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -18,8 +18,6 @@ from typing import Any
 import warp as wp
 
 from mujoco_warp._src.collision_convex import convex_narrowphase
-from mujoco_warp._src.collision_core import CollisionContext
-from mujoco_warp._src.collision_core import create_collision_context
 from mujoco_warp._src.collision_flex import flex_narrowphase
 from mujoco_warp._src.collision_primitive import primitive_narrowphase
 from mujoco_warp._src.collision_sdf import sdf_narrowphase
@@ -27,6 +25,7 @@ from mujoco_warp._src.math import upper_tri_index
 from mujoco_warp._src.types import MJ_MAXVAL
 from mujoco_warp._src.types import BroadphaseFilter
 from mujoco_warp._src.types import BroadphaseType
+from mujoco_warp._src.types import CollisionContext
 from mujoco_warp._src.types import CollisionType
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import DisableBit
@@ -789,7 +788,7 @@ def collision(m: Model, d: Data):
     d.nacon.zero_()
     return
 
-  ctx = create_collision_context(d.naconmax)
+  ctx = d.collision_ctx
 
   # zero counters
   wp.launch(_zero_nacon_ncollision, dim=1, outputs=[d.nacon, d.ncollision])

--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -895,6 +895,39 @@ class CollisionTest(parameterized.TestCase):
 
     self.assertEqual(d.nacon.numpy()[0], mjd.ncon)
 
+  def test_collision_ctx_persistent(self):
+    """Tests that collision() reuses the persistent d.collision_ctx buffers across calls."""
+    _, _, m, d = test_data.fixture("humanoid/humanoid.xml", keyframe=0)
+
+    ctx0 = d.collision_ctx
+    self.assertIsInstance(ctx0, types.CollisionContext)
+    ptrs0 = (ctx0.collision_pair.ptr, ctx0.collision_pairid.ptr, ctx0.collision_worldid.ptr)
+
+    sentinel = -123456
+    nacon0 = None
+    for _ in range(5):
+      # Sentinel the persistent buffer: collision() must overwrite it, which proves it
+      # writes broadphase output into d.collision_ctx rather than a per-call allocation.
+      d.collision_ctx.collision_worldid.fill_(sentinel)
+
+      mjw.collision(m, d)
+      ctx = d.collision_ctx
+
+      # same context object backed by the same device buffers (no per-step reallocation)
+      self.assertIs(ctx, ctx0)
+      self.assertEqual((ctx.collision_pair.ptr, ctx.collision_pairid.ptr, ctx.collision_worldid.ptr), ptrs0)
+
+      # broadphase wrote its results into the persistent buffer (not a private one)
+      ncol = int(d.ncollision.numpy()[0])
+      self.assertGreater(ncol, 0)
+      self.assertFalse((ctx.collision_worldid.numpy()[:ncol] == sentinel).any())
+
+      # buffer reuse does not change collision results
+      nacon = int(d.nacon.numpy()[0])
+      if nacon0 is None:
+        nacon0 = nacon
+      self.assertEqual(nacon, nacon0)
+
   def test_hfield_maxconpair(self):
     _XML = """
     <mujoco>

--- a/mujoco_warp/_src/collision_primitive.py
+++ b/mujoco_warp/_src/collision_primitive.py
@@ -17,7 +17,6 @@ from typing import Tuple
 
 import warp as wp
 
-from mujoco_warp._src.collision_core import CollisionContext
 from mujoco_warp._src.collision_core import Geom
 from mujoco_warp._src.collision_core import contact_params
 from mujoco_warp._src.collision_core import geom_collision_pair
@@ -37,6 +36,7 @@ from mujoco_warp._src.collision_primitive_core import sphere_sphere
 from mujoco_warp._src.math import make_frame
 from mujoco_warp._src.math import upper_trid_index
 from mujoco_warp._src.types import MJ_MAXVAL
+from mujoco_warp._src.types import CollisionContext
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import GeomType
 from mujoco_warp._src.types import Model

--- a/mujoco_warp/_src/collision_sdf.py
+++ b/mujoco_warp/_src/collision_sdf.py
@@ -17,13 +17,13 @@ from typing import Tuple
 
 import warp as wp
 
-from mujoco_warp._src.collision_core import CollisionContext
 from mujoco_warp._src.collision_core import contact_params
 from mujoco_warp._src.collision_core import geom_collision_pair
 from mujoco_warp._src.collision_core import write_contact
 from mujoco_warp._src.math import make_frame
 from mujoco_warp._src.ray import ray_mesh
 from mujoco_warp._src.types import MJ_MINVAL
+from mujoco_warp._src.types import CollisionContext
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import GeomType
 from mujoco_warp._src.types import Model

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1134,6 +1134,9 @@ def make_data(
     "njmax": njmax,
     "njmax_pad": sizes["njmax_pad"],
     "njmax_nnz": njmax_nnz,
+    "collision_ctx": types.CollisionContext(
+      **{f.name: _create_array(None, f.type, sizes) for f in dataclasses.fields(types.CollisionContext)}
+    ),
     "M": None,
     "qLD": None,
     # world body
@@ -1370,6 +1373,9 @@ def put_data(
     "njmax": njmax,
     "njmax_pad": sizes["njmax_pad"],
     "njmax_nnz": njmax_nnz,
+    "collision_ctx": types.CollisionContext(
+      **{f.name: _create_array(None, f.type, sizes) for f in dataclasses.fields(types.CollisionContext)}
+    ),
     # fields set after initialization:
     "solver_niter": None,
     "M": None,

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -25,7 +25,6 @@ import mujoco_warp as mjw
 from mujoco_warp import DisableBit
 from mujoco_warp import GeomType
 from mujoco_warp import test_data
-from mujoco_warp._src.collision_core import create_collision_context
 from mujoco_warp._src.collision_driver import MJ_COLLISION_TABLE
 from mujoco_warp._src.types import CollisionType
 
@@ -105,7 +104,7 @@ class SensorTest(parameterized.TestCase):
       """
       )
 
-      ctx = create_collision_context(d.naconmax)
+      ctx = d.collision_ctx
       primitive_pairs = [key for key, value in MJ_COLLISION_TABLE.items() if value == CollisionType.PRIMITIVE]
       mjw.primitive_narrowphase(m, d, ctx, primitive_pairs)
 

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1837,6 +1837,21 @@ class Constraint:
 
 
 @dataclasses.dataclass
+class CollisionContext:
+  """Collision driver intermediate arrays.
+
+  Attributes:
+    collision_pair: collision pairs from broadphase             (naconmax, 2)
+    collision_pairid: ids from broadphase                       (naconmax, 2)
+    collision_worldid: collision world ids from broadphase      (naconmax,)
+  """
+
+  collision_pair: array("naconmax", wp.vec2i)
+  collision_pairid: array("naconmax", wp.vec2i)
+  collision_worldid: array("naconmax", int)
+
+
+@dataclasses.dataclass
 class Data:
   """Dynamic state that updates each step.
 
@@ -1957,6 +1972,7 @@ class Data:
     njmax_nnz: number of non-zeros in constraint Jacobian
     nacon: number of detected contacts (across all worlds)      (1,)
     ncollision: collision count from broadphase                 (1,)
+    collision_ctx: collision driver scratch buffers
   """
 
   solver_niter: array("nworld", int)
@@ -2071,6 +2087,8 @@ class Data:
   njmax_nnz: int
   nacon: array(1, int)
   ncollision: array(1, int)
+
+  collision_ctx: CollisionContext
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
`collision()` runs once per physics step and appears to allocate three broadphase scratch arrays (`collision_pair`, `collision_pairid`, `collision_worldid`, each sized `naconmax`) with `wp.empty()` every call via the `create_collision_context()`.

Over longer training runs this alloc/free churn seems to fragment Warp's memory pool to the point where a small allocation fails despite ample free memory (e.g. ~190KB failing on a 24GB GPU after 100M+ steps). Inspecting the history shows this behavior introduced by #1067.

This PR aims to fix this behavior by allocating `CollisionContext` once in `make_data`/`put_data`, storing it as `d.collision_ctx`, and reusing it each step; `ncollision` is reset and the broadphase output rewritten every step. Also moving `CollisionContext` to `types.py` and where it becomes built via the standard `_create_array` machinery like `Contact`.

Lastly, adds new test `test_collision_ctx_persistent`, which fails on the old per-step-allocation behavior and passes with this change.