### PR TITLE
refactor island fields

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -97,17 +97,6 @@ def _create_constraint(
       efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=int)
     elif f.name == "iid":
       efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=int)
-    elif f.name == "iJ_rownnz":
-      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0) if sparse else (nworld, 0), dtype=int)
-    elif f.name == "iJ_rowadr":
-      efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0) if sparse else (nworld, 0), dtype=int)
-    elif f.name == "iJ_colind":
-      efc_kwargs[f.name] = wp.empty((nworld, 1, njmax_nnz if island_enabled else 0) if sparse else (nworld, 0, 0), dtype=int)
-    elif f.name == "iJ":
-      efc_kwargs[f.name] = wp.empty(
-        (nworld, 1, njmax_nnz if island_enabled else 0) if sparse else (nworld, njmax if island_enabled else 0, mjm.nv),
-        dtype=float,
-      )
     elif f.name == "iD":
       efc_kwargs[f.name] = wp.empty((nworld, njmax if island_enabled else 0), dtype=float)
     elif f.name == "iaref":
@@ -1338,7 +1327,7 @@ def _allocate_island_arrays(
   d.island_nefc = wp.empty((nworld, ntree_size), dtype=int)
   d.island_ne = wp.empty((nworld, ntree_size), dtype=int)
   d.island_nf = wp.empty((nworld, ntree_size), dtype=int)
-  d.island_efcadr = wp.empty((nworld, ntree_size), dtype=int)
+  d.island_iefcadr = wp.empty((nworld, ntree_size), dtype=int)
   d.nidof = wp.empty((nworld if island_enabled else 0,), dtype=int)
   d.map_dof2idof = wp.empty((nworld, nv_size), dtype=int)
   d.map_idof2dof = wp.empty((nworld, nv_size), dtype=int)
@@ -1599,7 +1588,7 @@ def make_data(
     "island_nefc": None,
     "island_ne": None,
     "island_nf": None,
-    "island_efcadr": None,
+    "island_iefcadr": None,
     "nidof": None,
     "map_dof2idof": None,
     "map_idof2dof": None,
@@ -1867,7 +1856,7 @@ def put_data(
     "island_nefc": None,
     "island_ne": None,
     "island_nf": None,
-    "island_efcadr": None,
+    "island_iefcadr": None,
     "nidof": None,
     "map_dof2idof": None,
     "map_idof2dof": None,
@@ -2159,7 +2148,7 @@ def get_data_into(
     result.island_nefc[:nisland] = d.island_nefc.numpy()[world_id, :nisland]
     result.island_ne[:nisland] = d.island_ne.numpy()[world_id, :nisland]
     result.island_nf[:nisland] = d.island_nf.numpy()[world_id, :nisland]
-    result.island_iefcadr[:nisland] = d.island_efcadr.numpy()[world_id, :nisland]
+    result.island_iefcadr[:nisland] = d.island_iefcadr.numpy()[world_id, :nisland]
     nv = mjm.nv
     result.map_dof2idof[:nv] = d.map_dof2idof.numpy()[world_id, :nv]
     result.map_idof2dof[:nv] = d.map_idof2dof.numpy()[world_id, :nv]
@@ -2173,29 +2162,6 @@ def get_data_into(
     result.iefc_frictionloss[:nefc] = d.efc.ifrictionloss.numpy()[world_id, :nefc]
     result.iefc_state[:nefc] = d.efc.istate.numpy()[world_id, :nefc]
     result.iefc_force[:nefc] = d.efc.iforce.numpy()[world_id, :nefc]
-
-    if is_sparse(mjm):
-      iefc_J = np.zeros((nefc, mjm.nv))
-      mujoco.mju_sparse2dense(
-        iefc_J,
-        d.efc.iJ.numpy()[world_id, 0],
-        d.efc.iJ_rownnz.numpy()[world_id, :nefc],
-        d.efc.iJ_rowadr.numpy()[world_id, :nefc],
-        d.efc.iJ_colind.numpy()[world_id, 0],
-      )
-    else:
-      iefc_J = d.efc.iJ.numpy()[world_id, :nefc, : mjm.nv]
-
-    if mujoco.mj_isSparse(mjm):
-      mujoco.mju_dense2sparse(
-        result.iefc_J,
-        iefc_J,
-        result.iefc_J_rownnz,
-        result.iefc_J_rowadr,
-        result.iefc_J_colind,
-      )
-    else:
-      result.iefc_J[: nefc * mjm.nv] = iefc_J.flatten()
 
 
 def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):

--- a/mujoco_warp/_src/island.py
+++ b/mujoco_warp/_src/island.py
@@ -800,7 +800,7 @@ def _init_efc_arrays(
 
 
 @event_scope
-def compute_island_mapping(m: types.Model, d: types.Data, ctx: IslandSolverContext):
+def compute_island_mapping(m: types.Model, d: types.Data, ctx: IslandSolverContext | None = None):
   """Compute DOF/constraint island mappings after island discovery.
 
   Populates island solver context arrays via ctx: nv, nefc, ne, nf,
@@ -838,7 +838,7 @@ def compute_island_mapping(m: types.Model, d: types.Data, ctx: IslandSolverConte
       d.island_nefc,
       d.island_ne,
       d.island_nf,
-      d.island_efcadr,
+      d.island_iefcadr,
       d.nidof,
     ],
   )
@@ -905,7 +905,7 @@ def compute_island_mapping(m: types.Model, d: types.Data, ctx: IslandSolverConte
     _island_scan_sizes,
     dim=d.nworld,
     inputs=[d.nisland],
-    outputs=[d.island_idofadr, d.island_nv, d.island_nefc, d.island_efcadr, d.nidof],
+    outputs=[d.island_idofadr, d.island_nv, d.island_nefc, d.island_iefcadr, d.nidof],
   )
 
   # 4. Map DOFs
@@ -930,7 +930,7 @@ def compute_island_mapping(m: types.Model, d: types.Data, ctx: IslandSolverConte
       d.nefc,
       d.njmax,
       d.efc.island,
-      d.island_efcadr,
+      d.island_iefcadr,
       d.island_ne,
       d.island_nf,
       d.efc.type,
@@ -942,12 +942,12 @@ def compute_island_mapping(m: types.Model, d: types.Data, ctx: IslandSolverConte
   )
 
   # 6. Scan Sparse Rows (if sparse)
-  if m.is_sparse:
+  if m.is_sparse and ctx is not None:
     wp.launch(
       _island_scan_sparse_rows,
       dim=d.nworld,
-      inputs=[d.nisland, d.efc.J_rownnz, d.island_nefc, d.island_efcadr, d.map_iefc2efc],
-      outputs=[d.efc.iJ_rownnz, d.efc.iJ_rowadr],
+      inputs=[d.nisland, d.efc.J_rownnz, d.island_nefc, d.island_iefcadr, d.map_iefc2efc],
+      outputs=[ctx.iJ_rownnz, ctx.iJ_rowadr],
     )
 
 
@@ -981,7 +981,7 @@ def gather_island_inputs(m: types.Model, d: types.Data, ctx: IslandSolverContext
       d.efc.J_rownnz,
       d.efc.J_rowadr,
       d.efc.J_colind,
-      d.efc.iJ_rowadr,
+      ctx.iJ_rowadr,
       d.njmax,
       d.map_iefc2efc,
       d.map_idof2dof,
@@ -994,8 +994,8 @@ def gather_island_inputs(m: types.Model, d: types.Data, ctx: IslandSolverContext
       d.efc.iid,
       d.efc.ifrictionloss,
       d.efc.iaref,
-      d.efc.iJ,
-      d.efc.iJ_colind,
+      ctx.iJ,
+      ctx.iJ_colind,
     ],
   )
 

--- a/mujoco_warp/_src/island_test.py
+++ b/mujoco_warp/_src/island_test.py
@@ -894,7 +894,7 @@ class IslandMappingTest(absltest.TestCase):
       mjd.island_dofadr[:nisland],
     )
     np.testing.assert_array_equal(
-      d.island_efcadr.numpy()[0, :nisland],
+      d.island_iefcadr.numpy()[0, :nisland],
       mjd.island_iefcadr[:nisland],
     )
     np.testing.assert_array_equal(

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -77,6 +77,9 @@ def _create_island_solver_context(m: types.Model, d: types.Data) -> IslandSolver
   alloc_h = m.opt.solver == types.SolverType.NEWTON
   alloc_island_cg = m.opt.solver == types.SolverType.CG
 
+  sparse = m.is_sparse
+  njmax_nnz = d.njmax_nnz
+
   return IslandSolverContext(
     Jaref=wp.empty((nworld, njmax), dtype=float),
     jv=wp.empty((nworld, njmax), dtype=float),
@@ -87,7 +90,7 @@ def _create_island_solver_context(m: types.Model, d: types.Data) -> IslandSolver
     prev_grad=wp.empty((nworld, nv), dtype=float) if alloc_island_cg else wp.empty((nworld, 0), dtype=float),
     prev_Mgrad=wp.empty((nworld, nv), dtype=float) if alloc_island_cg else wp.empty((nworld, 0), dtype=float),
     h=wp.zeros((nworld, nv_pad, nv_pad), dtype=float) if alloc_h else wp.empty((nworld, 0, 0), dtype=float),
-    # Per-island solver scalars
+    # Per-island solver fields
     cost=wp.empty((nworld, ntree), dtype=float),
     prev_cost=wp.empty((nworld, ntree), dtype=float),
     gauss=wp.empty((nworld, ntree), dtype=float),
@@ -99,6 +102,13 @@ def _create_island_solver_context(m: types.Model, d: types.Data) -> IslandSolver
     beta_den=wp.empty((nworld, ntree), dtype=float) if alloc_island_cg else wp.empty((nworld, 0), dtype=float),
     alpha=wp.empty((nworld, ntree), dtype=float),
     Ma=wp.empty((nworld, nv), dtype=float),
+    iJ_rownnz=wp.empty((nworld, njmax) if sparse else (nworld, 0), dtype=int),
+    iJ_rowadr=wp.empty((nworld, njmax) if sparse else (nworld, 0), dtype=int),
+    iJ_colind=wp.empty((nworld, 1, njmax_nnz) if sparse else (nworld, 0, 0), dtype=int),
+    iJ=wp.empty(
+      (nworld, 1, njmax_nnz) if sparse else (nworld, njmax, nv),
+      dtype=float,
+    ),
   )
 
 
@@ -3738,7 +3748,7 @@ def _update_constraint_efc_island(
   island_nefc_in: wp.array2d[int],
   island_ne_in: wp.array2d[int],
   island_nf_in: wp.array2d[int],
-  island_efcadr_in: wp.array2d[int],
+  island_iefcadr_in: wp.array2d[int],
   map_efc2iefc_in: wp.array2d[int],
   njmax_in: int,
   nacon_in: wp.array[int],
@@ -3768,7 +3778,7 @@ def _update_constraint_efc_island(
     return
 
   # Local position within island
-  iefcadr = island_efcadr_in[worldid, islandid]
+  iefcadr = island_iefcadr_in[worldid, islandid]
   local_iefcid = iefcid - iefcadr
   ine = island_ne_in[worldid, islandid]
   inf = island_nf_in[worldid, islandid]
@@ -3844,7 +3854,7 @@ def _update_constraint_init_qfrc_constraint_dense_island(
   nefc_in: wp.array[int],
   nidof_in: wp.array[int],
   island_nefc_in: wp.array2d[int],
-  island_efcadr_in: wp.array2d[int],
+  island_iefcadr_in: wp.array2d[int],
   njmax_in: int,
   # In:
   iefc_J_in: wp.array3d[float],
@@ -3868,7 +3878,7 @@ def _update_constraint_init_qfrc_constraint_dense_island(
   if island_done_in[worldid, islandid]:
     return
 
-  iefcadr = island_efcadr_in[worldid, islandid]
+  iefcadr = island_iefcadr_in[worldid, islandid]
   inefc = island_nefc_in[worldid, islandid]
   acc = float(0.0)
   for iefcid in range(iefcadr, iefcadr + inefc):
@@ -4111,7 +4121,7 @@ def _linesearch_kernel_island(
   island_nv_in: wp.array2d[int],
   island_ne_in: wp.array2d[int],
   island_nf_in: wp.array2d[int],
-  island_efcadr_in: wp.array2d[int],
+  island_iefcadr_in: wp.array2d[int],
   island_nefc_in: wp.array2d[int],
   map_efc2iefc_in: wp.array2d[int],
   njmax_in: int,
@@ -4150,7 +4160,7 @@ def _linesearch_kernel_island(
     island_alpha_out[worldid, islandid] = 0.0
     return
 
-  iefcadr = island_efcadr_in[worldid, islandid]
+  iefcadr = island_iefcadr_in[worldid, islandid]
   ine = island_ne_in[worldid, islandid]
   inf = island_nf_in[worldid, islandid]
   inv = island_nv_in[worldid, islandid]
@@ -5141,10 +5151,10 @@ def _init_context_island(m: types.Model, d: types.Data, ctx: IslandSolverContext
       d.island_idofadr,
       d.island_nv,
       d.njmax,
-      d.efc.iJ_rownnz,
-      d.efc.iJ_rowadr,
-      d.efc.iJ_colind,
-      d.efc.iJ,
+      ctx.iJ_rownnz,
+      ctx.iJ_rowadr,
+      ctx.iJ_colind,
+      ctx.iJ,
       d.iqacc,
       d.efc.iaref,
       d.efc_islandid,
@@ -5203,7 +5213,7 @@ def _update_constraint_island(m: types.Model, d: types.Data, ctx: IslandSolverCo
       d.island_nefc,
       d.island_ne,
       d.island_nf,
-      d.island_efcadr,
+      d.island_iefcadr,
       d.map_efc2iefc,
       d.njmax,
       d.nacon,
@@ -5227,10 +5237,10 @@ def _update_constraint_island(m: types.Model, d: types.Data, ctx: IslandSolverCo
       inputs=[
         d.nefc,
         d.njmax,
-        d.efc.iJ_rownnz,
-        d.efc.iJ_rowadr,
-        d.efc.iJ_colind,
-        d.efc.iJ,
+        ctx.iJ_rownnz,
+        ctx.iJ_rowadr,
+        ctx.iJ_colind,
+        ctx.iJ,
         d.efc.iforce,
         d.efc_islandid,
         ctx.done,
@@ -5245,9 +5255,9 @@ def _update_constraint_island(m: types.Model, d: types.Data, ctx: IslandSolverCo
         d.nefc,
         d.nidof,
         d.island_nefc,
-        d.island_efcadr,
+        d.island_iefcadr,
         d.njmax,
-        d.efc.iJ,
+        ctx.iJ,
         d.efc.iforce,
         d.dof_islandid,
         ctx.done,
@@ -5338,10 +5348,10 @@ def _update_gradient_incremental_island(m: types.Model, d: types.Data, ctx: Isla
       d.njmax,
       d.island_idofadr,
       d.island_nv,
-      d.efc.iJ_rownnz,
-      d.efc.iJ_rowadr,
-      d.efc.iJ_colind,
-      d.efc.iJ,
+      ctx.iJ_rownnz,
+      ctx.iJ_rowadr,
+      ctx.iJ_colind,
+      ctx.iJ,
       d.efc.iD,
       d.efc.istate,
       d.efc_islandid,
@@ -5384,10 +5394,10 @@ def _update_gradient_incremental_island(m: types.Model, d: types.Data, ctx: Isla
         d.nidof,
         d.map_efc2iefc,
         d.island_nv,
-        d.efc.iJ_rownnz,
-        d.efc.iJ_rowadr,
-        d.efc.iJ_colind,
-        d.efc.iJ,
+        ctx.iJ_rownnz,
+        ctx.iJ_rowadr,
+        ctx.iJ_colind,
+        ctx.iJ,
         d.efc.iD,
         d.efc.istate,
         ctx.Jaref,
@@ -5440,10 +5450,10 @@ def _linesearch_island(m: types.Model, d: types.Data, ctx: IslandSolverContext):
       d.island_idofadr,
       d.island_nv,
       d.njmax,
-      d.efc.iJ_rownnz,
-      d.efc.iJ_rowadr,
-      d.efc.iJ_colind,
-      d.efc.iJ,
+      ctx.iJ_rownnz,
+      ctx.iJ_rowadr,
+      ctx.iJ_colind,
+      ctx.iJ,
       ctx.search,
       d.efc_islandid,
       ctx.done,
@@ -5470,7 +5480,7 @@ def _linesearch_island(m: types.Model, d: types.Data, ctx: IslandSolverContext):
       d.island_nv,
       d.island_ne,
       d.island_nf,
-      d.island_efcadr,
+      d.island_iefcadr,
       d.island_nefc,
       d.map_efc2iefc,
       d.njmax,

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -311,7 +311,7 @@ class SolverTest(parameterized.TestCase):
         one2d_i(1),  # island_nv
         one2d_i(0),  # island_ne
         one2d_i(0),  # island_nf
-        one2d_i(0),  # island_efcadr
+        one2d_i(0),  # island_iefcadr
         one2d_i(1),  # island_nefc
         one2d_i(0),  # map_efc2iefc (unused for inequality)
         1,  # njmax

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1928,12 +1928,6 @@ class Constraint:
     island: island ID per constraint                  (nworld, njmax)
     itype: island constraint type                     (nworld, njmax)
     iid: island constraint id                         (nworld, njmax)
-    iJ_rownnz: island J_rownnz                        (nworld, njmax)
-    iJ_rowadr: island J_rowadr                        (nworld, njmax)
-    iJ_colind: island J_colind                        (nworld, 0, 0) dense
-                                                      (nworld, 1, njmax_nnz) sparse
-    iJ: island J                                      (nworld, njmax, nv) dense
-                                                      (nworld, 1, njmax_nnz) sparse
     iD: island constraint mass                        (nworld, njmax_pad)
     iaref: island aref                                (nworld, njmax)
     ifrictionloss: island frictionloss                (nworld, njmax)
@@ -1964,10 +1958,6 @@ class Constraint:
 
   itype: array("nworld", "njmax", int)
   iid: array("nworld", "njmax", int)
-  iJ_rownnz: array("nworld", "njmax", int)
-  iJ_rowadr: array("nworld", "njmax", int)
-  iJ_colind: wp.array3d[int]
-  iJ: wp.array3d[float]
   iD: array("nworld", "njmax_pad", float)
   iaref: array("nworld", "njmax", float)
   ifrictionloss: array("nworld", "njmax", float)
@@ -2084,7 +2074,7 @@ class Data:
     island_nefc: constraints per island                         (nworld, ntree)
     island_ne: equality constraints per island                  (nworld, ntree)
     island_nf: friction constraints per island                  (nworld, ntree)
-    island_efcadr: island start address in efc vector           (nworld, ntree)
+    island_iefcadr: island start address in efc vector          (nworld, ntree)
     map_dof2idof: global DOF -> island-local DOF                (nworld, nv)
     map_idof2dof: island-local DOF -> global DOF                (nworld, nv)
     map_efc2iefc: global EFC -> island-local EFC                (nworld, njmax)
@@ -2230,7 +2220,7 @@ class Data:
   island_nefc: array("nworld", "ntree", int)
   island_ne: array("nworld", "ntree", int)
   island_nf: array("nworld", "ntree", int)
-  island_efcadr: array("nworld", "ntree", int)
+  island_iefcadr: array("nworld", "ntree", int)
   map_dof2idof: array("nworld", "nv", int)
   map_idof2dof: array("nworld", "nv", int)
   map_efc2iefc: array("nworld", "njmax", int)
@@ -2313,6 +2303,12 @@ class IslandSolverContext:
   beta_den: wp.array2d[float]
   alpha: wp.array2d[float]
   Ma: wp.array2d[float]  # island-local Ma (nworld, nv)
+
+  # Re-ordered sparse Jacobian arrays
+  iJ_rownnz: wp.array2d[int]
+  iJ_rowadr: wp.array2d[int]
+  iJ_colind: wp.array3d[int]
+  iJ: wp.array3d[float]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
some island fields were removed from `mjData` so these fields have been moved from `Data` to `IslandSolverContext`. the `Data` field `island_efcadr` was rename to `island_iefcad` to match mujoco.