### PR TITLE
Fix render test failures on machines with GPU display.

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2869,7 +2869,7 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
     "opt.graph_conditional",
     "opt.contact_sensor_maxmatch",
   }
-  mj_only_fields = {"opt.jacobian"}
+  mj_only_fields = {"opt.jacobian", "vis.quality.offsamples"}
 
   if not isinstance(overrides, dict):
     overrides_dict = {}

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -240,7 +240,7 @@ class RenderTest(parameterized.TestCase):
   @absltest.skipIf(not _HAS_RENDERER, "MuJoCo rendering requires OpenGL")
   def test_segmentation_matches_mujoco(self):
     """Segmentation should match native MuJoCo's `(object_id, object_type)` output."""
-    mjm, mjd, m, d = test_data.fixture("primitives.xml", nworld=1)
+    mjm, mjd, m, d = test_data.fixture("primitives.xml", nworld=1, overrides={"vis.quality.offsamples": 0})
     cam_w, cam_h = 32, 32
 
     rc = mjw.create_render_context(
@@ -263,7 +263,7 @@ class RenderTest(parameterized.TestCase):
   @absltest.skipIf(not _HAS_RENDERER, "MuJoCo rendering requires OpenGL")
   def test_depth_matches_mujoco(self):
     """Depth values should match native MuJoCo (planar depth, not Euclidean)."""
-    mjm, mjd, m, d = test_data.fixture("primitives.xml", nworld=1)
+    mjm, mjd, m, d = test_data.fixture("primitives.xml", nworld=1, overrides={"vis.quality.offsamples": 0})
     cam_w, cam_h = 32, 32
 
     # mjwarp depth
@@ -369,7 +369,7 @@ class RenderTest(parameterized.TestCase):
   def test_backface_cull_matches_mujoco(self, asset: str, enclosure: str):
     """Backface-cull behavior must match native MuJoCo for every geom type."""
     xml = self._BACKFACE_CULL_SCENE.format(asset=asset, enclosure=enclosure)
-    mjm, mjd, m, d = test_data.fixture(xml=xml, nworld=1)
+    mjm, mjd, m, d = test_data.fixture(xml=xml, nworld=1, overrides={"vis.quality.offsamples": 0})
 
     cam_w, cam_h = 16, 16
     rc = mjw.create_render_context(


### PR DESCRIPTION
When an active GPU display server or context (like EGL/Wayland) is available, MuJoCo's native classic Renderer utilizes hardware acceleration and defaults to 4x multisampling (offsamples = 4).   Explicitly disable this for render comparison tests.