### PR TITLE
put_model supports batch_size for shared fields

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -42,19 +42,10 @@ def _is_array_spec(typ) -> bool:
   return isinstance(typ, wp.array) or type(typ).__name__ == "_ArrayAnnotation"
 
 
-def _is_batched_array_spec(spec) -> bool:
-  spec_shape = getattr(spec, "shape", (0,))
-  return bool(spec_shape) and spec_shape[0] == "*"
-
-
-def _array_data_shape(shape: tuple[int, ...], dtype) -> tuple[int, ...]:
-  return shape + tuple(getattr(dtype, "_shape_", ()) or ())
-
-
 def _broadcast_batch_data(data: Any, shape: tuple[int, ...], dtype) -> np.ndarray:
   """Broadcasts host data to a requested leading batch dimension."""
   data = np.array(data)
-  target_shape = _array_data_shape(shape, dtype)
+  target_shape = shape + tuple(getattr(dtype, "_shape_", ()) or ())
 
   if data.shape == target_shape:
     return data
@@ -65,41 +56,29 @@ def _broadcast_batch_data(data: Any, shape: tuple[int, ...], dtype) -> np.ndarra
   return np.broadcast_to(data, target_shape).copy()
 
 
-def _validate_model_batch_sizes(batch_sizes: dict[str, int] | None) -> dict[str, int]:
-  if batch_sizes is None:
-    return {}
-
-  model_fields = {f.name: f for f in dataclasses.fields(types.Model) if _is_array_spec(f.type)}
-  for field_name, batch_size in batch_sizes.items():
-    field = model_fields.get(field_name)
-    if field is None or not _is_batched_array_spec(field.type):
-      raise ValueError(f"Model field {field_name!r} is not a batched array field.")
-    if batch_size < 1:
-      raise ValueError(f"batch_sizes[{field_name!r}] must be positive, got {batch_size}.")
-
-  return batch_sizes
-
-
-def _create_array(data: Any, spec, sizes: dict[str, int]) -> wp.array | None:
+def _create_array(data: Any, spec, sizes: dict[str, int], batch_size: int = 1) -> wp.array | None:
   """Creates a warp array and populates it with data.
 
   The array shape is determined by a field spec referencing MjModel / MjData array sizes.
   """
   spec_shape = getattr(spec, "shape", (0,))
-  shape = None
-  if spec_shape != (0,):
-    shape = tuple(sizes[dim] if isinstance(dim, str) else dim for dim in spec_shape)
+  if spec_shape == (0,):
+    if data is None:
+      return None
+    return wp.array(np.array(data), dtype=spec.dtype)
 
-  if data is None and shape is None:
-    return None  # nothing to do
-  elif data is None:
+  shape = tuple(batch_size if dim == "*" else (sizes[dim] if isinstance(dim, str) else dim) for dim in spec_shape)
+
+  is_batched = spec_shape[0] == "*"
+
+  if data is None:
     array = wp.zeros(shape, dtype=spec.dtype)
   else:
-    if _is_batched_array_spec(spec) and shape[0] != 1:
+    if is_batched and shape[0] != 1:
       data = _broadcast_batch_data(data, shape, spec.dtype)
     array = wp.array(np.array(data), dtype=spec.dtype, shape=shape)
 
-  if _is_batched_array_spec(spec):
+  if is_batched:
     # add private attribute for JAX to determine which fields are batched
     array._is_batched = True
     if array.shape[0] == 1:
