### PR TITLE
Make the sleeping collision second pass incremental

### DIFF
--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -93,26 +93,6 @@ MJ_FLEX_COLLISION_TABLE = {
 }
 
 
-@cache_kernel
-def _zero_nacon_ncollision(enable_sleep: bool = False):
-  @wp.kernel(module="unique", enable_backward=False)
-  def zero_nacon_ncollision(
-    # In:
-    skip_in: wp.array[int],
-    # Data out:
-    nacon_out: wp.array[int],
-    ncollision_out: wp.array[int],
-  ):
-    ncollision_out[0] = 0
-    if wp.static(enable_sleep):
-      if skip_in[0] != 0:
-        nacon_out[0] = 0
-    else:
-      nacon_out[0] = 0
-
-  return zero_nacon_ncollision
-
-
 @wp.func
 def _plane_filter(
   size1: float, size2: float, margin1: float, margin2: float, xpos1: wp.vec3, xpos2: wp.vec3, xmat1: wp.mat33, xmat2: wp.mat33
@@ -402,7 +382,7 @@ def _binary_search(values: wp.array[Any], value: Any, lower: int, upper: int) ->
 
 
 @cache_kernel
-def _sap_project(opt_broadphase: int, enable_sleep: bool = False):
+def _sap_project(opt_broadphase: int):
   @wp.kernel(module="unique", enable_backward=False)
   def sap_project(
     # Model:
@@ -415,7 +395,6 @@ def _sap_project(opt_broadphase: int, enable_sleep: bool = False):
     nworld_in: int,
     # In:
     direction_in: wp.vec3,
-    skip_in: wp.array[int],
     # Out:
     projection_lower_out: wp.array2d[float],
     projection_upper_out: wp.array2d[float],
@@ -423,10 +402,6 @@ def _sap_project(opt_broadphase: int, enable_sleep: bool = False):
     segmented_index_out: wp.array[int],
   ):
     worldid, geomid = wp.tid()
-
-    if wp.static(enable_sleep):
-      if skip_in[0] == 0:
-        return
 
     xpos = geom_xpos_in[worldid, geomid]
     rbound = geom_rbound[worldid % geom_rbound.shape[0], geomid]
@@ -455,44 +430,40 @@ def _sap_project(opt_broadphase: int, enable_sleep: bool = False):
   return sap_project
 
 
-@cache_kernel
-def _sap_range(enable_sleep: bool = False):
-  @wp.kernel(module="unique", enable_backward=False)
-  def sap_range(
-    # Model:
-    ngeom: int,
-    # In:
-    projection_lower_in: wp.array2d[float],
-    projection_upper_in: wp.array2d[float],
-    sort_index_in: wp.array2d[int],
-    skip_in: wp.array[int],
-    # Out:
-    range_out: wp.array2d[int],
-  ):
-    worldid, geomid = wp.tid()
+@wp.kernel(enable_backward=False)
+def _sap_range(
+  # Model:
+  ngeom: int,
+  # In:
+  projection_lower_in: wp.array2d[float],
+  projection_upper_in: wp.array2d[float],
+  sort_index_in: wp.array2d[int],
+  # Out:
+  range_out: wp.array2d[int],
+):
+  worldid, geomid = wp.tid()
 
-    if wp.static(enable_sleep):
-      if skip_in[0] == 0:
-        range_out[worldid, geomid] = 0
-        return
+  # current bounding geom
+  idx = sort_index_in[worldid, geomid]
 
-    # current bounding geom
-    idx = sort_index_in[worldid, geomid]
+  upper = projection_upper_in[worldid, idx]
 
-    upper = projection_upper_in[worldid, idx]
+  limit = _binary_search(projection_lower_in[worldid], upper, geomid + 1, ngeom)
+  limit = wp.min(ngeom - 1, limit)
 
-    limit = _binary_search(projection_lower_in[worldid], upper, geomid + 1, ngeom)
-    limit = wp.min(ngeom - 1, limit)
-
-    # range of geoms for the sweep and prune process
-    range_out[worldid, geomid] = limit - geomid
-
-  return sap_range
+  # range of geoms for the sweep and prune process
+  range_out[worldid, geomid] = limit - geomid
 
 
 @cache_kernel
 def _sap_broadphase(
-  opt_broadphase_filter: int, ngeom_aabb: int, ngeom_rbound: int, ngeom_margin: int, ngeom_gap: int, enable_sleep: bool = False
+  opt_broadphase_filter: int,
+  ngeom_aabb: int,
+  ngeom_rbound: int,
+  ngeom_margin: int,
+  ngeom_gap: int,
+  enable_sleep: bool = False,
+  incremental: bool = False,
 ):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -515,7 +486,7 @@ def _sap_broadphase(
     sort_index_in: wp.array2d[int],
     cumulative_sum_in: wp.array[int],
     nsweep_in: int,
-    skip_in: wp.array[int],
+    body_awake_prev_in: wp.array2d[int],
     # Data out:
     ncollision_out: wp.array[int],
     # Out:
@@ -524,10 +495,6 @@ def _sap_broadphase(
     collision_worldid_out: wp.array[int],
   ):
     worldgeomid = wp.tid()
-
-    if wp.static(enable_sleep):
-      if skip_in[0] == 0:
-        return
 
     nworldgeom = nworld_in * ngeom
     nworkpackages = cumulative_sum_in[nworldgeom - 1]
@@ -568,6 +535,18 @@ def _sap_broadphase(
           continue
         if (s1 == SleepState.ASLEEP and s2 == SleepState.STATIC) or (s2 == SleepState.ASLEEP and s1 == SleepState.STATIC):
           continue
+
+        if wp.static(incremental):
+          # only re-emit pairs that pass 1 skipped (see _nxn_broadphase for rationale)
+          p1 = body_awake_prev_in[worldid, b1]
+          p2 = body_awake_prev_in[worldid, b2]
+          skipped_pass1 = (
+            (p1 == SleepState.ASLEEP and p2 == SleepState.ASLEEP)
+            or (p1 == SleepState.ASLEEP and p2 == SleepState.STATIC)
+            or (p2 == SleepState.ASLEEP and p1 == SleepState.STATIC)
+          )
+          if not skipped_pass1:
+            continue
 
       if (
         wp.static(_broadphase_filter(opt_broadphase_filter, ngeom_aabb, ngeom_rbound, ngeom_margin, ngeom_gap))(
@@ -620,7 +599,12 @@ def _segmented_sort(tile_size: int):
 
 
 @event_scope
-def sap_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.array] = None):
+def sap_broadphase(
+  m: Model,
+  d: Data,
+  ctx: CollisionContext,
+  awake_prev: Optional[wp.array] = None,
+):
   """Runs broadphase collision detection using a sweep-and-prune (SAP) algorithm.
 
   This method is more efficient than the N-squared approach for large numbers of
@@ -636,9 +620,15 @@ def sap_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
 
   - `SAP_TILE`: Uses a tile-based sort.
   - `SAP_SEGMENTED`: Uses a segmented sort.
+
+  Unlike `nxn_broadphase`, SAP cannot be wrapped in a CUDA graph conditional to skip the
+  incremental sleeping pass: its sort/scan utilities allocate scratch internally, which is
+  not allowed inside a conditional body. The incremental filter in the sweep kernel still
+  restricts the emitted pairs to those involving newly-awakened bodies.
   """
   nworldgeom = d.nworld * m.ngeom
-  skip_in = skip if skip is not None else wp.ones(1, dtype=int)
+  incremental = awake_prev is not None
+  awake_prev_in = awake_prev if awake_prev is not None else d.body_awake
   enable_sleep = bool(m.opt.enableflags & EnableBit.SLEEP)
 
   # TODO(team): direction
@@ -655,9 +645,9 @@ def sap_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
   segmented_index = wp.empty(d.nworld + 1 if m.opt.broadphase == BroadphaseType.SAP_SEGMENTED else 0, dtype=int)
 
   wp.launch(
-    kernel=_sap_project(m.opt.broadphase, enable_sleep),
+    kernel=_sap_project(m.opt.broadphase),
     dim=(d.nworld, m.ngeom),
-    inputs=[m.ngeom, m.geom_rbound, m.geom_margin, m.geom_gap, d.geom_xpos, d.nworld, direction, skip_in],
+    inputs=[m.ngeom, m.geom_rbound, m.geom_margin, m.geom_gap, d.geom_xpos, d.nworld, direction],
     outputs=[
       projection_lower.reshape((-1, m.ngeom)),
       projection_upper,
@@ -680,9 +670,9 @@ def sap_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
     )
 
   wp.launch(
-    kernel=_sap_range(enable_sleep),
+    kernel=_sap_range,
     dim=(d.nworld, m.ngeom),
-    inputs=[m.ngeom, projection_lower.reshape((-1, m.ngeom)), projection_upper, sort_index.reshape((-1, m.ngeom)), skip_in],
+    inputs=[m.ngeom, projection_lower.reshape((-1, m.ngeom)), projection_upper, sort_index.reshape((-1, m.ngeom))],
     outputs=[range_],
   )
 
@@ -700,6 +690,7 @@ def sap_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
       m.geom_margin.shape[0],
       m.geom_gap.shape[0],
       enable_sleep,
+      incremental,
     ),
     dim=nsweep,
     inputs=[
@@ -719,7 +710,7 @@ def sap_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
       sort_index.reshape((-1, m.ngeom)),
       cumulative_sum.reshape(-1),
       nsweep,
-      skip_in,
+      awake_prev_in,
     ],
     outputs=[d.ncollision, ctx.collision_pair, ctx.collision_pairid, ctx.collision_worldid],
   )
@@ -727,7 +718,13 @@ def sap_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
 
 @cache_kernel
 def _nxn_broadphase(
-  opt_broadphase_filter: int, ngeom_aabb: int, ngeom_rbound: int, ngeom_margin: int, ngeom_gap: int, enable_sleep: bool = False
+  opt_broadphase_filter: int,
+  ngeom_aabb: int,
+  ngeom_rbound: int,
+  ngeom_margin: int,
+  ngeom_gap: int,
+  enable_sleep: bool = False,
+  incremental: bool = False,
 ):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -746,7 +743,7 @@ def _nxn_broadphase(
     body_awake_in: wp.array2d[int],
     naconmax_in: int,
     # In:
-    skip_in: wp.array[int],
+    body_awake_prev_in: wp.array2d[int],
     # Data out:
     ncollision_out: wp.array[int],
     # Out:
@@ -755,10 +752,6 @@ def _nxn_broadphase(
     collision_worldid_out: wp.array[int],
   ):
     worldid, elementid = wp.tid()
-
-    if wp.static(enable_sleep):
-      if skip_in[0] == 0:
-        return
 
     geom = nxn_geom_pair[elementid]
     geom1 = geom[0]
@@ -773,6 +766,21 @@ def _nxn_broadphase(
         return
       if (s1 == SleepState.ASLEEP and s2 == SleepState.STATIC) or (s2 == SleepState.ASLEEP and s1 == SleepState.STATIC):
         return
+
+      if wp.static(incremental):
+        # On the incremental pass we only want pairs that were *not* already emitted in pass 1.
+        # Pass 1 skipped a pair iff both bodies were asleep, or one asleep and one static. Such a
+        # pair becomes relevant now only because one of its bodies was newly awakened, so re-emit
+        # it. Every other pair was handled in pass 1 and its contact geometry is unchanged.
+        p1 = body_awake_prev_in[worldid, b1]
+        p2 = body_awake_prev_in[worldid, b2]
+        skipped_pass1 = (
+          (p1 == SleepState.ASLEEP and p2 == SleepState.ASLEEP)
+          or (p1 == SleepState.ASLEEP and p2 == SleepState.STATIC)
+          or (p2 == SleepState.ASLEEP and p1 == SleepState.STATIC)
+        )
+        if not skipped_pass1:
+          return
 
     if (
       wp.static(_broadphase_filter(opt_broadphase_filter, ngeom_aabb, ngeom_rbound, ngeom_margin, ngeom_gap))(
@@ -797,8 +805,28 @@ def _nxn_broadphase(
   return kernel
 
 
+@wp.kernel(enable_backward=False)
+def _any_awake_changed(
+  # Data in:
+  body_awake_in: wp.array2d[int],
+  # In:
+  awake_prev_in: wp.array2d[int],
+  # Out:
+  changed_out: wp.array[int],
+):
+  worldid, bodyid = wp.tid()
+  # benign race: every thread that fires writes the same value
+  if awake_prev_in[worldid, bodyid] != body_awake_in[worldid, bodyid]:
+    changed_out[0] = 1
+
+
 @event_scope
-def nxn_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.array] = None):
+def nxn_broadphase(
+  m: Model,
+  d: Data,
+  ctx: CollisionContext,
+  awake_prev: Optional[wp.array] = None,
+):
   """Runs broadphase collision detection using a brute-force N-squared approach.
 
   This function iterates through a pre-filtered list of all possible geometry pairs and
@@ -810,41 +838,64 @@ def nxn_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
 
   The initial list of pairs is filtered at model creation time to exclude pairs based on
   `contype`/`conaffinity`, parent-child relationships, and explicit `<exclude>` tags.
+
+  Passing ``awake_prev`` runs the incremental sleeping pass: only pairs involving a newly-awakened
+  body are emitted. When graph conditionals are available the launch is wrapped in one gated on
+  whether any body woke since pass 1 (``awake_prev != body_awake``), so the broadphase is skipped
+  wholesale on steps where nothing woke; otherwise it runs unconditionally and the per-pair filter
+  restricts the emitted pairs.
   """
   enable_sleep = bool(m.opt.enableflags & EnableBit.SLEEP)
-  skip_in = skip if skip is not None else wp.ones(1, dtype=int)
-  wp.launch(
-    _nxn_broadphase(
-      m.opt.broadphase_filter,
-      m.geom_aabb.shape[0],
-      m.geom_rbound.shape[0],
-      m.geom_margin.shape[0],
-      m.geom_gap.shape[0],
-      enable_sleep,
-    ),
-    dim=(d.nworld, m.nxn_geom_pair_filtered.shape[0]),
-    inputs=[
-      m.geom_type,
-      m.geom_bodyid,
-      m.geom_aabb,
-      m.geom_rbound,
-      m.geom_margin,
-      m.geom_gap,
-      m.nxn_geom_pair_filtered,
-      m.nxn_pairid_filtered,
-      d.geom_xpos,
-      d.geom_xmat,
-      d.body_awake,
-      d.naconmax,
-      skip_in,
-    ],
-    outputs=[
-      d.ncollision,
-      ctx.collision_pair,
-      ctx.collision_pairid,
-      ctx.collision_worldid,
-    ],
-  )
+  incremental = awake_prev is not None
+  awake_prev_in = awake_prev if awake_prev is not None else d.body_awake
+
+  # On the incremental pass, skip the broadphase wholesale via a graph conditional when nothing woke
+  # since pass 1. A wake is exactly a body whose state changed between awake_prev and body_awake
+  # (nothing sleeps between the passes), so the condition is derived here rather than threaded in.
+  cond = None
+  if incremental and m.opt.graph_conditional:
+    cond = wp.zeros(1, dtype=int)
+    wp.launch(_any_awake_changed, dim=(d.nworld, m.nbody), inputs=[d.body_awake, awake_prev], outputs=[cond])
+
+  def _launch():
+    wp.launch(
+      _nxn_broadphase(
+        m.opt.broadphase_filter,
+        m.geom_aabb.shape[0],
+        m.geom_rbound.shape[0],
+        m.geom_margin.shape[0],
+        m.geom_gap.shape[0],
+        enable_sleep,
+        incremental,
+      ),
+      dim=(d.nworld, m.nxn_geom_pair_filtered.shape[0]),
+      inputs=[
+        m.geom_type,
+        m.geom_bodyid,
+        m.geom_aabb,
+        m.geom_rbound,
+        m.geom_margin,
+        m.geom_gap,
+        m.nxn_geom_pair_filtered,
+        m.nxn_pairid_filtered,
+        d.geom_xpos,
+        d.geom_xmat,
+        d.body_awake,
+        d.naconmax,
+        awake_prev_in,
+      ],
+      outputs=[
+        d.ncollision,
+        ctx.collision_pair,
+        ctx.collision_pairid,
+        ctx.collision_worldid,
+      ],
+    )
+
+  if cond is not None:
+    wp.capture_if(cond, on_true=_launch)
+  else:
+    _launch()
 
 
 def _narrowphase(m: Model, d: Data, ctx: CollisionContext):
@@ -866,7 +917,11 @@ def _narrowphase(m: Model, d: Data, ctx: CollisionContext):
 
 
 @event_scope
-def collision(m: Model, d: Data, skip: Optional[wp.array] = None):
+def collision(
+  m: Model,
+  d: Data,
+  awake_prev: Optional[wp.array] = None,
+):
   """Runs the full collision detection pipeline.
 
   This function orchestrates the broadphase and narrowphase collision detection stages. It
@@ -882,6 +937,10 @@ def collision(m: Model, d: Data, skip: Optional[wp.array] = None):
 
   This function will do nothing except zero out arrays if collision detection is disabled
   via `m.opt.disableflags` or if `d.nacon` is 0.
+
+  Passing `awake_prev` (the awake state snapshotted before the post-collision wake) runs the
+  incremental sleeping pass: contacts are appended to the existing buffer and only pairs involving
+  a newly-awakened body are emitted.
   """
   if d.naconmax == 0 or m.opt.disableflags & (DisableBit.CONSTRAINT | DisableBit.CONTACT):
     d.nacon.zero_()
@@ -889,20 +948,31 @@ def collision(m: Model, d: Data, skip: Optional[wp.array] = None):
 
   # TODO(team): create context outside collision?
   ctx = create_collision_context(d.naconmax)
-  skip_in = skip if skip is not None else wp.ones(1, dtype=int)
-  enable_sleep = bool(m.opt.enableflags & EnableBit.SLEEP)
 
-  # zero counters
-  wp.launch(_zero_nacon_ncollision(enable_sleep), dim=1, inputs=[skip_in], outputs=[d.nacon, d.ncollision])
+  incremental = awake_prev is not None
+
+  # The incremental sleeping pass appends newly-awakened contacts to the pass-1 buffer, so nacon is
+  # preserved and only ncollision (the broadphase pair counter) is reset. nxn_broadphase also skips
+  # its launch wholesale via a graph conditional when nothing woke; pre-zeroing ncollision here
+  # keeps the narrowphase below a no-op in that case. SAP cannot use a conditional (its sort/scan
+  # allocate internally), so it relies on the per-pair incremental filter instead.
+  if incremental:
+    d.ncollision.zero_()
+  else:
+    d.nacon.zero_()
+    d.ncollision.zero_()
 
   if m.opt.broadphase == BroadphaseType.NXN:
-    nxn_broadphase(m, d, ctx, skip)
+    nxn_broadphase(m, d, ctx, awake_prev)
   else:
-    sap_broadphase(m, d, ctx, skip)
+    sap_broadphase(m, d, ctx, awake_prev)
 
   _narrowphase(m, d, ctx)
 
-  if m.nflex > 0:
+  # Flex collision is not sleeping-aware: pass 1 emits every flex contact regardless of awake state,
+  # so the incremental pass has nothing to add (and re-running it would duplicate those contacts).
+  # It therefore only runs on the full pass.
+  if m.nflex > 0 and not incremental:
     flex_collision(m, d, ctx)
 
   if m.callback.contactfilter:

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -430,7 +430,7 @@ def _sap_project(opt_broadphase: int):
   return sap_project
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel
 def _sap_range(
   # Model:
   ngeom: int,
@@ -805,7 +805,7 @@ def _nxn_broadphase(
   return kernel
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel
 def _any_awake_changed(
   # Data in:
   body_awake_in: wp.array2d[int],
@@ -956,11 +956,9 @@ def collision(
   # its launch wholesale via a graph conditional when nothing woke; pre-zeroing ncollision here
   # keeps the narrowphase below a no-op in that case. SAP cannot use a conditional (its sort/scan
   # allocate internally), so it relies on the per-pair incremental filter instead.
-  if incremental:
-    d.ncollision.zero_()
-  else:
+  d.ncollision.zero_()
+  if not incremental:
     d.nacon.zero_()
-    d.ncollision.zero_()
 
   if m.opt.broadphase == BroadphaseType.NXN:
     nxn_broadphase(m, d, ctx, awake_prev)

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -635,8 +635,7 @@ def fwd_position(m: Model, d: Data, factorize: bool = True):
       awake_prev = wp.clone(d.body_awake)
       sleep.update_sleep(m, d)
       # pass 2: passing awake_prev runs the incremental pass, emitting only pairs involving a
-      # newly-awakened body and appending them to the pass-1 buffer. collision() skips the
-      # broadphase entirely via a CUDA graph conditional on steps where nothing woke.
+      # newly-awakened body and appending them to the pass-1 buffer.
       collision_driver.collision(m, d, awake_prev=awake_prev)
     else:
       collision_driver.collision(m, d)

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -628,12 +628,16 @@ def fwd_position(m: Model, d: Data, factorize: bool = True):
     if sleep_enabled:
       # pass 1
       collision_driver.collision(m, d)
-      # check for newly awake
-      skip = wp.zeros(1, dtype=int)
-      sleep.wake_collision(m, d, skip)
+      # wake any sleeping tree touched by an awake one
+      sleep.wake_collision(m, d)
+      # snapshot the awake state pass 1 used, before update_sleep overwrites it. a body is "newly
+      # awakened" if it was asleep here but awake after update_sleep below.
+      awake_prev = wp.clone(d.body_awake)
       sleep.update_sleep(m, d)
-      # pass 2: broadphase kernels early-return if skip[0] is 0
-      collision_driver.collision(m, d, skip)
+      # pass 2: passing awake_prev runs the incremental pass, emitting only pairs involving a
+      # newly-awakened body and appending them to the pass-1 buffer. collision() skips the
+      # broadphase entirely via a CUDA graph conditional on steps where nothing woke.
+      collision_driver.collision(m, d, awake_prev=awake_prev)
     else:
       collision_driver.collision(m, d)
 

--- a/mujoco_warp/_src/sleep.py
+++ b/mujoco_warp/_src/sleep.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Optional
-
 import warp as wp
 
 from mujoco_warp._src import types
@@ -337,7 +335,6 @@ def _wake_kernel(
   tree_awake_in: wp.array2d[int],
   # Out:
   tree_asleep_out: wp.array2d[int],  # kernel_analyzer: ignore
-  nwoke_out: wp.array[int],  # kernel_analyzer: ignore
 ):
   worldid, treeid = wp.tid()
 
@@ -360,9 +357,7 @@ def _wake_kernel(
     treeid,
     0.0,  # zero tolerance
   ):
-    woke = _wake_tree(ntree, worldid, treeid, K_AWAKE_VAL, tree_asleep_out)
-    if woke > 0:
-      wp.atomic_add(nwoke_out, worldid, woke)
+    _wake_tree(ntree, worldid, treeid, K_AWAKE_VAL, tree_asleep_out)
 
 
 @wp.kernel
@@ -378,7 +373,6 @@ def _wake_collision_kernel(
   nacon_in: wp.array[int],
   # Out:
   tree_asleep_out: wp.array2d[int],  # kernel_analyzer: ignore
-  skip_out: wp.array[int],  # kernel_analyzer: ignore
 ):
   conid = wp.tid()
   if conid >= nacon_in[0]:
@@ -413,9 +407,7 @@ def _wake_collision_kernel(
   sleeping_tree = tree2 if awake1 == 1 else tree1
   wakeval = tree_asleep_out[worldid, tree1] if awake1 == 1 else tree_asleep_out[worldid, tree2]
 
-  woke = _wake_tree(ntree, worldid, sleeping_tree, wakeval, tree_asleep_out)
-  if woke > 0:
-    wp.atomic_add(skip_out, 0, woke)
+  _wake_tree(ntree, worldid, sleeping_tree, wakeval, tree_asleep_out)
 
 
 @wp.kernel
@@ -439,8 +431,6 @@ def _wake_tendon_kernel(
   tree_awake_in: wp.array2d[int],
   # Data out:
   tree_asleep_out: wp.array2d[int],
-  # Out:
-  nwoke_out: wp.array[int],
 ):
   worldid, tenid = wp.tid()
 
@@ -487,9 +477,7 @@ def _wake_tendon_kernel(
 
         if t >= 0:
           if tree_awake_in[worldid, t] == 0:
-            woke = _wake_tree(ntree, worldid, t, wakeval, tree_asleep_out)
-            if woke > 0:
-              wp.atomic_add(nwoke_out, worldid, woke)
+            _wake_tree(ntree, worldid, t, wakeval, tree_asleep_out)
 
 
 @wp.func
@@ -560,8 +548,6 @@ def _wake_tendon_trees(
   wakeval: int,
   # Data out:
   tree_asleep_out: wp.array2d[int],
-  # Out:
-  nwoke_out: wp.array[int],
 ):
   """Wakes up all sleeping trees associated with a tendon."""
   if tenid < 0:
@@ -583,9 +569,7 @@ def _wake_tendon_trees(
 
     if t >= 0:
       if tree_awake_in[worldid, t] == 0:
-        woke = _wake_tree(ntree, worldid, t, wakeval, tree_asleep_out)
-        if woke > 0:
-          wp.atomic_add(nwoke_out, worldid, woke)
+        _wake_tree(ntree, worldid, t, wakeval, tree_asleep_out)
 
 
 @wp.kernel
@@ -610,8 +594,6 @@ def _wake_equality_kernel(
   tree_awake_in: wp.array2d[int],
   # Data out:
   tree_asleep_out: wp.array2d[int],  # kernel_analyzer: ignore
-  # Out:
-  nwoke_out: wp.array[int],  # kernel_analyzer: ignore
 ):
   worldid, eqid = wp.tid()
 
@@ -651,15 +633,11 @@ def _wake_equality_kernel(
       cycle1 = _sleep_cycle(tree_asleep_out, ntree, worldid, tree1)
       cycle2 = _sleep_cycle(tree_asleep_out, ntree, worldid, tree2)
       if cycle1 != cycle2:
-        w1 = _wake_tree(ntree, worldid, tree1, K_AWAKE_VAL, tree_asleep_out)
-        w2 = _wake_tree(ntree, worldid, tree2, K_AWAKE_VAL, tree_asleep_out)
-        if w1 + w2 > 0:
-          wp.atomic_add(nwoke_out, worldid, w1 + w2)
+        _wake_tree(ntree, worldid, tree1, K_AWAKE_VAL, tree_asleep_out)
+        _wake_tree(ntree, worldid, tree2, K_AWAKE_VAL, tree_asleep_out)
     else:
       sleeping_tree = tree1 if s1 == SleepState.ASLEEP else tree2
-      woke = _wake_tree(ntree, worldid, sleeping_tree, K_AWAKE_VAL, tree_asleep_out)
-      if woke > 0:
-        wp.atomic_add(nwoke_out, worldid, woke)
+      _wake_tree(ntree, worldid, sleeping_tree, K_AWAKE_VAL, tree_asleep_out)
 
   elif eqtype == EqType.TENDON:
     ten1 = id1
@@ -715,7 +693,6 @@ def _wake_equality_kernel(
         ten1,
         wakeval,
         tree_asleep_out,
-        nwoke_out,
       )
       _wake_tendon_trees(
         ntree,
@@ -732,7 +709,6 @@ def _wake_equality_kernel(
         ten2,
         wakeval,
         tree_asleep_out,
-        nwoke_out,
       )
 
   # TODO(team): Implement waking for EqType.FLEX constraints.
@@ -741,7 +717,6 @@ def _wake_equality_kernel(
 @event_scope
 def wake(m: types.Model, d: types.Data):
   """Wakes sleeping trees due to user changes/perturbations."""
-  nwoke = wp.zeros((d.nworld,), dtype=int)
   wp.launch(
     _wake_kernel,
     dim=(d.nworld, m.ntree),
@@ -757,16 +732,14 @@ def wake(m: types.Model, d: types.Data):
       d.qfrc_applied,
       d.xfrc_applied,
       d.tree_awake,
-      d.tree_asleep,
     ],
-    outputs=[nwoke],
+    outputs=[d.tree_asleep],
   )
 
 
 @event_scope
-def wake_collision(m: types.Model, d: types.Data, skip: Optional[wp.array] = None):
+def wake_collision(m: types.Model, d: types.Data):
   """Wakes sleeping trees that touch awake trees."""
-  skip_out = skip if skip is not None else wp.zeros(1, dtype=int)
   wp.launch(
     _wake_collision_kernel,
     dim=d.naconmax,
@@ -778,9 +751,8 @@ def wake_collision(m: types.Model, d: types.Data, skip: Optional[wp.array] = Non
       d.contact.geom,
       d.contact.worldid,
       d.nacon,
-      d.tree_asleep,
     ],
-    outputs=[skip_out],
+    outputs=[d.tree_asleep],
   )
 
 
@@ -790,7 +762,6 @@ def wake_tendon(m: types.Model, d: types.Data):
   if m.ntendon == 0:
     return
 
-  nwoke = wp.zeros((d.nworld,), dtype=int)
   wp.launch(
     _wake_tendon_kernel,
     dim=(d.nworld, m.ntendon),
@@ -811,7 +782,7 @@ def wake_tendon(m: types.Model, d: types.Data):
       d.ten_length,
       d.tree_awake,
     ],
-    outputs=[d.tree_asleep, nwoke],
+    outputs=[d.tree_asleep],
   )
 
 
@@ -821,7 +792,6 @@ def wake_equality(m: types.Model, d: types.Data):
   if m.neq == 0:
     return
 
-  nwoke = wp.zeros((d.nworld,), dtype=int)
   wp.launch(
     _wake_equality_kernel,
     dim=(d.nworld, m.neq),
@@ -842,9 +812,8 @@ def wake_equality(m: types.Model, d: types.Data):
       m.wrap_objid,
       d.eq_active,
       d.tree_awake,
-      d.tree_asleep,
     ],
-    outputs=[nwoke],
+    outputs=[d.tree_asleep],
   )
 
 
@@ -928,7 +897,6 @@ def _build_cycles(  # kernel_analyzer: ignore
   tree_asleep_out: wp.array2d[int],  # kernel_analyzer: ignore
   qvel_out: wp.array2d[float],  # kernel_analyzer: ignore
   qacc_out: wp.array2d[float],  # kernel_analyzer: ignore
-  nslept_out: wp.array[int],  # kernel_analyzer: ignore
 ):
   worldid = wp.tid()
 
@@ -937,7 +905,6 @@ def _build_cycles(  # kernel_analyzer: ignore
     if island_can_sleep_in[worldid, island_id] == 1:
       first_tree = int(-1)
       prev_tree = int(-1)
-      n = int(0)
       for t in range(ntree):
         if tree_island_in[worldid, t] == island_id:
           if first_tree == -1:
@@ -945,7 +912,6 @@ def _build_cycles(  # kernel_analyzer: ignore
           if prev_tree != -1:
             tree_asleep_out[worldid, prev_tree] = t
           prev_tree = t
-          n += 1
 
           # Zero velocities and accelerations
           dofadr = tree_dofadr[t]
@@ -956,7 +922,6 @@ def _build_cycles(  # kernel_analyzer: ignore
 
       if first_tree != -1:
         tree_asleep_out[worldid, prev_tree] = first_tree
-        wp.atomic_add(nslept_out, worldid, n)
 
   # Sleep unconstrained trees
   for t in range(ntree):
@@ -964,7 +929,6 @@ def _build_cycles(  # kernel_analyzer: ignore
     if island_id < 0 or island_id >= num_islands:
       if tree_asleep_out[worldid, t] == -1:
         tree_asleep_out[worldid, t] = t  # self-cycle
-        wp.atomic_add(nslept_out, worldid, 1)
 
       # Ensure sleeping tree dof velocity and acceleration remain exactly zero
       if tree_asleep_out[worldid, t] >= 0:
@@ -1013,7 +977,6 @@ def sleep(m: types.Model, d: types.Data):
   )
 
   # 3. Build sleep cycles for sleeping islands and sleep unconstrained trees
-  nslept = wp.zeros((d.nworld,), dtype=int)
   wp.launch(
     _build_cycles,
     dim=d.nworld,
@@ -1024,9 +987,10 @@ def sleep(m: types.Model, d: types.Data):
       d.nisland,
       d.tree_island,
       island_can_sleep,
+    ],
+    outputs=[
       d.tree_asleep,
       d.qvel,
       d.qacc,
     ],
-    outputs=[nslept],
   )


### PR DESCRIPTION
Speeds up the sleeping collision pipeline on the aloha clutter benchmark by making the second collision pass incremental. The two columns after the baseline show the contribution of each part of the change:

| metric | baseline | + incremental filter | + graph conditional |
|---|---|---|---|
| **steps_per_second** | 69,189 | 75,115 | **79,276** |
| run_time | 81.43 | 75.01 | 71.07 |
| collision pass 2 | 2,384 | 1,234 | 581 |
| &nbsp;&nbsp;└ nxn_broadphase | 1,058 | 950 | 294 |
| &nbsp;&nbsp;└ convex_narrowphase | 1,288 | 249 | 252 |
| nefc_mean | 114.80 | 115.05 | 115.05 |
| converged_worlds | 2048 | 2048 | 2048 |

About a 15% throughput improvement, with identical nefc and convergence. All numbers are from the standard benchmark with event tracing on (time units are from the event trace); with tracing off the final build runs around 81k steps/sec.

When sleeping is enabled the collision pipeline runs twice per step: pass 1 collides the awake bodies, wake_collision wakes any sleeping tree touched by an awake one, and pass 2 picks up collisions for the newly-awakened bodies. Previously pass 2 re-ran the entire collision pipeline from scratch (zeroing nacon and recomputing every contact) whenever anything woke anywhere across the batch, which in a large batched scene is essentially every step.

This makes pass 2 incremental. The broadphase keeps the pass-1 contact buffer and only emits pairs that pass 1 skipped because both bodies were asleep (or one asleep and one static) but are collidable now that a body has woken; those contacts are appended via the existing atomic nacon counter. The resulting contact set is identical to the old full recompute, since pass-1 pairs are always a subset of the post-wake pairs (waking never re-sleeps a body) and the incremental pass adds exactly the difference. This cuts the pass-2 narrowphase down to the handful of newly-awakened pairs (the "incremental filter" column above).

On top of that, the NXN broadphase wraps its launch in a CUDA graph conditional so the whole pass is skipped on steps where nothing woke, rather than launching kernels that early-return per thread (the "graph conditional" column). The wake condition is derived locally by comparing the pre-wake awake snapshot against the post-wake body_awake, which also makes it robust to wakes from sources other than collision (e.g. tendon limits) that update_sleep folds in before pass 2. SAP relies on the per-pair incremental filter only, since its sort/scan utilities allocate internally and cannot run inside a conditional body.

Flex collision is intentionally left out of the incremental pass: it is not sleeping-aware, so pass 1 already emits every flex contact regardless of awake state and the incremental pass has nothing to add.

This also removes the now-dead skip/nwoke/nslept wake counters that were write-only outputs threaded through the sleeping kernels, and drops the bespoke nacon/ncollision zeroing kernel in favor of plain zero_() calls.

uv run pytest -n 8 passes (1110 passed, 6 skipped).