### PR TITLE
Add per-world material texture IDs

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -53,6 +53,7 @@ from mujoco_warp._src.history import read_ctrl as read_ctrl
 from mujoco_warp._src.history import read_sensor as read_sensor
 from mujoco_warp._src.inverse import inverse as inverse
 from mujoco_warp._src.io import create_render_context as create_render_context
+from mujoco_warp._src.io import expand_mat_texid as expand_mat_texid
 from mujoco_warp._src.io import get_data_into as get_data_into
 from mujoco_warp._src.io import make_data as make_data
 from mujoco_warp._src.io import put_data as put_data

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -819,14 +819,18 @@ def expand_mat_texid(m: types.Model, nworld: int) -> wp.array:
   if nworld < 1:
     raise ValueError(f"nworld must be positive, got {nworld}.")
 
-  expected_shape = (nworld, m.nmat, int(mujoco.mjtTextureRole.mjNTEXROLE))
   current_shape = tuple(m.mat_texid.shape)
+  if len(current_shape) != 3:
+    raise ValueError(f"m.mat_texid has shape {current_shape}; expected (1, {m.nmat}, nrole) or ({nworld}, {m.nmat}, nrole).")
+
+  expected_shape = (nworld, m.nmat, current_shape[-1])
   if current_shape == expected_shape:
     return m.mat_texid
 
   if current_shape[0] != 1:
     raise ValueError(
-      f"m.mat_texid already has {current_shape[0]} world tables; expected 1 or {nworld}. "
+      f"m.mat_texid already has {current_shape[0]} world tables; expected 1 "
+      f"or {nworld}. "
       "Assign into m.mat_texid to update existing per-world storage."
     )
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -798,6 +798,44 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   return m
 
 
+def expand_mat_texid(m: types.Model, nworld: int) -> wp.array:
+  """Expands material texture ids to allow per-world texture assignment.
+
+  `put_model` initializes `mat_texid` with one shared material texture table.
+  Call this once before CUDA graph capture when different worlds need different
+  material texture ids. Reset-time changes should then assign into
+  `m.mat_texid` directly.
+
+  Texture ids must refer to textures already present in the compiled
+  `mujoco.MjModel` used to create the render context.
+
+  Args:
+    m: The model containing kinematic and dynamic information (device).
+    nworld: The number of per-world material texture tables to allocate.
+
+  Returns:
+    The expanded `m.mat_texid` array.
+  """
+  if nworld < 1:
+    raise ValueError(f"nworld must be positive, got {nworld}.")
+
+  expected_shape = (nworld, m.nmat, int(mujoco.mjtTextureRole.mjNTEXROLE))
+  current_shape = tuple(m.mat_texid.shape)
+  if current_shape == expected_shape:
+    return m.mat_texid
+
+  if current_shape[0] != 1:
+    raise ValueError(
+      f"m.mat_texid already has {current_shape[0]} world tables; expected 1 or {nworld}. "
+      "Assign into m.mat_texid to update existing per-world storage."
+    )
+
+  old_mat_texid = m.mat_texid
+  mat_texid = np.repeat(old_mat_texid.numpy(), nworld, axis=0)
+  m.mat_texid = wp.array(mat_texid, dtype=old_mat_texid.dtype, device=old_mat_texid.device)
+  return m.mat_texid
+
+
 def _get_padded_sizes(nv: int, njmax: int, is_sparse: bool, tile_size: int):
   # if dense - we just pad to the next multiple of 4 for nv, to get the fast load path.
   #            we pad to the next multiple of tile_size for njmax to avoid out of bounds accesses.

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1846,6 +1846,38 @@ class IOTest(parameterized.TestCase):
     cl_read = m.actuator_cranklength.numpy()
     np.testing.assert_allclose(cl_read[0, 0], 0.42, atol=1e-6)
 