@@ -187,7 +166,16 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   """
   # check for compatible cuda toolkit and driver versions
   warp_util.check_toolkit_driver()
-  batch_sizes = _validate_model_batch_sizes(batch_sizes)
+
+  batch_sizes = batch_sizes or {}
+  model_fields = {f.name: f.type for f in dataclasses.fields(types.Model) if _is_array_spec(f.type)}
+  for name, size in batch_sizes.items():
+    field_type = model_fields.get(name)
+    spec_shape = getattr(field_type, "shape", ())
+    if not spec_shape or spec_shape[0] != "*":
+      raise ValueError(f"Model field {name!r} is not a batched array field.")
+    if size < 1:
+      raise ValueError(f"batch_sizes[{name!r}] must be positive, got {size}.")
 
   # model: check supported features in array types
   for field, field_type, mj_type in (
@@ -835,14 +823,11 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
     m.nflexbending = len(m.flex_bending)
 
   # place m on device
-  sizes = dict({"*": 1}, **{f.name: getattr(m, f.name) for f in dataclasses.fields(types.Model) if f.type is int})
+  sizes = {f.name: getattr(m, f.name) for f in dataclasses.fields(types.Model) if f.type is int}
   for f in dataclasses.fields(types.Model):
     if _is_array_spec(f.type):
-      field_sizes = sizes
-      if f.name in batch_sizes:
-        field_sizes = dict(sizes)
-        field_sizes["*"] = batch_sizes[f.name]
-      setattr(m, f.name, _create_array(getattr(m, f.name), f.type, field_sizes))
+      batch_size = batch_sizes.get(f.name, 1)
+      setattr(m, f.name, _create_array(getattr(m, f.name), f.type, sizes, batch_size))
 
   return m
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -42,20 +42,6 @@ def _is_array_spec(typ) -> bool:
   return isinstance(typ, wp.array) or type(typ).__name__ == "_ArrayAnnotation"
 
 
-def _broadcast_batch_data(data: Any, shape: tuple[int, ...], dtype) -> np.ndarray:
-  """Broadcasts host data to a requested leading batch dimension."""
-  data = np.array(data)
-  target_shape = shape + tuple(getattr(dtype, "_shape_", ()) or ())
-
-  if data.shape == target_shape:
-    return data
-
-  tail_shape = target_shape[1:]
-  if data.shape != tail_shape and data.size == np.prod(tail_shape):
-    data = data.reshape(tail_shape)
-  return np.broadcast_to(data, target_shape).copy()
-
-
 def _create_array(data: Any, spec, sizes: dict[str, int], batch_size: int = 1) -> wp.array | None:
   """Creates a warp array and populates it with data.
 
@@ -69,14 +55,20 @@ def _create_array(data: Any, spec, sizes: dict[str, int], batch_size: int = 1) -
 
   shape = tuple(batch_size if dim == "*" else (sizes[dim] if isinstance(dim, str) else dim) for dim in spec_shape)
 
-  is_batched = spec_shape[0] == "*"
+  is_batched = spec_shape[0] in ("*", "nworld")
 
   if data is None:
     array = wp.zeros(shape, dtype=spec.dtype)
   else:
+    data = np.array(data)
     if is_batched and shape[0] != 1:
-      data = _broadcast_batch_data(data, shape, spec.dtype)
-    array = wp.array(np.array(data), dtype=spec.dtype, shape=shape)
+      target_shape = shape + getattr(spec.dtype, "_shape_", ())
+      if data.shape != target_shape:
+        tail_shape = target_shape[1:]
+        if data.size == np.prod(tail_shape):
+          data = data.reshape(tail_shape)
+        data = np.broadcast_to(data, target_shape).copy()
+    array = wp.array(data, dtype=spec.dtype, shape=shape)
 
   if is_batched:
     # add private attribute for JAX to determine which fields are batched
