### PR TITLE
Use scalar tile GEMM instead of cuBLASDx in the constraint solver

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -29,7 +29,6 @@ from mujoco_warp._src.types import IslandSolverContext
 from mujoco_warp._src.types import SolverContext
 from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
-from mujoco_warp._src.warp_util import scoped_mathdx_gemm_disabled
 
 wp.set_module_options({"enable_backward": False})
 
@@ -2307,7 +2306,7 @@ def update_gradient_JTDAJ_dense_tiled(nv_pad: int, tile_size: int, njmax: int):
 
   TILE_SIZE_K = tile_size
 
-  @wp.kernel(module="unique", enable_backward=False)
+  @wp.kernel(module="unique", enable_backward=False, module_options={"enable_mathdx_gemm": False})
   def kernel(
     # Data in:
     nefc_in: wp.array[int],
@@ -2692,7 +2691,7 @@ def update_gradient_cholesky(tile_size: int):
 
 @cache_kernel
 def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
-  @wp.kernel(module="unique", enable_backward=False)
+  @wp.kernel(module="unique", enable_backward=False, module_options={"enable_mathdx_gemm": False})
   def kernel(
     # In:
     ctx_done_in: wp.array[bool],
@@ -2724,7 +2723,7 @@ def update_gradient_cholesky_blocked(tile_size: int, matrix_size: int):
 def update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size: int):
   """Blocked Cholesky that skips factorization when no constraints changed."""
 
-  @wp.kernel(module="unique", enable_backward=False)
+  @wp.kernel(module="unique", enable_backward=False, module_options={"enable_mathdx_gemm": False})
   def kernel(
     # In:
     ctx_done_in: wp.array[bool],
@@ -2888,21 +2887,20 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
         outputs=[ctx.h],
       )
     else:
-      with scoped_mathdx_gemm_disabled():
-        wp.launch_tiled(
-          update_gradient_JTDAJ_dense_tiled(m.nv_pad, types.TILE_SIZE_JTDAJ_DENSE, d.njmax),
-          dim=d.nworld,
-          inputs=[
-            d.nefc,
-            d.M,
-            d.efc.J,
-            d.efc.D,
-            d.efc.state,
-            ctx.done,
-          ],
-          outputs=[ctx.h],
-          block_dim=m.block_dim.update_gradient_JTDAJ_dense,
-        )
+      wp.launch_tiled(
+        update_gradient_JTDAJ_dense_tiled(m.nv_pad, types.TILE_SIZE_JTDAJ_DENSE, d.njmax),
+        dim=d.nworld,
+        inputs=[
+          d.nefc,
+          d.M,
+          d.efc.J,
+          d.efc.D,
+          d.efc.state,
+          ctx.done,
+        ],
+        outputs=[ctx.h],
+        block_dim=m.block_dim.update_gradient_JTDAJ_dense,
+      )
 
     if m.opt.cone == types.ConeType.ELLIPTIC:
       # Optimization: launching update_gradient_JTCJ with limited number of blocks on a GPU.

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -89,7 +89,7 @@ class BlockDim:
   update_gradient_cholesky: int = 64
   update_gradient_cholesky_blocked: int = 32
   update_gradient_JTDAJ_sparse: int = 64
-  update_gradient_JTDAJ_dense: int = 96
+  update_gradient_JTDAJ_dense: int = 128
   linesearch_iterative: int = 32
   contact_jac_tiled: int = 32
   # derivative

--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -154,28 +154,3 @@ def check_toolkit_driver():
         """,
         stacklevel=2,
       )
-
-
-class scoped_mathdx_gemm_disabled:
-  """Temporarily disable Warp MathDx GEMM kernels within this scope."""
-
-  def __init__(self, disable: bool = True):
-    self._disable = disable
-    self._config = None
-    self._prev = None
-
-  def __enter__(self):
-    if not self._disable:
-      return self
-    config = getattr(wp, "config", None)
-    if config is None or not hasattr(config, "enable_mathdx_gemm"):
-      return self
-    self._config = config
-    self._prev = config.enable_mathdx_gemm
-    self._config.enable_mathdx_gemm = False
-    return self
-
-  def __exit__(self, exc_type, exc, tb):
-    if self._config is not None:
-      self._config.enable_mathdx_gemm = self._prev
-    return False


### PR DESCRIPTION
## Summary

The blocked-Cholesky solver kernels (`update_gradient_cholesky_blocked` and `update_gradient_cholesky_blocked_skip_unchanged`) run their `tile_matmul` through cuBLASDx (MathDx). This disables MathDx for them via the per-kernel `module_options={"enable_mathdx_gemm": False}` decorator option, routing them to Warp's built-in scalar register-blocked GEMM. The scalar path is both faster for these small, transpose-heavy tile shapes and dramatically cheaper to JIT-compile, since it avoids cuBLASDx's LTO step.

It also tidies the dense JTDAJ path. That launch was already forced onto the scalar GEMM through a `scoped_mathdx_gemm_disabled()` context manager that toggled the global `wp.config.enable_mathdx_gemm` around the launch. This replaces that fragile global-state toggle with the same per-kernel decorator (no backend change) and retunes its block dim from 96 to 128, the scalar-GEMM optimum.

## Motivation

The solver uses the upper-triangular convention (A = UᵀU), so its GEMMs are left-transpose products (AᵀB). For the 16×16 tiles used here, Warp's scalar GEMM keeps the accumulator in registers and handles this shape more efficiently than the cuBLASDx kernel, which also forces an expensive LTO compile on every cold start. Disabling MathDx for the Cholesky kernels recovers both.

The per-kernel decorator is declarative, applied at kernel-build time, and does not mutate global state, so it also lets us delete the `scoped_mathdx_gemm_disabled` helper entirely.

## Changes

- Add `module_options={"enable_mathdx_gemm": False}` to the three solver kernels that use `tile_matmul`: `update_gradient_cholesky_blocked`, `update_gradient_cholesky_blocked_skip_unchanged`, and `update_gradient_JTDAJ_dense_tiled`. The two blocked-Cholesky kernels move from cuBLASDx to scalar; `JTDAJ_dense` was already scalar (via the scoped wrap) and stays scalar, now selected by the decorator.
- Remove the `scoped_mathdx_gemm_disabled` context manager and its remaining call site, now redundant.
- Bump `BlockDim.update_gradient_JTDAJ_dense` from 96 to 128, the optimal block dim for the scalar GEMM (the occupancy trade-off shifts once cuBLASDx's shared-memory pressure is gone).

## Results

Measured on an RTX PRO 6000 (Blackwell, sm_120) with Warp 1.13, via `benchmarks/run.py` for end-to-end and cold-start JIT, and Nsight Systems node-level tracing for per-kernel GPU time.

End-to-end throughput and JIT compile time:

| Model | steps/sec | JIT compile |
| --- | --- | --- |
| three_humanoids (nv=81) | +2.8% | 66s → 32s (−52%) |
| unitree_g1_flat (nv=35) | +3.3% | 67s → 33s (−51%) |
| aloha_clutter (nv=136) | +3.8% | 109s → 75s (−31%) |
| humanoid (nv=27, dense) | neutral (+0.6%) | 41s → 41s |

Per-kernel GPU time (Nsight, full-factorize instances, low variance):

| Kernel | before | after | Δ | change |
| --- | --- | --- | --- | --- |
| `update_gradient_cholesky_blocked` | 379.7 µs (cuBLASDx) | 342 µs (scalar) | −10% | GEMM backend |
| `update_gradient_JTDAJ_dense_tiled` | 36.4 µs (scalar, bd 96) | 32.7 µs (scalar, bd 128) | −10% | block dim |

The Cholesky backend swap is the real win: it drives the end-to-end and JIT improvements on the blocked-Cholesky models (nv > 32), and eliminating cuBLASDx's LTO compile is what halves the JIT time there. The dense JTDAJ kernel was already on the scalar path, so its 10% gain is purely the block-dim retune and shows up only on dense models such as humanoid (which never enters the blocked Cholesky kernel); its end-to-end delta is within run-to-run noise.

## Testing

Existing solver regression tests pass. This is a GEMM-backend selection change with no algorithmic change, so numerical results are unaffected.
