### PR TITLE
update flex collisions

### DIFF
--- a/benchmarks/aloha/scene_cloth.xml
+++ b/benchmarks/aloha/scene_cloth.xml
@@ -93,6 +93,8 @@
     <flexcomp name="towel" type="grid" count="30 30 1" spacing="0.014 0.014 0.014"
               radius="0.006" dim="2" rgba="1 0.5 0.5 1" pos="0 0 0" mass=".1">
       <edge equality="true"/>
+      <!-- TODO(thowell): enable after implementing flex self collision contact filtering -->
+      <contact selfcollide="none"/>
       <elasticity young="3e3" poisson="0" thickness="1e-2" damping="1e-3" elastic2d="bend"/>
     </flexcomp>
   </worldbody>

--- a/benchmarks/cloth/scene.xml
+++ b/benchmarks/cloth/scene.xml
@@ -34,6 +34,8 @@
     <flexcomp name="towel" type="grid" count="30 30 1" spacing="0.05 0.05 0.05"
               radius="0.02" dim="2" rgba="1 0.5 0.5 1" pos="0 0 2" mass=".1">
       <edge equality="true"/>
+      <!-- TODO(thowell): enable after implementing flex self collision contact filtering -->
+      <contact selfcollide="none"/>
       <elasticity young="3e3" poisson="0" thickness="1e-2" damping="1e-3" elastic2d="bend"/>
     </flexcomp>
 

--- a/mujoco_warp/_src/collision_flex.py
+++ b/mujoco_warp/_src/collision_flex.py
@@ -13,10 +13,16 @@
 # limitations under the License.
 """Flex collision detection (geom vs flex triangles)."""
 
+from typing import Tuple
+
 import warp as wp
 
 from mujoco_warp._src import collision_primitive_core
+from mujoco_warp._src.collision_core import Geom
+from mujoco_warp._src.collision_gjk import ccd
 from mujoco_warp._src.math import make_frame
+from mujoco_warp._src.types import MJ_MAX_EPAFACES
+from mujoco_warp._src.types import MJ_MAX_EPAHORIZON
 from mujoco_warp._src.types import MJ_MAXVAL
 from mujoco_warp._src.types import MJ_MINMU
 from mujoco_warp._src.types import MJ_MINVAL
