### PR TITLE
Optimization: in-place dense Cholesky

### DIFF
--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -1056,7 +1056,8 @@ def _tile_cholesky_factorize_block(tile: TileSet):
     idx = wp.tile_load(block_elemid, shape=(block_area,), offset=(blk * block_area,), storage="shared")
     block = wp.tile_load_indexed(M_in[worldid], idx, shape=(block_area,), storage="shared")
 
-    L = wp.tile_cholesky(wp.tile_reshape(block, (block_size, block_size)), fill_mode="upper")
+    L = wp.tile_reshape(block, (block_size, block_size))
+    wp.tile_cholesky_inplace(L, fill_mode="upper")
     wp.tile_store(L_out[worldid], wp.tile_reshape(L, (block_area,)), offset=(qLD_block_adr[start],))
 
   return kernel
@@ -1064,15 +1065,12 @@ def _tile_cholesky_factorize_block(tile: TileSet):
 
 def _factor_block_dense(m: Model, d: Data, M: wp.array2d[float], L: wp.array2d[float]):
   for tile in m.M_tiles:
-    # Tiny blocks (<=16 dofs) underutilize extra warps and lose occupancy, so use a single warp;
-    # larger blocks expose more tile_cholesky parallelism (measured optima: 9->32, 27->96, 60->128).
-    block_dim = 32 if tile.size <= 16 else m.block_dim.cholesky_factorize
     wp.launch_tiled(
       _tile_cholesky_factorize_block(tile),
       dim=(d.nworld, tile.adr.size),
       inputs=[m.qLD_block_adr, M, tile.elemid, tile.adr],
       outputs=[L],
-      block_dim=block_dim,
+      block_dim=m.block_dim.cholesky_factorize,
     )
 
 
@@ -2970,7 +2968,8 @@ def _tile_cholesky_factorize_solve_block(tile: TileSet):
     idx = wp.tile_load(block_elemid, shape=(block_area,), offset=(blk * block_area,), storage="shared")
     block = wp.tile_load_indexed(M_in[worldid], idx, shape=(block_area,), storage="shared")
 
-    L = wp.tile_cholesky(wp.tile_reshape(block, (block_size, block_size)), fill_mode="upper")
+    L = wp.tile_reshape(block, (block_size, block_size))
+    wp.tile_cholesky_inplace(L, fill_mode="upper")
     wp.tile_store(L_out[worldid], wp.tile_reshape(L, (block_area,)), offset=(qLD_block_adr[start],))
 
     rhs = wp.tile_load(y[worldid], shape=(block_size,), offset=(start,))
@@ -2984,14 +2983,12 @@ def _factor_solve_block_dense(
   m: Model, d: Data, M: wp.array2d[float], x: wp.array2d[float], y: wp.array2d[float], L: wp.array2d[float]
 ):
   for tile in m.M_tiles:
-    # Tiny blocks (<=16 dofs) use a single warp; see _factor_block_dense.
-    block_dim = 32 if tile.size <= 16 else m.block_dim.cholesky_factorize_solve
     wp.launch_tiled(
       _tile_cholesky_factorize_solve_block(tile),
       dim=(d.nworld, tile.adr.size),
       inputs=[m.qLD_block_adr, M, tile.elemid, tile.adr, y],
       outputs=[x, L],
-      block_dim=block_dim,
+      block_dim=m.block_dim.cholesky_factorize_solve,
     )
 
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2657,9 +2657,9 @@ def _update_gradient_cholesky(tile_size: int):
       return
 
     mat_tile = wp.tile_load(h_in[worldid], shape=(TILE_SIZE, TILE_SIZE))
-    fact_tile = wp.tile_cholesky(mat_tile, fill_mode="upper")
+    wp.tile_cholesky_inplace(mat_tile, fill_mode="upper")
     input_tile = wp.tile_load(ctx_grad_in[worldid], shape=TILE_SIZE)
-    output_tile = wp.tile_cholesky_solve(fact_tile, input_tile, fill_mode="upper")
+    output_tile = wp.tile_cholesky_solve(mat_tile, input_tile, fill_mode="upper")
     wp.tile_store(ctx_Mgrad_out[worldid], output_tile)
 
   return kernel

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -56,6 +56,7 @@ class BlockDim:
     contact_sort: contact sort block dimension (sensor)
     energy_vel_kinetic: energy velocity kinetic block dimension (sensor)
     cholesky_factorize: block-dense Cholesky factorize block dimension (smooth)
