### PR TITLE
Fix transpose in sparse Newton Hessian assembly

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2302,12 +2302,16 @@ def _update_gradient_init_h_sparse(
   if ctx_done_in[worldid]:
     return
 
-  # NOTE: we could early-return on j > i, but that would be a hazard for future development.
+  # only write the upper triangle; Cholesky reads the upper triangle only
+  if j < i:
+    return
+
   if i >= nv or j >= nv:
     ctx_h_out[worldid, i, j] = 0.0
     return
 
-  elemid = M_elemid[i, j]
+  # M is stored in the lower triangle, so transpose the lookup for the upper
+  elemid = M_elemid[j, i]
   if elemid >= 0:
     ctx_h_out[worldid, i, j] = M_in[worldid, 0, elemid]
   else:


### PR DESCRIPTION
`_update_gradient_init_h_sparse` (added in #1356) writes the mass matrix into `h` via `M_elemid[i, j]`. `M_elemid[row, col]` is only populated where the column is an ancestor of the row, i.e. the lower triangle. The constraint term from `_JTDAJ_sparse` and the Cholesky factorization both operate on the upper triangle, so the upper-triangle Hessian was assembled without the mass matrix — an incorrect Newton Hessian on the sparse path.

This transposes the lookup to `M_elemid[j, i]` so `M` lands in the upper triangle, and skips writing the lower triangle since it is never read.

The solver still converges with the wrong Hessian (Newton degrades toward gradient descent), so existing tests pass and the only visible symptom is a large performance regression on the sparse Newton path (e.g. `three_humanoids`). With the fix, performance returns to the level intended by #1356.