@@ -1471,9 +1463,6 @@ def put_data(
     if f.name in d_kwargs:
       continue
     val = getattr(mjd, f.name, None)
-    if val is not None:
-      shape = val.shape if hasattr(val, "shape") else ()
-      val = np.full((nworld,) + shape, val)
     d_kwargs[f.name] = _create_array(val, f.type, sizes)
 
   d = types.Data(**d_kwargs)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -42,6 +42,44 @@ def _is_array_spec(typ) -> bool:
   return isinstance(typ, wp.array) or type(typ).__name__ == "_ArrayAnnotation"
 
 
+def _is_batched_array_spec(spec) -> bool:
+  spec_shape = getattr(spec, "shape", (0,))
+  return bool(spec_shape) and spec_shape[0] == "*"
+
+
+def _array_data_shape(shape: tuple[int, ...], dtype) -> tuple[int, ...]:
+  return shape + tuple(getattr(dtype, "_shape_", ()) or ())
+
+
+def _broadcast_batch_data(data: Any, shape: tuple[int, ...], dtype) -> np.ndarray:
+  """Broadcasts host data to a requested leading batch dimension."""
+  data = np.array(data)
+  target_shape = _array_data_shape(shape, dtype)
+
+  if data.shape == target_shape:
+    return data
+
+  tail_shape = target_shape[1:]
+  if data.shape != tail_shape and data.size == np.prod(tail_shape):
+    data = data.reshape(tail_shape)
+  return np.broadcast_to(data, target_shape).copy()
+
+
+def _validate_model_batch_sizes(batch_sizes: dict[str, int] | None) -> dict[str, int]:
+  if batch_sizes is None:
+    return {}
+
+  model_fields = {f.name: f for f in dataclasses.fields(types.Model) if _is_array_spec(f.type)}
+  for field_name, batch_size in batch_sizes.items():
+    field = model_fields.get(field_name)
+    if field is None or not _is_batched_array_spec(field.type):
+      raise ValueError(f"Model field {field_name!r} is not a batched array field.")
+    if batch_size < 1:
+      raise ValueError(f"batch_sizes[{field_name!r}] must be positive, got {batch_size}.")
+
+  return batch_sizes
+
+
 def _create_array(data: Any, spec, sizes: dict[str, int]) -> wp.array | None:
   """Creates a warp array and populates it with data.
 
@@ -57,13 +95,16 @@ def _create_array(data: Any, spec, sizes: dict[str, int]) -> wp.array | None:
   elif data is None:
     array = wp.zeros(shape, dtype=spec.dtype)
   else:
+    if _is_batched_array_spec(spec) and shape[0] != 1:
+      data = _broadcast_batch_data(data, shape, spec.dtype)
     array = wp.array(np.array(data), dtype=spec.dtype, shape=shape)
 
-  if spec_shape and spec_shape[0] == "*":
+  if _is_batched_array_spec(spec):
     # add private attribute for JAX to determine which fields are batched
     array._is_batched = True
-    # also set stride 0 to 0 which is expected legacy behavior (but is deprecated)
-    array.strides = (0,) + array.strides[1:]
+    if array.shape[0] == 1:
+      # also set stride 0 to 0 which is expected legacy behavior (but is deprecated)
+      array.strides = (0,) + array.strides[1:]
   return array
 
 
@@ -132,17 +173,21 @@ def is_sparse(mjm: mujoco.MjModel) -> bool:
     return bool(mujoco.mj_isSparse(mjm))
 
 
-def put_model(mjm: mujoco.MjModel) -> types.Model:
+def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) -> types.Model:
   """Creates a model on device.
 
   Args:
     mjm: The model containing kinematic and dynamic information (host).
+    batch_sizes: Optional per-field leading batch sizes for `Model` fields whose
+      array spec starts with `*`. Fields not listed here keep the default shared
+      leading dimension of 1.
 
   Returns:
     The model containing kinematic and dynamic information (device).
   """
   # check for compatible cuda toolkit and driver versions
   warp_util.check_toolkit_driver()
+  batch_sizes = _validate_model_batch_sizes(batch_sizes)
 
   # model: check supported features in array types
   for field, field_type, mj_type in (
@@ -793,7 +838,11 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   sizes = dict({"*": 1}, **{f.name: getattr(m, f.name) for f in dataclasses.fields(types.Model) if f.type is int})
   for f in dataclasses.fields(types.Model):
     if _is_array_spec(f.type):
-      setattr(m, f.name, _create_array(getattr(m, f.name), f.type, sizes))
+      field_sizes = sizes
+      if f.name in batch_sizes:
+        field_sizes = dict(sizes)
+        field_sizes["*"] = batch_sizes[f.name]
+      setattr(m, f.name, _create_array(getattr(m, f.name), f.type, field_sizes))
 
   return m
 

--- a/mujoco_warp/_src/io_jax_test.py
+++ b/mujoco_warp/_src/io_jax_test.py
@@ -214,6 +214,12 @@ class IOTest(parameterized.TestCase):
     self.assertGreater(m1.body_parentid.strides[0], 0)
     self.assertLen(m1.body_parentid.strides, m1.body_parentid.ndim)
 
+    m2 = mjw.put_model(mjm, batch_sizes={"geom_pos": 2})
+    self.assertTrue(hasattr(m2.geom_pos, "_is_batched"))
+    self.assertEqual(m2.geom_pos.shape[0], 2)
+    self.assertGreater(m2.geom_pos.strides[0], 0)
+    self.assertLen(m2.geom_pos.strides, m2.geom_pos.ndim)
+
   @parameterized.parameters(*_IO_TEST_MODELS)
   def test_put_data_nworld_array(self, xml):
     """Tests that put_data arrays that scale with nworld have leading dim nworld."""

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1445,7 +1445,7 @@ class IOTest(parameterized.TestCase):
           <material name="mat" texture="red" rgba="0.5 0.6 0.7 1"/>
         </asset>
         <worldbody>
-          <geom name="g" type="sphere" size="0.1" material="mat"/>
+          <geom type="sphere" size="0.1" material="mat"/>
         </worldbody>
       </mujoco>
       """
@@ -1485,12 +1485,8 @@ class IOTest(parameterized.TestCase):
     mjm = mujoco.MjModel.from_xml_string(
       """
       <mujoco>
-        <asset>
-          <texture name="red" type="2d" builtin="flat" width="4" height="4"/>
-          <material name="mat" texture="red"/>
-        </asset>
         <worldbody>
-          <geom type="sphere" size="0.1" material="mat"/>
+          <geom type="sphere" size="0.1"/>
         </worldbody>
       </mujoco>
       """

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1434,6 +1434,77 @@ class IOTest(parameterized.TestCase):
     mjwarp.reset_data(m, d)
     mjwarp.forward(m, d)
 
+  def test_put_model_batch_sizes(self):
+    """Test put_model can allocate selected batched Model fields per world."""
+    mjm = mujoco.MjModel.from_xml_string(
+      """
+      <mujoco>
+        <asset>
+          <texture name="red" type="2d" builtin="flat" width="4" height="4" rgb1="1 0 0" rgb2="1 0 0"/>
+          <texture name="green" type="2d" builtin="flat" width="4" height="4" rgb1="0 1 0" rgb2="0 1 0"/>
+          <material name="mat" texture="red" rgba="0.5 0.6 0.7 1"/>
+        </asset>
+        <worldbody>
+          <geom name="g" type="sphere" size="0.1" material="mat"/>
+        </worldbody>
+      </mujoco>
+      """
+    )
+
+    m_default = mjwarp.put_model(mjm)
+    m = mjwarp.put_model(mjm, batch_sizes={"mat_texid": 3, "geom_size": 2, "mat_rgba": 4})
+
+    nrole = int(mujoco.mjtTextureRole.mjNTEXROLE)
+    self.assertEqual(tuple(m.mat_texid.shape), (3, mjm.nmat, nrole))
+    self.assertEqual(tuple(m.geom_size.shape), (2, mjm.ngeom))
+    self.assertEqual(tuple(m.mat_rgba.shape), (4, mjm.nmat))
+    self.assertGreater(m.mat_texid.strides[0], 0)
+    self.assertGreater(m.geom_size.strides[0], 0)
+    self.assertGreater(m.mat_rgba.strides[0], 0)
+
+    np.testing.assert_array_equal(m.mat_texid.numpy(), np.repeat(m_default.mat_texid.numpy(), 3, axis=0))
+    np.testing.assert_allclose(m.geom_size.numpy(), np.repeat(m_default.geom_size.numpy(), 2, axis=0))
+    np.testing.assert_allclose(m.mat_rgba.numpy(), np.repeat(m_default.mat_rgba.numpy(), 4, axis=0))
+
+    # Fields not listed in batch_sizes keep the shared legacy allocation.
+    self.assertEqual(m.geom_pos.shape[0], 1)
+    self.assertEqual(m.geom_pos.strides[0], 0)
+
+    red_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "red")
+    green_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "green")
+    mat_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_MATERIAL, "mat")
+    rgb_role = int(mujoco.mjtTextureRole.mjTEXROLE_RGB)
+
+    mat_texid = m.mat_texid.numpy()
+    mat_texid[:, mat_id, rgb_role] = [red_id, green_id, red_id]
+    m.mat_texid.assign(mat_texid)
+    np.testing.assert_array_equal(m.mat_texid.numpy()[:, mat_id, rgb_role], [red_id, green_id, red_id])
+
+  def test_put_model_batch_sizes_errors(self):
+    """Test invalid put_model batch_sizes requests are rejected."""
+    mjm = mujoco.MjModel.from_xml_string(
+      """
+      <mujoco>
+        <asset>
+          <texture name="red" type="2d" builtin="flat" width="4" height="4"/>
+          <material name="mat" texture="red"/>
+        </asset>
+        <worldbody>
+          <geom type="sphere" size="0.1" material="mat"/>
+        </worldbody>
+      </mujoco>
+      """
+    )
+
+    with self.assertRaisesRegex(ValueError, "not a batched array field"):
+      mjwarp.put_model(mjm, batch_sizes={"missing": 2})
+    with self.assertRaisesRegex(ValueError, "not a batched array field"):
+      mjwarp.put_model(mjm, batch_sizes={"nmat": 2})
+    with self.assertRaisesRegex(ValueError, "not a batched array field"):
+      mjwarp.put_model(mjm, batch_sizes={"geom_type": 2})
+    with self.assertRaisesRegex(ValueError, "must be positive"):
+      mjwarp.put_model(mjm, batch_sizes={"mat_texid": 0})
+
   def test_set_fixed_body_subtreemass(self):
     """Test body_subtreemass accumulation for multi-level tree."""
     mjm, mjd, m, d = test_data.fixture(

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -43,6 +43,14 @@ def _unpack_rgb(packed):
   return np.stack([r, g, b], axis=-1)
 
 
+def _assert_channel_dominates(testcase, rgb, worldid, channel, other_channel):
+  testcase.assertGreater(
+    float(rgb[worldid, channel]),
+    float(rgb[worldid, other_channel]) + 0.1,
+    f"world {worldid} channel {channel} should dominate",
+  )
+
+
 class RenderTest(parameterized.TestCase):
   @parameterized.parameters(2, 512)
   def test_render(self, nworld: int):
@@ -191,6 +199,61 @@ class RenderTest(parameterized.TestCase):
     mjw.render(m, d, rc)
     rgb = _unpack_rgb(rc.rgb_data.numpy()[0]).reshape(32, 32, 3)
     self.assertGreater(int(rgb.max()), 10, "directional light + headlight should still light the scene")
+
+  def test_render_per_world_mat_texid_batch_size(self):
+    """Tests render uses per-world material texture IDs allocated by put_model."""
+    nworld = 2
+    mjm = mujoco.MjModel.from_xml_string(
+      """
+      <mujoco>
+        <asset>
+          <texture name="red" type="2d" builtin="flat" width="4" height="4"
+            rgb1="1 0 0" rgb2="1 0 0"/>
+          <texture name="green" type="2d" builtin="flat" width="4" height="4"
+            rgb1="0 1 0" rgb2="0 1 0"/>
+          <material name="mat" texture="red" rgba="1 1 1 1" texrepeat="1 1"/>
+        </asset>
+        <worldbody>
+          <camera name="cam" pos="0 0 2" xyaxes="1 0 0 0 1 0"/>
+          <geom name="plane" type="plane" size="2 2 0.1" material="mat"/>
+        </worldbody>
+      </mujoco>
+      """
+    )
+    mjd = mujoco.MjData(mjm)
+    mujoco.mj_forward(mjm, mjd)
+    m = mjw.put_model(mjm, batch_sizes={"mat_texid": nworld})
+    d = mjw.put_data(mjm, mjd, nworld=nworld)
+
+    red_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "red")
+    green_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "green")
+    mat_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_MATERIAL, "mat")
+    rgb_role = int(mujoco.mjtTextureRole.mjTEXROLE_RGB)
+
+    mat_texid = m.mat_texid.numpy()
+    mat_texid[:, mat_id, rgb_role] = [red_id, green_id]
+    m.mat_texid.assign(mat_texid)
+
+    rc = mjw.create_render_context(
+      mjm,
+      nworld=nworld,
+      cam_res=(16, 16),
+      render_rgb=True,
+      use_textures=True,
+      enable_specular=False,
+      enable_emission=False,
+    )
+    mjw.render(m, d, rc)
+    rgb = _unpack_rgb(rc.rgb_data.numpy()).reshape(nworld, 16, 16, 3).mean(axis=(1, 2))
+    _assert_channel_dominates(self, rgb, 0, 0, 1)
+    _assert_channel_dominates(self, rgb, 1, 1, 0)
+
+    mat_texid[:, mat_id, rgb_role] = [green_id, red_id]
+    m.mat_texid.assign(mat_texid)
+    mjw.render(m, d, rc)
+    rgb = _unpack_rgb(rc.rgb_data.numpy()).reshape(nworld, 16, 16, 3).mean(axis=(1, 2))
+    _assert_channel_dominates(self, rgb, 0, 1, 0)
+    _assert_channel_dominates(self, rgb, 1, 0, 1)
 
   def test_disable_ambient_lighting(self):
     xml = """

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -206,7 +206,7 @@ class RenderTest(parameterized.TestCase):
           <material name="mat" texture="red" rgba="1 1 1 1"/>
         </asset>
         <worldbody>
-          <camera name="cam" pos="0 0 2" xyaxes="1 0 0 0 1 0"/>
+          <camera pos="0 0 2" xyaxes="1 0 0 0 1 0"/>
           <geom type="plane" size="2 2 0.1" material="mat"/>
         </worldbody>
       </mujoco>

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -43,14 +43,6 @@ def _unpack_rgb(packed):
   return np.stack([r, g, b], axis=-1)
 
 
-def _assert_channel_dominates(testcase, rgb, worldid, channel, other_channel):
-  testcase.assertGreater(
-    float(rgb[worldid, channel]),
-    float(rgb[worldid, other_channel]) + 0.1,
-    f"world {worldid} channel {channel} should dominate",
-  )
-
-
 class RenderTest(parameterized.TestCase):
   @parameterized.parameters(2, 512)
   def test_render(self, nworld: int):
@@ -211,11 +203,11 @@ class RenderTest(parameterized.TestCase):
             rgb1="1 0 0" rgb2="1 0 0"/>
           <texture name="green" type="2d" builtin="flat" width="4" height="4"
             rgb1="0 1 0" rgb2="0 1 0"/>
-          <material name="mat" texture="red" rgba="1 1 1 1" texrepeat="1 1"/>
+          <material name="mat" texture="red" rgba="1 1 1 1"/>
         </asset>
         <worldbody>
           <camera name="cam" pos="0 0 2" xyaxes="1 0 0 0 1 0"/>
-          <geom name="plane" type="plane" size="2 2 0.1" material="mat"/>
+          <geom type="plane" size="2 2 0.1" material="mat"/>
         </worldbody>
       </mujoco>
       """
