### PR TITLE
Add CLAUDE.md; ban AI co-author commits in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - PR body should be plain, concise prose. Describe the problem, what the change does, and any non-obvious tradeoffs. Bullet points listing changes are fine, but avoid section headers, structured templates, and emojis. A good PR description reads like a short paragraph to a colleague, not a form.
 - PR and commit messages are rendered on GitHub, so don't hard-wrap them at 88 columns. Let each sentence flow on one line.
 - Push branches to your own fork, not to the google-deepmind/mujoco_warp repo directly.
+- Do not add AI assistants (e.g. Claude) as commit co-authors. The mujoco_warp CLA check requires all commit authors to have signed the CLA, and AI tools cannot sign it.
 - Amending commits is fine before a PR has reviewers looking at it. Once a PR is under review, use new commits so reviewers can see what changed.
 - When responding to PR review comments:
   - Reply to each comment individually confirming what you did (or why you didn't).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-See [AGENTS.md](AGENTS.md) for development workflow, commit/PR guidelines, and code style.
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for development workflow, commit/PR guidelines, and code style.


### PR DESCRIPTION
Adds a CLAUDE.md that points to AGENTS.md so Claude Code picks up the existing conventions automatically.

Also adds a rule to AGENTS.md that AI assistants must not be added as commit co-authors. The mujoco_warp CLA check requires all commit authors to have signed the CLA, and AI tools cannot sign it.