+  def test_expand_mat_texid(self):
+    """Test per-world material texture ids can be prepared and reset in-place."""
+    mjm, _, m, _ = test_data.fixture(
+      xml="""
+    <mujoco>
+      <asset>
+        <texture name="red" type="2d" builtin="flat" width="4" height="4" rgb1="1 0 0" rgb2="1 0 0"/>
+        <texture name="green" type="2d" builtin="flat" width="4" height="4" rgb1="0 1 0" rgb2="0 1 0"/>
+        <material name="mat" texture="red"/>
+      </asset>
+      <worldbody>
+        <geom type="sphere" size="0.1" material="mat"/>
+      </worldbody>
+    </mujoco>
+    """
+    )
+
+    red_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "red")
+    green_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "green")
+    mat_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_MATERIAL, "mat")
+    rgb_role = int(mujoco.mjtTextureRole.mjTEXROLE_RGB)
+
+    self.assertEqual(tuple(m.mat_texid.shape), (1, mjm.nmat, int(mujoco.mjtTextureRole.mjNTEXROLE)))
+    mat_texid = mjwarp.expand_mat_texid(m, nworld=3)
+    self.assertEqual(tuple(mat_texid.shape), (3, mjm.nmat, int(mujoco.mjtTextureRole.mjNTEXROLE)))
+    self.assertGreater(mat_texid.strides[0], 0)
+
+    mat_texid_np = mat_texid.numpy()
+    mat_texid_np[:, mat_id, rgb_role] = [red_id, green_id, red_id]
+    m.mat_texid.assign(mat_texid_np)
+    np.testing.assert_array_equal(m.mat_texid.numpy()[:, mat_id, rgb_role], [red_id, green_id, red_id])
+
   @parameterized.parameters(1, 4)
   def test_bvh_creation(self, nworld):
     """Test that the BVH is created correctly for single world and multiple worlds."""

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1868,15 +1868,44 @@ class IOTest(parameterized.TestCase):
     mat_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_MATERIAL, "mat")
     rgb_role = int(mujoco.mjtTextureRole.mjTEXROLE_RGB)
 
-    self.assertEqual(tuple(m.mat_texid.shape), (1, mjm.nmat, int(mujoco.mjtTextureRole.mjNTEXROLE)))
+    nrole = int(mujoco.mjtTextureRole.mjNTEXROLE)
+    self.assertEqual(tuple(m.mat_texid.shape), (1, mjm.nmat, nrole))
     mat_texid = mjwarp.expand_mat_texid(m, nworld=3)
-    self.assertEqual(tuple(mat_texid.shape), (3, mjm.nmat, int(mujoco.mjtTextureRole.mjNTEXROLE)))
+    self.assertEqual(tuple(mat_texid.shape), (3, mjm.nmat, nrole))
     self.assertGreater(mat_texid.strides[0], 0)
 
     mat_texid_np = mat_texid.numpy()
     mat_texid_np[:, mat_id, rgb_role] = [red_id, green_id, red_id]
     m.mat_texid.assign(mat_texid_np)
     np.testing.assert_array_equal(m.mat_texid.numpy()[:, mat_id, rgb_role], [red_id, green_id, red_id])
+
+  def test_expand_mat_texid_errors(self):
+    """Test invalid material texture id expansion requests are rejected."""
+    mjm, _, m, _ = test_data.fixture(
+      xml="""
+    <mujoco>
+      <asset>
+        <texture name="red" type="2d" builtin="flat" width="4" height="4"/>
+        <material name="mat" texture="red"/>
+      </asset>
+      <worldbody>
+        <geom type="sphere" size="0.1" material="mat"/>
+      </worldbody>
+    </mujoco>
+    """
+    )
+
+    with self.assertRaisesRegex(ValueError, "nworld must be positive"):
+      mjwarp.expand_mat_texid(m, nworld=0)
+
+    mat_texid = mjwarp.expand_mat_texid(m, nworld=3)
+    self.assertEqual(tuple(mat_texid.shape[:2]), (3, mjm.nmat))
+    with self.assertRaisesRegex(ValueError, "already has 3 world tables"):
+      mjwarp.expand_mat_texid(m, nworld=2)
+
+    m.mat_texid = wp.array(mat_texid.numpy()[0], dtype=mat_texid.dtype, device=mat_texid.device)
+    with self.assertRaisesRegex(ValueError, "expected \\(1,"):
+      mjwarp.expand_mat_texid(m, nworld=2)
 
   @parameterized.parameters(1, 4)
   def test_bvh_creation(self, nworld):

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -43,6 +43,29 @@ def _unpack_rgb(packed):
   return np.stack([r, g, b], axis=-1)
 
 
