### PR TITLE
Support per-world heightfield data

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -203,7 +203,7 @@ def ccd_hfield_kernel_builder(
     hfield_nrow: wp.array[int],
     hfield_ncol: wp.array[int],
     hfield_adr: wp.array[int],
-    hfield_data: wp.array[float],
+    hfield_data: wp.array2d[float],
     pair_dim: wp.array[int],
     pair_solref: wp.array2d[wp.vec2],
     pair_solreffriction: wp.array2d[wp.vec2],
@@ -375,6 +375,7 @@ def ccd_hfield_kernel_builder(
     prism[2, 2] = -size[3]
 
     adr = hfield_adr[geom1_dataid]
+    hfdata_worldid = worldid % hfield_data.shape[0]
 
     hfield_contact_dist = vec_maxconpair()
     hfield_contact_pos = mat_maxconpair()
@@ -404,7 +405,7 @@ def ccd_hfield_kernel_builder(
       for init_i in range(2):
         x = dx * float(cmin) - size[0]
         y = dy * float(r + dr[init_i]) - size[1]
-        z = hfield_data[adr + (r + dr[init_i]) * ncol + cmin] * size[2] + margin
+        z = hfield_data[hfdata_worldid, adr + (r + dr[init_i]) * ncol + cmin] * size[2] + margin
 
         prism[0] = prism[1]
         prism[1] = prism[2]
@@ -432,7 +433,7 @@ def ccd_hfield_kernel_builder(
           # add vert
           x = dx * float(c) - size[0]
           y = dy * float(r + dr[i]) - size[1]
-          z = hfield_data[adr + (r + dr[i]) * ncol + c] * size[2] + margin
+          z = hfield_data[hfdata_worldid, adr + (r + dr[i]) * ncol + c] * size[2] + margin
 
           prism[0] = prism[1]
           prism[1] = prism[2]

--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -660,6 +660,39 @@ class CollisionTest(parameterized.TestCase):
 
     self.assertEqual(mjd.ncon > 0, d.nacon.numpy()[0] > 0, "If MJ collides, MJW should too")
 
+  def test_per_world_hfield_data(self):
+    """Per-world hfield_data gives each world its own heightfield from one asset."""
+    nworld = 2
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <asset>
+          <hfield name="terrain" nrow="4" ncol="4" size="1 1 0.3 0.1"/>
+        </asset>
+        <worldbody>
+          <geom type="hfield" hfield="terrain"/>
+          <body pos="0 0 0.15">
+            <freejoint/>
+            <geom type="sphere" size="0.1"/>
+          </body>
+        </worldbody>
+      </mujoco>
+      """,
+      nworld=nworld,
+    )
+
+    # world 0 stays flat (ball clears it), world 1 is raised to full height (ball hits it)
+    heights = np.zeros((nworld, mjm.hfield_data.shape[0]), dtype=np.float32)
+    heights[1] = 1.0
+    m.hfield_data = wp.array(heights, dtype=float)
+
+    mjw.collision(m, d)
+
+    nacon = int(d.nacon.numpy()[0])
+    worldid = d.contact.worldid.numpy()[:nacon]
+    self.assertEqual((worldid == 0).sum(), 0)
+    self.assertGreater((worldid == 1).sum(), 0)
+
   def test_contact_exclude(self):
     """Tests contact exclude."""
     _, _, m, _ = test_data.fixture(

--- a/mujoco_warp/_src/ray.py
+++ b/mujoco_warp/_src/ray.py
@@ -457,7 +457,7 @@ def ray_hfield(
   hfield_nrow: wp.array[int],
   hfield_ncol: wp.array[int],
   hfield_adr: wp.array[int],
-  hfield_data: wp.array[float],
+  hfield_data: wp.array2d[float],
   # In:
   pos: wp.vec3,
   mat: wp.mat33,
@@ -477,6 +477,7 @@ def ray_hfield(
 
   size = hfield_size[hid]
   adr = hfield_adr[hid]
+  hfdata_worldid = worldid % hfield_data.shape[0]
 
   mat_col = wp.vec3(mat[0, 2], mat[1, 2], mat[2, 2])
 
@@ -553,17 +554,17 @@ def ray_hfield(
       v0 = wp.vec3(
         dx * float(c) - size[0],
         dy * float(r) - size[1],
-        hfield_data[adr + r * ncol + c] * size[2],
+        hfield_data[hfdata_worldid, adr + r * ncol + c] * size[2],
       )
       v1 = wp.vec3(
         dx * float(c + 1) - size[0],
         dy * float(r) - size[1],
-        hfield_data[adr + r * ncol + (c + 1)] * size[2],
+        hfield_data[hfdata_worldid, adr + r * ncol + (c + 1)] * size[2],
       )
       v2 = wp.vec3(
         dx * float(c + 1) - size[0],
         dy * float(r + 1) - size[1],
-        hfield_data[adr + (r + 1) * ncol + (c + 1)] * size[2],
+        hfield_data[hfdata_worldid, adr + (r + 1) * ncol + (c + 1)] * size[2],
       )
       sol, normal_tri = _ray_triangle(v0, v1, v2, lpnt, lvec, b0, b1)
       if sol >= 0.0 and (x < 0.0 or sol < x):
@@ -571,11 +572,15 @@ def ray_hfield(
         normal_local = normal_tri
 
       # second triangle
-      v0 = wp.vec3(dx * float(c) - size[0], dy * float(r) - size[1], hfield_data[adr + r * ncol + c] * size[2])
+      v0 = wp.vec3(dx * float(c) - size[0], dy * float(r) - size[1], hfield_data[hfdata_worldid, adr + r * ncol + c] * size[2])
       v1 = wp.vec3(
-        dx * float(c + 1) - size[0], dy * float(r + 1) - size[1], hfield_data[adr + (r + 1) * ncol + (c + 1)] * size[2]
+        dx * float(c + 1) - size[0],
+        dy * float(r + 1) - size[1],
+        hfield_data[hfdata_worldid, adr + (r + 1) * ncol + (c + 1)] * size[2],
       )
-      v2 = wp.vec3(dx * float(c) - size[0], dy * float(r + 1) - size[1], hfield_data[adr + (r + 1) * ncol + c] * size[2])
+      v2 = wp.vec3(
+        dx * float(c) - size[0], dy * float(r + 1) - size[1], hfield_data[hfdata_worldid, adr + (r + 1) * ncol + c] * size[2]
+      )
       sol, normal_tri = _ray_triangle(v0, v1, v2, lpnt, lvec, b0, b1)
       if sol >= 0.0 and (x < 0.0 or sol < x):
         x = sol
@@ -593,21 +598,21 @@ def ray_hfield(
         y = safe_div(lpnt[1] + all[i] * lvec[1] + size[1], dy)
         y0 = wp.max(0.0, wp.min(float(nrow - 2), wp.floor(y)))
         if i == 1:
-          z0 = hfield_data[adr + int(wp.round(y0 + 0.0)) * ncol + ncol - 1]
-          z1 = hfield_data[adr + int(wp.round(y0 + 1.0)) * ncol + ncol - 1]
+          z0 = hfield_data[hfdata_worldid, adr + int(wp.round(y0 + 0.0)) * ncol + ncol - 1]
+          z1 = hfield_data[hfdata_worldid, adr + int(wp.round(y0 + 1.0)) * ncol + ncol - 1]
         else:
-          z0 = hfield_data[adr + int(wp.round(y0 + 0.0)) * ncol]
-          z1 = hfield_data[adr + int(wp.round(y0 + 1.0)) * ncol]
+          z0 = hfield_data[hfdata_worldid, adr + int(wp.round(y0 + 0.0)) * ncol]
+          z1 = hfield_data[hfdata_worldid, adr + int(wp.round(y0 + 1.0)) * ncol]
       # side normal to y-axis
       else:
         y = safe_div(lpnt[0] + all[i] * lvec[0] + size[0], dx)
         y0 = wp.max(0.0, wp.min(float(ncol - 2), wp.floor(y)))
         if i == 3:
-          z0 = hfield_data[adr + int(wp.round(y0 + 0.0)) + (nrow - 1) * ncol]
-          z1 = hfield_data[adr + int(wp.round(y0 + 1.0)) + (nrow - 1) * ncol]
+          z0 = hfield_data[hfdata_worldid, adr + int(wp.round(y0 + 0.0)) + (nrow - 1) * ncol]
+          z1 = hfield_data[hfdata_worldid, adr + int(wp.round(y0 + 1.0)) + (nrow - 1) * ncol]
         else:
-          z0 = hfield_data[adr + int(wp.round(y0 + 0.0))]
-          z1 = hfield_data[adr + int(wp.round(y0 + 1.0))]
+          z0 = hfield_data[hfdata_worldid, adr + int(wp.round(y0 + 0.0))]
+          z1 = hfield_data[hfdata_worldid, adr + int(wp.round(y0 + 1.0))]
 
       # check if point is below line segments
       if z < z0 * (y0 + 1.0 - y) + z1 * (y - y0):
@@ -849,7 +854,7 @@ def _ray_geom_mesh(
   hfield_nrow: wp.array[int],
   hfield_ncol: wp.array[int],
   hfield_adr: wp.array[int],
-  hfield_data: wp.array[float],
+  hfield_data: wp.array2d[float],
   mat_rgba: wp.array2d[wp.vec4],
   # Data in:
   geom_xpos_in: wp.array2d[wp.vec3],
@@ -936,7 +941,7 @@ def _ray(
   hfield_nrow: wp.array[int],
   hfield_ncol: wp.array[int],
   hfield_adr: wp.array[int],
-  hfield_data: wp.array[float],
+  hfield_data: wp.array2d[float],
   mat_rgba: wp.array2d[wp.vec4],
   # Data in:
   geom_xpos_in: wp.array2d[wp.vec3],

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1659,7 +1659,7 @@ class Model:
   hfield_nrow: array("nhfield", int)
   hfield_ncol: array("nhfield", int)
   hfield_adr: array("nhfield", int)
-  hfield_data: array("nhfielddata", float)
+  hfield_data: array("*", "nhfielddata", float)
   mat_texid: array("*", "nmat", 10, int)
   mat_texrepeat: array("*", "nmat", wp.vec2)
   mat_emission: array("*", "nmat", float)


### PR DESCRIPTION
`hfield_data` is currently shared by all worlds, which prevents using different terrain in each world , e.g. for domain randomization of terrain.

This PR adds a batch/world-dimension to `hfield_data` and updates heightfield collision and ray casting to select the data for the current world. 