@@ -117,69 +123,64 @@ def _mix_flex_contact_params(
 
 
 @wp.func
-def _write_flex_contact(
-  # Data in:
-  naconmax_in: int,
+def _write_candidate_contact(
   # In:
+  max_candidates: int,
   dist: float,
   pos: wp.vec3,
-  frame: wp.mat33,
-  margin: float,
-  condim: int,
-  friction: vec5,
-  solref: wp.vec2,
-  solimp: vec5,
+  nrm: wp.vec3,
   geom: int,
   flexid: int,
+  elemid: int,
   vertid: int,
   worldid: int,
-  # Data out:
-  contact_dist_out: wp.array[float],
-  contact_pos_out: wp.array[wp.vec3],
-  contact_frame_out: wp.array[wp.mat33],
-  contact_includemargin_out: wp.array[float],
-  contact_friction_out: wp.array[vec5],
-  contact_solref_out: wp.array[wp.vec2],
-  contact_solreffriction_out: wp.array[wp.vec2],
-  contact_solimp_out: wp.array[vec5],
-  contact_dim_out: wp.array[int],
-  contact_geom_out: wp.array[wp.vec2i],
-  contact_flex_out: wp.array[wp.vec2i],
-  contact_vert_out: wp.array[wp.vec2i],
-  contact_worldid_out: wp.array[int],
-  contact_type_out: wp.array[int],
-  contact_geomcollisionid_out: wp.array[int],
-  nacon_out: wp.array[int],
+  # Out:
+  cand_dist_out: wp.array[float],
+  cand_pos_out: wp.array[wp.vec3],
+  cand_nrm_out: wp.array[wp.vec3],
+  cand_geom_out: wp.array[wp.vec2i],
+  cand_flex_out: wp.array[wp.vec2i],
+  cand_elem_out: wp.array[wp.vec2i],
+  cand_vert_out: wp.array[wp.vec2i],
+  cand_worldid_out: wp.array[int],
+  cand_type_out: wp.array[int],
+  cand_geomcollisionid_out: wp.array[int],
+  ncand_out: wp.array[int],
 ):
-  if dist >= margin or dist >= MJ_MAXVAL:
+  if dist >= MJ_MAXVAL:
     return
 
-  id_ = wp.atomic_add(nacon_out, 0, 1)
-  if id_ >= naconmax_in:
+  candid = wp.atomic_add(ncand_out, 0, 1)
+  if candid >= max_candidates:
     return
 
-  contact_dist_out[id_] = dist
-  contact_pos_out[id_] = pos
-  contact_frame_out[id_] = frame
-  contact_includemargin_out[id_] = margin
-  contact_friction_out[id_] = friction
-  contact_solref_out[id_] = solref
-  contact_solreffriction_out[id_] = wp.vec2(0.0, 0.0)
-  contact_solimp_out[id_] = solimp
-  contact_dim_out[id_] = condim
-  contact_geom_out[id_] = wp.vec2i(geom, -1)
-  contact_flex_out[id_] = wp.vec2i(-1, flexid)
-  contact_vert_out[id_] = wp.vec2i(-1, vertid)
-  contact_worldid_out[id_] = worldid
-  contact_type_out[id_] = 1
-  contact_geomcollisionid_out[id_] = 0
+  cand_dist_out[candid] = dist
+  cand_pos_out[candid] = pos
+  cand_nrm_out[candid] = nrm
+  if geom >= 0:
+    cand_geom_out[candid] = wp.vec2i(geom, -1)
+    cand_flex_out[candid] = wp.vec2i(-1, flexid)
+    cand_elem_out[candid] = wp.vec2i(-1, elemid)
+    cand_vert_out[candid] = wp.vec2i(-1, vertid)
+  elif geom == -2:
+    cand_geom_out[candid] = wp.vec2i(-1, -1)
+    cand_flex_out[candid] = wp.vec2i(flexid, flexid)
+    cand_elem_out[candid] = wp.vec2i(elemid, vertid)
+    cand_vert_out[candid] = wp.vec2i(-1, -1)
+  else:
+    cand_geom_out[candid] = wp.vec2i(-1, -1)
+    cand_flex_out[candid] = wp.vec2i(flexid, flexid)
+    cand_elem_out[candid] = wp.vec2i(-1, elemid)
+    cand_vert_out[candid] = wp.vec2i(vertid, -1)
+  cand_worldid_out[candid] = worldid
+  cand_type_out[candid] = 1
+  cand_geomcollisionid_out[candid] = 0
 
 
 @wp.func
-def _collide_geom_triangle(
-  # Data in:
-  naconmax_in: int,
+def _collide_geom_triangle_detect(
   # In:
+  max_candidates: int,
   gtype: int,
   pos: wp.vec3,
   rot: wp.mat33,
@@ -189,66 +190,49 @@ def _collide_geom_triangle(
   t3: wp.vec3,
   tri_radius: float,
   margin: float,
-  condim: int,
-  friction: vec5,
-  solref: wp.vec2,
-  solimp: vec5,
   geomid: int,
   flexid: int,
+  elemid: int,
   vertex_id: int,
   worldid: int,
-  # Data out:
-  contact_dist_out: wp.array[float],
-  contact_pos_out: wp.array[wp.vec3],
-  contact_frame_out: wp.array[wp.mat33],
-  contact_includemargin_out: wp.array[float],
-  contact_friction_out: wp.array[vec5],
-  contact_solref_out: wp.array[wp.vec2],
-  contact_solreffriction_out: wp.array[wp.vec2],
-  contact_solimp_out: wp.array[vec5],
-  contact_dim_out: wp.array[int],
-  contact_geom_out: wp.array[wp.vec2i],
-  contact_flex_out: wp.array[wp.vec2i],
-  contact_vert_out: wp.array[wp.vec2i],
-  contact_worldid_out: wp.array[int],
-  contact_type_out: wp.array[int],
-  contact_geomcollisionid_out: wp.array[int],
-  nacon_out: wp.array[int],
+  # Out:
+  cand_dist_out: wp.array[float],
+  cand_pos_out: wp.array[wp.vec3],
+  cand_nrm_out: wp.array[wp.vec3],
+  cand_geom_out: wp.array[wp.vec2i],
+  cand_flex_out: wp.array[wp.vec2i],
+  cand_elem_out: wp.array[wp.vec2i],
+  cand_vert_out: wp.array[wp.vec2i],
+  cand_worldid_out: wp.array[int],
+  cand_type_out: wp.array[int],
+  cand_geomcollisionid_out: wp.array[int],
+  ncand_out: wp.array[int],
 ):
   if gtype == int(GeomType.SPHERE):
     sphere_radius = size_val[0]
     dist, contact_pos, nrm = collision_primitive_core.sphere_triangle(pos, sphere_radius, t1, t2, t3, tri_radius)
     if dist < margin:
-      _write_flex_contact(
-        naconmax_in,
+      _write_candidate_contact(
+        max_candidates,
         dist,
         contact_pos,
-        make_frame(nrm),
-        margin,
-        condim,
-        friction,
-        solref,
-        solimp,
+        nrm,
         geomid,
         flexid,
+        elemid,
         vertex_id,
         worldid,
-        contact_dist_out,
-        contact_pos_out,
-        contact_frame_out,
-        contact_includemargin_out,
-        contact_friction_out,
-        contact_solref_out,
-        contact_solreffriction_out,
-        contact_solimp_out,
-        contact_dim_out,
-        contact_geom_out,
-        contact_flex_out,
-        contact_vert_out,
-        contact_worldid_out,
-        contact_type_out,
-        contact_geomcollisionid_out,
-        nacon_out,
+        cand_dist_out,
+        cand_pos_out,
+        cand_nrm_out,
+        cand_geom_out,
+        cand_flex_out,
+        cand_elem_out,
+        cand_vert_out,
+        cand_worldid_out,
+        cand_type_out,
+        cand_geomcollisionid_out,
+        ncand_out,
       )
     return
 
@@ -278,95 +262,63 @@ def _collide_geom_triangle(
   if dists[0] < margin:
     p1 = wp.vec3(poss[0, 0], poss[0, 1], poss[0, 2])
     n1 = wp.vec3(nrms[0, 0], nrms[0, 1], nrms[0, 2])
-    _write_flex_contact(
-      naconmax_in,
+    _write_candidate_contact(
+      max_candidates,
       dists[0],
       p1,
-      make_frame(n1),
-      margin,
-      condim,
-      friction,
-      solref,
-      solimp,
+      n1,
       geomid,
       flexid,
+      elemid,
       vertex_id,
       worldid,
-      contact_dist_out,
-      contact_pos_out,
-      contact_frame_out,
-      contact_includemargin_out,
-      contact_friction_out,
-      contact_solref_out,
-      contact_solreffriction_out,
-      contact_solimp_out,
-      contact_dim_out,
-      contact_geom_out,
-      contact_flex_out,
-      contact_vert_out,
-      contact_worldid_out,
-      contact_type_out,
-      contact_geomcollisionid_out,
-      nacon_out,
+      cand_dist_out,
+      cand_pos_out,
+      cand_nrm_out,
+      cand_geom_out,
+      cand_flex_out,
+      cand_elem_out,
+      cand_vert_out,
+      cand_worldid_out,
+      cand_type_out,
+      cand_geomcollisionid_out,
+      ncand_out,
     )
   if dists[1] < margin:
     p2 = wp.vec3(poss[1, 0], poss[1, 1], poss[1, 2])
     n2 = wp.vec3(nrms[1, 0], nrms[1, 1], nrms[1, 2])
-    _write_flex_contact(
-      naconmax_in,
+    _write_candidate_contact(
+      max_candidates,
       dists[1],
       p2,
-      make_frame(n2),
-      margin,
-      condim,
-      friction,
-      solref,
-      solimp,
+      n2,
       geomid,
       flexid,
+      elemid,
       vertex_id,
       worldid,
-      contact_dist_out,
-      contact_pos_out,
-      contact_frame_out,
-      contact_includemargin_out,
-      contact_friction_out,
-      contact_solref_out,
-      contact_solreffriction_out,
-      contact_solimp_out,
-      contact_dim_out,
-      contact_geom_out,
-      contact_flex_out,
-      contact_vert_out,
-      contact_worldid_out,
-      contact_type_out,
-      contact_geomcollisionid_out,
-      nacon_out,
+      cand_dist_out,
+      cand_pos_out,
+      cand_nrm_out,
+      cand_geom_out,
+      cand_flex_out,
+      cand_elem_out,
+      cand_vert_out,
+      cand_worldid_out,
+      cand_type_out,
+      cand_geomcollisionid_out,
+      ncand_out,
     )
 
 
 @wp.kernel
-def _flex_plane_narrowphase(
+def _flex_plane_narrowphase_detect(
   # Model:
   ngeom: int,
   nflexvert: int,
   geom_type: wp.array[int],
-  geom_condim: wp.array[int],
-  geom_priority: wp.array[int],
-  geom_solmix: wp.array2d[float],
-  geom_solref: wp.array2d[wp.vec2],
-  geom_solimp: wp.array2d[vec5],
-  geom_friction: wp.array2d[wp.vec3],
   geom_margin: wp.array2d[float],
-  geom_gap: wp.array2d[float],
-  flex_condim: wp.array[int],
-  flex_priority: wp.array[int],
-  flex_solmix: wp.array[float],
-  flex_solref: wp.array[wp.vec2],
-  flex_solimp: wp.array[vec5],
-  flex_friction: wp.array[wp.vec3],
   flex_margin: wp.array[float],
-  flex_gap: wp.array[float],
   flex_vertadr: wp.array[int],
   flex_radius: wp.array[float],
   flex_vertflexid: wp.array[int],
@@ -375,24 +327,20 @@ def _flex_plane_narrowphase(
   geom_xmat_in: wp.array2d[wp.mat33],
   flexvert_xpos_in: wp.array2d[wp.vec3],
   nworld_in: int,
-  naconmax_in: int,
-  # Data out:
-  contact_dist_out: wp.array[float],
-  contact_pos_out: wp.array[wp.vec3],
-  contact_frame_out: wp.array[wp.mat33],
-  contact_includemargin_out: wp.array[float],
-  contact_friction_out: wp.array[vec5],
-  contact_solref_out: wp.array[wp.vec2],
-  contact_solreffriction_out: wp.array[wp.vec2],
-  contact_solimp_out: wp.array[vec5],
-  contact_dim_out: wp.array[int],
-  contact_geom_out: wp.array[wp.vec2i],
-  contact_flex_out: wp.array[wp.vec2i],
-  contact_vert_out: wp.array[wp.vec2i],
-  contact_worldid_out: wp.array[int],
-  contact_type_out: wp.array[int],
-  contact_geomcollisionid_out: wp.array[int],
-  nacon_out: wp.array[int],
+  # In:
+  max_candidates: int,
+  # Out:
+  cand_dist_out: wp.array[float],
+  cand_pos_out: wp.array[wp.vec3],
+  cand_nrm_out: wp.array[wp.vec3],
+  cand_geom_out: wp.array[wp.vec2i],
+  cand_flex_out: wp.array[wp.vec2i],
+  cand_elem_out: wp.array[wp.vec2i],
+  cand_vert_out: wp.array[wp.vec2i],
+  cand_worldid_out: wp.array[int],
+  cand_type_out: wp.array[int],
+  cand_geomcollisionid_out: wp.array[int],
+  ncand_out: wp.array[int],
 ):
   worldid, vertid = wp.tid()
 
@@ -421,84 +369,693 @@ def _flex_plane_narrowphase(
     dist = signed_dist - radius
 
     if dist < margin:
-      condim, gap, solref, solimp, friction = _mix_flex_contact_params(
-        geom_condim[geomid],
-        geom_priority[geomid],
-        geom_solmix[worldid % geom_solmix.shape[0], geomid],
-        geom_solref[worldid % geom_solref.shape[0], geomid],
-        geom_solimp[worldid % geom_solimp.shape[0], geomid],
-        geom_friction[worldid % geom_friction.shape[0], geomid],
-        geom_gap[worldid % geom_gap.shape[0], geomid],
-        flex_condim[flexid],
-        flex_priority[flexid],
-        flex_solmix[flexid],
-        flex_solref[flexid],
-        flex_solimp[flexid],
-        flex_friction[flexid],
-        flex_gap[flexid],
-      )
-
       contact_pos = vert - plane_normal * (dist * 0.5 + radius)
-      _write_flex_contact(
-        naconmax_in,
+      _write_candidate_contact(
+        max_candidates,
         dist,
         contact_pos,
-        make_frame(plane_normal),
-        margin - gap,
-        condim,
-        friction,
-        solref,
-        solimp,
+        plane_normal,
         geomid,
         flexid,
+        -1,
         local_vertid,
         worldid,
-        contact_dist_out,
-        contact_pos_out,
-        contact_frame_out,
-        contact_includemargin_out,
-        contact_friction_out,
-        contact_solref_out,
-        contact_solreffriction_out,
-        contact_solimp_out,
-        contact_dim_out,
-        contact_geom_out,
-        contact_flex_out,
-        contact_vert_out,
-        contact_worldid_out,
-        contact_type_out,
-        contact_geomcollisionid_out,
-        nacon_out,
+        cand_dist_out,
+        cand_pos_out,
+        cand_nrm_out,
+        cand_geom_out,
+        cand_flex_out,
+        cand_elem_out,
+        cand_vert_out,
+        cand_worldid_out,
+        cand_type_out,
+        cand_geomcollisionid_out,
+        ncand_out,
       )
+
+
+@wp.func
+def _sphere_tetrahedron(
+  # In:
+  sphere_pos: wp.vec3,
+  sphere_radius: float,
+  t0: wp.vec3,
+  t1: wp.vec3,
+  t2: wp.vec3,
+  t3: wp.vec3,
+  tri_radius: float,
+) -> Tuple[float, wp.vec3, wp.vec3]:
+  d0, p0, n0 = collision_primitive_core.sphere_triangle(sphere_pos, sphere_radius, t0, t1, t2, tri_radius)
+  d1, p1, n1 = collision_primitive_core.sphere_triangle(sphere_pos, sphere_radius, t0, t2, t3, tri_radius)
+  d2, p2, n2 = collision_primitive_core.sphere_triangle(sphere_pos, sphere_radius, t0, t3, t1, tri_radius)
+  d3, p3, n3 = collision_primitive_core.sphere_triangle(sphere_pos, sphere_radius, t1, t3, t2, tri_radius)
+
+  min_d = d0
+  min_p = p0
+  min_n = n0
+
+  if d1 < min_d:
+    min_d = d1
+    min_p = p1
+    min_n = n1
+  if d2 < min_d:
+    min_d = d2
+    min_p = p2
+    min_n = n2
+  if d3 < min_d:
+    min_d = d3
+    min_p = p3
+    min_n = n3
+
+  return min_d, min_p, min_n
+
+
+@wp.func
+def _plane_vertex(
+  # In:
+  pos_v: wp.vec3,
+  rad: float,
+  t0: wp.vec3,
+  t1: wp.vec3,
+  t2: wp.vec3,
+) -> Tuple[bool, float, wp.vec3, wp.vec3]:
+  e1 = t1 - t0
+  e2 = t2 - t0
+  ev = pos_v - t0
+
+  nrm = wp.normalize(wp.cross(e1, e2))
+  dst = wp.dot(ev, nrm)
+  if dst <= -2.0 * rad:
+    return False, 0.0, wp.vec3(0.0), wp.vec3(0.0)
+
+  dist = -dst - 2.0 * rad
+  nrm_out = -nrm
+  contact_pos = pos_v - nrm * (0.5 * dst)
+  return True, dist, contact_pos, nrm_out
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def _flex_internal_collisions_detect(
+  # Model:
+  nflex: int,
+  flex_margin: wp.array[float],
+  flex_internal: wp.array[int],
+  flex_dim: wp.array[int],
+  flex_vertadr: wp.array[int],
+  flex_elemdataadr: wp.array[int],
+  flex_evpairadr: wp.array[int],
+  flex_evpairnum: wp.array[int],
+  flex_elem: wp.array[int],
+  flex_evpair: wp.array[wp.vec2i],
+  flex_radius: wp.array[float],
+  # Data in:
+  flexvert_xpos_in: wp.array2d[wp.vec3],
+  # In:
+  max_candidates: int,
+  # Out:
+  cand_dist_out: wp.array[float],
+  cand_pos_out: wp.array[wp.vec3],
+  cand_nrm_out: wp.array[wp.vec3],
+  cand_geom_out: wp.array[wp.vec2i],
+  cand_flex_out: wp.array[wp.vec2i],
+  cand_elem_out: wp.array[wp.vec2i],
+  cand_vert_out: wp.array[wp.vec2i],
+  cand_worldid_out: wp.array[int],
+  cand_type_out: wp.array[int],
+  cand_geomcollisionid_out: wp.array[int],
+  ncand_out: wp.array[int],
+):
+  worldid, pair_idx = wp.tid()
+
+  flexid = int(-1)
+  for i in range(nflex):
+    start = flex_evpairadr[i]
+    num = flex_evpairnum[i]
+    if pair_idx >= start and pair_idx < start + num:
+      flexid = i
+      break
+
+  if flexid < 0 or flex_internal[flexid] == 0:
+    return
+
+  ev = flex_evpair[pair_idx]
+  e = ev[0]
+  v = ev[1]
+
+  dim = flex_dim[flexid]
+  radius = flex_radius[flexid]
+  margin = flex_margin[flexid]
+  vert_adr = flex_vertadr[flexid]
+
+  sphere_pos = flexvert_xpos_in[worldid, vert_adr + v]
+
+  elem_data_idx = flex_elemdataadr[flexid] + e * (dim + 1)
+  v0_local = flex_elem[elem_data_idx]
+  p0 = flexvert_xpos_in[worldid, vert_adr + v0_local]
+
+  dist = float(MJ_MAXVAL)
+  contact_pos = wp.vec3(0.0)
+  nrm = wp.vec3(0.0)
+
+  if dim == 1:
+    v1_local = flex_elem[elem_data_idx + 1]
+    p1 = flexvert_xpos_in[worldid, vert_adr + v1_local]
+    capsule_pos = 0.5 * (p0 + p1)
+    capsule_axis = wp.normalize(p1 - p0)
+    capsule_half_len = 0.5 * wp.length(p1 - p0)
+    dist, contact_pos, nrm = collision_primitive_core.sphere_capsule(
+      sphere_pos, radius, capsule_pos, capsule_axis, radius, capsule_half_len
+    )
+  elif dim == 2:
+    v1_local = flex_elem[elem_data_idx + 1]
+    v2_local = flex_elem[elem_data_idx + 2]
+    p1 = flexvert_xpos_in[worldid, vert_adr + v1_local]
+    p2 = flexvert_xpos_in[worldid, vert_adr + v2_local]
+    dist, contact_pos, nrm = collision_primitive_core.sphere_triangle(sphere_pos, radius, p0, p1, p2, radius)
+  elif dim == 3:
+    v1_local = flex_elem[elem_data_idx + 1]
+    v2_local = flex_elem[elem_data_idx + 2]
+    v3_local = flex_elem[elem_data_idx + 3]
+    p1 = flexvert_xpos_in[worldid, vert_adr + v1_local]
+    p2 = flexvert_xpos_in[worldid, vert_adr + v2_local]
+    p3 = flexvert_xpos_in[worldid, vert_adr + v3_local]
+    dist, contact_pos, nrm = _sphere_tetrahedron(sphere_pos, radius, p0, p1, p2, p3, radius)
+
+  if dist < margin:
+    _write_candidate_contact(
+      max_candidates,
+      dist,
+      contact_pos,
+      nrm,
+      -1,
+      flexid,
+      e,
+      v,
+      worldid,
+      cand_dist_out,
+      cand_pos_out,
+      cand_nrm_out,
+      cand_geom_out,
+      cand_flex_out,
+      cand_elem_out,
+      cand_vert_out,
+      cand_worldid_out,
+      cand_type_out,
+      cand_geomcollisionid_out,
+      ncand_out,
+    )
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def _flex_tet_internal_collisions_detect(
+  # Model:
+  nflex: int,
+  flex_dim: wp.array[int],
+  flex_vertadr: wp.array[int],
+  flex_elemadr: wp.array[int],
+  flex_elemnum: wp.array[int],
+  flex_elemdataadr: wp.array[int],
+  flex_elem: wp.array[int],
+  flex_radius: wp.array[float],
+  # Data in:
+  flexvert_xpos_in: wp.array2d[wp.vec3],
+  # In:
+  max_candidates: int,
+  # Out:
+  cand_dist_out: wp.array[float],
+  cand_pos_out: wp.array[wp.vec3],
+  cand_nrm_out: wp.array[wp.vec3],
+  cand_geom_out: wp.array[wp.vec2i],
+  cand_flex_out: wp.array[wp.vec2i],
+  cand_elem_out: wp.array[wp.vec2i],
+  cand_vert_out: wp.array[wp.vec2i],
+  cand_worldid_out: wp.array[int],
+  cand_type_out: wp.array[int],
+  cand_geomcollisionid_out: wp.array[int],
+  ncand_out: wp.array[int],
+):
+  worldid, elemid = wp.tid()
+
+  flexid = int(-1)
+  for i in range(nflex):
+    if flex_dim[i] != 3:
+      continue
+    elem_adr = flex_elemadr[i]
+    elem_num = flex_elemnum[i]
+    if elemid >= elem_adr and elemid < elem_adr + elem_num:
+      flexid = i
+      break
+
+  if flexid < 0:
+    return
+
+  radius = flex_radius[flexid]
+  vert_adr = flex_vertadr[flexid]
+
+  local_elemid = elemid - flex_elemadr[flexid]
+  elem_data_idx = flex_elemdataadr[flexid] + local_elemid * 4
+
+  v0 = flex_elem[elem_data_idx]
+  v1 = flex_elem[elem_data_idx + 1]
+  v2 = flex_elem[elem_data_idx + 2]
+  v3 = flex_elem[elem_data_idx + 3]
+
+  p0 = flexvert_xpos_in[worldid, vert_adr + v0]
+  p1 = flexvert_xpos_in[worldid, vert_adr + v1]
+  p2 = flexvert_xpos_in[worldid, vert_adr + v2]
+  p3 = flexvert_xpos_in[worldid, vert_adr + v3]
+
+  # Test face (0,1,2) vs Vertex 3
+  ok0, dist0, pos0, nrm0 = _plane_vertex(p3, radius, p0, p1, p2)
+  if ok0:
+    _write_candidate_contact(
+      max_candidates,
+      dist0,
+      pos0,
+      nrm0,
+      -1,
+      flexid,
+      local_elemid,
+      v3,
+      worldid,
+      cand_dist_out,
+      cand_pos_out,
+      cand_nrm_out,
+      cand_geom_out,
+      cand_flex_out,
+      cand_elem_out,
+      cand_vert_out,
+      cand_worldid_out,
+      cand_type_out,
+      cand_geomcollisionid_out,
+      ncand_out,
+    )
+
+  # Test face (0,2,3) vs Vertex 1
+  ok1, dist1, pos1, nrm1 = _plane_vertex(p1, radius, p0, p2, p3)
+  if ok1:
+    _write_candidate_contact(
+      max_candidates,
+      dist1,
+      pos1,
+      nrm1,
+      -1,
+      flexid,
+      local_elemid,
+      v1,
+      worldid,
+      cand_dist_out,
+      cand_pos_out,
+      cand_nrm_out,
+      cand_geom_out,
+      cand_flex_out,
+      cand_elem_out,
+      cand_vert_out,
+      cand_worldid_out,
+      cand_type_out,
+      cand_geomcollisionid_out,
+      ncand_out,
+    )
+
+  # Test face (0,3,1) vs Vertex 2
+  ok2, dist2, pos2, nrm2 = _plane_vertex(p2, radius, p0, p3, p1)
+  if ok2:
+    _write_candidate_contact(
+      max_candidates,
+      dist2,
+      pos2,
+      nrm2,
+      -1,
+      flexid,
+      local_elemid,
+      v2,
+      worldid,
+      cand_dist_out,
+      cand_pos_out,
+      cand_nrm_out,
+      cand_geom_out,
+      cand_flex_out,
+      cand_elem_out,
+      cand_vert_out,
+      cand_worldid_out,
+      cand_type_out,
+      cand_geomcollisionid_out,
+      ncand_out,
+    )
+
+  # Test face (1,3,2) vs Vertex 0
+  ok3, dist3, pos3, nrm3 = _plane_vertex(p0, radius, p1, p3, p2)
+  if ok3:
+    _write_candidate_contact(
+      max_candidates,
+      dist3,
+      pos3,
+      nrm3,
+      -1,
+      flexid,
+      local_elemid,
+      v0,
+      worldid,
+      cand_dist_out,
+      cand_pos_out,
+      cand_nrm_out,
+      cand_geom_out,
+      cand_flex_out,
+      cand_elem_out,
+      cand_vert_out,
+      cand_worldid_out,
+      cand_type_out,
+      cand_geomcollisionid_out,
+      ncand_out,
+    )
+
+
+@wp.func
+def _exclude_self_collision(
+  # Model:
+  flex_vertbodyid: wp.array[int],
+  # In:
+  v1: wp.vec4i,
+  n1: int,
+  v2: wp.vec4i,
+  n2: int,
+  vert_adr: int,
+) -> bool:
+  for i in range(n1):
+    idx1 = v1[i]
+    if idx1 >= 0:
+      b1 = flex_vertbodyid[vert_adr + idx1]
+      for j in range(n2):
+        idx2 = v2[j]
+        if idx1 == idx2:
+          return True
+        if idx2 >= 0 and b1 >= 0:
+          b2 = flex_vertbodyid[vert_adr + idx2]
+          if b1 == b2:
+            return True
+  return False
+
+
+@wp.func
+def _get_element_vertices(
+  # Model:
+  flex_elem: wp.array[int],
+  # In:
+  dim: int,
+  elem_data_idx: int,
+) -> wp.vec4i:
+  v0 = flex_elem[elem_data_idx]
+  v1 = flex_elem[elem_data_idx + 1]
+  v2 = int(-1)
+  v3 = int(-1)
+  if dim >= 2:
+    v2 = flex_elem[elem_data_idx + 2]
+  if dim >= 3:
+    v3 = flex_elem[elem_data_idx + 3]
+  return wp.vec4i(v0, v1, v2, v3)
+
+
+@wp.func
+def _elements_overlap(
+  # Data in:
+  flexvert_xpos_in: wp.array2d[wp.vec3],
+  # In:
+  dim: int,
+  radius: float,
+  v1_indices: wp.vec4i,
+  v2_indices: wp.vec4i,
+  vert_adr: int,
+  worldid: int,
+) -> bool:
+  p1_0 = flexvert_xpos_in[worldid, vert_adr + v1_indices[0]]
+  p1_1 = flexvert_xpos_in[worldid, vert_adr + v1_indices[1]]
+
+  min1 = wp.min(p1_0, p1_1)
+  max1 = wp.max(p1_0, p1_1)
+
+  if dim >= 2:
+    p1_2 = flexvert_xpos_in[worldid, vert_adr + v1_indices[2]]
+    min1 = wp.min(min1, p1_2)
+    max1 = wp.max(max1, p1_2)
+  if dim >= 3:
+    p1_3 = flexvert_xpos_in[worldid, vert_adr + v1_indices[3]]
+    min1 = wp.min(min1, p1_3)
+    max1 = wp.max(max1, p1_3)
+
+  p2_0 = flexvert_xpos_in[worldid, vert_adr + v2_indices[0]]
+  p2_1 = flexvert_xpos_in[worldid, vert_adr + v2_indices[1]]
+
+  min2 = wp.min(p2_0, p2_1)
+  max2 = wp.max(p2_0, p2_1)
+
+  if dim >= 2:
+    p2_2 = flexvert_xpos_in[worldid, vert_adr + v2_indices[2]]
+    min2 = wp.min(min2, p2_2)
+    max2 = wp.max(max2, p2_2)
+  if dim >= 3:
+    p2_3 = flexvert_xpos_in[worldid, vert_adr + v2_indices[3]]
+    min2 = wp.min(min2, p2_3)
+    max2 = wp.max(max2, p2_3)
+
+  rbound = 2.0 * radius
+
+  if min1[0] - rbound > max2[0] or max1[0] + rbound < min2[0]:
+    return False
+  if min1[1] - rbound > max2[1] or max1[1] + rbound < min2[1]:
+    return False
+  if min1[2] - rbound > max2[2] or max1[2] + rbound < min2[2]:
+    return False
+
+  return True
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def _flex_active_element_collisions_detect(
+  # Model:
+  nflex: int,
+  opt_ccd_tolerance: wp.array[float],
+  flex_selfcollide: wp.array[int],
+  flex_dim: wp.array[int],
+  flex_vertadr: wp.array[int],
+  flex_elemadr: wp.array[int],
+  flex_elemnum: wp.array[int],
+  flex_elemdataadr: wp.array[int],
+  flex_vertbodyid: wp.array[int],
+  flex_elem: wp.array[int],
+  flex_radius: wp.array[float],
+  # Data in:
+  flexvert_xpos_in: wp.array2d[wp.vec3],
+  # In:
+  max_candidates: int,
+  gjk_iterations: int,
+  epa_iterations: int,
+  n_total_elems: int,
+  # Out:
+  workspace_verts_out: wp.array[wp.vec3],
+  epa_vert_out: wp.array2d[wp.vec3],
+  epa_vert_index_out: wp.array2d[int],
+  epa_face_out: wp.array2d[int],
+  epa_pr_out: wp.array2d[wp.vec3],
+  epa_norm2_out: wp.array2d[float],
+  epa_horizon_out: wp.array2d[int],
+  cand_dist_out: wp.array[float],
+  cand_pos_out: wp.array[wp.vec3],
+  cand_nrm_out: wp.array[wp.vec3],
+  cand_geom_out: wp.array[wp.vec2i],
+  cand_flex_out: wp.array[wp.vec2i],
+  cand_elem_out: wp.array[wp.vec2i],
+  cand_vert_out: wp.array[wp.vec2i],
+  cand_worldid_out: wp.array[int],
+  cand_type_out: wp.array[int],
+  cand_geomcollisionid_out: wp.array[int],
+  ncand_out: wp.array[int],
+):
+  worldid, elem1_global = wp.tid()
+
+  flexid = int(-1)
+  for i in range(nflex):
+    if flex_selfcollide[i] == 0:
+      continue
+    elem_adr = flex_elemadr[i]
+    elem_num = flex_elemnum[i]
+    if elem1_global >= elem_adr and elem1_global < elem_adr + elem_num:
+      flexid = i
+      break
+
+  if flexid < 0:
+    return
+
+  radius = flex_radius[flexid]
+  dim = flex_dim[flexid]
+  vert_adr = flex_vertadr[flexid]
+  elem_adr = flex_elemadr[flexid]
+  elem_num = flex_elemnum[flexid]
+
+  e1 = elem1_global - elem_adr
+  elem_data_idx1 = flex_elemdataadr[flexid] + e1 * (dim + 1)
+
+  v1_indices = _get_element_vertices(flex_elem, dim, elem_data_idx1)
+
+  unique_thread_id = worldid * n_total_elems + elem1_global
+
+  offset1 = unique_thread_id * 8
+  for idx in range(dim + 1):
+    workspace_verts_out[offset1 + idx] = flexvert_xpos_in[worldid, vert_adr + v1_indices[idx]]
+
+  for e2 in range(e1 + 1, elem_num):
+    elem_data_idx2 = flex_elemdataadr[flexid] + e2 * (dim + 1)
+    v2_indices = _get_element_vertices(flex_elem, dim, elem_data_idx2)
+
+    if _exclude_self_collision(flex_vertbodyid, v1_indices, dim + 1, v2_indices, dim + 1, vert_adr):
+      continue
+
+    overlap = _elements_overlap(flexvert_xpos_in, dim, radius, v1_indices, v2_indices, vert_adr, worldid)
+    if not overlap:
+      continue
+
+    if dim == 1:
+      p0 = workspace_verts_out[offset1]
+      p1 = workspace_verts_out[offset1 + 1]
+      cap1_pos = 0.5 * (p0 + p1)
+      cap1_axis = wp.normalize(p1 - p0)
+      cap1_half_len = 0.5 * wp.length(p1 - p0)
+
+      p2_0 = flexvert_xpos_in[worldid, vert_adr + v2_indices[0]]
+      p2_1 = flexvert_xpos_in[worldid, vert_adr + v2_indices[1]]
+      cap2_pos = 0.5 * (p2_0 + p2_1)
+      cap2_axis = wp.normalize(p2_1 - p2_0)
+      cap2_half_len = 0.5 * wp.length(p2_1 - p2_0)
+
+      margin = 0.0
+
+      contact_dist, contact_pos, contact_normal = collision_primitive_core.capsule_capsule(
+        cap1_pos, cap1_axis, radius, cap1_half_len, cap2_pos, cap2_axis, radius, cap2_half_len, margin
+      )
+
+      for c in range(2):
+        d_val = contact_dist[c]
+        if d_val < 0.0:
+          _write_candidate_contact(
+            max_candidates,
+            d_val,
+            contact_pos[c],
+            contact_normal[c],
+            -2,
+            flexid,
+            e1,
+            e2,
+            worldid,
+            cand_dist_out,
+            cand_pos_out,
+            cand_nrm_out,
+            cand_geom_out,
+            cand_flex_out,
+            cand_elem_out,
+            cand_vert_out,
+            cand_worldid_out,
+            cand_type_out,
+            cand_geomcollisionid_out,
+            ncand_out,
+          )
+    else:
+      offset2 = unique_thread_id * 8 + 4
+      for idx in range(dim + 1):
+        workspace_verts_out[offset2 + idx] = flexvert_xpos_in[worldid, vert_adr + v2_indices[idx]]
+
+      geom1 = Geom()
+      geom1.pos = wp.vec3(0.0)
+      geom1.rot = wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+      geom1.size = wp.vec3(0.0)
+      geom1.margin = 2.0 * radius
+      geom1.vert = workspace_verts_out
+      geom1.vertadr = offset1
+      geom1.vertnum = dim + 1
+      geom1.graphadr = -1
+      geom1.index = -1
+
+      geom2 = Geom()
+      geom2.pos = wp.vec3(0.0)
+      geom2.rot = wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+      geom2.size = wp.vec3(0.0)
+      geom2.margin = 2.0 * radius
+      geom2.vert = workspace_verts_out
+      geom2.vertadr = offset2
+      geom2.vertnum = dim + 1
+      geom2.graphadr = -1
+      geom2.index = -1
+
+      center1 = wp.vec3(0.0)
+      for idx in range(dim + 1):
+        center1 += workspace_verts_out[offset1 + idx]
+      center1 = center1 / float(dim + 1)
+
+      center2 = wp.vec3(0.0)
+      for idx in range(dim + 1):
+        center2 += workspace_verts_out[offset2 + idx]
+      center2 = center2 / float(dim + 1)
+
+      tol = opt_ccd_tolerance[worldid % opt_ccd_tolerance.shape[0]]
+
+      dist, ncontact, w1, w2, _ = ccd(
+        tol,
+        2.0 * radius,
+        gjk_iterations,
+        epa_iterations,
+        geom1,
+        geom2,
+        int(GeomType.MESH),
+        int(GeomType.MESH),
+        center1,
+        center2,
+        epa_vert_out[unique_thread_id],
+        epa_vert_index_out[unique_thread_id],
+        epa_face_out[unique_thread_id],
+        epa_pr_out[unique_thread_id],
+        epa_norm2_out[unique_thread_id],
+        epa_horizon_out[unique_thread_id],
+      )
+
+      phys_dist = dist
+      if ncontact > 0 and phys_dist < 0.0:
+        pos = 0.5 * (w1 + w2)
+        nrm = wp.normalize(w1 - w2)
+        _write_candidate_contact(
+          max_candidates,
+          phys_dist,
+          pos,
+          nrm,
+          -2,
+          flexid,
+          e1,
+          e2,
+          worldid,
+          cand_dist_out,
+          cand_pos_out,
+          cand_nrm_out,
+          cand_geom_out,
+          cand_flex_out,
+          cand_elem_out,
+          cand_vert_out,
+          cand_worldid_out,
+          cand_type_out,
+          cand_geomcollisionid_out,
+          ncand_out,
+        )
 
 
 @wp.kernel
-def _flex_narrowphase_dim2(
+def _flex_narrowphase_dim2_detect(
   # Model:
   ngeom: int,
   nflex: int,
   geom_type: wp.array[int],
   geom_contype: wp.array[int],
   geom_conaffinity: wp.array[int],
-  geom_condim: wp.array[int],
-  geom_priority: wp.array[int],
-  geom_solmix: wp.array2d[float],
-  geom_solref: wp.array2d[wp.vec2],
-  geom_solimp: wp.array2d[vec5],
   geom_size: wp.array2d[wp.vec3],
-  geom_friction: wp.array2d[wp.vec3],
   geom_margin: wp.array2d[float],
-  geom_gap: wp.array2d[float],
   flex_contype: wp.array[int],
   flex_conaffinity: wp.array[int],
-  flex_condim: wp.array[int],
-  flex_priority: wp.array[int],
-  flex_solmix: wp.array[float],
-  flex_solref: wp.array[wp.vec2],
-  flex_solimp: wp.array[vec5],
-  flex_friction: wp.array[wp.vec3],
   flex_margin: wp.array[float],
-  flex_gap: wp.array[float],
   flex_dim: wp.array[int],
   flex_vertadr: wp.array[int],
   flex_elemadr: wp.array[int],
@@ -511,24 +1068,20 @@ def _flex_narrowphase_dim2(
   geom_xmat_in: wp.array2d[wp.mat33],
   flexvert_xpos_in: wp.array2d[wp.vec3],
   nworld_in: int,
-  naconmax_in: int,
-  # Data out:
-  contact_dist_out: wp.array[float],
-  contact_pos_out: wp.array[wp.vec3],
-  contact_frame_out: wp.array[wp.mat33],
-  contact_includemargin_out: wp.array[float],
-  contact_friction_out: wp.array[vec5],
-  contact_solref_out: wp.array[wp.vec2],
-  contact_solreffriction_out: wp.array[wp.vec2],
-  contact_solimp_out: wp.array[vec5],
-  contact_dim_out: wp.array[int],
-  contact_geom_out: wp.array[wp.vec2i],
-  contact_flex_out: wp.array[wp.vec2i],
-  contact_vert_out: wp.array[wp.vec2i],
-  contact_worldid_out: wp.array[int],
-  contact_type_out: wp.array[int],
-  contact_geomcollisionid_out: wp.array[int],
-  nacon_out: wp.array[int],
+  # In:
+  max_candidates: int,
+  # Out:
+  cand_dist_out: wp.array[float],
+  cand_pos_out: wp.array[wp.vec3],
+  cand_nrm_out: wp.array[wp.vec3],
+  cand_geom_out: wp.array[wp.vec2i],
+  cand_flex_out: wp.array[wp.vec2i],
+  cand_elem_out: wp.array[wp.vec2i],
+  cand_vert_out: wp.array[wp.vec2i],
+  cand_worldid_out: wp.array[int],
+  cand_type_out: wp.array[int],
+  cand_geomcollisionid_out: wp.array[int],
+  ncand_out: wp.array[int],
 ):
   worldid, elemid = wp.tid()
 
@@ -549,7 +1102,8 @@ def _flex_narrowphase_dim2(
   tri_radius = flex_radius[flexid]
   tri_margin = flex_margin[flexid]
 
-  elem_data_idx = flex_elemdataadr[flexid] + (elemid - flex_elemadr[flexid]) * 3
+  local_elemid = elemid - flex_elemadr[flexid]
+  elem_data_idx = flex_elemdataadr[flexid] + local_elemid * 3
   v0_local = flex_elem[elem_data_idx]
   v1_local = flex_elem[elem_data_idx + 1]
   v2_local = flex_elem[elem_data_idx + 2]
@@ -583,25 +1137,8 @@ def _flex_narrowphase_dim2(
     geom_rot = geom_xmat_in[worldid, geomid]
     geom_size_val = geom_size[worldid % geom_size.shape[0], geomid]
 
-    condim, gap, solref, solimp, friction = _mix_flex_contact_params(
-      geom_condim[geomid],
-      geom_priority[geomid],
-      geom_solmix[worldid % geom_solmix.shape[0], geomid],
-      geom_solref[worldid % geom_solref.shape[0], geomid],
-      geom_solimp[worldid % geom_solimp.shape[0], geomid],
-      geom_friction[worldid % geom_friction.shape[0], geomid],
-      geom_gap[worldid % geom_gap.shape[0], geomid],
-      flex_condim[flexid],
-      flex_priority[flexid],
-      flex_solmix[flexid],
-      flex_solref[flexid],
-      flex_solimp[flexid],
-      flex_friction[flexid],
-      flex_gap[flexid],
-    )
-
-    _collide_geom_triangle(
-      naconmax_in,
+    _collide_geom_triangle_detect(
+      max_candidates,
       gtype,
       geom_pos,
       geom_rot,
@@ -611,60 +1148,38 @@ def _flex_narrowphase_dim2(
       t3,
       tri_radius,
       margin,
-      condim,
-      friction,
-      solref,
-      solimp,
       geomid,
       flexid,
-      v0_local,
+      local_elemid,
+      -1,
       worldid,
-      contact_dist_out,
-      contact_pos_out,
-      contact_frame_out,
-      contact_includemargin_out,
-      contact_friction_out,
-      contact_solref_out,
-      contact_solreffriction_out,
-      contact_solimp_out,
-      contact_dim_out,
-      contact_geom_out,
-      contact_flex_out,
-      contact_vert_out,
-      contact_worldid_out,
-      contact_type_out,
-      contact_geomcollisionid_out,
-      nacon_out,
+      cand_dist_out,
+      cand_pos_out,
+      cand_nrm_out,
+      cand_geom_out,
+      cand_flex_out,
+      cand_elem_out,
+      cand_vert_out,
+      cand_worldid_out,
+      cand_type_out,
+      cand_geomcollisionid_out,
+      ncand_out,
     )
 
 
 @wp.kernel
-def _flex_narrowphase_dim3(
+def _flex_narrowphase_dim3_detect(
   # Model:
   ngeom: int,
   nflex: int,
   geom_type: wp.array[int],
   geom_contype: wp.array[int],
   geom_conaffinity: wp.array[int],
-  geom_condim: wp.array[int],
-  geom_priority: wp.array[int],
-  geom_solmix: wp.array2d[float],
-  geom_solref: wp.array2d[wp.vec2],
-  geom_solimp: wp.array2d[vec5],
   geom_size: wp.array2d[wp.vec3],
-  geom_friction: wp.array2d[wp.vec3],
   geom_margin: wp.array2d[float],
-  geom_gap: wp.array2d[float],
   flex_contype: wp.array[int],
   flex_conaffinity: wp.array[int],
-  flex_condim: wp.array[int],
-  flex_priority: wp.array[int],
-  flex_solmix: wp.array[float],
-  flex_solref: wp.array[wp.vec2],
-  flex_solimp: wp.array[vec5],
-  flex_friction: wp.array[wp.vec3],
   flex_margin: wp.array[float],
-  flex_gap: wp.array[float],
   flex_dim: wp.array[int],
   flex_vertadr: wp.array[int],
   flex_shellnum: wp.array[int],
@@ -676,24 +1191,20 @@ def _flex_narrowphase_dim3(
   geom_xmat_in: wp.array2d[wp.mat33],
   flexvert_xpos_in: wp.array2d[wp.vec3],
   nworld_in: int,
-  naconmax_in: int,
-  # Data out:
-  contact_dist_out: wp.array[float],
-  contact_pos_out: wp.array[wp.vec3],
-  contact_frame_out: wp.array[wp.mat33],
-  contact_includemargin_out: wp.array[float],
-  contact_friction_out: wp.array[vec5],
-  contact_solref_out: wp.array[wp.vec2],
-  contact_solreffriction_out: wp.array[wp.vec2],
-  contact_solimp_out: wp.array[vec5],
-  contact_dim_out: wp.array[int],
-  contact_geom_out: wp.array[wp.vec2i],
-  contact_flex_out: wp.array[wp.vec2i],
-  contact_vert_out: wp.array[wp.vec2i],
-  contact_worldid_out: wp.array[int],
-  contact_type_out: wp.array[int],
-  contact_geomcollisionid_out: wp.array[int],
-  nacon_out: wp.array[int],
+  # In:
+  max_candidates: int,
+  # Out:
+  cand_dist_out: wp.array[float],
+  cand_pos_out: wp.array[wp.vec3],
+  cand_nrm_out: wp.array[wp.vec3],
+  cand_geom_out: wp.array[wp.vec2i],
+  cand_flex_out: wp.array[wp.vec2i],
+  cand_elem_out: wp.array[wp.vec2i],
+  cand_vert_out: wp.array[wp.vec2i],
+  cand_worldid_out: wp.array[int],
+  cand_type_out: wp.array[int],
+  cand_geomcollisionid_out: wp.array[int],
+  ncand_out: wp.array[int],
 ):
   worldid, shellid = wp.tid()
 
@@ -752,6 +1263,164 @@ def _flex_narrowphase_dim3(
     geom_rot = geom_xmat_in[worldid, geomid]
     geom_size_val = geom_size[worldid % geom_size.shape[0], geomid]
 
+    _collide_geom_triangle_detect(
+      max_candidates,
+      gtype,
+      geom_pos,
+      geom_rot,
+      geom_size_val,
+      t1,
+      t2,
+      t3,
+      tri_radius,
+      margin,
+      geomid,
+      flexid,
+      local_shellid,
+      -1,
+      worldid,
+      cand_dist_out,
+      cand_pos_out,
+      cand_nrm_out,
+      cand_geom_out,
+      cand_flex_out,
+      cand_elem_out,
+      cand_vert_out,
+      cand_worldid_out,
+      cand_type_out,
+      cand_geomcollisionid_out,
+      ncand_out,
+    )
+
+
+@wp.kernel
+def _filter_flex_candidates(
+  # In:
+  max_candidates: int,
+  ncand: wp.array[int],
+  epsilon: float,
+  cand_dist: wp.array[float],
+  cand_pos: wp.array[wp.vec3],
+  cand_geom: wp.array[wp.vec2i],
+  cand_flex: wp.array[wp.vec2i],
+  cand_worldid: wp.array[int],
+  # Out:
+  cand_active_out: wp.array[int],
+):
+  i = wp.tid()
+  limit = ncand[0]
+  if i >= limit:
+    return
+
+  geom_i = cand_geom[i][0]
+  flex_i = cand_flex[i][1]
+  world_i = cand_worldid[i]
+  pos_i = cand_pos[i]
+  dist_i = cand_dist[i]
+
+  keep = int(1)
+  for j in range(max_candidates):
+    if j >= limit:
+      break
+    if j == i:
+      continue
+    geom_j = cand_geom[j][0]
+    if (geom_i >= 0 and geom_j >= 0 and geom_j == geom_i) or (geom_i < 0 and geom_j < 0):
+      flex_j = cand_flex[j][1]
+      if flex_j == flex_i:
+        world_j = cand_worldid[j]
+        if world_j == world_i:
+          pos_j = cand_pos[j]
+          dist_j = cand_dist[j]
+
+          diff = pos_i - pos_j
+          if wp.dot(diff, diff) < epsilon * epsilon:
+            if dist_j < dist_i:
+              keep = 0
+            elif dist_j == dist_i and j < i:
+              keep = 0
+
+  cand_active_out[i] = keep
+
+
+@wp.kernel
+def _write_filtered_contacts(
+  # Model:
+  geom_type: wp.array[int],
+  geom_condim: wp.array[int],
+  geom_priority: wp.array[int],
+  geom_solmix: wp.array2d[float],
+  geom_solref: wp.array2d[wp.vec2],
+  geom_solimp: wp.array2d[vec5],
+  geom_friction: wp.array2d[wp.vec3],
+  geom_margin: wp.array2d[float],
+  geom_gap: wp.array2d[float],
+  flex_condim: wp.array[int],
+  flex_priority: wp.array[int],
+  flex_solmix: wp.array[float],
+  flex_solref: wp.array[wp.vec2],
+  flex_solimp: wp.array[vec5],
+  flex_friction: wp.array[wp.vec3],
+  flex_margin: wp.array[float],
+  flex_gap: wp.array[float],
+  flex_dim: wp.array[int],
+  # Data in:
+  naconmax_in: int,
+  # In:
+  ncand: wp.array[int],
+  cand_dist: wp.array[float],
+  cand_pos: wp.array[wp.vec3],
+  cand_nrm: wp.array[wp.vec3],
+  cand_geom: wp.array[wp.vec2i],
+  cand_flex: wp.array[wp.vec2i],
+  cand_elem: wp.array[wp.vec2i],
+  cand_vert: wp.array[wp.vec2i],
+  cand_worldid: wp.array[int],
+  cand_type: wp.array[int],
+  cand_geomcollisionid: wp.array[int],
+  cand_active: wp.array[int],
+  # Data out:
+  contact_dist_out: wp.array[float],
+  contact_pos_out: wp.array[wp.vec3],
+  contact_frame_out: wp.array[wp.mat33],
+  contact_includemargin_out: wp.array[float],
+  contact_friction_out: wp.array[vec5],
+  contact_solref_out: wp.array[wp.vec2],
+  contact_solreffriction_out: wp.array[wp.vec2],
+  contact_solimp_out: wp.array[vec5],
+  contact_dim_out: wp.array[int],
+  contact_geom_out: wp.array[wp.vec2i],
+  contact_flex_out: wp.array[wp.vec2i],
+  contact_elem_out: wp.array[wp.vec2i],
+  contact_vert_out: wp.array[wp.vec2i],
+  contact_worldid_out: wp.array[int],
+  contact_type_out: wp.array[int],
+  contact_geomcollisionid_out: wp.array[int],
+  nacon_out: wp.array[int],
+):
+  i = wp.tid()
+  if i >= ncand[0]:
+    return
+
+  if cand_active[i] == 0:
+    return
+
+  geomid = cand_geom[i][0]
+  worldid = cand_worldid[i]
+
+  condim = int(0)
+  margin = float(0.0)
+  gap = float(0.0)
+  solref = wp.vec2(0.0, 0.0)
+  solimp = vec5(0.0, 0.0, 0.0, 0.0, 0.0)
+  friction = vec5(0.0, 0.0, 0.0, 0.0, 0.0)
+
+  if geomid >= 0:
+    flexid = cand_flex[i][1]
+    geom_margin_val = geom_margin[worldid % geom_margin.shape[0], geomid]
+    tri_margin = flex_margin[flexid]
+    margin = geom_margin_val + tri_margin
+
     condim, gap, solref, solimp, friction = _mix_flex_contact_params(
       geom_condim[geomid],
       geom_priority[geomid],
@@ -768,43 +1437,57 @@ def _flex_narrowphase_dim3(
       flex_friction[flexid],
       flex_gap[flexid],
     )
+  else:
+    flex1 = cand_flex[i][0]
+    flex2 = cand_flex[i][1]
+    margin = 0.0
+    gap = 0.0
 
-    _collide_geom_triangle(
-      naconmax_in,
-      gtype,
-      geom_pos,
-      geom_rot,
-      geom_size_val,
-      t1,
-      t2,
-      t3,
-      tri_radius,
-      margin,
-      condim,
-      friction,
-      solref,
-      solimp,
-      geomid,
-      flexid,
-      v0_local,
-      worldid,
-      contact_dist_out,
-      contact_pos_out,
-      contact_frame_out,
-      contact_includemargin_out,
-      contact_friction_out,
-      contact_solref_out,
-      contact_solreffriction_out,
-      contact_solimp_out,
-      contact_dim_out,
-      contact_geom_out,
-      contact_flex_out,
-      contact_vert_out,
-      contact_worldid_out,
-      contact_type_out,
-      contact_geomcollisionid_out,
-      nacon_out,
+    mixed_condim, _, solref, solimp, friction = _mix_flex_contact_params(
+      flex_condim[flex1],
+      flex_priority[flex1],
+      flex_solmix[flex1],
+      flex_solref[flex1],
+      flex_solimp[flex1],
+      flex_friction[flex1],
+      0.0,
+      flex_condim[flex2],
+      flex_priority[flex2],
+      flex_solmix[flex2],
+      flex_solref[flex2],
+      flex_solimp[flex2],
+      flex_friction[flex2],
+      0.0,
     )
+
+    if cand_vert[i][0] >= 0 and flex_dim[flex1] == 3:
+      condim = 1
+    else:
+      condim = mixed_condim
+
+  id_ = wp.atomic_add(nacon_out, 0, 1)
+  if id_ >= naconmax_in:
+    return
+
+  contact_dist_out[id_] = cand_dist[i]
+  contact_pos_out[id_] = cand_pos[i]
+  contact_frame_out[id_] = make_frame(cand_nrm[i])
+  if geomid >= 0 and geom_type[geomid] == int(GeomType.PLANE):
+    contact_includemargin_out[id_] = margin - gap
+  else:
+    contact_includemargin_out[id_] = margin
+  contact_friction_out[id_] = friction
+  contact_solref_out[id_] = solref
+  contact_solreffriction_out[id_] = wp.vec2(0.0, 0.0)
+  contact_solimp_out[id_] = solimp
+  contact_dim_out[id_] = condim
+  contact_geom_out[id_] = cand_geom[i]
+  contact_flex_out[id_] = cand_flex[i]
+  contact_elem_out[id_] = cand_elem[i]
+  contact_vert_out[id_] = cand_vert[i]
+  contact_worldid_out[id_] = cand_worldid[i]
+  contact_type_out[id_] = cand_type[i]
+  contact_geomcollisionid_out[id_] = cand_geomcollisionid[i]
 
 
 @event_scope
@@ -813,8 +1496,21 @@ def flex_narrowphase(m: Model, d: Data):
   if m.nflex == 0:
     return
 
+  cand_dist = wp.empty(d.naconmax, dtype=float)
+  cand_pos = wp.empty(d.naconmax, dtype=wp.vec3)
+  cand_nrm = wp.empty(d.naconmax, dtype=wp.vec3)
+  cand_geom = wp.empty(d.naconmax, dtype=wp.vec2i)
+  cand_flex = wp.empty(d.naconmax, dtype=wp.vec2i)
+  cand_elem = wp.empty(d.naconmax, dtype=wp.vec2i)
+  cand_vert = wp.empty(d.naconmax, dtype=wp.vec2i)
+  cand_worldid = wp.empty(d.naconmax, dtype=int)
+  cand_type = wp.empty(d.naconmax, dtype=int)
+  cand_geomcollisionid = wp.empty(d.naconmax, dtype=int)
+
+  ncand = wp.zeros(1, dtype=int)
+
   wp.launch(
-    _flex_narrowphase_dim2,
+    _flex_narrowphase_dim2_detect,
     dim=(d.nworld, m.nflexelem),
     inputs=[
       m.ngeom,
@@ -822,25 +1518,11 @@ def flex_narrowphase(m: Model, d: Data):
       m.geom_type,
       m.geom_contype,
       m.geom_conaffinity,
-      m.geom_condim,
-      m.geom_priority,
-      m.geom_solmix,
-      m.geom_solref,
-      m.geom_solimp,
       m.geom_size,
-      m.geom_friction,
       m.geom_margin,
-      m.geom_gap,
       m.flex_contype,
       m.flex_conaffinity,
-      m.flex_condim,
-      m.flex_priority,
-      m.flex_solmix,
-      m.flex_solref,
-      m.flex_solimp,
-      m.flex_friction,
       m.flex_margin,
-      m.flex_gap,
       m.flex_dim,
       m.flex_vertadr,
       m.flex_elemadr,
@@ -855,27 +1537,22 @@ def flex_narrowphase(m: Model, d: Data):
       d.naconmax,
     ],
     outputs=[
-      d.contact.dist,
-      d.contact.pos,
-      d.contact.frame,
-      d.contact.includemargin,
-      d.contact.friction,
-      d.contact.solref,
-      d.contact.solreffriction,
-      d.contact.solimp,
-      d.contact.dim,
-      d.contact.geom,
-      d.contact.flex,
-      d.contact.vert,
-      d.contact.worldid,
-      d.contact.type,
-      d.contact.geomcollisionid,
-      d.nacon,
+      cand_dist,
+      cand_pos,
+      cand_nrm,
+      cand_geom,
+      cand_flex,
+      cand_elem,
+      cand_vert,
+      cand_worldid,
+      cand_type,
+      cand_geomcollisionid,
+      ncand,
     ],
   )
 
   wp.launch(
-    _flex_narrowphase_dim3,
+    _flex_narrowphase_dim3_detect,
     dim=(d.nworld, m.nflexshelldata // 3),
     inputs=[
       m.ngeom,
@@ -883,25 +1560,11 @@ def flex_narrowphase(m: Model, d: Data):
       m.geom_type,
       m.geom_contype,
       m.geom_conaffinity,
-      m.geom_condim,
-      m.geom_priority,
-      m.geom_solmix,
-      m.geom_solref,
-      m.geom_solimp,
       m.geom_size,
-      m.geom_friction,
       m.geom_margin,
-      m.geom_gap,
       m.flex_contype,
       m.flex_conaffinity,
-      m.flex_condim,
-      m.flex_priority,
-      m.flex_solmix,
-      m.flex_solref,
-      m.flex_solimp,
-      m.flex_friction,
       m.flex_margin,
-      m.flex_gap,
       m.flex_dim,
       m.flex_vertadr,
       m.flex_shellnum,
@@ -915,31 +1578,208 @@ def flex_narrowphase(m: Model, d: Data):
       d.naconmax,
     ],
     outputs=[
-      d.contact.dist,
-      d.contact.pos,
-      d.contact.frame,
-      d.contact.includemargin,
-      d.contact.friction,
-      d.contact.solref,
-      d.contact.solreffriction,
-      d.contact.solimp,
-      d.contact.dim,
-      d.contact.geom,
-      d.contact.flex,
-      d.contact.vert,
-      d.contact.worldid,
-      d.contact.type,
-      d.contact.geomcollisionid,
-      d.nacon,
+      cand_dist,
+      cand_pos,
+      cand_nrm,
+      cand_geom,
+      cand_flex,
+      cand_elem,
+      cand_vert,
+      cand_worldid,
+      cand_type,
+      cand_geomcollisionid,
+      ncand,
     ],
   )
 
   wp.launch(
-    _flex_plane_narrowphase,
+    _flex_plane_narrowphase_detect,
     dim=(d.nworld, m.nflexvert),
     inputs=[
       m.ngeom,
       m.nflexvert,
+      m.geom_type,
+      m.geom_margin,
+      m.flex_margin,
+      m.flex_vertadr,
+      m.flex_radius,
+      m.flex_vertflexid,
+      d.geom_xpos,
+      d.geom_xmat,
+      d.flexvert_xpos,
+      d.nworld,
+      d.naconmax,
+    ],
+    outputs=[
+      cand_dist,
+      cand_pos,
+      cand_nrm,
+      cand_geom,
+      cand_flex,
+      cand_elem,
+      cand_vert,
+      cand_worldid,
+      cand_type,
+      cand_geomcollisionid,
+      ncand,
+    ],
+  )
+
+  if m.nflexevpair > 0:
+    wp.launch(
+      _flex_internal_collisions_detect,
+      dim=(d.nworld, m.nflexevpair),
+      inputs=[
+        m.nflex,
+        m.flex_margin,
+        m.flex_internal,
+        m.flex_dim,
+        m.flex_vertadr,
+        m.flex_elemdataadr,
+        m.flex_evpairadr,
+        m.flex_evpairnum,
+        m.flex_elem,
+        m.flex_evpair,
+        m.flex_radius,
+        d.flexvert_xpos,
+        d.naconmax,
+      ],
+      outputs=[
+        cand_dist,
+        cand_pos,
+        cand_nrm,
+        cand_geom,
+        cand_flex,
+        cand_elem,
+        cand_vert,
+        cand_worldid,
+        cand_type,
+        cand_geomcollisionid,
+        ncand,
+      ],
+    )
+
+  if m.nflexelem > 0:
+    wp.launch(
+      _flex_tet_internal_collisions_detect,
+      dim=(d.nworld, m.nflexelem),
+      inputs=[
+        m.nflex,
+        m.flex_dim,
+        m.flex_vertadr,
+        m.flex_elemadr,
+        m.flex_elemnum,
+        m.flex_elemdataadr,
+        m.flex_elem,
+        m.flex_radius,
+        d.flexvert_xpos,
+        d.naconmax,
+      ],
+      outputs=[
+        cand_dist,
+        cand_pos,
+        cand_nrm,
+        cand_geom,
+        cand_flex,
+        cand_elem,
+        cand_vert,
+        cand_worldid,
+        cand_type,
+        cand_geomcollisionid,
+        ncand,
+      ],
+    )
+
+  selfcollide_enabled = m.has_flex_selfcollide
+
+  if selfcollide_enabled and m.nflexelem > 0:
+    workspace_verts = wp.empty(d.nworld * m.nflexelem * 8, dtype=wp.vec3)
+
+    epa_iterations = m.opt.ccd_iterations
+    if m.max_flex_dim > 1:
+      epa_vert = wp.empty(shape=(d.nworld * m.nflexelem, 10 + 2 * epa_iterations), dtype=wp.vec3)
+      epa_vert_index = wp.empty(shape=(d.nworld * m.nflexelem, 10 + 2 * epa_iterations), dtype=int)
+      epa_face = wp.empty(shape=(d.nworld * m.nflexelem, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=int)
+      epa_pr = wp.empty(shape=(d.nworld * m.nflexelem, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=wp.vec3)
+      epa_norm2 = wp.empty(shape=(d.nworld * m.nflexelem, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=float)
+      epa_horizon = wp.empty(shape=(d.nworld * m.nflexelem, MJ_MAX_EPAHORIZON), dtype=int)
+    else:
+      epa_vert = wp.empty(shape=(1, 1), dtype=wp.vec3)
+      epa_vert_index = wp.empty(shape=(1, 1), dtype=int)
+      epa_face = wp.empty(shape=(1, 1), dtype=int)
+      epa_pr = wp.empty(shape=(1, 1), dtype=wp.vec3)
+      epa_norm2 = wp.empty(shape=(1, 1), dtype=float)
+      epa_horizon = wp.empty(shape=(1, 1), dtype=int)
+
+    if selfcollide_enabled:
+      wp.launch(
+        _flex_active_element_collisions_detect,
+        dim=(d.nworld, m.nflexelem),
+        inputs=[
+          m.nflex,
+          m.opt.ccd_tolerance,
+          m.flex_selfcollide,
+          m.flex_dim,
+          m.flex_vertadr,
+          m.flex_elemadr,
+          m.flex_elemnum,
+          m.flex_elemdataadr,
+          m.flex_vertbodyid,
+          m.flex_elem,
+          m.flex_radius,
+          d.flexvert_xpos,
+          d.naconmax,
+          m.opt.ccd_iterations,
+          epa_iterations,
+          m.nflexelem,
+        ],
+        outputs=[
+          workspace_verts,
+          epa_vert,
+          epa_vert_index,
+          epa_face,
+          epa_pr,
+          epa_norm2,
+          epa_horizon,
+          cand_dist,
+          cand_pos,
+          cand_nrm,
+          cand_geom,
+          cand_flex,
+          cand_elem,
+          cand_vert,
+          cand_worldid,
+          cand_type,
+          cand_geomcollisionid,
+          ncand,
+        ],
+      )
+
+  # Filter duplicate contacts (e.g. from shared vertices or edges)
+  cand_active = wp.empty(d.naconmax, dtype=int)
+  wp.launch(
+    _filter_flex_candidates,
+    dim=d.naconmax,
+    inputs=[
+      d.naconmax,
+      ncand,
+      1e-3,  # epsilon
+      cand_dist,
+      cand_pos,
+      cand_geom,
+      cand_flex,
+      cand_worldid,
+    ],
+    outputs=[
+      cand_active,
+    ],
+  )
+
+  # Copy filtered contacts to the main d.contact array, computing contact parameters on-the-fly
+  wp.launch(
+    _write_filtered_contacts,
+    dim=d.naconmax,
+    inputs=[
       m.geom_type,
       m.geom_condim,
       m.geom_priority,
@@ -957,14 +1797,20 @@ def flex_narrowphase(m: Model, d: Data):
       m.flex_friction,
       m.flex_margin,
       m.flex_gap,
-      m.flex_vertadr,
-      m.flex_radius,
-      m.flex_vertflexid,
-      d.geom_xpos,
-      d.geom_xmat,
-      d.flexvert_xpos,
-      d.nworld,
+      m.flex_dim,
       d.naconmax,
+      ncand,
+      cand_dist,
+      cand_pos,
+      cand_nrm,
+      cand_geom,
+      cand_flex,
+      cand_elem,
+      cand_vert,
+      cand_worldid,
+      cand_type,
+      cand_geomcollisionid,
+      cand_active,
     ],
     outputs=[
       d.contact.dist,
@@ -978,6 +1824,7 @@ def flex_narrowphase(m: Model, d: Data):
       d.contact.dim,
       d.contact.geom,
       d.contact.flex,
+      d.contact.elem,
       d.contact.vert,
       d.contact.worldid,
       d.contact.type,

--- a/mujoco_warp/_src/collision_flex_test.py
+++ b/mujoco_warp/_src/collision_flex_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for flex element collision."""
 
+import numpy as np
 from absl.testing import absltest
 
 import mujoco_warp as mjwarp
@@ -66,6 +67,280 @@ class FlexCollisionTest(absltest.TestCase):
 
     # Sphere is just above the cloth, so there should be contacts
     self.assertGreater(nacon, 0, "Expected contacts between sphere and cloth")
+
+  def test_sphere_cloth_no_duplicates(self):
+    """Test that duplicate/redundant contacts are filtered out."""
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option solver="CG" tolerance="1e-6" timestep=".001"/>
+        <worldbody>
+          <!-- Sphere positioned exactly above a vertex shared by multiple elements -->
+          <body pos="0 0 0.1">
+            <freejoint/>
+            <geom type="sphere" size=".1" mass="1"/>
+          </body>
+          <!-- Cloth (dim=2 flex) -->
+          <flexcomp name="cloth" type="grid" count="3 3 1" spacing=".2 .2 .1" pos="-.2 -.2 0"
+                    radius=".02" dim="2" mass=".5">
+            <contact condim="3" selfcollide="none"/>
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """
+    )
+
+    d.nacon.zero_()
+    mjwarp.kinematics(m, d)
+    mjwarp.collision(m, d)
+
+    nacon = int(d.nacon.numpy()[0])
+    self.assertGreater(nacon, 0)
+
+    # Retrieve contact positions
+    pos = d.contact.pos.numpy()[:nacon]
+
+    # Verify that contact positions are unique (no two contacts are closer than epsilon)
+    for i in range(nacon):
+      for j in range(i + 1, nacon):
+        dist = np.linalg.norm(pos[i] - pos[j])
+        self.assertGreater(dist, 1e-3, f"Duplicate contacts found at positions: {pos[i]} and {pos[j]}")
+
+  def test_flex_internal_collision(self):
+    """Test that predefined element-vertex internal collisions generate contacts."""
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <flexcomp name="cloth" type="grid" count="3 3 1" spacing=".2 .2 .1" pos="0 0 0"
+                    radius=".02" dim="2" mass=".5">
+            <contact selfcollide="none" internal="true" margin="0.05"/>
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """
+    )
+
+    self.assertGreater(m.nflexevpair, 0)
+
+    # Find a pair
+    evpair = m.flex_evpair.numpy()[0]
+    e = int(evpair[0])
+    v = int(evpair[1])
+
+    # Vertices of element e
+    dim = int(m.flex_dim.numpy()[0])
+    elem_data_idx = int(m.flex_elemdataadr.numpy()[0]) + e * (dim + 1)
+    v_indices = m.flex_elem.numpy()[elem_data_idx : elem_data_idx + dim + 1]
+
+    # Move vertex v close to v0
+    v0_global_idx = int(m.flex_vertadr.numpy()[0]) + int(v_indices[0])
+    v_global_idx = int(m.flex_vertadr.numpy()[0]) + v
+
+    p0 = d.flexvert_xpos.numpy()[0, v0_global_idx]
+
+    # Set vertex v to be at p0 + small offset in Z (overlapping the element)
+    xpos = d.flexvert_xpos.numpy()
+    xpos[0, v_global_idx] = p0 + np.array([0.0, 0.0, 0.01])
+    d.flexvert_xpos.assign(xpos)
+
+    # Run collision detection
+    mjwarp.collision(m, d)
+
+    nacon = int(d.nacon.numpy()[0])
+    self.assertGreater(nacon, 0, "Expected at least one contact from internal self-collision")
+
+    # Verify contact properties
+    self.assertEqual(int(d.contact.geom.numpy()[0, 0]), -1)
+    self.assertEqual(int(d.contact.geom.numpy()[0, 1]), -1)
+    self.assertEqual(int(d.contact.flex.numpy()[0, 0]), 0)
+    self.assertEqual(int(d.contact.flex.numpy()[0, 1]), 0)
+    self.assertEqual(int(d.contact.dim.numpy()[0]), 3)
+
+  def test_flex_self_collision_1d(self):
+    """Test active element self-collisions for 1D ropes (Capsule-Capsule)."""
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <flexcomp name="rope" type="grid" count="4 1 1" spacing=".2 .2 .1" pos="0 0 0"
+                    radius=".02" dim="1" mass=".5">
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """
+    )
+    m.flex_selfcollide.assign(np.array([4], dtype=np.int32))
+    m.nflexevpair = 0
+
+    # Fold rope so vertex 3 is close to vertex 0
+    v0_global_idx = int(m.flex_vertadr.numpy()[0])
+    v_global_idx = int(m.flex_vertadr.numpy()[0]) + 3
+    xpos = d.flexvert_xpos.numpy()
+    xpos[0, v_global_idx] = xpos[0, v0_global_idx] + np.array([0.0, 0.0, 0.01])
+    d.flexvert_xpos.assign(xpos)
+
+    # Run collision detection
+    mjwarp.collision(m, d)
+
+    nacon = int(d.nacon.numpy()[0])
+    self.assertGreater(nacon, 0, "Expected at least one contact from 1D self-collision")
+
+    # Verify contact properties
+    found = False
+    for idx in range(nacon):
+      g0 = int(d.contact.geom.numpy()[idx, 0])
+      g1 = int(d.contact.geom.numpy()[idx, 1])
+      f0 = int(d.contact.flex.numpy()[idx, 0])
+      f1 = int(d.contact.flex.numpy()[idx, 1])
+      e0 = int(d.contact.elem.numpy()[idx, 0])
+      e1 = int(d.contact.elem.numpy()[idx, 1])
+
+      if g0 == -1 and g1 == -1 and f0 == 0 and f1 == 0:
+        if (e0 == 0 and e1 == 2) or (e0 == 2 and e1 == 0):
+          found = True
+          self.assertGreaterEqual(int(d.contact.dim.numpy()[idx]), 3)
+          break
+
+    self.assertTrue(found, "Expected active element self-collision contact between element 0 and 2 not found")
+
+  def test_flex_self_collision_2d(self):
+    """Test active element self-collisions for 2D meshes (Triangle-Triangle via GJK/EPA)."""
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <flexcomp name="cloth" type="grid" count="3 3 1" spacing=".2 .2 .1" pos="0 0 0"
+                    radius=".02" dim="2" mass=".5">
+            <contact selfcollide="auto"/>
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """
+    )
+
+    elem_num = m.flex_elemnum.numpy()[0]
+    dim = int(m.flex_dim.numpy()[0])
+    elem_data_idx = int(m.flex_elemdataadr.numpy()[0])
+    elem_verts = m.flex_elem.numpy()[elem_data_idx : elem_data_idx + elem_num * (dim + 1)].reshape(elem_num, dim + 1)
+
+    # Find two elements with disjoint vertices
+    e1 = -1
+    e2 = -1
+    for i in range(elem_num):
+      for j in range(i + 1, elem_num):
+        if len(set(elem_verts[i]) & set(elem_verts[j])) == 0:
+          e1 = i
+          e2 = j
+          break
+      if e1 >= 0:
+        break
+
+    self.assertGreaterEqual(e1, 0)
+    self.assertGreaterEqual(e2, 0)
+
+    # Calculate center of element 1
+    vert_adr = int(m.flex_vertadr.numpy()[0])
+    xpos = d.flexvert_xpos.numpy()
+
+    p_center1 = np.zeros(3)
+    for v_idx in elem_verts[e1]:
+      p_center1 += xpos[0, vert_adr + v_idx]
+    p_center1 /= dim + 1
+
+    # Calculate center of element 2
+    p_center2 = np.zeros(3)
+    for v_idx in elem_verts[e2]:
+      p_center2 += xpos[0, vert_adr + v_idx]
+    p_center2 /= dim + 1
+
+    # Move element 2 vertices close to element 1 center
+    shift = p_center1 - p_center2 + np.array([0.0, 0.0, 0.005])
+    for v_idx in elem_verts[e2]:
+      xpos[0, vert_adr + v_idx] += shift
+
+    d.flexvert_xpos.assign(xpos)
+
+    # Run collision detection
+    mjwarp.collision(m, d)
+
+    nacon = int(d.nacon.numpy()[0])
+    self.assertGreater(nacon, 0, "Expected at least one contact from 2D self-collision")
+
+    # Verify contact properties
+    found = False
+    for idx in range(nacon):
+      g0 = int(d.contact.geom.numpy()[idx, 0])
+      g1 = int(d.contact.geom.numpy()[idx, 1])
+      f0 = int(d.contact.flex.numpy()[idx, 0])
+      f1 = int(d.contact.flex.numpy()[idx, 1])
+      elem0 = int(d.contact.elem.numpy()[idx, 0])
+      elem1 = int(d.contact.elem.numpy()[idx, 1])
+
+      if g0 == -1 and g1 == -1 and f0 == 0 and f1 == 0:
+        if (elem0 == e1 and elem1 == e2) or (elem0 == e2 and elem1 == e1):
+          found = True
+          self.assertGreaterEqual(int(d.contact.dim.numpy()[idx]), 3)
+          break
+
+    self.assertTrue(found, f"Expected active element self-collision contact between element {e1} and {e2} not found")
+
+  def test_flex_self_collision_weld_exclusion(self):
+    """Test self-collision exclusions when vertices are welded to the same body."""
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <flexcomp name="rope" type="grid" count="4 1 1" spacing=".2 .2 .1" pos="0 0 0"
+                    radius=".02" dim="1" mass=".5">
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """
+    )
+    m.flex_selfcollide.assign(np.array([4], dtype=np.int32))
+    m.nflexevpair = 0
+
+    # Fold rope
+    v0_global_idx = int(m.flex_vertadr.numpy()[0])
+    v_global_idx = int(m.flex_vertadr.numpy()[0]) + 3
+    xpos = d.flexvert_xpos.numpy()
+    xpos[0, v_global_idx] = xpos[0, v0_global_idx] + np.array([0.0, 0.0, 0.01])
+    d.flexvert_xpos.assign(xpos)
+
+    # Weld vertex 0 and 3 to same body ID (e.g. 1)
+    vertbody = m.flex_vertbodyid.numpy()
+    vertbody[v0_global_idx] = 1
+    vertbody[v_global_idx] = 1
+    m.flex_vertbodyid.assign(vertbody)
+
+    # Run collision detection
+    mjwarp.collision(m, d)
+
+    nacon = int(d.nacon.numpy()[0])
+    self.assertEqual(nacon, 0, "Expected 0 contacts due to weld same-body exclusion")
+
+  def test_flex_self_collision_no_adjacent_contacts(self):
+    """Test that a flat cloth does not generate any self-collision contacts."""
+    _, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco model="Poncho">
+        <option solver="CG" tolerance="1e-6" jacobian="sparse"/>
+        <worldbody>
+          <flexcomp name="cloth" type="grid" count="10 10 1" spacing="0.05 0.05 0.05"
+                    radius="0.01" dim="2" rgba="1 0.5 0.5 1" pos="0 0 2" mass=".1">
+            <contact selfcollide="auto"/>
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """
+    )
+
+    mjwarp.kinematics(m, d)
+    mjwarp.collision(m, d)
+
+    nacon = int(d.nacon.numpy()[0])
+    self.assertEqual(nacon, 0, f"Expected 0 self-collision contacts on a flat cloth, but got {nacon}")
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from typing import Tuple
+
 import warp as wp
 
 from mujoco_warp._src import math
@@ -1905,6 +1907,115 @@ def _limit_tendon(
     )
 
 
+@wp.func
+def _get_contact_bodies_and_weights(
+  # Model:
+  geom_bodyid: wp.array[int],
+  flex_dim: wp.array[int],
+  flex_vertadr: wp.array[int],
+  flex_elemdataadr: wp.array[int],
+  flex_shelldataadr: wp.array[int],
+  flex_vertbodyid: wp.array[int],
+  flex_elem: wp.array[int],
+  flex_shell: wp.array[int],
+  # Data in:
+  flexvert_xpos_in: wp.array2d[wp.vec3],
+  # In:
+  conid: int,
+  side: int,
+  geom: wp.vec2i,
+  flex: wp.vec2i,
+  elem: wp.vec2i,
+  vert: wp.vec2i,
+  con_pos: wp.vec3,
+  worldid: int,
+) -> Tuple[wp.vec4i, wp.vec4]:
+  geom_id = geom[side]
+  flex_id = flex[side]
+  elem_id = elem[side]
+  vert_id = vert[side]
+
+  # Rigid Geom Side
+  if geom_id >= 0:
+    return wp.vec4i(geom_bodyid[geom_id], -1, -1, -1), wp.vec4(1.0, 0.0, 0.0, 0.0)
+
+  # Plane-Vertex or Vertex-only flex contact
+  flex_vert_start = flex_vertadr[flex_id]
+  if vert_id >= 0:
+    body = flex_vertbodyid[flex_vert_start + vert_id]
+    return wp.vec4i(body, -1, -1, -1), wp.vec4(1.0, 0.0, 0.0, 0.0)
+
+  # Element contact: Retrieve local vertices
+  dim = flex_dim[flex_id]
+
+  if dim == 2:
+    elem_data_start = flex_elemdataadr[flex_id] + elem_id * 3
+    v0 = flex_elem[elem_data_start + 0]
+    v1 = flex_elem[elem_data_start + 1]
+    v2 = flex_elem[elem_data_start + 2]
+
+    x0 = flexvert_xpos_in[worldid, flex_vert_start + v0]
+    x1 = flexvert_xpos_in[worldid, flex_vert_start + v1]
+    x2 = flexvert_xpos_in[worldid, flex_vert_start + v2]
+
+    d0 = wp.length(con_pos - x0)
+    d1 = wp.length(con_pos - x1)
+    d2 = wp.length(con_pos - x2)
+
+    w0 = 1.0 / wp.max(types.MJ_MINVAL, d0)
+    w1 = 1.0 / wp.max(types.MJ_MINVAL, d1)
+    w2 = 1.0 / wp.max(types.MJ_MINVAL, d2)
+
+    w_sum = w0 + w1 + w2
+    w0 = w0 / w_sum
+    w1 = w1 / w_sum
+    w2 = w2 / w_sum
+
+    b0 = flex_vertbodyid[flex_vert_start + v0]
+    b1 = flex_vertbodyid[flex_vert_start + v1]
+    b2 = flex_vertbodyid[flex_vert_start + v2]
+
+    return wp.vec4i(b0, b1, b2, -1), wp.vec4(w0, w1, w2, 0.0)
+
+  elif dim == 3:
+    elem_data_start = flex_elemdataadr[flex_id] + elem_id * 4
+    v0 = flex_elem[elem_data_start + 0]
+    v1 = flex_elem[elem_data_start + 1]
+    v2 = flex_elem[elem_data_start + 2]
+    v3 = flex_elem[elem_data_start + 3]
+
+    x0 = flexvert_xpos_in[worldid, flex_vert_start + v0]
+    x1 = flexvert_xpos_in[worldid, flex_vert_start + v1]
+    x2 = flexvert_xpos_in[worldid, flex_vert_start + v2]
+    x3 = flexvert_xpos_in[worldid, flex_vert_start + v3]
+
+    d0 = wp.length(con_pos - x0)
+    d1 = wp.length(con_pos - x1)
+    d2 = wp.length(con_pos - x2)
+    d3 = wp.length(con_pos - x3)
+
+    w0 = 1.0 / wp.max(types.MJ_MINVAL, d0)
+    w1 = 1.0 / wp.max(types.MJ_MINVAL, d1)
+    w2 = 1.0 / wp.max(types.MJ_MINVAL, d2)
+    w3 = 1.0 / wp.max(types.MJ_MINVAL, d3)
+
+    w_sum = w0 + w1 + w2 + w3
+    w0 = w0 / w_sum
+    w1 = w1 / w_sum
+    w2 = w2 / w_sum
+    w3 = w3 / w_sum
+
+    b0 = flex_vertbodyid[flex_vert_start + v0]
+    b1 = flex_vertbodyid[flex_vert_start + v1]
+    b2 = flex_vertbodyid[flex_vert_start + v2]
+    b3 = flex_vertbodyid[flex_vert_start + v3]
+
+    return wp.vec4i(b0, b1, b2, b3), wp.vec4(w0, w1, w2, w3)
+
+  else:
+    return wp.vec4i(-1, -1, -1, -1), wp.vec4(0.0, 0.0, 0.0, 0.0)
+
+
 @cache_kernel
 def _efc_contact_init(cone_type: types.ConeType, is_sparse: bool):
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
@@ -1918,8 +2029,6 @@ def _efc_contact_init(cone_type: types.ConeType, is_sparse: bool):
     body_dofadr: wp.array[int],
     dof_parentid: wp.array[int],
     geom_bodyid: wp.array[int],
-    flex_vertadr: wp.array[int],
-    flex_vertbodyid: wp.array[int],
     # Data in:
     njmax_in: int,
     njmax_nnz_in: int,
@@ -1930,7 +2039,122 @@ def _efc_contact_init(cone_type: types.ConeType, is_sparse: bool):
     includemargin_in: wp.array[float],
     worldid_in: wp.array[int],
     geom_in: wp.array[wp.vec2i],
+    type_in: wp.array[int],
+    # Data out:
+    nefc_out: wp.array[int],
+    contact_efc_address_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_J_rownnz_out: wp.array2d[int],
+    efc_J_rowadr_out: wp.array2d[int],
+    # Out:
+    efc_nnz_out: wp.array[int],
+  ):
+    conid = wp.tid()
+
+    if conid >= nacon_in[0]:
+      return
+
+    if not type_in[conid] & ContactType.CONSTRAINT:
+      return
+
+    condim = condim_in[conid]
+
+    includemargin = includemargin_in[conid]
+    pos = dist_in[conid] - includemargin
+    active = pos < 0
+
+    if not active:
+      return
+
+    if wp.static(IS_ELLIPTIC):
+      ndim = condim
+    else:
+      if condim == 1:
+        ndim = 1
+      else:
+        ndim = 2 * (condim - 1)
+
+    worldid = worldid_in[conid]
+
+    # Allocate contiguous block of efcids for all dimids
+    base_efcid = wp.atomic_add(nefc_out, worldid, ndim)
+    for dim in range(ndim):
+      efcid = base_efcid + dim
+      if efcid >= njmax_in:
+        contact_efc_address_out[conid, dim] = -1
+      else:
+        contact_efc_address_out[conid, dim] = efcid
+        # This is redundant with the _efc_row call later but needed for the jac calculation
+        efc_id_out[worldid, efcid] = conid
+
+    if wp.static(IS_SPARSE):
+      geom = geom_in[conid]
+      body1 = body_weldid[geom_bodyid[geom[0]]]
+      body2 = body_weldid[geom_bodyid[geom[1]]]
+
+      da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
+      da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
+
+      # count non-zeros
+      rownnz = int(0)
+      while da1 >= 0 or da2 >= 0:
+        da = wp.max(da1, da2)
+        # skip common dofs
+        if da1 == da and da2 == da:
+          break
+        if da1 == da:
+          da1 = dof_parentid[da1]
+        if da2 == da:
+          da2 = dof_parentid[da2]
+        rownnz += 1
+
+      rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz * ndim)
+      if rowadr + rownnz * ndim > njmax_nnz_in:
+        return
+      for dim in range(ndim):
+        efcid = base_efcid + dim
+        if efcid < njmax_in:
+          efc_J_rowadr_out[worldid, efcid] = rowadr + dim * rownnz
+          efc_J_rownnz_out[worldid, efcid] = rownnz
+
+  return kernel
+
+
+@cache_kernel
+def _efc_contact_init_flex(cone_type: types.ConeType, is_sparse: bool):
+  IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
+  IS_SPARSE = is_sparse
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    body_parentid: wp.array[int],
+    body_weldid: wp.array[int],
+    body_dofnum: wp.array[int],
+    body_dofadr: wp.array[int],
+    dof_parentid: wp.array[int],
+    geom_bodyid: wp.array[int],
+    flex_dim: wp.array[int],
+    flex_vertadr: wp.array[int],
+    flex_elemdataadr: wp.array[int],
+    flex_shelldataadr: wp.array[int],
+    flex_vertbodyid: wp.array[int],
+    flex_elem: wp.array[int],
+    flex_shell: wp.array[int],
+    # Data in:
+    flexvert_xpos_in: wp.array2d[wp.vec3],
+    njmax_in: int,
+    njmax_nnz_in: int,
+    nacon_in: wp.array[int],
+    # In:
+    dist_in: wp.array[float],
+    pos_in: wp.array[wp.vec3],
+    condim_in: wp.array[int],
+    includemargin_in: wp.array[float],
+    worldid_in: wp.array[int],
+    geom_in: wp.array[wp.vec2i],
     flex_in: wp.array[wp.vec2i],
+    elem_in: wp.array[wp.vec2i],
     vert_in: wp.array[wp.vec2i],
     type_in: wp.array[int],
     # Data out:
@@ -1982,39 +2206,97 @@ def _efc_contact_init(cone_type: types.ConeType, is_sparse: bool):
 
     if wp.static(IS_SPARSE):
       geom = geom_in[conid]
+      flex = flex_in[conid]
+      elem = elem_in[conid]
+      vert = vert_in[conid]
+      con_pos = pos_in[conid]
 
-      if geom[0] >= 0:
-        body1 = geom_bodyid[geom[0]]
-      else:
-        flex = flex_in[conid]
-        vert = vert_in[conid]
-        body1 = flex_vertbodyid[flex_vertadr[flex[0]] + vert[0]]
+      body_ids1, weights1 = _get_contact_bodies_and_weights(
+        geom_bodyid,
+        flex_dim,
+        flex_vertadr,
+        flex_elemdataadr,
+        flex_shelldataadr,
+        flex_vertbodyid,
+        flex_elem,
+        flex_shell,
+        flexvert_xpos_in,
+        conid,
+        0,
+        geom,
+        flex,
+        elem,
+        vert,
+        con_pos,
+        worldid,
+      )
+      body_ids2, weights2 = _get_contact_bodies_and_weights(
+        geom_bodyid,
+        flex_dim,
+        flex_vertadr,
+        flex_elemdataadr,
+        flex_shelldataadr,
+        flex_vertbodyid,
+        flex_elem,
+        flex_shell,
+        flexvert_xpos_in,
+        conid,
+        1,
+        geom,
+        flex,
+        elem,
+        vert,
+        con_pos,
+        worldid,
+      )
 
-      if geom[1] >= 0:
-        body2 = geom_bodyid[geom[1]]
-      else:
-        flex = flex_in[conid]
-        vert = vert_in[conid]
-        body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
+      b1_0 = body_weldid[body_ids1[0]]
+      b1_1 = body_weldid[body_ids1[1]] if body_ids1[1] >= 0 else -1
+      b1_2 = body_weldid[body_ids1[2]] if body_ids1[2] >= 0 else -1
+      b1_3 = body_weldid[body_ids1[3]] if body_ids1[3] >= 0 else -1
 
-      # skip fixed bodies
-      body1 = body_weldid[body1]
-      body2 = body_weldid[body2]
+      b2_0 = body_weldid[body_ids2[0]]
+      b2_1 = body_weldid[body_ids2[1]] if body_ids2[1] >= 0 else -1
+      b2_2 = body_weldid[body_ids2[2]] if body_ids2[2] >= 0 else -1
+      b2_3 = body_weldid[body_ids2[3]] if body_ids2[3] >= 0 else -1
 
-      da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
-      da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
+      dof1_0 = int(body_dofadr[b1_0] + body_dofnum[b1_0] - 1) if b1_0 >= 0 else -1
+      dof1_1 = int(body_dofadr[b1_1] + body_dofnum[b1_1] - 1) if b1_1 >= 0 else -1
+      dof1_2 = int(body_dofadr[b1_2] + body_dofnum[b1_2] - 1) if b1_2 >= 0 else -1
+      dof1_3 = int(body_dofadr[b1_3] + body_dofnum[b1_3] - 1) if b1_3 >= 0 else -1
+
+      dof2_0 = int(body_dofadr[b2_0] + body_dofnum[b2_0] - 1) if b2_0 >= 0 else -1
+      dof2_1 = int(body_dofadr[b2_1] + body_dofnum[b2_1] - 1) if b2_1 >= 0 else -1
+      dof2_2 = int(body_dofadr[b2_2] + body_dofnum[b2_2] - 1) if b2_2 >= 0 else -1
+      dof2_3 = int(body_dofadr[b2_3] + body_dofnum[b2_3] - 1) if b2_3 >= 0 else -1
 
       # count non-zeros
       rownnz = int(0)
-      while da1 >= 0 or da2 >= 0:
-        da = wp.max(da1, da2)
-        # skip common dofs
-        if da1 == da and da2 == da:
-          break
-        if da1 == da:
-          da1 = dof_parentid[da1]
-        if da2 == da:
-          da2 = dof_parentid[da2]
+      while (
+        dof1_0 >= 0 or dof1_1 >= 0 or dof1_2 >= 0 or dof1_3 >= 0 or dof2_0 >= 0 or dof2_1 >= 0 or dof2_2 >= 0 or dof2_3 >= 0
+      ):
+        da1_max = wp.max(dof1_0, wp.max(dof1_1, wp.max(dof1_2, dof1_3)))
+        da2_max = wp.max(dof2_0, wp.max(dof2_1, wp.max(dof2_2, dof2_3)))
+        da = wp.max(da1_max, da2_max)
+
+        if dof1_0 == da:
+          dof1_0 = dof_parentid[dof1_0]
+        if dof1_1 == da:
+          dof1_1 = dof_parentid[dof1_1]
+        if dof1_2 == da:
+          dof1_2 = dof_parentid[dof1_2]
+        if dof1_3 == da:
+          dof1_3 = dof_parentid[dof1_3]
+
+        if dof2_0 == da:
+          dof2_0 = dof_parentid[dof2_0]
+        if dof2_1 == da:
+          dof2_1 = dof_parentid[dof2_1]
+        if dof2_2 == da:
+          dof2_2 = dof_parentid[dof2_2]
+        if dof2_3 == da:
+          dof2_3 = dof_parentid[dof2_3]
+
         rownnz += 1
 
       rowadr = wp.atomic_add(efc_nnz_out, worldid, rownnz * ndim)
@@ -2044,8 +2326,6 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
     dof_bodyid: wp.array[int],
     dof_parentid: wp.array[int],
     geom_bodyid: wp.array[int],
-    flex_vertadr: wp.array[int],
-    flex_vertbodyid: wp.array[int],
     body_isdofancestor: wp.array2d[int],
     # Data in:
     qvel_in: wp.array2d[float],
@@ -2058,8 +2338,6 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
     # In:
     condim_in: wp.array[int],
     geom_in: wp.array[wp.vec2i],
-    flex_in: wp.array[wp.vec2i],
-    vert_in: wp.array[wp.vec2i],
     pos_in: wp.array[wp.vec3],
     frame_in: wp.array2d[wp.vec3],
     friction_in: wp.array2d[float],
@@ -2082,23 +2360,8 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
     condim = condim_in[conid]
 
     geom = geom_in[conid]
-    if geom[0] >= 0:
-      body1 = geom_bodyid[geom[0]]
-    else:
-      flex = flex_in[conid]
-      vert = vert_in[conid]
-      body1 = flex_vertbodyid[flex_vertadr[flex[0]] + vert[0]]
-
-    if geom[1] >= 0:
-      body2 = geom_bodyid[geom[1]]
-    else:
-      flex = flex_in[conid]
-      vert = vert_in[conid]
-      body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
-
-    # skip fixed bodies
-    body1 = body_weldid[body1]
-    body2 = body_weldid[body2]
+    body1 = body_weldid[geom_bodyid[geom[0]]]
+    body2 = body_weldid[geom_bodyid[geom[1]]]
 
     con_pos = pos_in[conid]
 
@@ -2201,6 +2464,274 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
 
 
 @cache_kernel
+def _efc_contact_jac_sparse_flex(cone_type: types.ConeType):
+  IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    body_parentid: wp.array[int],
+    body_rootid: wp.array[int],
+    body_weldid: wp.array[int],
+    body_dofnum: wp.array[int],
+    body_dofadr: wp.array[int],
+    dof_bodyid: wp.array[int],
+    dof_parentid: wp.array[int],
+    geom_bodyid: wp.array[int],
+    flex_dim: wp.array[int],
+    flex_vertadr: wp.array[int],
+    flex_elemdataadr: wp.array[int],
+    flex_shelldataadr: wp.array[int],
+    flex_vertbodyid: wp.array[int],
+    flex_elem: wp.array[int],
+    flex_shell: wp.array[int],
+    body_isdofancestor: wp.array2d[int],
+    # Data in:
+    qvel_in: wp.array2d[float],
+    subtree_com_in: wp.array2d[wp.vec3],
+    cdof_in: wp.array2d[wp.spatial_vector],
+    flexvert_xpos_in: wp.array2d[wp.vec3],
+    contact_efc_address_in: wp.array2d[int],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    nacon_in: wp.array[int],
+    # In:
+    condim_in: wp.array[int],
+    geom_in: wp.array[wp.vec2i],
+    flex_in: wp.array[wp.vec2i],
+    elem_in: wp.array[wp.vec2i],
+    vert_in: wp.array[wp.vec2i],
+    pos_in: wp.array[wp.vec3],
+    frame_in: wp.array2d[wp.vec3],
+    friction_in: wp.array2d[float],
+    worldid_in: wp.array[int],
+    # Data out:
+    efc_J_colind_out: wp.array3d[int],
+    efc_J_out: wp.array3d[float],
+    efc_Jqvel_out: wp.array2d[float],
+  ):
+    conid, dimid = wp.tid()
+
+    if conid >= nacon_in[0]:
+      return
+
+    efcid = contact_efc_address_in[conid, dimid]
+    if efcid < 0:
+      return
+
+    worldid = worldid_in[conid]
+    condim = condim_in[conid]
+
+    geom = geom_in[conid]
+    flex = flex_in[conid]
+    elem = elem_in[conid]
+    vert = vert_in[conid]
+    con_pos = pos_in[conid]
+
+    body_ids1, weights1 = _get_contact_bodies_and_weights(
+      geom_bodyid,
+      flex_dim,
+      flex_vertadr,
+      flex_elemdataadr,
+      flex_shelldataadr,
+      flex_vertbodyid,
+      flex_elem,
+      flex_shell,
+      flexvert_xpos_in,
+      conid,
+      0,
+      geom,
+      flex,
+      elem,
+      vert,
+      con_pos,
+      worldid,
+    )
+    body_ids2, weights2 = _get_contact_bodies_and_weights(
+      geom_bodyid,
+      flex_dim,
+      flex_vertadr,
+      flex_elemdataadr,
+      flex_shelldataadr,
+      flex_vertbodyid,
+      flex_elem,
+      flex_shell,
+      flexvert_xpos_in,
+      conid,
+      1,
+      geom,
+      flex,
+      elem,
+      vert,
+      con_pos,
+      worldid,
+    )
+
+    # skip fixed bodies
+    b1_0 = body_weldid[body_ids1[0]]
+    b1_1 = body_weldid[body_ids1[1]] if body_ids1[1] >= 0 else -1
+    b1_2 = body_weldid[body_ids1[2]] if body_ids1[2] >= 0 else -1
+    b1_3 = body_weldid[body_ids1[3]] if body_ids1[3] >= 0 else -1
+
+    b2_0 = body_weldid[body_ids2[0]]
+    b2_1 = body_weldid[body_ids2[1]] if body_ids2[1] >= 0 else -1
+    b2_2 = body_weldid[body_ids2[2]] if body_ids2[2] >= 0 else -1
+    b2_3 = body_weldid[body_ids2[3]] if body_ids2[3] >= 0 else -1
+
+    if not wp.static(IS_ELLIPTIC):
+      frame_0 = frame_in[conid, 0]
+      if condim > 1:
+        dimid2 = dimid / 2 + 1
+        frii = friction_in[conid, dimid2 - 1]
+
+    dof1_0 = int(body_dofadr[b1_0] + body_dofnum[b1_0] - 1) if b1_0 >= 0 else -1
+    dof1_1 = int(body_dofadr[b1_1] + body_dofnum[b1_1] - 1) if b1_1 >= 0 else -1
+    dof1_2 = int(body_dofadr[b1_2] + body_dofnum[b1_2] - 1) if b1_2 >= 0 else -1
+    dof1_3 = int(body_dofadr[b1_3] + body_dofnum[b1_3] - 1) if b1_3 >= 0 else -1
+    da1 = wp.max(dof1_0, wp.max(dof1_1, wp.max(dof1_2, dof1_3)))
+
+    dof2_0 = int(body_dofadr[b2_0] + body_dofnum[b2_0] - 1) if b2_0 >= 0 else -1
+    dof2_1 = int(body_dofadr[b2_1] + body_dofnum[b2_1] - 1) if b2_1 >= 0 else -1
+    dof2_2 = int(body_dofadr[b2_2] + body_dofnum[b2_2] - 1) if b2_2 >= 0 else -1
+    dof2_3 = int(body_dofadr[b2_3] + body_dofnum[b2_3] - 1) if b2_3 >= 0 else -1
+    da2 = wp.max(dof2_0, wp.max(dof2_1, wp.max(dof2_2, dof2_3)))
+
+    da = wp.max(da1, da2)
+
+    rowadr = efc_J_rowadr_in[worldid, efcid]
+    rownnz = efc_J_rownnz_in[worldid, efcid]
+
+    Jqvel = float(0.0)
+    nnz = int(0)
+    dofid = int(da)
+
+    while True:
+      if nnz >= rownnz:
+        break
+
+      if dofid == da:
+        jac1p = wp.vec3(0.0)
+        jac1r = wp.vec3(0.0)
+        if dof1_0 == da:
+          jp, jr = support.jac_dof(
+            body_parentid, body_rootid, dof_bodyid, body_isdofancestor, subtree_com_in, cdof_in, con_pos, b1_0, dofid, worldid
+          )
+          jac1p += jp * weights1[0]
+          jac1r += jr * weights1[0]
+        if dof1_1 == da:
+          jp, jr = support.jac_dof(
+            body_parentid, body_rootid, dof_bodyid, body_isdofancestor, subtree_com_in, cdof_in, con_pos, b1_1, dofid, worldid
+          )
+          jac1p += jp * weights1[1]
+          jac1r += jr * weights1[1]
+        if dof1_2 == da:
+          jp, jr = support.jac_dof(
+            body_parentid, body_rootid, dof_bodyid, body_isdofancestor, subtree_com_in, cdof_in, con_pos, b1_2, dofid, worldid
+          )
+          jac1p += jp * weights1[2]
+          jac1r += jr * weights1[2]
+        if dof1_3 == da:
+          jp, jr = support.jac_dof(
+            body_parentid, body_rootid, dof_bodyid, body_isdofancestor, subtree_com_in, cdof_in, con_pos, b1_3, dofid, worldid
+          )
+          jac1p += jp * weights1[3]
+          jac1r += jr * weights1[3]
+
+        jac2p = wp.vec3(0.0)
+        jac2r = wp.vec3(0.0)
+        if dof2_0 == da:
+          jp, jr = support.jac_dof(
+            body_parentid, body_rootid, dof_bodyid, body_isdofancestor, subtree_com_in, cdof_in, con_pos, b2_0, dofid, worldid
+          )
+          jac2p += jp * weights2[0]
+          jac2r += jr * weights2[0]
+        if dof2_1 == da:
+          jp, jr = support.jac_dof(
+            body_parentid, body_rootid, dof_bodyid, body_isdofancestor, subtree_com_in, cdof_in, con_pos, b2_1, dofid, worldid
+          )
+          jac2p += jp * weights2[1]
+          jac2r += jr * weights2[1]
+        if dof2_2 == da:
+          jp, jr = support.jac_dof(
+            body_parentid, body_rootid, dof_bodyid, body_isdofancestor, subtree_com_in, cdof_in, con_pos, b2_2, dofid, worldid
+          )
+          jac2p += jp * weights2[2]
+          jac2r += jr * weights2[2]
+        if dof2_3 == da:
+          jp, jr = support.jac_dof(
+            body_parentid, body_rootid, dof_bodyid, body_isdofancestor, subtree_com_in, cdof_in, con_pos, b2_3, dofid, worldid
+          )
+          jac2p += jp * weights2[3]
+          jac2r += jr * weights2[3]
+
+        jacp_dif = jac2p - jac1p
+        jacr_dif = jac2r - jac1r
+
+        if wp.static(IS_ELLIPTIC):
+          J = float(0.0)
+          if dimid < 3:
+            frame_row = frame_in[conid, dimid]
+            for xyz in range(3):
+              J += frame_row[xyz] * jacp_dif[xyz]
+          else:
+            frame_row = frame_in[conid, dimid - 3]
+            for xyz in range(3):
+              J += frame_row[xyz] * jacr_dif[xyz]
+        else:
+          J = float(0.0)
+          Ji = float(0.0)
+
+          for xyz in range(3):
+            J += frame_0[xyz] * jacp_dif[xyz]
+
+            if condim > 1:
+              if dimid2 < 3:
+                Ji += frame_in[conid, dimid2][xyz] * jacp_dif[xyz]
+              else:
+                Ji += frame_in[conid, dimid2 - 3][xyz] * jacr_dif[xyz]
+
+          if condim > 1:
+            if dimid % 2 == 0:
+              J += Ji * frii
+            else:
+              J -= Ji * frii
+
+        sparseid = rowadr + nnz
+        efc_J_colind_out[worldid, 0, sparseid] = dofid
+        efc_J_out[worldid, 0, sparseid] = J
+        nnz += 1
+        Jqvel += J * qvel_in[worldid, dofid]
+
+        # Advance tree pointers
+        if dof1_0 == da:
+          dof1_0 = dof_parentid[dof1_0]
+        if dof1_1 == da:
+          dof1_1 = dof_parentid[dof1_1]
+        if dof1_2 == da:
+          dof1_2 = dof_parentid[dof1_2]
+        if dof1_3 == da:
+          dof1_3 = dof_parentid[dof1_3]
+        da1 = wp.max(dof1_0, wp.max(dof1_1, wp.max(dof1_2, dof1_3)))
+
+        if dof2_0 == da:
+          dof2_0 = dof_parentid[dof2_0]
+        if dof2_1 == da:
+          dof2_1 = dof_parentid[dof2_1]
+        if dof2_2 == da:
+          dof2_2 = dof_parentid[dof2_2]
+        if dof2_3 == da:
+          dof2_3 = dof_parentid[dof2_3]
+        da2 = wp.max(dof2_0, wp.max(dof2_1, wp.max(dof2_2, dof2_3)))
+
+        da = wp.max(da1, da2)
+        dofid = da
+
+    efc_Jqvel_out[worldid, efcid] = Jqvel
+
+  return kernel
+
+
+@cache_kernel
 def _efc_contact_jac_dense(tile_size: int, cone_type: types.ConeType):
   TILE_SIZE = tile_size
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
@@ -2210,8 +2741,6 @@ def _efc_contact_jac_dense(tile_size: int, cone_type: types.ConeType):
     # Model:
     body_rootid: wp.array[int],
     geom_bodyid: wp.array[int],
-    flex_vertadr: wp.array[int],
-    flex_vertbodyid: wp.array[int],
     body_isdofancestor: wp.array2d[int],
     # Data in:
     ne_in: wp.array[int],
@@ -2228,8 +2757,6 @@ def _efc_contact_jac_dense(tile_size: int, cone_type: types.ConeType):
     nv_padded: int,
     condim_in: wp.array[int],
     geom_in: wp.array[wp.vec2i],
-    flex_in: wp.array[wp.vec2i],
-    vert_in: wp.array[wp.vec2i],
     pos_in: wp.array[wp.vec3],
     frame_in: wp.array2d[wp.vec3],
     friction_in: wp.array2d[float],
@@ -2261,19 +2788,8 @@ def _efc_contact_jac_dense(tile_size: int, cone_type: types.ConeType):
         condim = condim_in[conid]
 
         geom = geom_in[conid]
-        if geom[0] >= 0:
-          body1 = geom_bodyid[geom[0]]
-        else:
-          flex = flex_in[conid]
-          vert = vert_in[conid]
-          body1 = flex_vertbodyid[flex_vertadr[flex[0]] + vert[0]]
-
-        if geom[1] >= 0:
-          body2 = geom_bodyid[geom[1]]
-        else:
-          flex = flex_in[conid]
-          vert = vert_in[conid]
-          body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
+        body1 = geom_bodyid[geom[0]]
+        body2 = geom_bodyid[geom[1]]
 
         con_pos = pos_in[conid]
         offset1 = con_pos - subtree_com_in[worldid, body_rootid[body1]]
@@ -2346,6 +2862,311 @@ def _efc_contact_jac_dense(tile_size: int, cone_type: types.ConeType):
 
 
 @cache_kernel
+def _efc_contact_jac_dense_flex(tile_size: int, cone_type: types.ConeType):
+  TILE_SIZE = tile_size
+  IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    body_rootid: wp.array[int],
+    geom_bodyid: wp.array[int],
+    flex_dim: wp.array[int],
+    flex_vertadr: wp.array[int],
+    flex_elemdataadr: wp.array[int],
+    flex_shelldataadr: wp.array[int],
+    flex_vertbodyid: wp.array[int],
+    flex_elem: wp.array[int],
+    flex_shell: wp.array[int],
+    body_isdofancestor: wp.array2d[int],
+    # Data in:
+    ne_in: wp.array[int],
+    nf_in: wp.array[int],
+    nl_in: wp.array[int],
+    nefc_in: wp.array[int],
+    qvel_in: wp.array2d[float],
+    subtree_com_in: wp.array2d[wp.vec3],
+    cdof_in: wp.array2d[wp.spatial_vector],
+    flexvert_xpos_in: wp.array2d[wp.vec3],
+    contact_efc_address_in: wp.array2d[int],
+    efc_id_in: wp.array2d[int],
+    njmax_in: int,
+    # In:
+    nv_padded: int,
+    condim_in: wp.array[int],
+    geom_in: wp.array[wp.vec2i],
+    flex_in: wp.array[wp.vec2i],
+    elem_in: wp.array[wp.vec2i],
+    vert_in: wp.array[wp.vec2i],
+    pos_in: wp.array[wp.vec3],
+    frame_in: wp.array2d[wp.vec3],
+    friction_in: wp.array2d[float],
+    # Data out:
+    efc_J_out: wp.array3d[float],
+    efc_Jqvel_out: wp.array2d[float],
+  ):
+    worldid, dof_block_id, tid = wp.tid()
+
+    dof_start = dof_block_id * wp.static(TILE_SIZE)
+    if dof_start >= nv_padded:
+      return
+
+    cdof_tile = wp.tile_load(cdof_in[worldid], shape=TILE_SIZE, offset=dof_start, bounds_check=True)
+    qvel_tile = wp.tile_load(qvel_in[worldid], shape=TILE_SIZE, offset=dof_start, bounds_check=True)
+
+    efcid_start = ne_in[worldid] + nf_in[worldid] + nl_in[worldid]
+    efcid_end = wp.min(nefc_in[worldid], njmax_in)
+
+    prev_conid = int(-1)
+    condim = int(0)
+
+    for efcid in range(efcid_start, efcid_end):
+      conid = efc_id_in[worldid, efcid]
+
+      # Recompute per-contact data only when contact changes
+      if conid != prev_conid:
+        prev_conid = conid
+        condim = condim_in[conid]
+
+        geom = geom_in[conid]
+        flex = flex_in[conid]
+        elem = elem_in[conid]
+        vert = vert_in[conid]
+        con_pos = pos_in[conid]
+
+        body_ids1, weights1 = _get_contact_bodies_and_weights(
+          geom_bodyid,
+          flex_dim,
+          flex_vertadr,
+          flex_elemdataadr,
+          flex_shelldataadr,
+          flex_vertbodyid,
+          flex_elem,
+          flex_shell,
+          flexvert_xpos_in,
+          conid,
+          0,
+          geom,
+          flex,
+          elem,
+          vert,
+          con_pos,
+          worldid,
+        )
+        body_ids2, weights2 = _get_contact_bodies_and_weights(
+          geom_bodyid,
+          flex_dim,
+          flex_vertadr,
+          flex_elemdataadr,
+          flex_shelldataadr,
+          flex_vertbodyid,
+          flex_elem,
+          flex_shell,
+          flexvert_xpos_in,
+          conid,
+          1,
+          geom,
+          flex,
+          elem,
+          vert,
+          con_pos,
+          worldid,
+        )
+
+        b1_0 = body_ids1[0]
+        b1_1 = body_ids1[1]
+        b1_2 = body_ids1[2]
+        b1_3 = body_ids1[3]
+
+        b2_0 = body_ids2[0]
+        b2_1 = body_ids2[1]
+        b2_2 = body_ids2[2]
+        b2_3 = body_ids2[3]
+
+        # Weighted jacp for side 1
+        jacp1_tile = wp.tile_map(
+          support._compute_jacp,
+          cdof_tile,
+          con_pos - subtree_com_in[worldid, body_rootid[b1_0]],
+          wp.tile_load(body_isdofancestor[b1_0], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+        )
+        jacp1_tile = wp.tile_map(wp.mul, jacp1_tile, weights1[0])
+        if b1_1 >= 0:
+          t_jacp = wp.tile_map(
+            support._compute_jacp,
+            cdof_tile,
+            con_pos - subtree_com_in[worldid, body_rootid[b1_1]],
+            wp.tile_load(body_isdofancestor[b1_1], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacp1_tile = wp.tile_map(wp.add, jacp1_tile, wp.tile_map(wp.mul, t_jacp, weights1[1]))
+        if b1_2 >= 0:
+          t_jacp = wp.tile_map(
+            support._compute_jacp,
+            cdof_tile,
+            con_pos - subtree_com_in[worldid, body_rootid[b1_2]],
+            wp.tile_load(body_isdofancestor[b1_2], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacp1_tile = wp.tile_map(wp.add, jacp1_tile, wp.tile_map(wp.mul, t_jacp, weights1[2]))
+        if b1_3 >= 0:
+          t_jacp = wp.tile_map(
+            support._compute_jacp,
+            cdof_tile,
+            con_pos - subtree_com_in[worldid, body_rootid[b1_3]],
+            wp.tile_load(body_isdofancestor[b1_3], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacp1_tile = wp.tile_map(wp.add, jacp1_tile, wp.tile_map(wp.mul, t_jacp, weights1[3]))
+
+        # Weighted jacp for side 2
+        jacp2_tile = wp.tile_map(
+          support._compute_jacp,
+          cdof_tile,
+          con_pos - subtree_com_in[worldid, body_rootid[b2_0]],
+          wp.tile_load(body_isdofancestor[b2_0], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+        )
+        jacp2_tile = wp.tile_map(wp.mul, jacp2_tile, weights2[0])
+        if b2_1 >= 0:
+          t_jacp = wp.tile_map(
+            support._compute_jacp,
+            cdof_tile,
+            con_pos - subtree_com_in[worldid, body_rootid[b2_1]],
+            wp.tile_load(body_isdofancestor[b2_1], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacp2_tile = wp.tile_map(wp.add, jacp2_tile, wp.tile_map(wp.mul, t_jacp, weights2[1]))
+        if b2_2 >= 0:
+          t_jacp = wp.tile_map(
+            support._compute_jacp,
+            cdof_tile,
+            con_pos - subtree_com_in[worldid, body_rootid[b2_2]],
+            wp.tile_load(body_isdofancestor[b2_2], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacp2_tile = wp.tile_map(wp.add, jacp2_tile, wp.tile_map(wp.mul, t_jacp, weights2[2]))
+        if b2_3 >= 0:
+          t_jacp = wp.tile_map(
+            support._compute_jacp,
+            cdof_tile,
+            con_pos - subtree_com_in[worldid, body_rootid[b2_3]],
+            wp.tile_load(body_isdofancestor[b2_3], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacp2_tile = wp.tile_map(wp.add, jacp2_tile, wp.tile_map(wp.mul, t_jacp, weights2[3]))
+
+        jacp_dif_tile = wp.tile_map(wp.sub, jacp2_tile, jacp1_tile)
+
+        # Weighted jacr for side 1
+        jacr1_tile = wp.tile_map(
+          support._compute_jacr,
+          cdof_tile,
+          wp.tile_load(body_isdofancestor[b1_0], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+        )
+        jacr1_tile = wp.tile_map(wp.mul, jacr1_tile, weights1[0])
+        if b1_1 >= 0:
+          t_jacr = wp.tile_map(
+            support._compute_jacr,
+            cdof_tile,
+            wp.tile_load(body_isdofancestor[b1_1], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacr1_tile = wp.tile_map(wp.add, jacr1_tile, wp.tile_map(wp.mul, t_jacr, weights1[1]))
+        if b1_2 >= 0:
+          t_jacr = wp.tile_map(
+            support._compute_jacr,
+            cdof_tile,
+            wp.tile_load(body_isdofancestor[b1_2], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacr1_tile = wp.tile_map(wp.add, jacr1_tile, wp.tile_map(wp.mul, t_jacr, weights1[2]))
+        if b1_3 >= 0:
+          t_jacr = wp.tile_map(
+            support._compute_jacr,
+            cdof_tile,
+            wp.tile_load(body_isdofancestor[b1_3], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacr1_tile = wp.tile_map(wp.add, jacr1_tile, wp.tile_map(wp.mul, t_jacr, weights1[3]))
+
+        # Weighted jacr for side 2
+        jacr2_tile = wp.tile_map(
+          support._compute_jacr,
+          cdof_tile,
+          wp.tile_load(body_isdofancestor[b2_0], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+        )
+        jacr2_tile = wp.tile_map(wp.mul, jacr2_tile, weights2[0])
+        if b2_1 >= 0:
+          t_jacr = wp.tile_map(
+            support._compute_jacr,
+            cdof_tile,
+            wp.tile_load(body_isdofancestor[b2_1], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacr2_tile = wp.tile_map(wp.add, jacr2_tile, wp.tile_map(wp.mul, t_jacr, weights2[1]))
+        if b2_2 >= 0:
+          t_jacr = wp.tile_map(
+            support._compute_jacr,
+            cdof_tile,
+            wp.tile_load(body_isdofancestor[b2_2], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacr2_tile = wp.tile_map(wp.add, jacr2_tile, wp.tile_map(wp.mul, t_jacr, weights2[2]))
+        if b2_3 >= 0:
+          t_jacr = wp.tile_map(
+            support._compute_jacr,
+            cdof_tile,
+            wp.tile_load(body_isdofancestor[b2_3], shape=TILE_SIZE, offset=dof_start, bounds_check=True),
+          )
+          jacr2_tile = wp.tile_map(wp.add, jacr2_tile, wp.tile_map(wp.mul, t_jacr, weights2[3]))
+
+        jacr_dif_tile = wp.tile_map(wp.sub, jacr2_tile, jacr1_tile)
+
+        if not wp.static(IS_ELLIPTIC):
+          frame_0 = frame_in[conid, 0]
+          Ji_0p_tile = wp.tile_map(wp.dot, jacp_dif_tile, frame_0)
+
+          if condim > 1:
+            Ji_0r_tile = wp.tile_map(wp.dot, jacr_dif_tile, frame_0)
+            frame_1 = frame_in[conid, 1]
+            Ji_1p_tile = wp.tile_map(wp.dot, jacp_dif_tile, frame_1)
+            Ji_1r_tile = wp.tile_map(wp.dot, jacr_dif_tile, frame_1)
+            frame_2 = frame_in[conid, 2]
+            Ji_2p_tile = wp.tile_map(wp.dot, jacp_dif_tile, frame_2)
+            Ji_2r_tile = wp.tile_map(wp.dot, jacr_dif_tile, frame_2)
+
+      if wp.static(IS_ELLIPTIC):
+        dimid = efcid - contact_efc_address_in[conid, 0]
+        if dimid < 3:
+          frame_idx = dimid
+        else:
+          frame_idx = dimid - 3
+
+        frame_row = frame_in[conid, frame_idx]
+
+        if dimid < 3:
+          J_tile = wp.tile_map(wp.dot, jacp_dif_tile, frame_row)
+        else:
+          J_tile = wp.tile_map(wp.dot, jacr_dif_tile, frame_row)
+      else:
+        J_tile = Ji_0p_tile
+        if condim > 1:
+          dimid = efcid - contact_efc_address_in[conid, 0]
+          dimid2 = dimid / 2 + 1
+          frii = friction_in[conid, dimid2 - 1]
+          frii_sign = frii * (1.0 - 2.0 * float(dimid & 1))
+
+          if dimid2 == 1:
+            J_tile = wp.tile_map(wp.add, J_tile, wp.tile_map(wp.mul, Ji_1p_tile, frii_sign))
+          elif dimid2 == 2:
+            J_tile = wp.tile_map(wp.add, J_tile, wp.tile_map(wp.mul, Ji_2p_tile, frii_sign))
+          elif dimid2 == 3:
+            J_tile = wp.tile_map(wp.add, J_tile, wp.tile_map(wp.mul, Ji_0r_tile, frii_sign))
+          elif dimid2 == 4:
+            J_tile = wp.tile_map(wp.add, J_tile, wp.tile_map(wp.mul, Ji_1r_tile, frii_sign))
+          else:
+            J_tile = wp.tile_map(wp.add, J_tile, wp.tile_map(wp.mul, Ji_2r_tile, frii_sign))
+
+      wp.tile_store(efc_J_out[worldid, efcid], J_tile, offset=dof_start, bounds_check=True)
+
+      Jqvel_tile = wp.tile_map(wp.mul, J_tile, qvel_tile)
+      Jqvel_sum = wp.tile_reduce(wp.add, Jqvel_tile)
+      if tid == 0:
+        wp.atomic_add(efc_Jqvel_out[worldid], efcid, wp.tile_extract(Jqvel_sum, 0))
+
+  return kernel
+
+
+@cache_kernel
 def _efc_contact_update(cone_type: types.ConeType):
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
 
@@ -2357,8 +3178,6 @@ def _efc_contact_update(cone_type: types.ConeType):
     opt_impratio_invsqrt: wp.array[float],
     body_invweight0: wp.array2d[wp.vec2],
     geom_bodyid: wp.array[int],
-    flex_vertadr: wp.array[int],
-    flex_vertbodyid: wp.array[int],
     # Data in:
     contact_efc_address_in: wp.array2d[int],
     efc_Jqvel_in: wp.array2d[float],
@@ -2369,8 +3188,6 @@ def _efc_contact_update(cone_type: types.ConeType):
     includemargin_in: wp.array[float],
     worldid_in: wp.array[int],
     geom_in: wp.array[wp.vec2i],
-    flex_in: wp.array[wp.vec2i],
-    vert_in: wp.array[wp.vec2i],
     friction_in: wp.array[vec5],
     solref_in: wp.array[wp.vec2],
     solreffriction_in: wp.array[wp.vec2],
@@ -2419,22 +3236,229 @@ def _efc_contact_update(cone_type: types.ConeType):
     geom = geom_in[conid]
     Jqvel = efc_Jqvel_in[worldid, efcid]
 
-    if geom[0] >= 0:
-      body1 = geom_bodyid[geom[0]]
-    else:
-      flex = flex_in[conid]
-      vert = vert_in[conid]
-      body1 = flex_vertbodyid[flex_vertadr[flex[0]] + vert[0]]
-
-    if geom[1] >= 0:
-      body2 = geom_bodyid[geom[1]]
-    else:
-      flex = flex_in[conid]
-      vert = vert_in[conid]
-      body2 = flex_vertbodyid[flex_vertadr[flex[1]] + vert[1]]
+    body1 = geom_bodyid[geom[0]]
+    body2 = geom_bodyid[geom[1]]
 
     body_invweight0_id = worldid % body_invweight0.shape[0]
     invweight = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
+
+    ref = solref_in[conid]
+    pos_aref = pos
+
+    if wp.static(IS_ELLIPTIC):
+      if dimid > 0:
+        solreffriction = solreffriction_in[conid]
+
+        # non-normal directions use solreffriction (if non-zero)
+        if solreffriction[0] or solreffriction[1]:
+          ref = solreffriction
+
+        invweight = invweight * impratio_invsqrt * impratio_invsqrt
+        friction = friction_in[conid]
+
+        if dimid > 1:
+          fri0 = friction[0]
+          frii = friction[dimid - 1]
+          fri = fri0 * fri0 / (frii * frii)
+          invweight *= fri
+
+        pos_aref = 0.0
+    else:
+      if condim > 1:
+        friction = friction_in[conid]
+        fri0 = friction[0]
+        invweight = invweight + fri0 * fri0 * invweight
+        invweight = invweight * 2.0 * fri0 * fri0 * impratio_invsqrt * impratio_invsqrt
+
+    if condim == 1:
+      efc_type = ConstraintType.CONTACT_FRICTIONLESS
+    elif wp.static(IS_ELLIPTIC):
+      efc_type = ConstraintType.CONTACT_ELLIPTIC
+    else:
+      efc_type = ConstraintType.CONTACT_PYRAMIDAL
+
+    _efc_row(
+      opt_disableflags,
+      worldid,
+      timestep,
+      efcid,
+      pos_aref,
+      pos,
+      invweight,
+      ref,
+      solimp_in[conid],
+      includemargin,
+      Jqvel,
+      0.0,
+      efc_type,
+      conid,
+      efc_type_out,
+      efc_id_out,
+      efc_pos_out,
+      efc_margin_out,
+      efc_D_out,
+      efc_vel_out,
+      efc_aref_out,
+      efc_frictionloss_out,
+    )
+
+  return kernel
+
+
+@cache_kernel
+def _efc_contact_update_flex(cone_type: types.ConeType):
+  IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    opt_timestep: wp.array[float],
+    opt_disableflags: int,
+    opt_impratio_invsqrt: wp.array[float],
+    body_invweight0: wp.array2d[wp.vec2],
+    geom_bodyid: wp.array[int],
+    flex_dim: wp.array[int],
+    flex_vertadr: wp.array[int],
+    flex_elemdataadr: wp.array[int],
+    flex_shelldataadr: wp.array[int],
+    flex_vertbodyid: wp.array[int],
+    flex_elem: wp.array[int],
+    flex_shell: wp.array[int],
+    # Data in:
+    flexvert_xpos_in: wp.array2d[wp.vec3],
+    contact_efc_address_in: wp.array2d[int],
+    efc_Jqvel_in: wp.array2d[float],
+    nacon_in: wp.array[int],
+    # In:
+    dist_in: wp.array[float],
+    pos_in: wp.array[wp.vec3],
+    condim_in: wp.array[int],
+    includemargin_in: wp.array[float],
+    worldid_in: wp.array[int],
+    geom_in: wp.array[wp.vec2i],
+    flex_in: wp.array[wp.vec2i],
+    elem_in: wp.array[wp.vec2i],
+    vert_in: wp.array[wp.vec2i],
+    friction_in: wp.array[vec5],
+    solref_in: wp.array[wp.vec2],
+    solreffriction_in: wp.array[wp.vec2],
+    solimp_in: wp.array[vec5],
+    type_in: wp.array[int],
+    # Data out:
+    efc_type_out: wp.array2d[int],
+    efc_id_out: wp.array2d[int],
+    efc_pos_out: wp.array2d[float],
+    efc_margin_out: wp.array2d[float],
+    efc_D_out: wp.array2d[float],
+    efc_vel_out: wp.array2d[float],
+    efc_aref_out: wp.array2d[float],
+    efc_frictionloss_out: wp.array2d[float],
+  ):
+    conid, dimid = wp.tid()
+
+    if conid >= nacon_in[0]:
+      return
+
+    if not type_in[conid] & ContactType.CONSTRAINT:
+      return
+
+    condim = condim_in[conid]
+
+    if wp.static(IS_ELLIPTIC):
+      if dimid > condim - 1:
+        return
+    else:
+      if condim == 1 and dimid > 0:
+        return
+      elif condim > 1 and dimid >= 2 * (condim - 1):
+        return
+
+    efcid = contact_efc_address_in[conid, dimid]
+    if efcid < 0:
+      return
+
+    worldid = worldid_in[conid]
+    timestep = opt_timestep[worldid % opt_timestep.shape[0]]
+    impratio_invsqrt = opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
+
+    includemargin = includemargin_in[conid]
+    pos = dist_in[conid] - includemargin
+
+    geom = geom_in[conid]
+    flex = flex_in[conid]
+    elem = elem_in[conid]
+    vert = vert_in[conid]
+    con_pos = pos_in[conid]
+    Jqvel = efc_Jqvel_in[worldid, efcid]
+
+    body_ids1, weights1 = _get_contact_bodies_and_weights(
+      geom_bodyid,
+      flex_dim,
+      flex_vertadr,
+      flex_elemdataadr,
+      flex_shelldataadr,
+      flex_vertbodyid,
+      flex_elem,
+      flex_shell,
+      flexvert_xpos_in,
+      conid,
+      0,
+      geom,
+      flex,
+      elem,
+      vert,
+      con_pos,
+      worldid,
+    )
+    body_ids2, weights2 = _get_contact_bodies_and_weights(
+      geom_bodyid,
+      flex_dim,
+      flex_vertadr,
+      flex_elemdataadr,
+      flex_shelldataadr,
+      flex_vertbodyid,
+      flex_elem,
+      flex_shell,
+      flexvert_xpos_in,
+      conid,
+      1,
+      geom,
+      flex,
+      elem,
+      vert,
+      con_pos,
+      worldid,
+    )
+
+    b1_0 = body_ids1[0]
+    b1_1 = body_ids1[1]
+    b1_2 = body_ids1[2]
+    b1_3 = body_ids1[3]
+
+    b2_0 = body_ids2[0]
+    b2_1 = body_ids2[1]
+    b2_2 = body_ids2[2]
+    b2_3 = body_ids2[3]
+
+    body_invweight0_id = worldid % body_invweight0.shape[0]
+
+    invweight1 = weights1[0] * body_invweight0[body_invweight0_id, b1_0][0]
+    if b1_1 >= 0:
+      invweight1 += weights1[1] * body_invweight0[body_invweight0_id, b1_1][0]
+    if b1_2 >= 0:
+      invweight1 += weights1[2] * body_invweight0[body_invweight0_id, b1_2][0]
+    if b1_3 >= 0:
+      invweight1 += weights1[3] * body_invweight0[body_invweight0_id, b1_3][0]
+
+    invweight2 = weights2[0] * body_invweight0[body_invweight0_id, b2_0][0]
+    if b2_1 >= 0:
+      invweight2 += weights2[1] * body_invweight0[body_invweight0_id, b2_1][0]
+    if b2_2 >= 0:
+      invweight2 += weights2[2] * body_invweight0[body_invweight0_id, b2_2][0]
+    if b2_3 >= 0:
+      invweight2 += weights2[3] * body_invweight0[body_invweight0_id, b2_3][0]
+
+    invweight = invweight1 + invweight2
 
     ref = solref_in[conid]
     pos_aref = pos
@@ -2984,152 +4008,318 @@ def make_constraint(m: types.Model, d: types.Data):
         copy=False,
       )
 
-      wp.launch(
-        _efc_contact_init(m.opt.cone, m.is_sparse),
-        dim=d.naconmax,
-        inputs=[
-          m.body_weldid,
-          m.body_dofnum,
-          m.body_dofadr,
-          m.dof_parentid,
-          m.geom_bodyid,
-          m.flex_vertadr,
-          m.flex_vertbodyid,
-          d.njmax,
-          d.njmax_nnz,
-          d.nacon,
-          d.contact.dist,
-          d.contact.dim,
-          d.contact.includemargin,
-          d.contact.worldid,
-          d.contact.geom,
-          d.contact.flex,
-          d.contact.vert,
-          d.contact.type,
-        ],
-        outputs=[
-          d.nefc,
-          d.contact.efc_address,
-          d.efc.id,
-          d.efc.J_rownnz,
-          d.efc.J_rowadr,
-          efc_nnz,
-        ],
-      )
+      has_flex = m.nflex > 0
 
-      if m.is_sparse:
+      if has_flex:
         wp.launch(
-          _efc_contact_jac_sparse(m.opt.cone),
-          dim=(d.naconmax, nmaxdim),
+          _efc_contact_init_flex(m.opt.cone, m.is_sparse),
+          dim=d.naconmax,
           inputs=[
             m.body_parentid,
-            m.body_rootid,
             m.body_weldid,
             m.body_dofnum,
             m.body_dofadr,
-            m.dof_bodyid,
             m.dof_parentid,
             m.geom_bodyid,
+            m.flex_dim,
             m.flex_vertadr,
+            m.flex_elemdataadr,
+            m.flex_shelldataadr,
             m.flex_vertbodyid,
-            m.body_isdofancestor,
-            d.qvel,
-            d.subtree_com,
-            d.cdof,
-            d.contact.efc_address,
-            d.efc.J_rownnz,
-            d.efc.J_rowadr,
+            m.flex_elem,
+            m.flex_shell,
+            d.flexvert_xpos,
+            d.njmax,
+            d.njmax_nnz,
             d.nacon,
+            d.contact.dist,
+            d.contact.pos,
             d.contact.dim,
+            d.contact.includemargin,
+            d.contact.worldid,
             d.contact.geom,
             d.contact.flex,
+            d.contact.elem,
             d.contact.vert,
-            d.contact.pos,
-            contact_frame_2d,
-            contact_friction_2d,
-            d.contact.worldid,
+            d.contact.type,
           ],
           outputs=[
-            d.efc.J_colind,
-            d.efc.J,
-            d.efc.Jqvel,
+            d.nefc,
+            d.contact.efc_address,
+            d.efc.id,
+            d.efc.J_rownnz,
+            d.efc.J_rowadr,
+            efc_nnz,
           ],
         )
+      else:
+        wp.launch(
+          _efc_contact_init(m.opt.cone, m.is_sparse),
+          dim=d.naconmax,
+          inputs=[
+            m.body_weldid,
+            m.body_dofnum,
+            m.body_dofadr,
+            m.dof_parentid,
+            m.geom_bodyid,
+            d.njmax,
+            d.njmax_nnz,
+            d.nacon,
+            d.contact.dist,
+            d.contact.dim,
+            d.contact.includemargin,
+            d.contact.worldid,
+            d.contact.geom,
+            d.contact.type,
+          ],
+          outputs=[
+            d.nefc,
+            d.contact.efc_address,
+            d.efc.id,
+            d.efc.J_rownnz,
+            d.efc.J_rowadr,
+            efc_nnz,
+          ],
+        )
+
+      if m.is_sparse:
+        if has_flex:
+          wp.launch(
+            _efc_contact_jac_sparse_flex(m.opt.cone),
+            dim=(d.naconmax, nmaxdim),
+            inputs=[
+              m.body_parentid,
+              m.body_rootid,
+              m.body_weldid,
+              m.body_dofnum,
+              m.body_dofadr,
+              m.dof_bodyid,
+              m.dof_parentid,
+              m.geom_bodyid,
+              m.flex_dim,
+              m.flex_vertadr,
+              m.flex_elemdataadr,
+              m.flex_shelldataadr,
+              m.flex_vertbodyid,
+              m.flex_elem,
+              m.flex_shell,
+              m.body_isdofancestor,
+              d.qvel,
+              d.subtree_com,
+              d.cdof,
+              d.flexvert_xpos,
+              d.contact.efc_address,
+              d.efc.J_rownnz,
+              d.efc.J_rowadr,
+              d.nacon,
+              d.contact.dim,
+              d.contact.geom,
+              d.contact.flex,
+              d.contact.elem,
+              d.contact.vert,
+              d.contact.pos,
+              contact_frame_2d,
+              contact_friction_2d,
+              d.contact.worldid,
+            ],
+            outputs=[
+              d.efc.J_colind,
+              d.efc.J,
+              d.efc.Jqvel,
+            ],
+          )
+        else:
+          wp.launch(
+            _efc_contact_jac_sparse(m.opt.cone),
+            dim=(d.naconmax, nmaxdim),
+            inputs=[
+              m.body_parentid,
+              m.body_rootid,
+              m.body_weldid,
+              m.body_dofnum,
+              m.body_dofadr,
+              m.dof_bodyid,
+              m.dof_parentid,
+              m.geom_bodyid,
+              m.body_isdofancestor,
+              d.qvel,
+              d.subtree_com,
+              d.cdof,
+              d.contact.efc_address,
+              d.efc.J_rownnz,
+              d.efc.J_rowadr,
+              d.nacon,
+              d.contact.dim,
+              d.contact.geom,
+              d.contact.pos,
+              contact_frame_2d,
+              contact_friction_2d,
+              d.contact.worldid,
+            ],
+            outputs=[
+              d.efc.J_colind,
+              d.efc.J,
+              d.efc.Jqvel,
+            ],
+          )
       else:
         d.efc.Jqvel.zero_()
         tile_size = m.block_dim.contact_jac_tiled
         n_dof_blocks = (m.nv_pad + tile_size - 1) // tile_size
 
-        wp.launch_tiled(
-          _efc_contact_jac_dense(tile_size, m.opt.cone),
-          dim=(d.nworld, n_dof_blocks),
+        if has_flex:
+          wp.launch_tiled(
+            _efc_contact_jac_dense_flex(tile_size, m.opt.cone),
+            dim=(d.nworld, n_dof_blocks),
+            inputs=[
+              m.body_rootid,
+              m.geom_bodyid,
+              m.flex_dim,
+              m.flex_vertadr,
+              m.flex_elemdataadr,
+              m.flex_shelldataadr,
+              m.flex_vertbodyid,
+              m.flex_elem,
+              m.flex_shell,
+              m.body_isdofancestor,
+              d.ne,
+              d.nf,
+              d.nl,
+              d.nefc,
+              d.qvel,
+              d.subtree_com,
+              d.cdof,
+              d.flexvert_xpos,
+              d.contact.efc_address,
+              d.efc.id,
+              d.njmax,
+              m.nv_pad,
+              d.contact.dim,
+              d.contact.geom,
+              d.contact.flex,
+              d.contact.elem,
+              d.contact.vert,
+              d.contact.pos,
+              contact_frame_2d,
+              contact_friction_2d,
+            ],
+            outputs=[
+              d.efc.J,
+              d.efc.Jqvel,
+            ],
+            block_dim=tile_size,
+          )
+        else:
+          wp.launch_tiled(
+            _efc_contact_jac_dense(tile_size, m.opt.cone),
+            dim=(d.nworld, n_dof_blocks),
+            inputs=[
+              m.body_rootid,
+              m.geom_bodyid,
+              m.body_isdofancestor,
+              d.ne,
+              d.nf,
+              d.nl,
+              d.nefc,
+              d.qvel,
+              d.subtree_com,
+              d.cdof,
+              d.contact.efc_address,
+              d.efc.id,
+              d.njmax,
+              m.nv_pad,
+              d.contact.dim,
+              d.contact.geom,
+              d.contact.pos,
+              contact_frame_2d,
+              contact_friction_2d,
+            ],
+            outputs=[
+              d.efc.J,
+              d.efc.Jqvel,
+            ],
+            block_dim=tile_size,
+          )
+
+      if has_flex:
+        wp.launch(
+          _efc_contact_update_flex(m.opt.cone),
+          dim=(d.naconmax, nmaxdim),
           inputs=[
-            m.body_rootid,
+            m.opt.timestep,
+            m.opt.disableflags,
+            m.opt.impratio_invsqrt,
+            m.body_invweight0,
             m.geom_bodyid,
+            m.flex_dim,
             m.flex_vertadr,
+            m.flex_elemdataadr,
+            m.flex_shelldataadr,
             m.flex_vertbodyid,
-            m.body_isdofancestor,
-            d.ne,
-            d.nf,
-            d.nl,
-            d.nefc,
-            d.qvel,
-            d.subtree_com,
-            d.cdof,
+            m.flex_elem,
+            m.flex_shell,
+            d.flexvert_xpos,
             d.contact.efc_address,
-            d.efc.id,
-            d.njmax,
-            m.nv_pad,
+            d.efc.Jqvel,
+            d.nacon,
+            d.contact.dist,
+            d.contact.pos,
             d.contact.dim,
+            d.contact.includemargin,
+            d.contact.worldid,
             d.contact.geom,
             d.contact.flex,
+            d.contact.elem,
             d.contact.vert,
-            d.contact.pos,
-            contact_frame_2d,
-            contact_friction_2d,
+            d.contact.friction,
+            d.contact.solref,
+            d.contact.solreffriction,
+            d.contact.solimp,
+            d.contact.type,
           ],
           outputs=[
-            d.efc.J,
-            d.efc.Jqvel,
+            d.efc.type,
+            d.efc.id,
+            d.efc.pos,
+            d.efc.margin,
+            d.efc.D,
+            d.efc.vel,
+            d.efc.aref,
+            d.efc.frictionloss,
           ],
-          block_dim=tile_size,
         )
-
-      wp.launch(
-        _efc_contact_update(m.opt.cone),
-        dim=(d.naconmax, nmaxdim),
-        inputs=[
-          m.opt.timestep,
-          m.opt.disableflags,
-          m.opt.impratio_invsqrt,
-          m.body_invweight0,
-          m.geom_bodyid,
-          m.flex_vertadr,
-          m.flex_vertbodyid,
-          d.contact.efc_address,
-          d.efc.Jqvel,
-          d.nacon,
-          d.contact.dist,
-          d.contact.dim,
-          d.contact.includemargin,
-          d.contact.worldid,
-          d.contact.geom,
-          d.contact.flex,
-          d.contact.vert,
-          d.contact.friction,
-          d.contact.solref,
-          d.contact.solreffriction,
-          d.contact.solimp,
-          d.contact.type,
-        ],
-        outputs=[
-          d.efc.type,
-          d.efc.id,
-          d.efc.pos,
-          d.efc.margin,
-          d.efc.D,
-          d.efc.vel,
-          d.efc.aref,
-          d.efc.frictionloss,
-        ],
-      )
+      else:
+        wp.launch(
+          _efc_contact_update(m.opt.cone),
+          dim=(d.naconmax, nmaxdim),
+          inputs=[
+            m.opt.timestep,
+            m.opt.disableflags,
+            m.opt.impratio_invsqrt,
+            m.body_invweight0,
+            m.geom_bodyid,
+            d.contact.efc_address,
+            d.efc.Jqvel,
+            d.nacon,
+            d.contact.dist,
+            d.contact.dim,
+            d.contact.includemargin,
+            d.contact.worldid,
+            d.contact.geom,
+            d.contact.friction,
+            d.contact.solref,
+            d.contact.solreffriction,
+            d.contact.solimp,
+            d.contact.type,
+          ],
+          outputs=[
+            d.efc.type,
+            d.efc.id,
+            d.efc.pos,
+            d.efc.margin,
+            d.efc.D,
+            d.efc.vel,
+            d.efc.aref,
+            d.efc.frictionloss,
+          ],
+        )

--- a/mujoco_warp/_src/constraint_test.py
+++ b/mujoco_warp/_src/constraint_test.py
@@ -332,6 +332,58 @@ class ConstraintTest(parameterized.TestCase):
     _assert_eq(d.nefc.numpy()[0], mjd.nefc, "nefc")
     _assert_efc_eq(mjm, m, d, mjd, mjd.nefc, "efc", m.nv)
 
+  @parameterized.product(
+    xml=(
+      """
+      <mujoco>
+        <option solver="CG" tolerance="1e-6" timestep=".001"/>
+        <worldbody>
+          <!-- Sphere positioned to press into the cloth -->
+          <body pos="0 0 0.05">
+            <freejoint/>
+            <geom type="sphere" size=".1" mass="1"/>
+          </body>
+          <!-- Cloth (dim=2 flex) -->
+          <flexcomp name="cloth" type="grid" count="3 3 1" spacing=".3 .3 .1" pos="-.3 -.3 0"
+                    radius=".02" dim="2" mass=".5">
+            <contact condim="3" selfcollide="none"/>
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """,
+      """
+      <mujoco>
+        <option solver="CG" tolerance="1e-6" timestep=".001"/>
+        <worldbody>
+          <!-- Box positioned to press into the soft body -->
+          <body pos="0 0 0.1">
+            <freejoint/>
+            <geom type="box" size=".05 .05 .05" mass="1"/>
+          </body>
+          <!-- Soft body (dim=3 flex) -->
+          <flexcomp name="softbody" type="grid" count="2 2 2" spacing=".15 .15 .15" pos="-.075 -.075 0"
+                    radius=".01" dim="3" mass=".5">
+            <contact condim="3" selfcollide="none"/>
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """,
+    ),
+    cone=(ConeType.PYRAMIDAL, ConeType.ELLIPTIC),
+    jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),
+  )
+  def test_flex_barycentric_jacobian(self, xml, cone, jacobian):
+    """Test barycentric contact Jacobian calculation for flex."""
+    mjm, mjd, m, d = test_data.fixture(xml=xml, overrides={"opt.cone": cone, "opt.jacobian": jacobian})
+
+    mjw.kinematics(m, d)
+    mjw.make_constraint(m, d)
+
+    self.assertGreater(mjd.nefc, 0, "Expected active contacts")
+    self.assertEqual(d.nefc.numpy()[0], mjd.nefc, "nefc mismatch")
+
+    _assert_efc_eq(mjm, m, d, mjd, mjd.nefc, f"efc_flex_dim{m.flex_dim.numpy()[0]}", m.nv)
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -297,6 +297,8 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.nmaxcondim = np.concatenate(condim_arrays).max()
   m.nmaxpyramid = np.maximum(1, 2 * (m.nmaxcondim - 1))
   m.has_sdf_geom = (mjm.geom_type == mujoco.mjtGeom.mjGEOM_SDF).any()
+  m.has_flex_selfcollide = bool(mjm.nflex > 0 and np.any(mjm.flex_selfcollide != 0))
+  m.max_flex_dim = int(np.max(mjm.flex_dim)) if mjm.nflex > 0 else 0
   m.block_dim = types.BlockDim()
   # Derive CG solver block_dim from nv: clamp(round_up_to_32(nv), 32, 256)
   _nv_block = max(32, min(256, ((mjm.nv + 31) // 32) * 32))
@@ -1123,7 +1125,13 @@ def make_data(
     else:
       njmax_nnz = njmax * mjm.nv
 
-  contact = types.Contact(**{f.name: _create_array(None, f.type, sizes) for f in dataclasses.fields(types.Contact)})
+  contact_kwargs = {}
+  for f in dataclasses.fields(types.Contact):
+    if f.name in ["flex", "elem", "vert"] and mjm.nflex == 0:
+      contact_kwargs[f.name] = wp.empty(0, dtype=wp.vec2i)
+    else:
+      contact_kwargs[f.name] = _create_array(None, f.type, sizes)
+  contact = types.Contact(**contact_kwargs)
   contact.efc_address = wp.array(np.full((naconmax, sizes["nmaxpyramid"]), -1, dtype=int), dtype=int)
 
   efc = _create_constraint(mjm, nworld, njmax, njmax_nnz, sizes, ENABLE_ISLANDS)
@@ -1138,11 +1146,6 @@ def make_data(
     efc.J_rowadr = wp.zeros((nworld, 0), dtype=int)
     efc.J_colind = wp.zeros((nworld, 0, 0), dtype=int)
     efc.J = wp.zeros((nworld, sizes["njmax_pad"], sizes["nv_pad"]), dtype=float)
-
-  contact_kwargs = {}
-  for f in dataclasses.fields(types.Contact):
-    contact_kwargs[f.name] = _create_array(None, f.type, sizes)
-  contact = types.Contact(**contact_kwargs)
 
   # world body and static geom (attached to the world) poses are precomputed
   # this speeds up scenes with many static geoms (e.g. terrains)
@@ -1328,6 +1331,9 @@ def put_data(
   contact_kwargs = {"efc_address": None, "worldid": None, "type": None, "geomcollisionid": None}
   for f in dataclasses.fields(types.Contact):
     if f.name in contact_kwargs:
+      continue
+    if f.name in ["flex", "elem", "vert"] and mjm.nflex == 0:
+      contact_kwargs[f.name] = wp.empty(0, dtype=wp.vec2i)
       continue
     val = getattr(mjd.contact, f.name)
     val = np.repeat(val, nworld, axis=0)
@@ -1612,6 +1618,10 @@ def get_data_into(
   result.contact.solimp[:ncon] = d.contact.solimp.numpy()[ncon_filter]
   result.contact.dim[:ncon] = d.contact.dim.numpy()[ncon_filter]
   result.contact.geom[:ncon] = d.contact.geom.numpy()[ncon_filter]
+  if mjm.nflex > 0:
+    result.contact.flex[:ncon] = d.contact.flex.numpy()[ncon_filter]
+    result.contact.elem[:ncon] = d.contact.elem.numpy()[ncon_filter]
+    result.contact.vert[:ncon] = d.contact.vert.numpy()[ncon_filter]
   result.contact.efc_address[:ncon] = contact_efc_address_ordered[:ncon]
 
   if is_sparse(mjm):
@@ -1897,6 +1907,7 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     contact_dim_out: wp.array[int],
     contact_geom_out: wp.array[wp.vec2i],
     contact_flex_out: wp.array[wp.vec2i],
+    contact_elem_out: wp.array[wp.vec2i],
     contact_vert_out: wp.array[wp.vec2i],
     contact_efc_address_out: wp.array2d[int],
     contact_worldid_out: wp.array[int],
@@ -1924,8 +1935,12 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     contact_solimp_out[conid] = types.vec5(0.0, 0.0, 0.0, 0.0, 0.0)
     contact_dim_out[conid] = 0
     contact_geom_out[conid] = wp.vec2i(0, 0)
-    contact_flex_out[conid] = wp.vec2i(0, 0)
-    contact_vert_out[conid] = wp.vec2i(0, 0)
+    if contact_flex_out.shape[0] > 0:
+      contact_flex_out[conid] = wp.vec2i(0, 0)
+    if contact_elem_out.shape[0] > 0:
+      contact_elem_out[conid] = wp.vec2i(0, 0)
+    if contact_vert_out.shape[0] > 0:
+      contact_vert_out[conid] = wp.vec2i(0, 0)
     for i in range(nefcaddress):
       contact_efc_address_out[conid, i] = -1
     contact_worldid_out[conid] = 0
@@ -2008,6 +2023,7 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
       d.contact.dim,
       d.contact.geom,
       d.contact.flex,
+      d.contact.elem,
       d.contact.vert,
       d.contact.efc_address,
       d.contact.worldid,

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -951,6 +951,7 @@ class Model:
     nflexbending: number of bending parameters in all flexes
     nflexelemedge: number of element edge ids in all flexes
     nflexshelldata: number of shell fragment vertex ids in all flexes
+    nflexevpair: number of element-vertex pairs in all flexes
     nJfe: number of non-zeros in sparse flexedge Jacobian
     nmesh: number of meshes
     nmeshvert: number of vertices for all meshes
@@ -1105,6 +1106,8 @@ class Model:
     flex_friction: friction for (slide, spin, roll)          (nflex, 3)
     flex_margin: detect contact if dist<margin               (nflex,)
     flex_gap: include in solver if dist<margin-gap           (nflex,)
+    flex_internal: internal collision enabled                (nflex,)
+    flex_selfcollide: self-collision mode                    (nflex,)
     flex_dim: 1: lines, 2: triangles, 3: tetrahedra          (nflex,)
     flex_vertadr: first vertex address                       (nflex,)
     flex_vertnum: number of vertices                         (nflex,)
@@ -1118,12 +1121,15 @@ class Model:
     flex_bendingadr: first bending data address              (nflex,)
     flex_shellnum: number of shells                          (nflex,)
     flex_shelldataadr: first shell data address              (nflex,)
+    flex_evpairadr: first element-vertex pair address        (nflex,)
+    flex_evpairnum: number of element-vertex pairs           (nflex,)
     flex_vertbodyid: vertex body ids                         (nflexvert,)
     flex_edge: edge vertex ids (2 per edge)                  (nflexedge, 2)
     flex_edgeflap: adjacent vertex ids (dim=2 only)          (nflexedge, 2)
     flex_elem: element vertex ids (dim+1 per elem)           (nflexelemdata,)
     flex_elemedge: element edge ids                          (nflexelemedge,)
     flex_shell: shell fragment vertex ids (dim per frag)     (nflexshelldata,)
+    flex_evpair: element-vertex pair indices                 (nflexevpair, 2)
     flex_vert: vertex local positions                        (nflexvert, 3)
     flexedge_length0: edge lengths in qpos0                  (nflexedge,)
     flexedge_invweight0: inv. inertia for the edge           (nflexedge,)
@@ -1280,6 +1286,8 @@ class Model:
     is_sparse: whether to use sparse representations
     has_fluid: True if wind, density, or viscosity are non-zero at put_model time
     has_sdf_geom: whether the model contains SDF geoms
+    has_flex_selfcollide: whether any flex has self-collision enabled
+    max_flex_dim: maximum flex dimension in the model
     block_dim: block dim options
     body_tree: list of body ids by tree level
     body_branches: flattened body ids for all branches
@@ -1387,6 +1395,7 @@ class Model:
   nflexbending: int
   nflexelemedge: int
   nflexshelldata: int
+  nflexevpair: int
   nJfe: int
   nmesh: int
   nmeshvert: int
@@ -1541,6 +1550,8 @@ class Model:
   flex_friction: array("nflex", wp.vec3)
   flex_margin: array("nflex", float)
   flex_gap: array("nflex", float)
+  flex_internal: array("nflex", int)
+  flex_selfcollide: array("nflex", int)
   flex_dim: array("nflex", int)
   flex_vertadr: array("nflex", int)
   flex_vertnum: array("nflex", int)
@@ -1554,12 +1565,15 @@ class Model:
   flex_bendingadr: array("nflex", int)
   flex_shellnum: array("nflex", int)
   flex_shelldataadr: array("nflex", int)
+  flex_evpairadr: array("nflex", int)
+  flex_evpairnum: array("nflex", int)
   flex_vertbodyid: array("nflexvert", int)
   flex_edge: array("nflexedge", wp.vec2i)
   flex_edgeflap: array("nflexedge", wp.vec2i)
   flex_elem: array("nflexelemdata", int)
   flex_elemedge: array("nflexelemedge", int)
   flex_shell: array("nflexshelldata", int)
+  flex_evpair: array("nflexevpair", wp.vec2i)
   flex_vert: array("nflexvert", wp.vec3)
   flexedge_length0: array("nflexedge", float)
   flexedge_invweight0: array("nflexedge", float)
@@ -1714,6 +1728,8 @@ class Model:
   is_sparse: bool
   has_fluid: bool
   has_sdf_geom: bool
+  has_flex_selfcollide: bool
+  max_flex_dim: int
   block_dim: BlockDim
   body_tree: tuple[wp.array[int], ...]
   body_branches: wp.array[int]
@@ -1819,6 +1835,7 @@ class Contact:
     dim: contact space dimensionality: 1, 3, 4 or 6                  (naconmax,)
     geom: geom ids; -1 for flex                                      (naconmax, 2)
     flex: flex ids; -1 for geom                                      (naconmax, 2)
+    elem: element ids; -1 for geom or flex vertex                    (naconmax, 2)
     vert: vertex ids for flex/mesh contact                           (naconmax, 2)
     efc_address: address in efc; -1: not included                    (naconmax, nmaxpyramid)
     worldid: world id                                                (naconmax,)
@@ -1839,6 +1856,7 @@ class Contact:
   dim: array("naconmax", int)
   geom: array("naconmax", wp.vec2i)
   flex: array("naconmax", wp.vec2i)
+  elem: array("naconmax", wp.vec2i)
   vert: array("naconmax", wp.vec2i)
   efc_address: array("naconmax", "nmaxpyramid", int)
   worldid: array("naconmax", int)


### PR DESCRIPTION
update flex collisions to better follow the mujoco implementation

fixes aloha cloth benchmark scene (nworld=1)

https://github.com/user-attachments/assets/68a0d3c9-6afd-429f-be5f-643b469212a2

```
mjwarp-testspeed /tmp/benchmark_assets/aloha_cloth/scene_cloth.xml --nworld=32 --nconmax=4096 --nccdmax=1 --njmax=40_000
```

```
Total JIT time: 0.49 s
Total simulation time: 113.24 s
Total steps per second: 283
Total realtime factor: 0.57 x
Total time per step: 3538754.84 ns
Total converged worlds: 32 / 32
```

---
these changes should not affect benchmarks w/o flex

humanoid

```
mjwarp-testspeed benchmarks/humanoid/humanoid.xml --nworld=8192 --nconmax=24 --njmax=64
```

this pr
```
Total JIT time: 0.45 s
Total simulation time: 1.59 s
Total steps per second: 5,157,683
Total realtime factor: 25,788.41 x
Total time per step: 193.89 ns
Total converged worlds: 8192 / 8192
```

083e5efd730c57fbcda50e6796c9f803f093bb04
```
Total JIT time: 0.89 s
Total simulation time: 1.58 s
Total steps per second: 5,189,397
Total realtime factor: 25,946.99 x
Total time per step: 192.70 ns
Total converged worlds: 8192 / 8192
```

three humanoids

```
mjwarp-testspeed benchmarks/humanoid/three_humanoids.xml --nworld=8192 --nconmax=100 --njmax=192
```

this pr
```
Total JIT time: 0.48 s
Total simulation time: 10.11 s
Total steps per second: 810,624
Total realtime factor: 4,053.12 x
Total time per step: 1233.62 ns
Total converged worlds: 8192 / 8192
```

083e5efd730c57fbcda50e6796c9f803f093bb04
```
Total JIT time: 0.49 s
Total simulation time: 10.06 s
Total steps per second: 814,538
Total realtime factor: 4,072.69 x
Total time per step: 1227.69 ns
Total converged worlds: 8192 / 8192
```