+_TEXTURE_SWAP_XML = """
+<mujoco>
+  <asset>
+    <texture name="red" type="2d" builtin="flat" width="4" height="4" rgb1="1 0 0" rgb2="1 0 0"/>
+    <texture name="green" type="2d" builtin="flat" width="4" height="4" rgb1="0 1 0" rgb2="0 1 0"/>
+    <material name="mat" texture="red" rgba="1 1 1 1" texrepeat="1 1"/>
+  </asset>
+  <worldbody>
+    <camera name="cam" pos="0 0 2" xyaxes="1 0 0 0 1 0"/>
+    <geom name="plane" type="plane" size="2 2 0.1" material="mat"/>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _assert_channel_dominates(testcase, rgb, worldid, channel, other_channel):
+  testcase.assertGreater(
+    float(rgb[worldid, channel]),
+    float(rgb[worldid, other_channel]) + 50.0,
+    f"world {worldid} channel {channel} should dominate",
+  )
+
+
 class RenderTest(parameterized.TestCase):
   @parameterized.parameters(2, 512)
   def test_render(self, nworld: int):
@@ -139,6 +162,45 @@ class RenderTest(parameterized.TestCase):
 
     self.assertGreater(np.count_nonzero(rgb), 0)
     self.assertTrue(np.any(seg[..., 1] == int(mjw.ObjType.GEOM)))
+
+  def test_render_per_world_mat_texid_reset(self):
+    nworld = 2
+    mjm, _, m, d = test_data.fixture(xml=_TEXTURE_SWAP_XML, nworld=nworld)
+    rc = mjw.create_render_context(
+      mjm,
+      nworld=nworld,
+      cam_res=(16, 16),
+      render_rgb=True,
+      use_textures=True,
+      enable_specular=False,
+      enable_emission=False,
+    )
+
+    red_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "red")
+    green_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "green")
+    mat_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_MATERIAL, "mat")
+    rgb_role = int(mujoco.mjtTextureRole.mjTEXROLE_RGB)
+
+    mjw.expand_mat_texid(m, nworld)
+    mat_texid = m.mat_texid.numpy()
+    mat_texid[0, mat_id, rgb_role] = red_id
+    mat_texid[1, mat_id, rgb_role] = green_id
+    storage = m.mat_texid
+    m.mat_texid.assign(mat_texid)
+
+    mjw.render(m, d, rc)
+    rgb = _unpack_rgb(rc.rgb_data.numpy()).mean(axis=1)
+    _assert_channel_dominates(self, rgb, 0, 0, 1)
+    _assert_channel_dominates(self, rgb, 1, 1, 0)
+
+    mat_texid[:, mat_id, rgb_role] = [green_id, red_id]
+    m.mat_texid.assign(mat_texid)
+    self.assertIs(m.mat_texid, storage)
+
+    mjw.render(m, d, rc)
+    rgb = _unpack_rgb(rc.rgb_data.numpy()).mean(axis=1)
+    _assert_channel_dominates(self, rgb, 0, 1, 0)
+    _assert_channel_dominates(self, rgb, 1, 0, 1)
 
   def test_render_spot_light_with_attenuation(self):
     """Kernel runs under `has_spot_lights=True` and non-default attenuation."""


### PR DESCRIPTION
This adds support for per-world material texture assignment in MuJoCo Warp rendering. `mat_texid` can now be expanded from the default shared material texture table to one table per world, allowing downstream users to randomize which preloaded texture a material uses without recompiling the model or rebuilding the render context.

The render path already indexes material fields by world, so the change keeps the shared-model fast path by default and only allocates per-world texture ID storage when `expand_mat_texid` is called. Tests cover in-place texture ID updates and verify that two worlds can render the same material with different textures, then swap them without recompilation.

This is how it can be used:

```python
import mujoco
import mujoco_warp as mjw

mjm = mujoco.MjModel.from_xml_path("scene.xml")
mjd = mujoco.MjData(mjm)

nworld = 4
m = mjw.put_model(mjm)
d = mjw.put_data(mjm, mjd, nworld=nworld)

mjw.expand_mat_texid(m, nworld)

mat_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_MATERIAL, "table_mat")
tex_ids = [
    mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, name)
    for name in ("wood", "marble", "metal", "checker")
]
rgb_role = int(mujoco.mjtTextureRole.mjTEXROLE_RGB)

mat_texid = m.mat_texid.numpy()
mat_texid[:, mat_id, rgb_role] = tex_ids
m.mat_texid.assign(mat_texid)

rc = mjw.create_render_context(mjm, nworld=nworld, use_textures=True)
mjw.render(m, d, rc)
```

And here's an example of 4 worlds table texture randomization with panda:


https://github.com/user-attachments/assets/e4eb8b82-62b6-4c19-be72-0d6b23609be9

This should not affect the rendering performance but I can run the benchmarks if desired.
