### PR TITLE
Default to awake on make_data/put_data/reset_data; add --init_asleep CLI flag

### DIFF
--- a/benchmarks/aloha/__init__.py
+++ b/benchmarks/aloha/__init__.py
@@ -51,6 +51,7 @@ BENCHMARKS = [
     "njmax": 1024,
     "nvmax": 64,
     "override": "opt.enableflags=SLEEP",
+    "init_asleep": True,
     "replay": "pick_clutter.npz",
     "assets": [
       (ASSETS[0], "aloha"),

--- a/mujoco_warp/_src/cli.py
+++ b/mujoco_warp/_src/cli.py
@@ -45,6 +45,10 @@ NOISE_RATE = flags.DEFINE_float("noise_rate", 0.1, "add noise to ctrl signal (no
 NVMAX = flags.DEFINE_integer("nvmax", None, "maximum active DOFs per world")
 
 
+INIT_ASLEEP = flags.DEFINE_bool(
+  "init_asleep", False, "initialize all trees as asleep before simulation (requires sleep enabled)"
+)
+
 DEVICE = flags.DEFINE_string("device", None, "override the default Warp device")
 REPLAY = flags.DEFINE_string("replay", None, "NPZ file with ctrl sequence to replay")
 
@@ -151,6 +155,9 @@ def init_structs(
     m = mjw.put_model(mjm)
     if OVERRIDE.value:
       override_model(m, OVERRIDE.value)
+    if INIT_ASLEEP.value:
+      mjd.tree_asleep[:] = np.arange(mjm.ntree, dtype=np.int32)
+
     d = mjw.put_data(
       mjm,
       mjd,

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1508,9 +1508,9 @@ def make_data(
     efc.J_colind = wp.zeros((nworld, 0, 0), dtype=int)
     efc.J = wp.zeros((nworld, sizes["njmax_pad"], sizes["nv_pad"]), dtype=float)
 
-  # world body and static geom (attached to the world) poses are precomputed
-  # this speeds up scenes with many static geoms (e.g. terrains)
-  # TODO(team): remove this when we introduce dof islands + sleeping
+  # Compute initial kinematic state. Static geom positions (geom_xpos, geom_xmat) are set here
+  # and never updated by the physics loop (see smooth.py geom_kinematics), so this call is the
+  # only place they are initialized. Also seeds body poses (xquat, xmat, ximat) at qpos0.
   mjd = mujoco.MjData(mjm)
   mujoco.mj_kinematics(mjm, mjd)
 
@@ -1564,14 +1564,9 @@ def make_data(
     "map_iefc2efc": None,
     "dof_islandid": None,
     "efc_islandid": None,
-    "tree_asleep": wp.array(
-      np.tile(np.arange(mjm.ntree, dtype=np.int32), (nworld, 1))
-      if nv_compact
-      else np.full((nworld, mjm.ntree), -(1 + types.MJ_MINAWAKE)),
-      dtype=int,
-    ),
-    "tree_awake": wp.array(np.zeros((nworld, mjm.ntree)) if nv_compact else np.ones((nworld, mjm.ntree)), dtype=int),
-    "body_awake": wp.array(_initial_body_awake(mjm, nworld, nv_compact), dtype=int),
+    "tree_asleep": wp.array(np.full((nworld, mjm.ntree), -(1 + types.MJ_MINAWAKE), dtype=np.int32), dtype=int),
+    "tree_awake": wp.array(np.ones((nworld, mjm.ntree), dtype=np.int32), dtype=int),
+    "body_awake": wp.array(_initial_body_awake(mjm, nworld, False), dtype=int),
   }
   for f in dataclasses.fields(types.Data):
     if f.name in d_kwargs:
@@ -1709,8 +1704,13 @@ def put_data(
     else:
       njmax_nnz = njmax * mjm.nv
 
-  # ensure static geom positions are computed
-  # TODO: remove once MjData creation semantics are fixed
+  # Capture sleep state before mj_kinematics, which resets tree_asleep as a side effect.
+  tree_asleep_init = mjd.tree_asleep.copy()
+  body_awake_init = mjd.body_awake.copy()
+
+  # Ensure kinematic state is populated. mujoco.MjData() does not call mj_kinematics, so a freshly
+  # created mjd has zero geom positions. Static geoms are never updated by the physics loop
+  # (see smooth.py geom_kinematics), so without this call they would remain at (0,0,0).
   mujoco.mj_kinematics(mjm, mjd)
 
   # create contact
@@ -1835,14 +1835,9 @@ def put_data(
     "map_iefc2efc": None,
     "dof_islandid": None,
     "efc_islandid": None,
-    "tree_asleep": wp.array(
-      np.tile(np.arange(mjm.ntree, dtype=np.int32), (nworld, 1))
-      if nv_compact
-      else np.full((nworld, mjm.ntree), -(1 + types.MJ_MINAWAKE)),
-      dtype=int,
-    ),
-    "tree_awake": wp.array(np.zeros((nworld, mjm.ntree)) if nv_compact else np.ones((nworld, mjm.ntree)), dtype=int),
-    "body_awake": wp.array(_initial_body_awake(mjm, nworld, nv_compact), dtype=int),
+    "tree_asleep": wp.array(np.tile(tree_asleep_init, (nworld, 1)), dtype=int),
+    "tree_awake": wp.array(np.tile((tree_asleep_init < 0).astype(np.int32), (nworld, 1)), dtype=int),
+    "body_awake": wp.array(np.tile(body_awake_init.astype(np.int32), (nworld, 1)), dtype=int),
   }
   for f in dataclasses.fields(types.Data):
     if f.name in d_kwargs:
@@ -2328,7 +2323,6 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     body_treeid: wp.array[int],
     # In:
     mj_minawake: int,
-    sleep_enabled: int,
     reset_in: wp.array[bool],
     # Data out:
     tree_asleep_out: wp.array2d[int],
@@ -2344,12 +2338,8 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
         return
 
     if elemid < ntree:
-      if sleep_enabled == 1:
-        tree_asleep_out[worldid, elemid] = elemid
-        tree_awake_out[worldid, elemid] = 0
-      else:
-        tree_asleep_out[worldid, elemid] = -(1 + mj_minawake)
-        tree_awake_out[worldid, elemid] = 1
+      tree_asleep_out[worldid, elemid] = -(1 + mj_minawake)
+      tree_awake_out[worldid, elemid] = 1
 
     if elemid < nbody:
       if body_treeid[elemid] < 0:
@@ -2358,10 +2348,7 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
         else:
           body_awake_out[worldid, elemid] = int(types.SleepState.STATIC)
       else:
-        if sleep_enabled == 1:
-          body_awake_out[worldid, elemid] = int(types.SleepState.ASLEEP)
-        else:
-          body_awake_out[worldid, elemid] = int(types.SleepState.AWAKE)
+        body_awake_out[worldid, elemid] = int(types.SleepState.AWAKE)
       body_awake_ind_out[worldid, elemid] = elemid
 
     if elemid < nv:
@@ -2414,7 +2401,7 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
   wp.launch(
     reset_sleep,
     dim=(d.nworld, max(m.ntree, m.nbody, m.nv)),
-    inputs=[m.nv, m.nbody, m.ntree, m.body_mocapid, m.body_treeid, types.MJ_MINAWAKE, int(sleep_enabled), reset_input],
+    inputs=[m.nv, m.nbody, m.ntree, m.body_mocapid, m.body_treeid, types.MJ_MINAWAKE, reset_input],
     outputs=[
       d.tree_asleep,
       d.tree_awake,


### PR DESCRIPTION
Previously, make_data, put_data, and reset_data all defaulted to initializing every tree as asleep when sleep was enabled. This is unsafe for most simulations whose initial state includes non-sleeping bodies.

make_data and reset_data now always initialize bodies as awake. put_data reads tree_asleep and body_awake from the supplied mjd (which native MuJoCo initializes awake), captured before the mj_kinematics call that resets those fields as a side effect.

A new --init_asleep CLI flag in testspeed/viewer sets all trees to sleep before put_data, preserving the aloha_clutter benchmark's initial-state assumption. The benchmark config is updated to opt in.

reset_data also drops the sleep_enabled branch from its reset_sleep kernel since the initial state is always awake regardless of whether sleep is enabled.