### PR TITLE
Reduce convex CCD overhead and improve launch balance

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -19,8 +19,11 @@ import warp as wp
 
 from mujoco_warp._src.collision_core import CollisionContext
 from mujoco_warp._src.collision_core import Geom
+from mujoco_warp._src.collision_core import contact_margin_gap
+from mujoco_warp._src.collision_core import contact_material_params
 from mujoco_warp._src.collision_core import contact_params
 from mujoco_warp._src.collision_core import geom_collision_pair
+from mujoco_warp._src.collision_core import geom_collision_pair_from_types
 from mujoco_warp._src.collision_core import write_contact
 from mujoco_warp._src.collision_gjk import ccd
 from mujoco_warp._src.collision_gjk import epa_phase
@@ -728,6 +731,17 @@ def ccd_kernel_builder(
   def eval_ccd_write_contact(
     # Model:
     opt_ccd_tolerance: wp.array[float],
+    geom_condim: wp.array[int],
+    geom_priority: wp.array[int],
+    geom_solmix: wp.array2d[float],
+    geom_solref: wp.array2d[wp.vec2],
+    geom_solimp: wp.array2d[vec5],
+    geom_friction: wp.array2d[wp.vec3],
+    pair_dim: wp.array[int],
+    pair_solref: wp.array2d[wp.vec2],
+    pair_solreffriction: wp.array2d[wp.vec2],
+    pair_solimp: wp.array2d[vec5],
+    pair_friction: wp.array2d[vec5],
     # Data in:
     naconmax_in: int,
     naccdmax_in: int,
@@ -756,13 +770,6 @@ def ccd_kernel_builder(
     nccd_in: wp.array[int],
     margin: float,
     gap: float,
-    condim: int,
-    friction: vec5,
-    solref: wp.vec2,
-    solreffriction: wp.vec2,
-    solimp: vec5,
-    x1: wp.vec3,
-    x2: wp.vec3,
     pairid: wp.vec2i,
     # Data out:
     contact_dist_out: wp.array[float],
@@ -780,29 +787,26 @@ def ccd_kernel_builder(
     contact_type_out: wp.array[int],
     contact_geomcollisionid_out: wp.array[int],
     nacon_out: wp.array[int],
-    # Data out:
     overflow_out: wp.array[int],
-  ) -> int:
-    points = mat43()
-    witness1 = mat43()
-    witness2 = mat43()
+  ):
     geom1.margin = margin
     geom2.margin = margin
+    tolerance = opt_ccd_tolerance[worldid % opt_ccd_tolerance.shape[0]]
     is_collision_sensor = pairid[1] >= 0
     if is_collision_sensor:
       cutoff = 1.0e32
     else:
       cutoff = gap
     needs_epa, dist, ncollision, w1, w2, gjk_result, geom1, geom2 = gjk_phase(
-      opt_ccd_tolerance[worldid % opt_ccd_tolerance.shape[0]],
+      tolerance,
       cutoff,
       gjk_iterations,
       geom1,
       geom2,
       geomtype1,
       geomtype2,
-      x1,
-      x2,
+      geom1.pos,
+      geom2.pos,
     )
 
     ccdid = int(-1)
@@ -814,9 +818,9 @@ def ccd_kernel_builder(
         if wp.static(warn_overflow):
           wp.printf("CCD overflow - please increase naccdmax to %u\n", ccdid)
         wp.atomic_or(overflow_out, worldid, OverflowType.CCD)
-        return 0
+        return
       dist, ncollision, w1, w2, multiccd_idx = epa_phase(
-        opt_ccd_tolerance[worldid % opt_ccd_tolerance.shape[0]],
+        tolerance,
         epa_iterations,
         gjk_result,
         geom1,
@@ -831,8 +835,8 @@ def ccd_kernel_builder(
         epa_horizon_in[ccdid],
       )
 
-    if dist >= gap and pairid[1] == -1:
-      return 0
+    if dist >= gap and not is_collision_sensor:
+      return
 
     # CCD operates on margin-inflated shapes (support() inflates each geom by
     # 0.5 * margin).  The returned dist is therefore relative to the inflated
@@ -841,10 +845,16 @@ def ccd_kernel_builder(
     # with the primitive narrowphase, which reports un-inflated distances.
     dist += margin
 
+    witness1 = mat43()
+    witness2 = mat43()
     witness1[0] = w1
     witness2[0] = w2
 
-    if wp.static(use_multiccd or (geomtype1 == GeomType.BOX and geomtype2 == GeomType.BOX)):
+    if wp.static(
+      (use_multiccd or (geomtype1 == GeomType.BOX and geomtype2 == GeomType.BOX))
+      and (geomtype1 == GeomType.BOX or geomtype1 == GeomType.MESH)
+      and (geomtype2 == GeomType.BOX or geomtype2 == GeomType.MESH)
+    ):
       if wp.static(geomtype1 == GeomType.MESH):
         # verify that geom1 mesh data is present for multicontact
         if geom1.mesh_polyadr < 0:
@@ -879,23 +889,34 @@ def ccd_kernel_builder(
           geomtype2,
         )
 
-    for i in range(ncollision):
-      points[i] = 0.5 * (witness1[i] + witness2[i])
-    normal = witness1[0] - witness2[0]
-    frame = make_frame(normal)
+    condim, friction, solref, solreffriction, solimp = contact_material_params(
+      geom_condim,
+      geom_priority,
+      geom_solmix,
+      geom_solref,
+      geom_solimp,
+      geom_friction,
+      pair_dim,
+      pair_solref,
+      pair_solreffriction,
+      pair_solimp,
+      pair_friction,
+      geoms,
+      pairid[0],
+      worldid,
+    )
 
-    # flip if collision sensor
-    if pairid[1] >= 0:
+    frame = make_frame(witness1[0] - witness2[0])
+    if is_collision_sensor:
       frame *= -1.0
       geoms = wp.vec2i(geoms[1], geoms[0])
 
-    nactive = int(0)  # number of contacts contributing to the physics
     for i in range(ncollision):
-      active = write_contact(
+      write_contact(
         naconmax_in,
         i,
         dist,
-        points[i],
+        0.5 * (witness1[i] + witness2[i]),
         frame,
         margin,
         gap,
@@ -923,9 +944,6 @@ def ccd_kernel_builder(
         contact_geomcollisionid_out,
         nacon_out,
       )
-      nactive += active
-
-    return nactive
 
   # runs convex collision on a set of geom pairs to recover contact info (non-heightfield)
   @wp.kernel(module="unique", enable_backward=False, launch_bounds=(block_dim, _CCD_MIN_BLOCKS))
@@ -1022,31 +1040,18 @@ def ccd_kernel_builder(
         continue
 
       worldid = collision_worldid_in[collisionid]
-
-      _, margin, gap, condim, friction, solref, solreffriction, solimp = contact_params(
-        geom_condim,
-        geom_priority,
-        geom_solmix,
-        geom_solref,
-        geom_solimp,
-        geom_friction,
+      pairid = collision_pairid_in[collisionid]
+      margin, gap = contact_margin_gap(
         geom_margin,
         geom_gap,
-        pair_dim,
-        pair_solref,
-        pair_solreffriction,
-        pair_solimp,
         pair_margin,
         pair_gap,
-        pair_friction,
-        collision_pair_in,
-        collision_pairid_in,
-        collisionid,
+        geoms,
+        pairid[0],
         worldid,
       )
 
-      geom1, geom2 = geom_collision_pair(
-        geom_type,
+      geom1, geom2 = geom_collision_pair_from_types(
         geom_dataid,
         geom_size,
         mesh_vertadr,
@@ -1065,12 +1070,25 @@ def ccd_kernel_builder(
         mesh_polymap,
         geom_xpos_in,
         geom_xmat_in,
+        geomtype1,
+        geomtype2,
         geoms,
         worldid,
       )
 
       eval_ccd_write_contact(
         opt_ccd_tolerance,
+        geom_condim,
+        geom_priority,
+        geom_solmix,
+        geom_solref,
+        geom_solimp,
+        geom_friction,
+        pair_dim,
+        pair_solref,
+        pair_solreffriction,
+        pair_solimp,
+        pair_friction,
         naconmax_in,
         naccdmax_in,
         epa_vert_in,
@@ -1097,14 +1115,7 @@ def ccd_kernel_builder(
         nccd_in,
         margin,
         gap,
-        condim,
-        friction,
-        solref,
-        solreffriction,
-        solimp,
-        geom1.pos,
-        geom2.pos,
-        collision_pairid_in[collisionid],
+        pairid,
         contact_dist_out,
         contact_pos_out,
         contact_frame_out,

--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -1137,11 +1137,15 @@ def ccd_kernel_builder(
   return ccd_kernel
 
 
-def _ccd_grid_size(kernel, naconmax: int) -> int:
+def _ccd_grid_size(kernel, naconmax: int, device) -> int:
   # Grid-stride launch width for the CCD kernel: a few device waves, capped at the contact
   # capacity. The kernel strides over the actual candidate count, so we avoid launching one
   # (mostly idle) thread per naconmax slot.
-  block_size, min_grid_size = wp.get_suggested_block_size(kernel)
+  if device.is_cpu:
+    # Warp forces CPU block_dim to 1 and has no CUDA occupancy information.
+    return naconmax
+
+  block_size, min_grid_size = wp.get_suggested_block_size(kernel, device)
   return max(1, min(naconmax, _CCD_OVERSUBSCRIBE_WAVES * block_size * min_grid_size))
 
 
@@ -1337,7 +1341,7 @@ def convex_narrowphase(m: Model, d: Data, ctx: CollisionContext, collision_table
         m.block_dim.convex_ccd,
         bool(m.opt.warn_overflow),
       )
-      ccd_grid = _ccd_grid_size(ccd_k, d.naconmax)
+      ccd_grid = _ccd_grid_size(ccd_k, d.naconmax, d.ncollision.device)
       wp.launch(
         ccd_k,
         dim=ccd_grid,

--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -710,8 +710,8 @@ def ccd_hfield_kernel_builder(
   return ccd_hfield_kernel
 
 
-_CCD_OVERSUBSCRIBE_WAVES = 4
-_CCD_MIN_BLOCKS = 2
+_CCD_OVERSUBSCRIBE_WAVES = 2
+_CCD_MIN_BLOCKS = 8
 
 
 @cache_kernel

--- a/mujoco_warp/_src/collision_core.py
+++ b/mujoco_warp/_src/collision_core.py
@@ -63,9 +63,8 @@ class Geom:
 
 
 @wp.func
-def geom_collision_pair(
+def geom_collision_pair_from_types(
   # Model:
-  geom_type: wp.array[int],
   geom_dataid: wp.array2d[int],
   geom_size: wp.array2d[wp.vec3],
   mesh_vertadr: wp.array[int],
@@ -86,6 +85,8 @@ def geom_collision_pair(
   geom_xpos_in: wp.array2d[wp.vec3],
   geom_xmat_in: wp.array2d[wp.mat33],
   # In:
+  geom_type1: int,
+  geom_type2: int,
   geoms: wp.vec2i,
   worldid: int,
 ) -> Tuple[Geom, Geom]:
@@ -94,8 +95,6 @@ def geom_collision_pair(
 
   g1 = geoms[0]
   g2 = geoms[1]
-  geom_type1 = geom_type[g1]
-  geom_type2 = geom_type[g2]
 
   geom1.pos = geom_xpos_in[worldid, g1]
   geom1.rot = geom_xmat_in[worldid, g1]
@@ -154,6 +153,61 @@ def geom_collision_pair(
   geom2.margin = 0.0
 
   return geom1, geom2
+
+
+@wp.func
+def geom_collision_pair(
+  # Model:
+  geom_type: wp.array[int],
+  geom_dataid: wp.array2d[int],
+  geom_size: wp.array2d[wp.vec3],
+  mesh_vertadr: wp.array[int],
+  mesh_vertnum: wp.array[int],
+  mesh_graphadr: wp.array[int],
+  mesh_vert: wp.array[wp.vec3],
+  mesh_graph: wp.array[int],
+  mesh_polynum: wp.array[int],
+  mesh_polyadr: wp.array[int],
+  mesh_polynormal: wp.array[wp.vec3],
+  mesh_polyvertadr: wp.array[int],
+  mesh_polyvertnum: wp.array[int],
+  mesh_polyvert: wp.array[int],
+  mesh_polymapadr: wp.array[int],
+  mesh_polymapnum: wp.array[int],
+  mesh_polymap: wp.array[int],
+  # Data in:
+  geom_xpos_in: wp.array2d[wp.vec3],
+  geom_xmat_in: wp.array2d[wp.mat33],
+  # In:
+  geoms: wp.vec2i,
+  worldid: int,
+) -> Tuple[Geom, Geom]:
+  geom_type1 = geom_type[geoms[0]]
+  geom_type2 = geom_type[geoms[1]]
+  return geom_collision_pair_from_types(
+    geom_dataid,
+    geom_size,
+    mesh_vertadr,
+    mesh_vertnum,
+    mesh_graphadr,
+    mesh_vert,
+    mesh_graph,
+    mesh_polynum,
+    mesh_polyadr,
+    mesh_polynormal,
+    mesh_polyvertadr,
+    mesh_polyvertnum,
+    mesh_polyvert,
+    mesh_polymapadr,
+    mesh_polymapnum,
+    mesh_polymap,
+    geom_xpos_in,
+    geom_xmat_in,
+    geom_type1,
+    geom_type2,
+    geoms,
+    worldid,
+  )
 
 
 @wp.func
@@ -234,7 +288,33 @@ def write_contact(
 
 
 @wp.func
-def contact_params(
+def contact_margin_gap(
+  # Model:
+  geom_margin: wp.array2d[float],
+  geom_gap: wp.array2d[float],
+  pair_margin: wp.array2d[float],
+  pair_gap: wp.array2d[float],
+  # In:
+  geoms: wp.vec2i,
+  pairid: int,
+  worldid: int,
+) -> Tuple[float, float]:
+  if pairid > -1:
+    margin = pair_margin[worldid % pair_margin.shape[0], pairid]
+    gap = pair_gap[worldid % pair_gap.shape[0], pairid]
+  else:
+    g1 = geoms[0]
+    g2 = geoms[1]
+    margin_id = worldid % geom_margin.shape[0]
+    gap_id = worldid % geom_gap.shape[0]
+    margin = geom_margin[margin_id, g1] + geom_margin[margin_id, g2]
+    gap = geom_gap[gap_id, g1] + geom_gap[gap_id, g2]
+
+  return margin, gap
+
+
+@wp.func
+def contact_material_params(
   # Model:
   geom_condim: wp.array[int],
   geom_priority: wp.array[int],
@@ -242,35 +322,17 @@ def contact_params(
   geom_solref: wp.array2d[wp.vec2],
   geom_solimp: wp.array2d[vec5],
   geom_friction: wp.array2d[wp.vec3],
-  geom_margin: wp.array2d[float],
-  geom_gap: wp.array2d[float],
   pair_dim: wp.array[int],
   pair_solref: wp.array2d[wp.vec2],
   pair_solreffriction: wp.array2d[wp.vec2],
   pair_solimp: wp.array2d[vec5],
-  pair_margin: wp.array2d[float],
-  pair_gap: wp.array2d[float],
   pair_friction: wp.array2d[vec5],
   # In:
-  collision_pair_in: wp.array[wp.vec2i],
-  collision_pairid_in: wp.array[wp.vec2i],
-  cid: int,
+  geoms: wp.vec2i,
+  pairid: int,
   worldid: int,
 ):
-  """Resolve contact parameters for a collision pair.
-
-  Uses explicit pair overrides when available, otherwise mixes geom-level
-  properties by priority and solmix weights.
-  """
-  geoms = collision_pair_in[cid]
-  pairid = collision_pairid_in[cid][0]
-
-  # TODO(team): early return if collision sensor but no contact
-  # (ie, pairid[0] < -1 and pairid[1] < 0)
-
   if pairid > -1:
-    margin = pair_margin[worldid % pair_margin.shape[0], pairid]
-    gap = pair_gap[worldid % pair_gap.shape[0], pairid]
     condim = pair_dim[pairid]
     friction = pair_friction[worldid % pair_friction.shape[0], pairid]
     solref = pair_solref[worldid % pair_solref.shape[0], pairid]
@@ -283,8 +345,6 @@ def contact_params(
     friction_id = worldid % geom_friction.shape[0]
     solref_id = worldid % geom_solref.shape[0]
     solimp_id = worldid % geom_solimp.shape[0]
-    margin_id = worldid % geom_margin.shape[0]
-    gap_id = worldid % geom_gap.shape[0]
 
     solmix1 = geom_solmix[solmix_id, g1]
     solmix2 = geom_solmix[solmix_id, g2]
@@ -327,9 +387,6 @@ def contact_params(
 
     solreffriction = wp.vec2(0.0, 0.0)
     solimp = mix * geom_solimp[solimp_id, g1] + (1.0 - mix) * geom_solimp[solimp_id, g2]
-    # geom priority is ignored
-    margin = geom_margin[margin_id, g1] + geom_margin[margin_id, g2]
-    gap = geom_gap[gap_id, g1] + geom_gap[gap_id, g2]
 
   friction = vec5(
     wp.max(MJ_MINMU, friction[0]),
@@ -337,6 +394,62 @@ def contact_params(
     wp.max(MJ_MINMU, friction[2]),
     wp.max(MJ_MINMU, friction[3]),
     wp.max(MJ_MINMU, friction[4]),
+  )
+
+  return condim, friction, solref, solreffriction, solimp
+
+
+@wp.func
+def contact_params(
+  # Model:
+  geom_condim: wp.array[int],
+  geom_priority: wp.array[int],
+  geom_solmix: wp.array2d[float],
+  geom_solref: wp.array2d[wp.vec2],
+  geom_solimp: wp.array2d[vec5],
+  geom_friction: wp.array2d[wp.vec3],
+  geom_margin: wp.array2d[float],
+  geom_gap: wp.array2d[float],
+  pair_dim: wp.array[int],
+  pair_solref: wp.array2d[wp.vec2],
+  pair_solreffriction: wp.array2d[wp.vec2],
+  pair_solimp: wp.array2d[vec5],
+  pair_margin: wp.array2d[float],
+  pair_gap: wp.array2d[float],
+  pair_friction: wp.array2d[vec5],
+  # In:
+  collision_pair_in: wp.array[wp.vec2i],
+  collision_pairid_in: wp.array[wp.vec2i],
+  cid: int,
+  worldid: int,
+):
+  """Resolve contact parameters for a collision pair.
+
+  Uses explicit pair overrides when available, otherwise mixes geom-level
+  properties by priority and solmix weights.
+  """
+  geoms = collision_pair_in[cid]
+  pairid = collision_pairid_in[cid][0]
+
+  # TODO(team): early return if collision sensor but no contact
+  # (ie, pairid[0] < -1 and pairid[1] < 0)
+
+  margin, gap = contact_margin_gap(geom_margin, geom_gap, pair_margin, pair_gap, geoms, pairid, worldid)
+  condim, friction, solref, solreffriction, solimp = contact_material_params(
+    geom_condim,
+    geom_priority,
+    geom_solmix,
+    geom_solref,
+    geom_solimp,
+    geom_friction,
+    pair_dim,
+    pair_solref,
+    pair_solreffriction,
+    pair_solimp,
+    pair_friction,
+    geoms,
+    pairid,
+    worldid,
   )
 
   return geoms, margin, gap, condim, friction, solref, solreffriction, solimp

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -77,7 +77,7 @@ class BlockDim:
   # collision_driver
   segmented_sort: int = 128
   # collision_convex
-  convex_ccd: int = 256
+  convex_ccd: int = 64
   # forward
   actuator_velocity: int = 32
   # ray


### PR DESCRIPTION
The convex CCD kernel resolves and mixes all contact material parameters before GJK, even though most candidates do not produce a contact. It also constructs three `mat43` temporaries before determining whether the candidate survives and uses 256-thread blocks, which provide limited block-level scheduling granularity for the divergent GJK/EPA workload.

This change resolves only margin and gap before GJK and defers condition dimension, friction, and solver parameter loads until a contact survives. It defers the two witness `mat43` values until after GJK/EPA rejection and eliminates the separate contact-point `mat43` entirely. The specialized kernels also reuse their compile-time geometry types instead of loading and dispatching on them again.

The launch geometry changes from 256 threads with two blocks per SM and four grid waves to 64 threads with eight blocks per SM and two waves. This retains the same 128-register cap and theoretical occupancy while improving scheduling granularity. CUDA grid sizing queries the actual data device, while CPU launches retain the full contact-capacity grid because Warp uses a block dimension of one there.

On an RTX PRO 6000 Blackwell using the official Aloha replay configurations, convex narrowphase time decreased from 66.55 to 63.25 µs for pot, a 5.0% improvement, and the combined clutter collision passes decreased from 1.277 to 1.205 ms, a 5.6% improvement. The default pot trajectory completes without CCD overflow. Pre-commit and the full test suite pass (987 passed, 7 skipped).