### PR TITLE
update contact initialization in io.put_data

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1775,7 +1775,7 @@ def put_data(
       contact_kwargs[f.name] = wp.empty(0, dtype=wp.vec2i)
       continue
     val = getattr(mjd.contact, f.name)
-    val = np.repeat(val, nworld, axis=0)
+    val = np.tile(val, (nworld,) + (1,) * (val.ndim - 1))
     width = ((0, naconmax - val.shape[0]),) + ((0, 0),) * (val.ndim - 1)
     val = np.pad(val, width)
     contact_kwargs[f.name] = _create_array(val, f.type, sizes)

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -2663,6 +2663,33 @@ class IOTest(parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, "ls_parallel_min_step was removed in MuJoCo Warp 3.9.1"):
       override_model(m, {"opt.ls_parallel_min_step": 0.01})
 
+  def test_put_data_contact_batching(self):
+    """Tests that contacts are batched correctly (tiled, not repeated) across worlds."""
+    nworld = 2
+    mjm, mjd, _, d = test_data.fixture("humanoid/humanoid.xml", keyframe=0, nworld=nworld)
+    self.assertGreater(mjd.ncon, 1, "The test model must have at least 2 contacts")
+
+    # For each contact field, verify that it is tiled correctly
+    ncon = mjd.ncon
+    for field in [
+      "dist",
+      "pos",
+      "frame",
+      "includemargin",
+      "friction",
+      "solref",
+      "solreffriction",
+      "solimp",
+      "dim",
+      "geom",
+    ]:
+      val_device = getattr(d.contact, field).numpy()
+      val_host = getattr(mjd.contact, field)
+      for w in range(nworld):
+        device_slice = val_device[w * ncon : (w + 1) * ncon].reshape(-1)
+        host_slice = val_host[:ncon].reshape(-1)
+        _assert_eq(device_slice, host_slice, f"{field} mismatch in world {w}")
+
 
 # TODO(team): test set_const_0 sparse
 


### PR DESCRIPTION
This PR fixes a bug in how contact fields are batched across multiple worlds in io.put_data. Currently, contact parameters (such as contact positions and distances) are batched using np.repeat instead of np.tile, causing contact values to be duplicated consecutively for each world rather than aligned correctly. For instance, with 2 worlds and 3 contacts [c0, c1, c2], the previous code populated the device contacts as [c0, c0, c1, c1, c2, c2] instead of [c0, c1, c2, c0, c1, c2], mismatching the world allocations defined in contact.worldid. This change replaces np.repeat with np.tile to ensure proper batching across worlds, and adds a corresponding unit test to prevent regression.