### PR TITLE
Fix JTCJ_island missing off-diagonal cone terms

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -4950,14 +4950,23 @@ def _update_gradient_JTCJ_island(
             if i != jj:
               wp.atomic_add(ih_out[worldid, idofadr + jj], idofadr + i, val)
 
-            if dim1id != dim2id:
+        if dim1id != dim2id:
+          # Swap-pair contribution: hcone * J[ic2, i] * J[ic1, j].
+          # Together with the loop above this gives the full
+          # hcone * (J[ic1, i] * J[ic2, j] + J[ic2, i] * J[ic1, j])
+          # contribution to cell (i, j).
+          for i in range(inv):
+            J2i = iefc_J_in[worldid, ic2, idofadr + i]
+            if J2i == 0.0:
+              continue
+            for jj in range(i + 1):
               J1j = iefc_J_in[worldid, ic1, idofadr + jj]
-              J2i = iefc_J_in[worldid, ic2, idofadr + i]
-              if J1j != 0.0 and J2i != 0.0:
-                val2 = hcone * J1j * J2i
-                wp.atomic_add(ih_out[worldid, idofadr + i], idofadr + jj, val2)
-                if i != jj:
-                  wp.atomic_add(ih_out[worldid, idofadr + jj], idofadr + i, val2)
+              if J1j == 0.0:
+                continue
+              val = hcone * J2i * J1j
+              wp.atomic_add(ih_out[worldid, idofadr + i], idofadr + jj, val)
+              if i != jj:
+                wp.atomic_add(ih_out[worldid, idofadr + jj], idofadr + i, val)
 
 
 @wp.kernel


### PR DESCRIPTION
## Summary
- The dense-Jacobian branch of `_update_gradient_JTCJ_island` drops the swap-pair cone term `hcone * J[ic2, i] * J[ic1, j]` for the `dim1id != dim2id` case whenever any of the four J entries used in the inner block is zero. Per-cell H is then short the `J[ic2, a] * J[ic1, b]` half of the off-diagonal cone contribution.
- Replace the conditional swap-pair block with a separate full loop for the second rank-1 term, gated on `dim1id != dim2id`. Both loops keep the original aggressive `J==0` early-skip.
- Matches the value computed by monolithic `_update_gradient_JTCJ_dense` (`solver.py:2700-2704`).

## Why no existing test catches this
The scalar `_cholesky_factorize_solve_island` clamps mid-factorization (`s <= 1e-6 -> s = 1e-6`), absorbing the small indefiniteness the bug leaves in per-island H. It becomes visible the moment the per-island solve uses any Cholesky variant without diagonal clamping (e.g. `wp.tile_cholesky` on the per-island H sub-block), where it surfaces as NaN qacc — reproducible with `constraints.xml` keyframe 2 + elliptic cone + Newton + dense Jacobian.

## Performance (RTX PRO 6000, 3-run averages)
- `three_humanoids` @ nworld=8192, islands ON: 394k → 392k sps (noise; no elliptic islands)
- `aloha_clutter` @ nworld=512, islands ON: 20.6k → 20.9k sps (+1.2%)

## Test plan
- [x] `solver_test.py` (196 passed)