### PR TITLE
_is_batched

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -39,6 +39,26 @@ def _is_array_spec(typ) -> bool:
   return isinstance(typ, wp.array) or type(typ).__name__ == "_ArrayAnnotation"
 
 
+def _mark_batched(obj):
+  """Recursively set _is_batched = True on all batched warp arrays within obj."""
+  if not dataclasses.is_dataclass(obj):
+    return
+  for f in dataclasses.fields(obj):
+    val = getattr(obj, f.name, None)
+    if val is None:
+      continue
+    if dataclasses.is_dataclass(val):
+      _mark_batched(val)
+      continue
+    if not isinstance(val, wp.array):
+      continue
+    if not _is_array_spec(f.type):
+      continue
+    spec_shape = getattr(f.type, "shape", ())
+    if spec_shape and spec_shape[0] in ("*", "nworld"):
+      val._is_batched = True
+
+
 def _create_array(data: Any, spec, sizes: dict[str, int], batch_size: int = 1) -> wp.array | None:
   """Creates a warp array and populates it with data.
 
@@ -67,12 +87,6 @@ def _create_array(data: Any, spec, sizes: dict[str, int], batch_size: int = 1) -
         data = np.broadcast_to(data, target_shape).copy()
     array = wp.array(data, dtype=spec.dtype, shape=shape)
 
-  if is_batched:
-    # add private attribute for JAX to determine which fields are batched
-    array._is_batched = True
-    if array.shape[0] == 1:
-      # also set stride 0 to 0 which is expected legacy behavior (but is deprecated)
-      array.strides = (0,) + array.strides[1:]
   return array
 
 
@@ -1065,6 +1079,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
       batch_size = batch_sizes.get(f.name, 1)
       setattr(m, f.name, _create_array(getattr(m, f.name), f.type, sizes, batch_size))
 
+  _mark_batched(m)
   return m
 
 
@@ -1594,6 +1609,7 @@ def make_data(
   d.dof_cdof.fill_(-1)
   d.cdof_dof.fill_(-1)
 
+  _mark_batched(d)
   return d
 
 
@@ -1880,6 +1896,7 @@ def put_data(
 
   d.nacon = wp.array([mjd.ncon * nworld], dtype=int)
 
+  _mark_batched(d)
   return d
 
 
@@ -3840,4 +3857,5 @@ def create_render_context(
 
   bvh.build_scene_bvh(mjm, mjd, rc, nworld)
 
+  _mark_batched(rc)
   return rc

--- a/mujoco_warp/_src/io_jax_test.py
+++ b/mujoco_warp/_src/io_jax_test.py
@@ -203,22 +203,14 @@ class IOTest(parameterized.TestCase):
 
     self.assertTrue(hasattr(m1.geom_pos, "_is_batched"))
     self.assertEqual(m1.geom_pos.shape[0], 1)
-    self.assertEqual(m1.geom_pos.strides[0], 0)
-    self.assertLen(m1.geom_pos.strides, m1.geom_pos.ndim)
     self.assertTrue(hasattr(m1.opt.gravity, "_is_batched"))
     self.assertEqual(m1.opt.gravity.shape[0], 1)
-    self.assertEqual(m1.opt.gravity.strides[0], 0)
-    self.assertLen(m1.opt.gravity.strides, m1.opt.gravity.ndim)
     self.assertFalse(hasattr(m1.body_parentid, "_is_batched"))
     self.assertGreater(m1.body_parentid.shape[0], 0)
-    self.assertGreater(m1.body_parentid.strides[0], 0)
-    self.assertLen(m1.body_parentid.strides, m1.body_parentid.ndim)
 
     m2 = mjw.put_model(mjm, batch_sizes={"geom_pos": 2})
     self.assertTrue(hasattr(m2.geom_pos, "_is_batched"))
     self.assertEqual(m2.geom_pos.shape[0], 2)
-    self.assertGreater(m2.geom_pos.strides[0], 0)
-    self.assertLen(m2.geom_pos.strides, m2.geom_pos.ndim)
 
   @parameterized.parameters(*_IO_TEST_MODELS)
   def test_put_data_nworld_array(self, xml):

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -28,6 +28,7 @@ import mujoco_warp as mjwarp
 from mujoco_warp import ConeType
 from mujoco_warp import IntegratorType
 from mujoco_warp import test_data
+from mujoco_warp._src import io
 from mujoco_warp._src import types
 from mujoco_warp._src import warp_util
 from mujoco_warp._src.io import put_model
@@ -504,6 +505,32 @@ class IOTest(parameterized.TestCase):
       self.assertTrue((eid[a : a + n] == eid[a]).all())
       if a > 0:  # maximal: the preceding row belongs to a different instance
         self.assertTrue(etype[a - 1] != etype[a] or eid[a - 1] != eid[a])
+
+  @parameterized.parameters(types.Model, types.Data, types.RenderContext)
+  def test_is_batched_metadata(self, dataclass_type):
+    """Verify that all fields specified with 'nworld' or '*' are marked with _is_batched=True."""
+    fixture_outputs = test_data.fixture("pendula.xml")
+    if dataclass_type is types.RenderContext:
+      obj = io.create_render_context(fixture_outputs[0], nworld=1)
+    else:
+      obj = next(o for o in fixture_outputs if isinstance(o, dataclass_type))
+
+    for f in dataclasses.fields(dataclass_type):
+      if not io._is_array_spec(f.type):
+        continue
+      spec_shape = getattr(f.type, "shape", ())
+      if not (spec_shape and spec_shape[0] in ("*", "nworld")):
+        continue
+      arr = getattr(obj, f.name)
+      if arr is None:
+        continue
+      self.assertTrue(
+        getattr(arr, "_is_batched", False),
+        msg=(
+          f"{dataclass_type.__name__} field '{f.name}' has shape spec {spec_shape} "
+          "but its instantiated array does not have _is_batched=True"
+        ),
+      )
 
   @parameterized.parameters(*_IO_TEST_MODELS)
   def test_put_data_sizes(self, xml):
@@ -1466,23 +1493,29 @@ class IOTest(parameterized.TestCase):
     )
 
     m_default = mjwarp.put_model(mjm)
-    m = mjwarp.put_model(mjm, batch_sizes={"mat_texid": 3, "geom_size": 2, "mat_rgba": 4})
+    batch_sizes = {"mat_texid": 3, "geom_size": 2, "mat_rgba": 4}
+    m = mjwarp.put_model(mjm, batch_sizes=batch_sizes)
 
     nrole = int(mujoco.mjtTextureRole.mjNTEXROLE)
     self.assertEqual(tuple(m.mat_texid.shape), (3, mjm.nmat, nrole))
     self.assertEqual(tuple(m.geom_size.shape), (2, mjm.ngeom))
     self.assertEqual(tuple(m.mat_rgba.shape), (4, mjm.nmat))
-    self.assertGreater(m.mat_texid.strides[0], 0)
-    self.assertGreater(m.geom_size.strides[0], 0)
-    self.assertGreater(m.mat_rgba.strides[0], 0)
 
     np.testing.assert_array_equal(m.mat_texid.numpy(), np.repeat(m_default.mat_texid.numpy(), 3, axis=0))
     np.testing.assert_allclose(m.geom_size.numpy(), np.repeat(m_default.geom_size.numpy(), 2, axis=0))
     np.testing.assert_allclose(m.mat_rgba.numpy(), np.repeat(m_default.mat_rgba.numpy(), 4, axis=0))
 
-    # Fields not listed in batch_sizes keep the shared legacy allocation.
-    self.assertEqual(m.geom_pos.shape[0], 1)
-    self.assertEqual(m.geom_pos.strides[0], 0)
+    # field has batched dimension and defaults to batch size 1
+    for f in dataclasses.fields(types.Model):
+      if not io._is_array_spec(f.type):
+        continue
+      spec_shape = getattr(f.type, "shape", ())
+      if not spec_shape or spec_shape[0] != "*":
+        continue
+      val = getattr(m, f.name)
+      if val is not None:
+        expected = batch_sizes.get(f.name, 1)
+        self.assertEqual(val.shape[0], expected, f"Field {f.name} does not have batch dimension {expected}")
 
     red_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "red")
     green_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_TEXTURE, "green")


### PR DESCRIPTION
`io._create_array` sets the array attribute `_is_batched`. however not all arrays are constructed with this method. as a result some batched fields were not correctly marked. this pr marks all arrays that are part of `Model`, `Data`, and `RenderContext`. additionally these dataclasses' fields are checked in io_test.py `test_is_batched_metadata`.