+    cholesky_factorize_solve: block-dense Cholesky factorize+solve block dimension (smooth)
     cholesky_solve: Cholesky solve block dimension (smooth)
     solve_LD_sparse_fused: solve LD sparse fused block dimension (smooth)
     update_gradient_cholesky: update gradient Cholesky block dimension (solver)
@@ -81,9 +82,9 @@ class BlockDim:
   # sensor
   contact_sort: int = 64
   energy_vel_kinetic: int = 32
-  # smooth -- block tile-Cholesky widths for non-tiny blocks; the launchers clamp by block size
-  cholesky_factorize: int = 96
-  cholesky_factorize_solve: int = 128
+  # smooth -- block tile-Cholesky widths
+  cholesky_factorize: int = 32
+  cholesky_factorize_solve: int = 32
   cholesky_solve: int = 64
   solve_LD_sparse_fused: int = 128
   # solver


### PR DESCRIPTION
## Summary

The dense block-Cholesky kernels factored each block with the out-of-place `wp.tile_cholesky`, which allocates a separate output tile and so holds the matrix in shared memory twice (e.g. ~18 KB for a 48×48 float block — about 2× the 9 KB of actual data). That caps occupancy at ~10% of the SM's warp slots, leaving these (data-independent) factorizations latency-bound rather than compute-bound.

This switches the three dense factorization kernels — `_tile_cholesky_factorize_block` and `_tile_cholesky_factorize_solve_block` (smooth) and `_update_gradient_cholesky` (the nv ≤ 32 Newton-gradient path) — to `wp.tile_cholesky_inplace`, which overwrites the input and roughly halves the shared footprint, lifting occupancy where shared memory is the binding limiter. All three kernels are `enable_backward=False`, so the in-place variant's lack of an adjoint does not matter.

With the smaller footprint a single warp per matrix maximizes occupancy across block sizes, so the change also retunes the `cholesky_factorize` / `cholesky_factorize_solve` block dimensions from 96/128 to 32. The retune is what unlocks the win — in-place at the old block_dim is roughly neutral; the gain comes from in-place making the one-warp launch viable.

## Performance

RTX PRO 6000 Blackwell, nworld=8192, Newton solver, default (AUTO) Jacobian — mujoco_warp uses sparse when nv > 32, so humanoid is dense and the others sparse (nsys, CUDA 12.9; per-scene njmax/nconmax sized for the steady-state contact count; min of 3 runs).

| scene | Jacobian | dense-Cholesky old → new | total GPU / step old → new |
|---|---|---|---|
| humanoid | dense | 132 → 122 µs (1.08×) | 667 → 655 µs (1.02×) |
| three_humanoids | sparse | 295 → 234 µs (1.26×) | 4092 → 4025 µs (1.02×) |
| unitree_g1 (flat) | sparse | 292 → 201 µs (1.45×) | 2986 → 2894 µs (1.03×) |
| aloha (clutter) | sparse | 202 → 196 µs (1.03×) | 166.8 → 169.1 ms (neutral) |

The dense factorization is independent of the Jacobian layout, so the kernel speedup holds in both modes. It scales with the size of the maximally-coupled dense block — `wp.tile_cholesky`'s shared/occupancy cost climbs steeply with block size while the in-place path stays lean, so g1's 35-dof block gains 1.45× while the 27-dof blocks (humanoid, three_humanoids) gain ~1.1–1.3×.

End-to-end, the dense Cholesky is 7–20% of the solver step for these models, so the total improves by 1.02–1.03×. aloha is contact-dominated (~167 ms/step, dense Cholesky ≈0.1%), so its total is unchanged — the ±2 ms swing is run-to-run variance in the unchanged contact work, far above the ~5 µs of dense-Cholesky savings.

Stacked on the sparse JTDAJ assembly (#1458), g1's M-factorization drops from 12.0% to 8.6% of the solver step; the two optimizations are independent.
