### PR TITLE
Size jtcj_max_pairs from the kinematic dof chain

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -450,26 +450,6 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
 
   m.max_ten_J_rownnz = int(mjm.ten_J_rownnz.max()) if mjm.ntendon else 0
 
-  # Upper bound on a contact's Jacobian support, to size the elliptic-cone JTCJ launch (one
-  # thread per (contact, support-pair)). A contact's row spans the dof chains of weld(b1) and
-  # weld(b2) (see _efc_contact_jac_sparse in constraint.py); take the largest union over all
-  # geom-carrying bodies -- a safe superset, since over-estimating only adds skipped threads.
-  # A body's dof chain is exactly the sparsity of its deepest dof's row in the (ancestor-
-  # structured) mass matrix, so reuse MuJoCo's precomputed M_colind rather than re-walking.
-  def _dof_chain(body):
-    if mjm.body_dofnum[body] == 0:
-      return frozenset()
-    dof = int(mjm.body_dofadr[body] + mjm.body_dofnum[body] - 1)
-    adr = int(mjm.M_rowadr[dof])
-    return frozenset(int(mjm.M_colind[adr + k]) for k in range(int(mjm.M_rownnz[dof])))
-
-  chains = list({_dof_chain(int(mjm.body_weldid[b])) for b in mjm.geom_bodyid})
-  max_rownnz = 0
-  for i, chain_i in enumerate(chains):
-    for chain_j in chains[i:]:
-      max_rownnz = max(max_rownnz, len(chain_i | chain_j))
-  m.jtcj_max_pairs = max(max_rownnz * (max_rownnz + 1) // 2, 1)
-
   # body ids grouped by tree level (depth-based traversal)
   bodies, body_depth = {}, np.zeros(mjm.nbody, dtype=int) - 1
   for i in range(mjm.nbody):
@@ -525,6 +505,13 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
       body_isdofancestor[bodyid, dofid] = 1
       dofid = mjm.dof_parentid[dofid]
   m.body_isdofancestor = body_isdofancestor
+
+  # Upper bound on a contact's Jacobian support-pair count, to size the elliptic-cone JTCJ
+  # launch. Use body_isdofancestor (the full dof tree), not the mass-matrix sparsity, which the
+  # simple-dof optimization diagonalizes -- that undercounts the support and NaNs the solve.
+  support_chains = [set(np.flatnonzero(row).tolist()) for row in np.unique(body_isdofancestor[mjm.geom_bodyid], axis=0)]
+  max_support = max((len(ci | cj) for i, ci in enumerate(support_chains) for cj in support_chains[i:]), default=0)
+  m.jtcj_max_pairs = max(max_support * (max_support + 1) // 2, 1)
 
   # precalculated geom pairs
   filterparent = not (mjm.opt.disableflags & types.DisableBit.FILTERPARENT)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -409,6 +409,40 @@ class SolverTest(parameterized.TestCase):
         _assert_eq(d.qfrc_constraint.numpy()[0], mjd.qfrc_constraint, "qfrc_constraint")
         _assert_eq(d.efc.force.numpy()[0, : mjd.nefc], mjd.efc_force, "efc_force")
 
+  def test_solve_elliptic_sparse_diagonal_inertia(self):
+    """Sparse elliptic Newton solve over diagonal-inertia bodies must not NaN (jtcj sizing)."""
+    n = 12  # 72 dofs -> sparse path
+    bodies = "".join(
+      f'<body pos="{(i % 4) * 0.25 - 0.4:.3f} {(i // 4) * 0.25 - 0.3:.3f} 0.020">'
+      f'<freejoint/><geom type="box" size="0.04 0.05 0.03" mass="0.5"/></body>'
+      for i in range(n)
+    )
+    xml = f"""
+    <mujoco>
+      <option cone="elliptic" solver="Newton" iterations="20" ls_iterations="20" integrator="implicitfast"/>
+      <worldbody>
+        <geom name="floor" type="plane" size="5 5 .1" friction="1 0.01 0.001"/>
+        {bodies}
+      </worldbody>
+    </mujoco>
+    """
+    mjm, mjd, m, _ = test_data.fixture(xml=xml, overrides={"opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE})
+    self.assertTrue(m.is_sparse)
+
+    mjd.qvel[0::6] = 1.5  # slide -> cone middle zone
+    mujoco.mj_forward(mjm, mjd)
+    self.assertGreater(mjd.nefc, 0)
+
+    d = mjw.put_data(mjm, mjd)
+    d.qacc.fill_(wp.inf)
+    d.qfrc_constraint.fill_(wp.inf)
+    d.efc.force.fill_(wp.inf)
+    mjw.solve(m, d)
+
+    qacc = d.qacc.numpy()[0]
+    self.assertTrue(np.all(np.isfinite(qacc)), "Newton solve produced non-finite qacc")
+    _assert_eq(qacc, mjd.qacc, "qacc")
+
   @parameterized.parameters(
     (ConeType.PYRAMIDAL, SolverType.CG, 25, 5),
     (ConeType.PYRAMIDAL, SolverType.NEWTON, 2, 4),

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -419,14 +419,14 @@ class SolverTest(parameterized.TestCase):
     )
     xml = f"""
     <mujoco>
-      <option cone="elliptic" solver="Newton" iterations="20" ls_iterations="20" integrator="implicitfast"/>
+      <option cone="elliptic" solver="Newton" jacobian="sparse" iterations="20" ls_iterations="20" integrator="implicitfast"/>
       <worldbody>
         <geom name="floor" type="plane" size="5 5 .1" friction="1 0.01 0.001"/>
         {bodies}
       </worldbody>
     </mujoco>
     """
-    mjm, mjd, m, _ = test_data.fixture(xml=xml, overrides={"opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE})
+    mjm, mjd, m, _ = test_data.fixture(xml=xml)
     self.assertTrue(m.is_sparse)
 
     mjd.qvel[0::6] = 1.5  # slide -> cone middle zone


### PR DESCRIPTION
## Summary

`jtcj_max_pairs` (added in #1411 to size the sparse elliptic-cone JTCJ launch, one thread per `(contact, support-pair)`) was computed from the **mass-matrix row sparsity** (`M_rownnz`/`M_colind`) of a body's deepest dof. That sparsity reflects *dynamic coupling*, not *kinematic support*: the "simple dof" optimization diagonalizes `M` rows for decoupled dofs, so a body with a **diagonal inertia tensor** — or the translational dofs of a **free joint** — gets a near-empty `M` row and a far-too-small `jtcj_max_pairs`.

When the bound is too small the launch grid `dim=(dim_block, jtcj_max_pairs)` leaves support pairs without a thread, so the assembled cone Hessian is missing entries and becomes **indefinite**; the Newton per-block Cholesky then returns **NaN**, which propagates to `qacc`/`qvel`/`qpos`.

Minimal repro — free boxes (diagonal inertia) sliding on a plane, elliptic cone + Newton + sparse Jacobian:

```
jtcj_max_pairs = 3   (a box-world contact needs rownnz=6 -> 21 pairs)
converged worlds: 0 / 1024   (all NaN)
```

## Fix

Size `jtcj_max_pairs` from **`body_isdofancestor`** — the per-body dof tree already computed in `put_model` (it walks `dof_parentid`). That is exactly a contact's Jacobian support and is immune to the simple-dof diagonalization. This can only enlarge the bound, so it stays a safe over-estimate (over-estimating just adds skipped threads).

With the fix the same scene gives `jtcj_max_pairs = 78` and `converged worlds: 1024 / 1024`.

## Performance

The fix only changes `jtcj_max_pairs` for bodies with decoupled dofs (diagonal inertia / free-joint translation). Articulated models with coupled inertia are unchanged, so #1411's reported speedups stand. `jtcj_max_pairs`, current vs fixed:

| model | current | fixed |
|---|---|---|
| humanoid | 231 | 231 |
| three_humanoids | 465 | 465 |
| unitree_g1 | 276 | 276 |
| unitree_g1 + hands | 435 | 435 |
| aloha_clutter | 105 | 105 |
| free-box pile (diagonal inertia) | 3 | 78 |

`mjwarp-testspeed` (elliptic, Newton) confirms parity end-to-end — current vs fixed step throughput (best of 3, interleaved):

- `three_humanoids` (nworld=8192): 511k vs 511k steps/s, 8192/8192 converged.
- `aloha_clutter` (the #1411 headline model, nworld=512, replay): 42.6k vs 42.9k steps/s, 512/512 converged, identical solver metrics (`ncon_mean` 318.365, `nefc_mean` ~472, `solver_niter_mean` 7.82).

Both match within <1% (`jtcj_max_pairs` is identical, so the launch is byte-for-byte the same).

## Test

`SolverTest.test_solve_elliptic_sparse_diagonal_inertia`: sliding free boxes (diagonal inertia) on a plane with elliptic cone + Newton + sparse Jacobian; asserts `qacc` is finite and matches MuJoCo. NaNs without the fix.
