### PR TITLE
update sleep implementation

### DIFF
--- a/mujoco_warp/_src/sleep.py
+++ b/mujoco_warp/_src/sleep.py
@@ -374,12 +374,13 @@ def _wake_collision_kernel(
   # Data in:
   tree_awake_in: wp.array2d[int],
   contact_geom_in: wp.array[wp.vec2i],
+  contact_worldid_in: wp.array[int],
   nacon_in: wp.array[int],
   # Out:
   tree_asleep_out: wp.array2d[int],  # kernel_analyzer: ignore
   skip_out: wp.array[int],  # kernel_analyzer: ignore
 ):
-  worldid, conid = wp.tid()
+  conid = wp.tid()
   if conid >= nacon_in[0]:
     return
 
@@ -398,6 +399,7 @@ def _wake_collision_kernel(
   if tree1 < 0 or tree2 < 0:
     return
 
+  worldid = contact_worldid_in[conid]
   awake1 = tree_awake_in[worldid, tree1]
   awake2 = tree_awake_in[worldid, tree2]
 
@@ -405,7 +407,6 @@ def _wake_collision_kernel(
     return
 
   if awake1 == 0 and awake2 == 0:
-    wp.printf("contact between sleeping bodies %d and %d\n", b1, b2)
     return
 
   # wake sleeping tree
@@ -768,13 +769,14 @@ def wake_collision(m: types.Model, d: types.Data, skip: Optional[wp.array] = Non
   skip_out = skip if skip is not None else wp.zeros(1, dtype=int)
   wp.launch(
     _wake_collision_kernel,
-    dim=(d.nworld, d.naconmax),
+    dim=d.naconmax,
     inputs=[
       m.ntree,
       m.body_treeid,
       m.geom_bodyid,
       d.tree_awake,
       d.contact.geom,
+      d.contact.worldid,
       d.nacon,
       d.tree_asleep,
     ],

--- a/mujoco_warp/_src/sleep_test.py
+++ b/mujoco_warp/_src/sleep_test.py
@@ -23,6 +23,7 @@ from absl.testing import parameterized
 
 import mujoco_warp as mjwarp
 from mujoco_warp import test_data
+from mujoco_warp._src import forward
 from mujoco_warp._src import io
 from mujoco_warp._src import sleep
 from mujoco_warp._src import types
@@ -814,6 +815,72 @@ class SleepTest(parameterized.TestCase):
     # Verify that World 0 remained awake and World 1 remained asleep
     self.assertEqual(d.tree_awake.numpy()[0, 0], 1, "World 0 should remain awake")
     self.assertEqual(d.tree_awake.numpy()[1, 0], 0, "World 1 should remain asleep")
+
+  def test_wake_collision_cross_world(self):
+    """Verify that collisions in one world do not wake up islands in another world."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option>
+          <flag sleep="enable" island="enable"/>
+        </option>
+        <worldbody>
+          <geom name="floor" type="plane" size="10 10 .1"/>
+          <body name="box1" pos="0 0 0.1">
+            <joint type="free"/>
+            <geom name="box1_geom" type="box" size=".1 .1 .1" mass="1.0"/>
+          </body>
+          <body name="box2" pos="1.5 0 0.1">
+            <joint type="free"/>
+            <geom name="box2_geom" type="box" size=".1 .1 .1" mass="1.0"/>
+          </body>
+        </worldbody>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+
+    # World 0: box1 is awake, box2 is asleep. They are far apart (no collision).
+    # World 1: box1 is awake, box2 is asleep. But they are close to each other (colliding!).
+    qpos = d.qpos.numpy()
+
+    # World 0 positions: box1 at (0, 0, 0.1), box2 at (1.5, 0, 0.1) -> no collision
+    qpos[0, 0:3] = [0.0, 0.0, 0.1]
+    qpos[0, 7:10] = [1.5, 0.0, 0.1]
+
+    # World 1 positions: box1 at (0, 0, 0.1), box2 at (0.15, 0, 0.1) -> colliding!
+    qpos[1, 0:3] = [0.0, 0.0, 0.1]
+    qpos[1, 7:10] = [0.15, 0.0, 0.1]
+
+    d.qpos = wp.array(qpos, dtype=float)
+
+    # Manually put box2 (tree 1) to sleep in both worlds.
+    # box1 (tree 0) is awake.
+    tree_asleep = d.tree_asleep.numpy()
+    tree_asleep[0, 0] = -1  # awake
+    tree_asleep[0, 1] = 1  # asleep (self-cycle 1)
+
+    tree_asleep[1, 0] = -1  # awake
+    tree_asleep[1, 1] = 1  # asleep (self-cycle 1)
+
+    d.tree_asleep = wp.array(tree_asleep, dtype=int)
+    sleep.update_sleep(m, d)
+
+    # Verify starting states:
+    self.assertEqual(d.tree_awake.numpy()[0, 0], 1, "World 0 box1 should start awake")
+    self.assertEqual(d.tree_awake.numpy()[0, 1], 0, "World 0 box2 should start asleep")
+    self.assertEqual(d.tree_awake.numpy()[1, 0], 1, "World 1 box1 should start awake")
+    self.assertEqual(d.tree_awake.numpy()[1, 1], 0, "World 1 box2 should start asleep")
+
+    # Step position-dependent phase (kinematics, collision, wake_collision, etc.)
+    forward.fwd_position(m, d)
+
+    # Verification:
+    # World 1: box1 (awake) and box2 (asleep) collide. So box2 MUST wake up!
+    self.assertEqual(d.tree_awake.numpy()[1, 1], 1, "World 1 box2 should wake up due to collision with box1")
+
+    # World 0: box1 (awake) and box2 (asleep) do NOT collide. So box2 MUST remain asleep!
+    self.assertEqual(d.tree_awake.numpy()[0, 1], 0, "World 0 box2 should remain asleep (no collision with box1)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
refactor `_wake_collision_kernel` to fix bug in sleep implementation that involved potential cross world contact leak and remove print. additionally adds a related test that would have failed before the fix.