@@ -227,11 +219,8 @@ class RenderTest(parameterized.TestCase):
 
     red_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "red")
     green_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "green")
-    mat_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_MATERIAL, "mat")
-    rgb_role = int(mujoco.mjtTextureRole.mjTEXROLE_RGB)
-
     mat_texid = m.mat_texid.numpy()
-    mat_texid[:, mat_id, rgb_role] = [red_id, green_id]
+    mat_texid[:, 0, 1] = [red_id, green_id]
     m.mat_texid.assign(mat_texid)
 
     rc = mjw.create_render_context(
@@ -245,15 +234,20 @@ class RenderTest(parameterized.TestCase):
     )
     mjw.render(m, d, rc)
     rgb = _unpack_rgb(rc.rgb_data.numpy()).reshape(nworld, 16, 16, 3).mean(axis=(1, 2))
-    _assert_channel_dominates(self, rgb, 0, 0, 1)
-    _assert_channel_dominates(self, rgb, 1, 1, 0)
 
-    mat_texid[:, mat_id, rgb_role] = [green_id, red_id]
+    # Assert world 0 is red (channel 0 dominates), world 1 is green (channel 1 dominates)
+    self.assertGreater(rgb[0, 0], rgb[0, 1] + 0.1)
+    self.assertGreater(rgb[1, 1], rgb[1, 0] + 0.1)
+
+    # Swap textures and re-render to verify dynamic updates
+    mat_texid[:, 0, 1] = [green_id, red_id]
     m.mat_texid.assign(mat_texid)
     mjw.render(m, d, rc)
     rgb = _unpack_rgb(rc.rgb_data.numpy()).reshape(nworld, 16, 16, 3).mean(axis=(1, 2))
