### PR TITLE
Require cost improvement in line search

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1202,7 +1202,11 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
         swap_hi = swap_hi_hi_next or swap_hi_mid or swap_hi_lo_next
 
         # check for convergence
-        ls_done = (not swap_lo and not swap_hi) or (lo[1] < 0.0 and lo[1] > -gtol) or (hi[1] > 0.0 and hi[1] < gtol)
+        ls_done = (
+          (not swap_lo and not swap_hi)
+          or (lo[0] < 0.0 and lo[1] < 0.0 and lo[1] > -gtol)
+          or (hi[0] < 0.0 and hi[1] > 0.0 and hi[1] < gtol)
+        )
 
         # update alpha if improved
         improved = lo[0] < 0.0 or hi[0] < 0.0

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -272,6 +272,53 @@ class SolverTest(parameterized.TestCase):
     self.assertLess(ctx.improvement.numpy()[0], 0.001)
     self.assertGreater(ctx.improvement.numpy()[0], 0.0004)
 
+  def test_linesearch_requires_cost_improvement_to_converge(self):
+    """Line search should not converge at an unimproved bound."""
+    _, _, m, d = test_data.fixture(
+      "constraints.xml",
+      overrides={
+        "opt.cone": ConeType.PYRAMIDAL,
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_DENSE,
+        "opt.iterations": 0,
+        "opt.ls_iterations": 50,
+      },
+    )
+    ctx = solver._create_solver_context(m, d)
+
+    # Exercise derivative convergence with a loose scaled tolerance.
+    m.stat.meaninertia.fill_(1.0e9)
+    d.ne = wp.array([1], dtype=int)
+    d.nf = wp.array([0], dtype=int)
+    d.nefc = wp.array([4], dtype=int)
+    d.nacon = wp.array([0], dtype=int)
+    d.M.zero_()
+    d.qacc.zero_()
+    d.efc.Ma.zero_()
+    d.qfrc_smooth.zero_()
+
+    efc_j = np.zeros(d.efc.J.shape, dtype=np.float32)
+    efc_j[0, :4, 0] = [1.0, -1.0, -1.0, 1.0]
+    d.efc.J.assign(efc_j)
+
+    efc_d = np.zeros(d.efc.D.shape, dtype=np.float32)
+    efc_d[0, :4] = [0.0030866014, 1.7318993, 4555.986, 0.14425136]
+    d.efc.D.assign(efc_d)
+    d.efc.frictionloss.zero_()
+
+    search = np.zeros(ctx.search.shape, dtype=np.float32)
+    search[0, 0] = 1.0
+    ctx.search.assign(search)
+    jaref = np.zeros(ctx.Jaref.shape, dtype=np.float32)
+    jaref[0, :4] = [-4.634305, 1.5213286, 0.03916324, 1.388601]
+    ctx.Jaref.assign(jaref)
+    ctx.search_dot.fill_(1.0)
+    ctx.done.fill_(False)
+
+    solver._linesearch(m, d, ctx)
+
+    self.assertGreater(d.qacc.numpy()[0, 0], 0.03)
+    self.assertGreater(ctx.improvement.numpy()[0], 5.0e-4)
+
   @parameterized.parameters(
     (ConeType.PYRAMIDAL, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE),
     (ConeType.ELLIPTIC, SolverType.CG, 10, 5, mujoco.mjtJacobian.mjJAC_DENSE),


### PR DESCRIPTION
The iterative line search can stop at a bracket endpoint solely because its derivative is within `gtol`, even when that endpoint has not reduced the objective. With a large scaled tolerance, this can accept the zero-step endpoint and leave the solver at its warm start.

Require negative shifted cost for derivative-based convergence, matching the existing check for the initial Newton trial. Add a regression test covering a loose scaled tolerance where the current implementation returns a zero step instead of continuing to an improving point.