-    _assert_channel_dominates(self, rgb, 0, 1, 0)
-    _assert_channel_dominates(self, rgb, 1, 0, 1)
+
+    # Assert world 0 is green (channel 1 dominates), world 1 is red (channel 0 dominates)
+    self.assertGreater(rgb[0, 1], rgb[0, 0] + 0.1)
+    self.assertGreater(rgb[1, 0], rgb[1, 1] + 0.1)
 
   def test_disable_ambient_lighting(self):
     xml = """


### PR DESCRIPTION
This adds an optional `batch_sizes` argument to `put_model`, allowing callers to allocate selected batched Model fields with a real per-world leading dimension instead of the default shared dimension of 1. This is useful for downstream apps that need to randomize model fields such as `mat_texid, mat_rgba`, or `geom_size` across worlds without recompiling the MuJoCo model.

Fields not listed in `batch_sizes` keep the existing shared allocation and stride-0 behavior, so the default `put_model(mjm)` path is unchanged. Requested fields are initialized by broadcasting the host MuJoCo values across the requested leading dimension, after which callers can assign per-world values directly.

Example downstream use for texture randomization:

```
import mujoco
import mujoco_warp as mjw
import numpy as np

mjm = mujoco.MjModel.from_xml_path("scene.xml")
mjd = mujoco.MjData(mjm)

nworld = 1024
m = mjw.put_model(mjm, batch_sizes={"mat_texid": nworld})
d = mjw.put_data(mjm, mjd, nworld=nworld)

mat_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_MATERIAL, "table")
rgb_role = int(mujoco.mjtTextureRole.mjTEXROLE_RGB)

texture_ids = np.array([
    mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, name)
    for name in ["wood", "metal", "marble", "checker"]
])

mat_texid = m.mat_texid.numpy()
mat_texid[:, mat_id, rgb_role] = np.random.choice(texture_ids, size=nworld)
m.mat_texid.assign(mat_texid)
```
