### PR TITLE
cg solver: support sleeping

### DIFF
--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -42,6 +42,7 @@ from mujoco_warp._src.types import IntegratorType
 from mujoco_warp._src.types import JointType
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import OverflowType
+from mujoco_warp._src.types import SolverType
 from mujoco_warp._src.types import TrnType
 from mujoco_warp._src.types import vec10
 from mujoco_warp._src.warp_util import cache_kernel
@@ -1257,8 +1258,7 @@ def _qfrc_smooth(enable_sleep: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
-    body_treeid: wp.array[int],
-    dof_bodyid: wp.array[int],
+    dof_treeid: wp.array[int],
     # Data in:
     qfrc_applied_in: wp.array2d[float],
     tree_awake_in: wp.array2d[int],
@@ -1271,8 +1271,7 @@ def _qfrc_smooth(enable_sleep: bool):
     worldid, dofid = wp.tid()
 
     if wp.static(enable_sleep):
-      bodyid = dof_bodyid[dofid]
-      tree = body_treeid[bodyid]
+      tree = dof_treeid[dofid]
       if tree >= 0 and tree_awake_in[worldid, tree] == 0:
         qfrc_smooth_out[worldid, dofid] = 0.0
         return
@@ -1301,8 +1300,7 @@ def fwd_acceleration(m: Model, d: Data, factorize: bool = False):
     _qfrc_smooth(enable_sleep),
     dim=(d.nworld, m.nv),
     inputs=[
-      m.body_treeid,
-      m.dof_bodyid,
+      m.dof_treeid,
       d.qfrc_applied,
       d.tree_awake,
       d.qfrc_bias,
@@ -1313,7 +1311,7 @@ def fwd_acceleration(m: Model, d: Data, factorize: bool = False):
   )
   xfrc_accumulate(m, d, d.qfrc_smooth)
 
-  if enable_sleep:
+  if enable_sleep and m.opt.solver == SolverType.NEWTON:
     # update the active-DOF set (needs contacts from fwd_position) and solve
     # the smooth acceleration in compacted dense space.
     island.update_active_dofs(m, d)

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -42,6 +42,7 @@ from mujoco_warp._src.types import IntegratorType
 from mujoco_warp._src.types import JointType
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import OverflowType
+from mujoco_warp._src.types import SolverType
 from mujoco_warp._src.types import TrnType
 from mujoco_warp._src.types import vec10
 from mujoco_warp._src.warp_util import cache_kernel
@@ -1313,7 +1314,7 @@ def fwd_acceleration(m: Model, d: Data, factorize: bool = False):
   )
   xfrc_accumulate(m, d, d.qfrc_smooth)
 
-  if enable_sleep:
+  if enable_sleep and m.opt.solver == SolverType.NEWTON:
     # update the active-DOF set (needs contacts from fwd_position) and solve
     # the smooth acceleration in compacted dense space.
     island.update_active_dofs(m, d)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -381,12 +381,6 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   if mjm.nv > nv_max and mjm.opt.jacobian == mujoco.mjtJacobian.mjJAC_DENSE:
     raise ValueError(f"Dense is unsupported for nv > {nv_max} (nv = {mjm.nv}).")
 
-  # sleeping is supported via a dof-compaction approach.  awake dofs are compacted into dense
-  # nvmax-sized arrays.  nvmax is chosen to fit the worst-case active dof set. sleeping is only
-  # supported for Newton solver and requires nv <= nvmax.
-  if (mjm.opt.enableflags & mujoco.mjtEnableBit.mjENBL_SLEEP) and mjm.opt.solver != mujoco.mjtSolver.mjSOL_NEWTON:
-    raise ValueError(f"sleeping requires the Newton solver (got solver={types.SolverType(mjm.opt.solver).name})")
-
   collision_sensors = (mujoco.mjtSensor.mjSENS_GEOMDIST, mujoco.mjtSensor.mjSENS_GEOMNORMAL, mujoco.mjtSensor.mjSENS_GEOMFROMTO)
   is_collision_sensor = np.isin(mjm.sensor_type, collision_sensors)
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -308,12 +308,6 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   if mjm.nv > nv_max and mjm.opt.jacobian == mujoco.mjtJacobian.mjJAC_DENSE:
     raise ValueError(f"Dense is unsupported for nv > {nv_max} (nv = {mjm.nv}).")
 
-  # sleeping is supported via a dof-compaction approach.  awake dofs are compacted into dense
-  # nvmax-sized arrays.  nvmax is chosen to fit the worst-case active dof set. sleeping is only
-  # supported for Newton solver and requires nv <= nvmax.
-  if (mjm.opt.enableflags & mujoco.mjtEnableBit.mjENBL_SLEEP) and mjm.opt.solver != mujoco.mjtSolver.mjSOL_NEWTON:
-    raise ValueError(f"sleeping requires the Newton solver (got solver={types.SolverType(mjm.opt.solver).name})")
-
   collision_sensors = (mujoco.mjtSensor.mjSENS_GEOMDIST, mujoco.mjtSensor.mjSENS_GEOMNORMAL, mujoco.mjtSensor.mjSENS_GEOMFROMTO)
   is_collision_sensor = np.isin(mjm.sensor_type, collision_sensors)
 

--- a/mujoco_warp/_src/sleep_test.py
+++ b/mujoco_warp/_src/sleep_test.py
@@ -33,8 +33,8 @@ wp.set_module_options({"enable_backward": False})
 
 
 class SleepTest(parameterized.TestCase):
-  @parameterized.parameters(1, 2)
-  def test_sleep_initiation(self, nworld):
+  @parameterized.product(nworld=[1, 2], solver=list(types.SolverType))
+  def test_sleep_initiation(self, nworld, solver):
     """Verify that a stationary body on a flat plane goes to sleep."""
     mjm, mjd, m, d = test_data.fixture(
       xml="""
@@ -52,6 +52,7 @@ class SleepTest(parameterized.TestCase):
       </mujoco>
       """,
       nworld=nworld,
+      overrides={"opt.solver": solver},
     )
 
     # Set initial state: close to the ground, with zero velocity
@@ -84,8 +85,8 @@ class SleepTest(parameterized.TestCase):
       self.assertTrue((qvel == 0.0).all(), f"World {w} qvel not zeroed")
       self.assertTrue((qacc == 0.0).all(), f"World {w} qacc not zeroed")
 
-  @parameterized.parameters(1, 2)
-  def test_collision_waking(self, nworld):
+  @parameterized.product(nworld=[1, 2], solver=list(types.SolverType))
+  def test_collision_waking(self, nworld, solver):
     """Verify that a moving body colliding with a sleeping body wakes it up."""
     mjm, mjd, m, d = test_data.fixture(
       xml="""
@@ -107,6 +108,7 @@ class SleepTest(parameterized.TestCase):
       </mujoco>
       """,
       nworld=nworld,
+      overrides={"opt.solver": solver},
     )
 
     # Set initial state: target is sitting, bullet is moving towards target
@@ -135,8 +137,8 @@ class SleepTest(parameterized.TestCase):
       self.assertEqual(d.tree_awake.numpy()[w, 0], 1, f"Target tree in world {w} should have woken up upon contact")
       self.assertLess(d.tree_asleep.numpy()[w, 0], 0, f"Target tree_asleep in world {w} should be negative (awake)")
 
-  @parameterized.parameters(1, 2)
-  def test_tendon_waking(self, nworld):
+  @parameterized.product(nworld=[1, 2], solver=list(types.SolverType))
+  def test_tendon_waking(self, nworld, solver):
     """Verify that pulling an awake body wakes up a connected sleeping body through a tendon."""
     mjm, mjd, m, d = test_data.fixture(
       xml="""
@@ -163,6 +165,7 @@ class SleepTest(parameterized.TestCase):
       </mujoco>
       """,
       nworld=nworld,
+      overrides={"opt.solver": solver},
     )
 
     # Put b2 (tree 1) to sleep manually
@@ -186,8 +189,8 @@ class SleepTest(parameterized.TestCase):
     for w in range(nworld):
       self.assertEqual(d.tree_awake.numpy()[w, 1], 1, f"b2 in world {w} should have woken up due to tendon constraint")
 
-  @parameterized.parameters(1, 2)
-  def test_equality_waking(self, nworld):
+  @parameterized.product(nworld=[1, 2], solver=list(types.SolverType))
+  def test_equality_waking(self, nworld, solver):
     """Verify that moving an awake body wakes up a connected sleeping body (weld equality)."""
     mjm, mjd, m, d = test_data.fixture(
       xml="""
@@ -211,6 +214,7 @@ class SleepTest(parameterized.TestCase):
       </mujoco>
       """,
       nworld=nworld,
+      overrides={"opt.solver": solver},
     )
 
     # Put b2 (tree 1) to sleep manually
@@ -233,8 +237,8 @@ class SleepTest(parameterized.TestCase):
     for w in range(nworld):
       self.assertEqual(d.tree_awake.numpy()[w, 1], 1, f"b2 in world {w} should have woken up due to weld constraint")
 
-  @parameterized.parameters(1, 2)
-  def test_waking_unaffected_by_sleeping(self, nworld):
+  @parameterized.product(nworld=[1, 2], solver=list(types.SolverType))
+  def test_waking_unaffected_by_sleeping(self, nworld, solver):
     """Verify that sleeping trees do not affect the physical rollout trajectories of awake trees."""
     xml = """
     <mujoco>
@@ -258,6 +262,7 @@ class SleepTest(parameterized.TestCase):
     _, _, m_sleep, d_sleep = test_data.fixture(
       xml=xml,
       nworld=nworld,
+      overrides={"opt.solver": solver},
     )
 
     # Place b1 exactly on the ground so it sleeps
@@ -270,6 +275,7 @@ class SleepTest(parameterized.TestCase):
     _, _, m_nosleep, d_nosleep = test_data.fixture(
       xml=xml,
       nworld=nworld,
+      overrides={"opt.solver": solver},
     )
 
     qpos_nosleep = d_nosleep.qpos.numpy()

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -27,6 +27,7 @@ from mujoco_warp._src.types import CamLightType
 from mujoco_warp._src.types import ConeType
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import DisableBit
+from mujoco_warp._src.types import EnableBit
 from mujoco_warp._src.types import EqType
 from mujoco_warp._src.types import JointType
 from mujoco_warp._src.types import Model
@@ -2982,8 +2983,9 @@ def transmission(m: Model, d: Data):
 
 
 @cache_kernel
-def _solve_LD_sparse_fused(nv: int, nlevels: int):
+def _solve_LD_sparse_fused(nv: int, nlevels: int, sleep_enabled: bool = False):
   """Fused sparse backsubstitution: UP + diag + DOWN in one kernel."""
+  SLEEP_ENABLED = sleep_enabled
 
   @wp.func_native(snippet="WP_TILE_SYNC();")
   def _syncthreads():
@@ -2992,7 +2994,10 @@ def _solve_LD_sparse_fused(nv: int, nlevels: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
+    dof_treeid: wp.array[int],
     qLD_block_adr: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
     # In:
     L: wp.array2d[float],
     D: wp.array2d[float],
@@ -3010,7 +3015,14 @@ def _solve_LD_sparse_fused(nv: int, nlevels: int):
     # Copy y to x_out for sparse-block dofs only.
     for dofid in range(tid, NV, BLOCK_DIM):
       if qLD_block_adr[dofid] == Q_LD_BLOCK_SPARSE:
-        x_out[worldid, dofid] = y[worldid, dofid]
+        if wp.static(SLEEP_ENABLED):
+          treeid = dof_treeid[dofid]
+          if tree_awake_in[worldid, treeid] != 0:
+            x_out[worldid, dofid] = y[worldid, dofid]
+          else:
+            x_out[worldid, dofid] = 0.0
+        else:
+          x_out[worldid, dofid] = y[worldid, dofid]
     _syncthreads()
 
     # Forward substitution (all_updates only references sparse-block dofs)
@@ -3022,13 +3034,23 @@ def _solve_LD_sparse_fused(nv: int, nlevels: int):
       for u in range(tid, level_size, BLOCK_DIM):
         update = all_updates[level_offset + u]
         i, k, Madr_ki = update[0], update[1], update[2]
-        wp.atomic_sub(x_out[worldid], i, L[worldid, Madr_ki] * x_out[worldid, k])
+        if wp.static(SLEEP_ENABLED):
+          treeid = dof_treeid[i]
+          if tree_awake_in[worldid, treeid] != 0:
+            wp.atomic_sub(x_out[worldid], i, L[worldid, Madr_ki] * x_out[worldid, k])
+        else:
+          wp.atomic_sub(x_out[worldid], i, L[worldid, Madr_ki] * x_out[worldid, k])
       _syncthreads()
 
     # Diagonal multiply (sparse-block dofs only)
     for dofid in range(tid, NV, BLOCK_DIM):
       if qLD_block_adr[dofid] == Q_LD_BLOCK_SPARSE:
-        x_out[worldid, dofid] *= D[worldid, dofid]
+        if wp.static(SLEEP_ENABLED):
+          treeid = dof_treeid[dofid]
+          if tree_awake_in[worldid, treeid] != 0:
+            x_out[worldid, dofid] *= D[worldid, dofid]
+        else:
+          x_out[worldid, dofid] *= D[worldid, dofid]
     _syncthreads()
 
     # Backward substitution
@@ -3040,7 +3062,12 @@ def _solve_LD_sparse_fused(nv: int, nlevels: int):
       for u in range(tid, level_size, BLOCK_DIM):
         update = all_updates[level_offset + u]
         i, k, Madr_ki = update[0], update[1], update[2]
-        wp.atomic_sub(x_out[worldid], k, L[worldid, Madr_ki] * x_out[worldid, i])
+        if wp.static(SLEEP_ENABLED):
+          treeid = dof_treeid[i]
+          if tree_awake_in[worldid, treeid] != 0:
+            wp.atomic_sub(x_out[worldid], k, L[worldid, Madr_ki] * x_out[worldid, i])
+        else:
+          wp.atomic_sub(x_out[worldid], k, L[worldid, Madr_ki] * x_out[worldid, i])
       _syncthreads()
 
   return kernel
@@ -3053,6 +3080,7 @@ def _solve_LD_sparse(
   D: wp.array2d[float],
   x: wp.array2d[float],
   y: wp.array2d[float],
+  sleep_enabled: bool = False,
 ):
   """Computes sparse backsubstitution: x = inv(L'*D*L)*y."""
   nlevels = len(m.qLD_updates)
@@ -3063,9 +3091,9 @@ def _solve_LD_sparse(
     dim_block = 1
 
   wp.launch(
-    _solve_LD_sparse_fused(m.nv, nlevels),
+    _solve_LD_sparse_fused(m.nv, nlevels, sleep_enabled),
     dim=(d.nworld, dim_block),
-    inputs=[m.qLD_block_adr, L, D, m.qLD_all_updates, m.qLD_level_offsets, y],
+    inputs=[m.dof_treeid, m.qLD_block_adr, d.tree_awake, L, D, m.qLD_all_updates, m.qLD_level_offsets, y],
     outputs=[x],
     block_dim=dim_block,
   )
@@ -3098,11 +3126,16 @@ def _small_cholesky_solve(
 
 
 @cache_kernel
-def _small_cholesky_solve_block(block_size: int):
+def _small_cholesky_solve_block(block_size: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
+
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
+    dof_treeid: wp.array[int],
     qLD_block_adr: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
     # In:
     block_dof: wp.array[int],
     D_in: wp.array2d[float],
@@ -3114,6 +3147,14 @@ def _small_cholesky_solve_block(block_size: int):
     worldid, blk = wp.tid()
     start = block_dof[blk]
     size = wp.static(block_size)
+
+    if wp.static(SLEEP_ENABLED):
+      treeid = dof_treeid[start]
+      if tree_awake_in[worldid, treeid] == 0:
+        for i in range(wp.static(block_size)):
+          x_out[worldid, start + i] = 0.0
+        return
+
     factor_adr = qLD_block_adr[start]
     if factor_adr == Q_LD_BLOCK_COMPACT:
       for i in range(wp.static(block_size)):
@@ -3125,31 +3166,41 @@ def _small_cholesky_solve_block(block_size: int):
 
 
 @cache_kernel
-def _tile_cholesky_solve_block(tile: TileSet):
+def _tile_cholesky_solve_block(tile: TileSet, sleep_enabled: bool = False):
   # One diagonal block per (world, block) thread group; no densify, so a 2D grid suffices.
   block_size = tile.size
   block_area = block_size * block_size
+  SLEEP_ENABLED = sleep_enabled
 
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
+    dof_treeid: wp.array[int],
     qLD_block_adr: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
     # In:
     block_dof: wp.array[int],
     L_in: wp.array2d[float],
     y: wp.array2d[float],
     # Out:
-    x: wp.array2d[float],
+    x_out: wp.array2d[float],
   ):
     worldid, blk = wp.tid()
     start = block_dof[blk]
+
+    if wp.static(SLEEP_ENABLED):
+      treeid = dof_treeid[start]
+      if tree_awake_in[worldid, treeid] == 0:
+        wp.tile_store(x_out[worldid], wp.tile_zeros(shape=(block_size,), dtype=float), offset=(start,))
+        return
 
     L = wp.tile_reshape(
       wp.tile_load(L_in[worldid], shape=(block_area,), offset=(qLD_block_adr[start],)), (block_size, block_size)
     )
     rhs = wp.tile_load(y[worldid], shape=(block_size,), offset=(start,))
     sol = wp.tile_cholesky_solve(L, rhs, fill_mode="upper")
-    wp.tile_store(x[worldid], sol, offset=(start,))
+    wp.tile_store(x_out[worldid], sol, offset=(start,))
 
   return kernel
 
@@ -3161,13 +3212,14 @@ def _solve_blocks(
   D: wp.array2d[float],
   x: wp.array2d[float],
   y: wp.array2d[float],
+  sleep_enabled: bool = False,
 ):
   for tile in m.M_tiles:
     if tile.elemid.size == 0:
       wp.launch(
-        _small_cholesky_solve_block(tile.size),
+        _small_cholesky_solve_block(tile.size, sleep_enabled),
         dim=(d.nworld, tile.adr.size),
-        inputs=[m.qLD_block_adr, tile.adr, D, L, y],
+        inputs=[m.dof_treeid, m.qLD_block_adr, d.tree_awake, tile.adr, D, L, y],
         outputs=[x],
         block_dim=m.block_dim.small_cholesky,
       )
@@ -3176,9 +3228,9 @@ def _solve_blocks(
       # for better occupancy while moderate blocks still want a couple warps (16/27->64, 60->32).
       block_dim = m.block_dim.cholesky_solve if tile.size <= 40 else 32
       wp.launch_tiled(
-        _tile_cholesky_solve_block(tile),
+        _tile_cholesky_solve_block(tile, sleep_enabled),
         dim=(d.nworld, tile.adr.size),
-        inputs=[m.qLD_block_adr, tile.adr, L, y],
+        inputs=[m.dof_treeid, m.qLD_block_adr, d.tree_awake, tile.adr, L, y],
         outputs=[x],
         block_dim=block_dim,
       )
@@ -3191,6 +3243,7 @@ def solve_LD(
   D: wp.array2d[float],
   x: wp.array2d[float],
   y: wp.array2d[float],
+  sleep_enabled: bool = False,
 ):
   """Computes backsubstitution for the inertia factorization.
 
@@ -3204,11 +3257,12 @@ def solve_LD(
     D: Reciprocal diagonal for compact and sparse blocks.
     x: Output array for the solution.
     y: Input right-hand side array.
+    sleep_enabled: Whether to skip calculation for asleep trees.
   """
   if m.M_tiles:
-    _solve_blocks(m, d, L, D, x, y)
+    _solve_blocks(m, d, L, D, x, y, sleep_enabled)
   if L.shape[1] > m.qLD_block_total:
-    _solve_LD_sparse(m, d, L[:, m.qLD_block_total :], D, x, y)
+    _solve_LD_sparse(m, d, L[:, m.qLD_block_total :], D, x, y, sleep_enabled)
 
 
 @event_scope
@@ -3221,7 +3275,8 @@ def solve_m(m: Model, d: Data, x: wp.array2d[float], y: wp.array2d[float]):
     x: Output array for the solution.
     y: Input right-hand side array.
   """
-  solve_LD(m, d, d.qLD, d.qLDiagInv, x, y)
+  sleep_enabled = bool(m.opt.enableflags & EnableBit.SLEEP) and not bool(m.opt.disableflags & DisableBit.ISLAND)
+  solve_LD(m, d, d.qLD, d.qLDiagInv, x, y, sleep_enabled)
 
 
 @cache_kernel

--- a/mujoco_warp/_src/smooth.py
+++ b/mujoco_warp/_src/smooth.py
@@ -27,6 +27,7 @@ from mujoco_warp._src.types import CamLightType
 from mujoco_warp._src.types import ConeType
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import DisableBit
+from mujoco_warp._src.types import EnableBit
 from mujoco_warp._src.types import EqType
 from mujoco_warp._src.types import JointType
 from mujoco_warp._src.types import Model
@@ -2979,8 +2980,9 @@ def transmission(m: Model, d: Data):
 
 
 @cache_kernel
-def _solve_LD_sparse_fused(nv: int, nlevels: int):
+def _solve_LD_sparse_fused(nv: int, nlevels: int, sleep_enabled: bool = False):
   """Fused sparse backsubstitution: UP + diag + DOWN in one kernel."""
+  SLEEP_ENABLED = sleep_enabled
 
   @wp.func_native(snippet="WP_TILE_SYNC();")
   def _syncthreads():
@@ -2989,7 +2991,11 @@ def _solve_LD_sparse_fused(nv: int, nlevels: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
+    body_treeid: wp.array[int],
+    dof_bodyid: wp.array[int],
     qLD_block_adr: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
     # In:
     L: wp.array2d[float],
     D: wp.array2d[float],
@@ -3007,7 +3013,14 @@ def _solve_LD_sparse_fused(nv: int, nlevels: int):
     # Copy y to x_out for sparse-block dofs only.
     for dofid in range(tid, NV, BLOCK_DIM):
       if qLD_block_adr[dofid] == Q_LD_BLOCK_SPARSE:
-        x_out[worldid, dofid] = y[worldid, dofid]
+        if wp.static(SLEEP_ENABLED):
+          treeid = body_treeid[dof_bodyid[dofid]]
+          if tree_awake_in[worldid, treeid] != 0:
+            x_out[worldid, dofid] = y[worldid, dofid]
+          else:
+            x_out[worldid, dofid] = 0.0
+        else:
+          x_out[worldid, dofid] = y[worldid, dofid]
     _syncthreads()
 
     # Forward substitution (all_updates only references sparse-block dofs)
@@ -3019,13 +3032,23 @@ def _solve_LD_sparse_fused(nv: int, nlevels: int):
       for u in range(tid, level_size, BLOCK_DIM):
         update = all_updates[level_offset + u]
         i, k, Madr_ki = update[0], update[1], update[2]
-        wp.atomic_sub(x_out[worldid], i, L[worldid, Madr_ki] * x_out[worldid, k])
+        if wp.static(SLEEP_ENABLED):
+          treeid = body_treeid[dof_bodyid[i]]
+          if tree_awake_in[worldid, treeid] != 0:
+            wp.atomic_sub(x_out[worldid], i, L[worldid, Madr_ki] * x_out[worldid, k])
+        else:
+          wp.atomic_sub(x_out[worldid], i, L[worldid, Madr_ki] * x_out[worldid, k])
       _syncthreads()
 
     # Diagonal multiply (sparse-block dofs only)
     for dofid in range(tid, NV, BLOCK_DIM):
       if qLD_block_adr[dofid] == Q_LD_BLOCK_SPARSE:
-        x_out[worldid, dofid] *= D[worldid, dofid]
+        if wp.static(SLEEP_ENABLED):
+          treeid = body_treeid[dof_bodyid[dofid]]
+          if tree_awake_in[worldid, treeid] != 0:
+            x_out[worldid, dofid] *= D[worldid, dofid]
+        else:
+          x_out[worldid, dofid] *= D[worldid, dofid]
     _syncthreads()
 
     # Backward substitution
@@ -3037,7 +3060,12 @@ def _solve_LD_sparse_fused(nv: int, nlevels: int):
       for u in range(tid, level_size, BLOCK_DIM):
         update = all_updates[level_offset + u]
         i, k, Madr_ki = update[0], update[1], update[2]
-        wp.atomic_sub(x_out[worldid], k, L[worldid, Madr_ki] * x_out[worldid, i])
+        if wp.static(SLEEP_ENABLED):
+          treeid = body_treeid[dof_bodyid[i]]
+          if tree_awake_in[worldid, treeid] != 0:
+            wp.atomic_sub(x_out[worldid], k, L[worldid, Madr_ki] * x_out[worldid, i])
+        else:
+          wp.atomic_sub(x_out[worldid], k, L[worldid, Madr_ki] * x_out[worldid, i])
       _syncthreads()
 
   return kernel
@@ -3050,6 +3078,7 @@ def _solve_LD_sparse(
   D: wp.array2d[float],
   x: wp.array2d[float],
   y: wp.array2d[float],
+  sleep_enabled: bool = False,
 ):
   """Computes sparse backsubstitution: x = inv(L'*D*L)*y."""
   nlevels = len(m.qLD_updates)
@@ -3060,9 +3089,9 @@ def _solve_LD_sparse(
     dim_block = 1
 
   wp.launch(
-    _solve_LD_sparse_fused(m.nv, nlevels),
+    _solve_LD_sparse_fused(m.nv, nlevels, sleep_enabled),
     dim=(d.nworld, dim_block),
-    inputs=[m.qLD_block_adr, L, D, m.qLD_all_updates, m.qLD_level_offsets, y],
+    inputs=[m.body_treeid, m.dof_bodyid, m.qLD_block_adr, d.tree_awake, L, D, m.qLD_all_updates, m.qLD_level_offsets, y],
     outputs=[x],
     block_dim=dim_block,
   )
@@ -3095,11 +3124,17 @@ def _small_cholesky_solve(
 
 
 @cache_kernel
-def _small_cholesky_solve_block(block_size: int):
+def _small_cholesky_solve_block(block_size: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
+
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
+    body_treeid: wp.array[int],
+    dof_bodyid: wp.array[int],
     qLD_block_adr: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
     # In:
     block_dof: wp.array[int],
     D_in: wp.array2d[float],
@@ -3111,6 +3146,14 @@ def _small_cholesky_solve_block(block_size: int):
     worldid, blk = wp.tid()
     start = block_dof[blk]
     size = wp.static(block_size)
+
+    if wp.static(SLEEP_ENABLED):
+      treeid = body_treeid[dof_bodyid[start]]
+      if tree_awake_in[worldid, treeid] == 0:
+        for i in range(wp.static(block_size)):
+          x_out[worldid, start + i] = 0.0
+        return
+
     factor_adr = qLD_block_adr[start]
     if factor_adr == Q_LD_BLOCK_COMPACT:
       for i in range(wp.static(block_size)):
@@ -3122,31 +3165,43 @@ def _small_cholesky_solve_block(block_size: int):
 
 
 @cache_kernel
-def _tile_cholesky_solve_block(tile: TileSet):
+def _tile_cholesky_solve_block(tile: TileSet, sleep_enabled: bool = False):
   # One diagonal block per (world, block) thread group; no densify, so a 2D grid suffices.
   block_size = tile.size
   block_area = block_size * block_size
+  SLEEP_ENABLED = sleep_enabled
 
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
+    body_treeid: wp.array[int],
+    dof_bodyid: wp.array[int],
     qLD_block_adr: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
     # In:
     block_dof: wp.array[int],
     L_in: wp.array2d[float],
     y: wp.array2d[float],
     # Out:
-    x: wp.array2d[float],
+    x_out: wp.array2d[float],
   ):
     worldid, blk = wp.tid()
     start = block_dof[blk]
+
+    if wp.static(SLEEP_ENABLED):
+      treeid = body_treeid[dof_bodyid[start]]
+      if tree_awake_in[worldid, treeid] == 0:
+        for i in range(block_size):
+          x_out[worldid, start + i] = 0.0
+        return
 
     L = wp.tile_reshape(
       wp.tile_load(L_in[worldid], shape=(block_area,), offset=(qLD_block_adr[start],)), (block_size, block_size)
     )
     rhs = wp.tile_load(y[worldid], shape=(block_size,), offset=(start,))
     sol = wp.tile_cholesky_solve(L, rhs, fill_mode="upper")
-    wp.tile_store(x[worldid], sol, offset=(start,))
+    wp.tile_store(x_out[worldid], sol, offset=(start,))
 
   return kernel
 
@@ -3158,13 +3213,14 @@ def _solve_blocks(
   D: wp.array2d[float],
   x: wp.array2d[float],
   y: wp.array2d[float],
+  sleep_enabled: bool = False,
 ):
   for tile in m.M_tiles:
     if tile.elemid.size == 0:
       wp.launch(
-        _small_cholesky_solve_block(tile.size),
+        _small_cholesky_solve_block(tile.size, sleep_enabled),
         dim=(d.nworld, tile.adr.size),
-        inputs=[m.qLD_block_adr, tile.adr, D, L, y],
+        inputs=[m.body_treeid, m.dof_bodyid, m.qLD_block_adr, d.tree_awake, tile.adr, D, L, y],
         outputs=[x],
         block_dim=m.block_dim.small_cholesky,
       )
@@ -3173,9 +3229,9 @@ def _solve_blocks(
       # for better occupancy while moderate blocks still want a couple warps (16/27->64, 60->32).
       block_dim = m.block_dim.cholesky_solve if tile.size <= 40 else 32
       wp.launch_tiled(
-        _tile_cholesky_solve_block(tile),
+        _tile_cholesky_solve_block(tile, sleep_enabled),
         dim=(d.nworld, tile.adr.size),
-        inputs=[m.qLD_block_adr, tile.adr, L, y],
+        inputs=[m.body_treeid, m.dof_bodyid, m.qLD_block_adr, d.tree_awake, tile.adr, L, y],
         outputs=[x],
         block_dim=block_dim,
       )
@@ -3188,6 +3244,7 @@ def solve_LD(
   D: wp.array2d[float],
   x: wp.array2d[float],
   y: wp.array2d[float],
+  sleep_enabled: bool = False,
 ):
   """Computes backsubstitution for the inertia factorization.
 
@@ -3201,11 +3258,12 @@ def solve_LD(
     D: Reciprocal diagonal for compact and sparse blocks.
     x: Output array for the solution.
     y: Input right-hand side array.
+    sleep_enabled: Whether to skip calculation for asleep trees.
   """
   if m.M_tiles:
-    _solve_blocks(m, d, L, D, x, y)
+    _solve_blocks(m, d, L, D, x, y, sleep_enabled)
   if L.shape[1] > m.qLD_block_total:
-    _solve_LD_sparse(m, d, L[:, m.qLD_block_total :], D, x, y)
+    _solve_LD_sparse(m, d, L[:, m.qLD_block_total :], D, x, y, sleep_enabled)
 
 
 @event_scope
@@ -3218,7 +3276,8 @@ def solve_m(m: Model, d: Data, x: wp.array2d[float], y: wp.array2d[float]):
     x: Output array for the solution.
     y: Input right-hand side array.
   """
-  solve_LD(m, d, d.qLD, d.qLDiagInv, x, y)
+  sleep_enabled = bool(m.opt.enableflags & EnableBit.SLEEP)
+  solve_LD(m, d, d.qLD, d.qLDiagInv, x, y, sleep_enabled)
 
 
 @cache_kernel

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -39,6 +39,11 @@ wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 _BLOCK_CHOLESKY_DIM = 32
 
 
+def _is_sleep_enabled(m: types.Model) -> bool:
+  """Returns whether sleeping is enabled and island processing is not disabled."""
+  return bool(m.opt.enableflags & types.EnableBit.SLEEP) and not bool(m.opt.disableflags & types.DisableBit.ISLAND)
+
+
 def create_inverse_context(m: types.Model, d: types.Data) -> InverseContext:
   """Create an InverseContext with allocated workspace arrays.
 
@@ -840,6 +845,7 @@ def _linesearch_iterative_kernel(
   is_sparse: bool,
   incremental: bool,
   warn_overflow: bool,
+  sleep_enabled: bool = False,
 ):
   """Factory for iterative linesearch kernel.
 
@@ -850,12 +856,14 @@ def _linesearch_iterative_kernel(
     is_sparse: Use sparse matrix representation for constraint Jacobian.
     incremental: State changes are tracked: flag exhausted rays, reuse jv on unchanged search.
     warn_overflow: Whether to print overflow warnings.
+    sleep_enabled: Bypasses update for asleep trees.
   """
   LS_ITERATIONS = ls_iterations
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
   FUSE_JV = fuse_jv
   INCREMENTAL = incremental
   IS_SPARSE = is_sparse
+  SLEEP_ENABLED = sleep_enabled
 
   # Native snippet for CUDA __syncthreads()
   @wp.func_native(snippet="WP_TILE_SYNC();")
@@ -880,10 +888,12 @@ def _linesearch_iterative_kernel(
     opt_ls_tolerance: wp.array[float],
     opt_impratio_invsqrt: wp.array[float],
     stat_meaninertia: wp.array[float],
+    dof_treeid: wp.array[int],
     # Data in:
     ne_in: wp.array[int],
     nf_in: wp.array[int],
     nefc_in: wp.array[int],
+    tree_awake_in: wp.array2d[int],
     qfrc_smooth_in: wp.array2d[float],
     contact_friction_in: wp.array[types.vec5],
     contact_dim_in: wp.array[int],
@@ -1324,8 +1334,14 @@ def _linesearch_iterative_kernel(
 
     # qacc and Ma update
     for dofid in range(tid, nv, wp.block_dim()):
-      qacc_out[worldid, dofid] += alpha * ctx_search_in[worldid, dofid]
-      efc_Ma_out[worldid, dofid] += alpha * ctx_mv_in[worldid, dofid]
+      if wp.static(SLEEP_ENABLED):
+        treeid = dof_treeid[dofid]
+        if tree_awake_in[worldid, treeid] != 0:
+          qacc_out[worldid, dofid] += alpha * ctx_search_in[worldid, dofid]
+          efc_Ma_out[worldid, dofid] += alpha * ctx_mv_in[worldid, dofid]
+      else:
+        qacc_out[worldid, dofid] += alpha * ctx_search_in[worldid, dofid]
+        efc_Ma_out[worldid, dofid] += alpha * ctx_mv_in[worldid, dofid]
 
     # Jaref update
     for efcid in range(tid, nefc, wp.block_dim()):
@@ -1364,6 +1380,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
       m.is_sparse,
       _use_incremental(m),
       bool(m.opt.warn_overflow),
+      _is_sleep_enabled(m) and m.opt.solver == types.SolverType.CG,
     ),
     dim=d.nworld,
     inputs=[
@@ -1372,9 +1389,11 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
       m.opt.ls_tolerance,
       m.opt.impratio_invsqrt,
       m.stat.meaninertia,
+      m.dof_treeid,
       d.ne,
       d.nf,
       d.nefc,
+      d.tree_awake,
       d.qfrc_smooth,
       d.contact.friction,
       d.contact.dim,
@@ -1563,21 +1582,33 @@ def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext):
 
 
 @cache_kernel
-def _solve_init_dof(warmstart: bool, sparse: bool):
+def _solve_init_dof(warmstart: bool, sparse: bool, sleep_enabled: bool = False):
   WARMSTART = warmstart
   SPARSE = sparse
+  SLEEP_ENABLED = sleep_enabled
 
   @wp.kernel(module="unique", enable_backward=False, grid_stride=False)
   def kernel(
+    # Model:
+    dof_treeid: wp.array[int],
     # Data in:
     nefc_in: wp.array[int],
     qacc_warmstart_in: wp.array2d[float],
+    tree_awake_in: wp.array2d[int],
     qacc_smooth_in: wp.array2d[float],
     # Data out:
     qacc_out: wp.array2d[float],
     qfrc_constraint_out: wp.array2d[float],
   ):
     worldid, dofid = wp.tid()
+
+    if wp.static(SLEEP_ENABLED):
+      if tree_awake_in[worldid, dof_treeid[dofid]] == 0:
+        qacc_out[worldid, dofid] = 0.0
+        if wp.static(SPARSE):
+          if nefc_in[worldid] == 0:
+            qfrc_constraint_out[worldid, dofid] = 0.0
+        return
 
     if wp.static(WARMSTART):
       qacc_out[worldid, dofid] = qacc_warmstart_in[worldid, dofid]
@@ -1661,38 +1692,54 @@ def _solve_init_jaref_kernel(is_sparse: bool, nv: int, dofs_per_thread: int, com
   return kernel
 
 
-@wp.kernel
-def _solve_init_search_cg_tiled(
-  # Model:
-  nv: int,
-  # In:
-  ctx_grad_in: wp.array2d[float],
-  ctx_Mgrad_in: wp.array2d[float],
-  # Out:
-  ctx_search_out: wp.array2d[float],
-  ctx_search_dot_out: wp.array[float],
-  ctx_prev_grad_out: wp.array2d[float],
-  ctx_prev_Mgrad_out: wp.array2d[float],
-):
-  worldid, tid = wp.tid()
+@cache_kernel
+def _solve_init_search_cg_tiled(nv: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
 
-  local_search_dot = float(0.0)
-  BLOCK_DIM = wp.block_dim()
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    dof_treeid: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
+    # In:
+    ctx_grad_in: wp.array2d[float],
+    ctx_Mgrad_in: wp.array2d[float],
+    # Out:
+    ctx_search_out: wp.array2d[float],
+    ctx_search_dot_out: wp.array[float],
+    ctx_prev_grad_out: wp.array2d[float],
+    ctx_prev_Mgrad_out: wp.array2d[float],
+  ):
+    worldid, tid = wp.tid()
 
-  for dofid in range(tid, nv, BLOCK_DIM):
-    mgrad = ctx_Mgrad_in[worldid, dofid]
-    search = -1.0 * mgrad
-    ctx_search_out[worldid, dofid] = search
-    local_search_dot += search * search
+    local_search_dot = float(0.0)
+    BLOCK_DIM = wp.block_dim()
 
-    ctx_prev_grad_out[worldid, dofid] = ctx_grad_in[worldid, dofid]
-    ctx_prev_Mgrad_out[worldid, dofid] = mgrad
+    for dofid in range(tid, nv, BLOCK_DIM):
+      if wp.static(SLEEP_ENABLED):
+        treeid = dof_treeid[dofid]
+        if tree_awake_in[worldid, treeid] == 0:
+          ctx_search_out[worldid, dofid] = 0.0
+          ctx_prev_grad_out[worldid, dofid] = 0.0
+          ctx_prev_Mgrad_out[worldid, dofid] = 0.0
+          continue
 
-  search_dot_tile = wp.tile(local_search_dot, preserve_type=True)
-  search_dot_sum = wp.tile_reduce(wp.add, search_dot_tile)
+      mgrad = ctx_Mgrad_in[worldid, dofid]
+      search = -1.0 * mgrad
+      ctx_search_out[worldid, dofid] = search
+      local_search_dot += search * search
 
-  if tid == 0:
-    ctx_search_dot_out[worldid] = search_dot_sum[0]
+      ctx_prev_grad_out[worldid, dofid] = ctx_grad_in[worldid, dofid]
+      ctx_prev_Mgrad_out[worldid, dofid] = mgrad
+
+    search_dot_tile = wp.tile(local_search_dot, preserve_type=True)
+    search_dot_sum = wp.tile_reduce(wp.add, search_dot_tile)
+
+    if tid == 0:
+      ctx_search_dot_out[worldid] = search_dot_sum[0]
+
+  return kernel
 
 
 @cache_kernel
@@ -2199,38 +2246,51 @@ def _update_gradient_grad(stable_fast: bool):
   return kernel
 
 
-@wp.kernel
-def _update_gradient_grad_tiled(
-  # Model:
-  nv: int,
-  # Data in:
-  qfrc_smooth_in: wp.array2d[float],
-  qfrc_constraint_in: wp.array2d[float],
-  efc_Ma_in: wp.array2d[float],
-  # In:
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_grad_out: wp.array2d[float],
-  ctx_grad_dot_out: wp.array[float],
-):
-  worldid, tid = wp.tid()
+@cache_kernel
+def _update_gradient_grad_tiled(nv: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    dof_treeid: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
+    qfrc_smooth_in: wp.array2d[float],
+    qfrc_constraint_in: wp.array2d[float],
+    efc_Ma_in: wp.array2d[float],
+    # In:
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_grad_out: wp.array2d[float],
+    ctx_grad_dot_out: wp.array[float],
+  ):
+    worldid, tid = wp.tid()
 
-  local_grad_dot = float(0.0)
-  BLOCK_DIM = wp.block_dim()
+    if ctx_done_in[worldid]:
+      return
 
-  for dofid in range(tid, nv, BLOCK_DIM):
-    grad = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - qfrc_constraint_in[worldid, dofid]
-    ctx_grad_out[worldid, dofid] = grad
-    local_grad_dot += grad * grad
+    local_grad_dot = float(0.0)
+    BLOCK_DIM = wp.block_dim()
 
-  grad_dot_tile = wp.tile(local_grad_dot, preserve_type=True)
-  grad_dot_sum = wp.tile_reduce(wp.add, grad_dot_tile)
+    for dofid in range(tid, nv, BLOCK_DIM):
+      if wp.static(SLEEP_ENABLED):
+        treeid = dof_treeid[dofid]
+        if tree_awake_in[worldid, treeid] == 0:
+          ctx_grad_out[worldid, dofid] = 0.0
+          continue
 
-  if tid == 0:
-    ctx_grad_dot_out[worldid] = grad_dot_sum[0]
+      grad = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - qfrc_constraint_in[worldid, dofid]
+      ctx_grad_out[worldid, dofid] = grad
+      local_grad_dot += grad * grad
+
+    grad_dot_tile = wp.tile(local_grad_dot, preserve_type=True)
+    grad_dot_sum = wp.tile_reduce(wp.add, grad_dot_tile)
+
+    if tid == 0:
+      ctx_grad_dot_out[worldid] = grad_dot_sum[0]
+
+  return kernel
 
 
 @cache_kernel
@@ -3062,9 +3122,9 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
   # grad = Ma - qfrc_smooth - qfrc_constraint
   if m.opt.solver == types.SolverType.CG:
     wp.launch_tiled(
-      _update_gradient_grad_tiled,
+      _update_gradient_grad_tiled(m.nv, _is_sleep_enabled(m)),
       dim=d.nworld,
-      inputs=[m.nv, d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, ctx.done],
+      inputs=[m.dof_treeid, d.tree_awake, d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, ctx.done],
       outputs=[ctx.grad, ctx.grad_dot],
       block_dim=m.block_dim.update_gradient_grad,
     )
@@ -3291,111 +3351,116 @@ def _solve_beta_zero(
   ctx_beta_den_out[worldid] = 0.0
 
 
-@wp.kernel
-def _solve_beta_accumulate_tiled(
-  # Model:
-  nv: int,
-  # In:
-  ctx_grad_in: wp.array2d[float],
-  ctx_Mgrad_in: wp.array2d[float],
-  ctx_prev_grad_in: wp.array2d[float],
-  ctx_prev_Mgrad_in: wp.array2d[float],
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_beta_num_out: wp.array[float],
-  ctx_beta_den_out: wp.array[float],
-):
-  worldid, tid = wp.tid()
+@cache_kernel
+def _solve_beta_accumulate_tiled(nv: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    dof_treeid: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
+    # In:
+    ctx_grad_in: wp.array2d[float],
+    ctx_Mgrad_in: wp.array2d[float],
+    ctx_prev_grad_in: wp.array2d[float],
+    ctx_prev_Mgrad_in: wp.array2d[float],
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_beta_num_out: wp.array[float],
+    ctx_beta_den_out: wp.array[float],
+  ):
+    worldid, tid = wp.tid()
 
-  local_num = float(0.0)
-  local_den = float(0.0)
-  BLOCK_DIM = wp.block_dim()
+    if ctx_done_in[worldid]:
+      return
 
-  for dofid in range(tid, nv, BLOCK_DIM):
-    prev_Mgrad = ctx_prev_Mgrad_in[worldid, dofid]
-    num = ctx_grad_in[worldid, dofid] * (ctx_Mgrad_in[worldid, dofid] - prev_Mgrad)
-    den = ctx_prev_grad_in[worldid, dofid] * prev_Mgrad
-    local_num += num
-    local_den += den
+    local_num = float(0.0)
+    local_den = float(0.0)
+    BLOCK_DIM = wp.block_dim()
 
-  num_tile = wp.tile(local_num, preserve_type=True)
-  num_sum = wp.tile_reduce(wp.add, num_tile)
+    for dofid in range(tid, nv, BLOCK_DIM):
+      if wp.static(SLEEP_ENABLED):
+        treeid = dof_treeid[dofid]
+        if tree_awake_in[worldid, treeid] == 0:
+          continue
 
-  den_tile = wp.tile(local_den, preserve_type=True)
-  den_sum = wp.tile_reduce(wp.add, den_tile)
+      prev_Mgrad = ctx_prev_Mgrad_in[worldid, dofid]
+      num = ctx_grad_in[worldid, dofid] * (ctx_Mgrad_in[worldid, dofid] - prev_Mgrad)
+      den = ctx_prev_grad_in[worldid, dofid] * prev_Mgrad
+      local_num += num
+      local_den += den
 
-  if tid == 0:
-    ctx_beta_num_out[worldid] = num_sum[0]
-    ctx_beta_den_out[worldid] = den_sum[0]
+    num_tile = wp.tile(local_num, preserve_type=True)
+    num_sum = wp.tile_reduce(wp.add, num_tile)
 
+    den_tile = wp.tile(local_den, preserve_type=True)
+    den_sum = wp.tile_reduce(wp.add, den_tile)
 
-@wp.kernel
-def _solve_beta_accumulate(
-  # In:
-  ctx_grad_in: wp.array2d[float],
-  ctx_Mgrad_in: wp.array2d[float],
-  ctx_prev_grad_in: wp.array2d[float],
-  ctx_prev_Mgrad_in: wp.array2d[float],
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_beta_num_out: wp.array[float],
-  ctx_beta_den_out: wp.array[float],
-):
-  worldid, dofid = wp.tid()
+    if tid == 0:
+      ctx_beta_num_out[worldid] = num_sum[0]
+      ctx_beta_den_out[worldid] = den_sum[0]
 
-  if ctx_done_in[worldid]:
-    return
-
-  prev_Mgrad = ctx_prev_Mgrad_in[worldid, dofid]
-  num = ctx_grad_in[worldid, dofid] * (ctx_Mgrad_in[worldid, dofid] - prev_Mgrad)
-  den = ctx_prev_grad_in[worldid, dofid] * prev_Mgrad
-  wp.atomic_add(ctx_beta_num_out, worldid, num)
-  wp.atomic_add(ctx_beta_den_out, worldid, den)
+  return kernel
 
 
-@wp.kernel
-def _solve_search_update_cg_tiled(
-  # Model:
-  nv: int,
-  # In:
-  ctx_grad_in: wp.array2d[float],
-  ctx_Mgrad_in: wp.array2d[float],
-  ctx_search_in: wp.array2d[float],
-  ctx_beta_in: wp.array[float],
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_search_out: wp.array2d[float],
-  ctx_search_dot_out: wp.array[float],
-  ctx_prev_grad_out: wp.array2d[float],
-  ctx_prev_Mgrad_out: wp.array2d[float],
-):
-  worldid, tid = wp.tid()
+@cache_kernel
+def _solve_search_update_cg_tiled(nv: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    dof_treeid: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
+    # In:
+    ctx_grad_in: wp.array2d[float],
+    ctx_Mgrad_in: wp.array2d[float],
+    ctx_search_in: wp.array2d[float],
+    ctx_beta_in: wp.array[float],
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_search_out: wp.array2d[float],
+    ctx_search_dot_out: wp.array[float],
+    ctx_prev_grad_out: wp.array2d[float],
+    ctx_prev_Mgrad_out: wp.array2d[float],
+  ):
+    worldid, tid = wp.tid()
 
-  local_search_dot = float(0.0)
-  BLOCK_DIM = wp.block_dim()
-  beta = ctx_beta_in[worldid]
+    if ctx_done_in[worldid]:
+      return
 
-  for dofid in range(tid, nv, BLOCK_DIM):
-    mgrad = ctx_Mgrad_in[worldid, dofid]
-    search = -1.0 * mgrad + beta * ctx_search_in[worldid, dofid]
+    local_search_dot = float(0.0)
+    BLOCK_DIM = wp.block_dim()
+    beta = ctx_beta_in[worldid]
 
-    ctx_search_out[worldid, dofid] = search
-    local_search_dot += search * search
+    for dofid in range(tid, nv, BLOCK_DIM):
+      if wp.static(SLEEP_ENABLED):
+        treeid = dof_treeid[dofid]
+        if tree_awake_in[worldid, treeid] == 0:
+          ctx_search_out[worldid, dofid] = 0.0
+          ctx_prev_grad_out[worldid, dofid] = 0.0
+          ctx_prev_Mgrad_out[worldid, dofid] = 0.0
+          continue
 
-    ctx_prev_grad_out[worldid, dofid] = ctx_grad_in[worldid, dofid]
-    ctx_prev_Mgrad_out[worldid, dofid] = mgrad
+      mgrad = ctx_Mgrad_in[worldid, dofid]
+      search = -1.0 * mgrad + beta * ctx_search_in[worldid, dofid]
 
-  search_dot_tile = wp.tile(local_search_dot, preserve_type=True)
-  search_dot_sum = wp.tile_reduce(wp.add, search_dot_tile)
+      ctx_search_out[worldid, dofid] = search
+      local_search_dot += search * search
 
-  if tid == 0:
-    ctx_search_dot_out[worldid] = search_dot_sum[0]
+      ctx_prev_grad_out[worldid, dofid] = ctx_grad_in[worldid, dofid]
+      ctx_prev_Mgrad_out[worldid, dofid] = mgrad
+
+    search_dot_tile = wp.tile(local_search_dot, preserve_type=True)
+    search_dot_sum = wp.tile_reduce(wp.add, search_dot_tile)
+
+    if tid == 0:
+      ctx_search_dot_out[worldid] = search_dot_sum[0]
+
+  return kernel
 
 
 @cache_kernel
@@ -3559,15 +3624,16 @@ def _solver_iteration(
 
   # polak-ribiere
   if m.opt.solver == types.SolverType.CG:
+    sleep_enabled = _is_sleep_enabled(m)
     wp.launch(
       _solve_beta_zero,
       dim=d.nworld,
       outputs=[ctx.beta, ctx.beta_den],
     )
     wp.launch_tiled(
-      _solve_beta_accumulate_tiled,
+      _solve_beta_accumulate_tiled(m.nv, sleep_enabled),
       dim=d.nworld,
-      inputs=[m.nv, ctx.grad, ctx.Mgrad, ctx.prev_grad, ctx.prev_Mgrad, ctx.done],
+      inputs=[m.dof_treeid, d.tree_awake, ctx.grad, ctx.Mgrad, ctx.prev_grad, ctx.prev_Mgrad, ctx.done],
       outputs=[ctx.beta, ctx.beta_den],
       block_dim=m.block_dim.solve_beta_accumulate,
     )
@@ -3594,9 +3660,9 @@ def _solver_iteration(
       ],
     )
     wp.launch_tiled(
-      _solve_search_update_cg_tiled,
+      _solve_search_update_cg_tiled(m.nv, sleep_enabled),
       dim=d.nworld,
-      inputs=[m.nv, ctx.grad, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
+      inputs=[m.dof_treeid, d.tree_awake, ctx.grad, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
       outputs=[ctx.search, ctx.search_dot, ctx.prev_grad, ctx.prev_Mgrad],
       block_dim=m.block_dim.solve_search_update_cg,
     )
@@ -3669,30 +3735,34 @@ def init_context(m: types.Model, d: types.Data, ctx: SolverContext | InverseCont
 
 @event_scope
 def solve(m: types.Model, d: types.Data):
-  if m.opt.enableflags & types.EnableBit.SLEEP:
+  sleep_enabled = _is_sleep_enabled(m)
+  if sleep_enabled and m.opt.solver == types.SolverType.NEWTON:
     # Self-contained like the island branch below: rebuild the active-DOF mapping from
     # tree_awake so solve() works when called directly (not only via fwd_acceleration).
     island.update_active_dofs(m, d)
     solve_compact(m, d)
-    if m.ntree > 1:
-      island.compute_island_mapping(m, d)
-    return
-
-  if d.njmax == 0 or m.nv == 0:
+  elif d.njmax == 0 or m.nv == 0:
     wp.copy(d.qacc, d.qacc_smooth)
     d.solver_niter.fill_(0)
   else:
     ctx = _create_solver_context(m, d)
     _solve(m, d, ctx)
 
+  if sleep_enabled and m.ntree > 1:
+    island.compute_island_mapping(m, d)
+
 
 def _solve(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = False):
   """Finds forces that satisfy constraints."""
   warmstart = not (m.opt.disableflags & types.DisableBit.WARMSTART)
   wp.launch(
-    _solve_init_dof(warmstart, m.is_sparse),
+    _solve_init_dof(
+      warmstart,
+      m.is_sparse,
+      _is_sleep_enabled(m) and m.opt.solver == types.SolverType.CG and not compact,
+    ),
     dim=(d.nworld, m.nv),
-    inputs=[d.nefc, d.qacc_warmstart, d.qacc_smooth],
+    inputs=[m.dof_treeid, d.nefc, d.qacc_warmstart, d.tree_awake, d.qacc_smooth],
     outputs=[d.qacc, d.qfrc_constraint],
   )
 
@@ -3707,9 +3777,9 @@ def _solve(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = Fa
   # CG search = -Mgrad
   if m.opt.solver == types.SolverType.CG:
     wp.launch_tiled(
-      _solve_init_search_cg_tiled,
+      _solve_init_search_cg_tiled(m.nv, _is_sleep_enabled(m)),
       dim=d.nworld,
-      inputs=[m.nv, ctx.grad, ctx.Mgrad],
+      inputs=[m.dof_treeid, d.tree_awake, ctx.grad, ctx.Mgrad],
       outputs=[ctx.search, ctx.search_dot, ctx.prev_grad, ctx.prev_Mgrad],
       block_dim=m.block_dim.solve_init_search_cg,
     )

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -111,6 +111,11 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
   )
 
 
+def _is_sleep_enabled(m: types.Model) -> bool:
+  """Whether rigid body sleeping is enabled and island discovery is active."""
+  return bool(m.opt.enableflags & types.EnableBit.SLEEP) and not bool(m.opt.disableflags & types.DisableBit.ISLAND)
+
+
 @wp.func
 def _rescale(nv: int, meaninertia: float, value: float) -> float:
   return value / (meaninertia * float(nv))
@@ -821,7 +826,12 @@ def _compute_efc_eval_pt_3alphas_elliptic(
 
 @cache_kernel
 def _linesearch_iterative_kernel(
-  ls_iterations: int, cone_type: types.ConeType, fuse_jv: bool, is_sparse: bool, incremental: bool
+  ls_iterations: int,
+  cone_type: types.ConeType,
+  fuse_jv: bool,
+  is_sparse: bool,
+  incremental: bool,
+  sleep_enabled: bool = False,
 ):
   """Factory for iterative linesearch kernel.
 
@@ -831,12 +841,14 @@ def _linesearch_iterative_kernel(
     fuse_jv: Whether to compute jv = J @ search in-kernel (efficient for small nv).
     is_sparse: Use sparse matrix representation for constraint Jacobian.
     incremental: State changes are tracked: flag exhausted rays, reuse jv on unchanged search.
+    sleep_enabled: Bypasses update for asleep trees.
   """
   LS_ITERATIONS = ls_iterations
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
   FUSE_JV = fuse_jv
   INCREMENTAL = incremental
   IS_SPARSE = is_sparse
+  SLEEP_ENABLED = sleep_enabled
 
   # Native snippet for CUDA __syncthreads()
   @wp.func_native(snippet="WP_TILE_SYNC();")
@@ -861,10 +873,13 @@ def _linesearch_iterative_kernel(
     opt_ls_tolerance: wp.array[float],
     opt_impratio_invsqrt: wp.array[float],
     stat_meaninertia: wp.array[float],
+    body_treeid: wp.array[int],
+    dof_bodyid: wp.array[int],
     # Data in:
     ne_in: wp.array[int],
     nf_in: wp.array[int],
     nefc_in: wp.array[int],
+    tree_awake_in: wp.array2d[int],
     qfrc_smooth_in: wp.array2d[float],
     contact_friction_in: wp.array[types.vec5],
     contact_dim_in: wp.array[int],
@@ -1302,8 +1317,14 @@ def _linesearch_iterative_kernel(
 
     # qacc and Ma update
     for dofid in range(tid, nv, wp.block_dim()):
-      qacc_out[worldid, dofid] += alpha * ctx_search_in[worldid, dofid]
-      efc_Ma_out[worldid, dofid] += alpha * ctx_mv_in[worldid, dofid]
+      if wp.static(SLEEP_ENABLED):
+        treeid = body_treeid[dof_bodyid[dofid]]
+        if tree_awake_in[worldid, treeid] != 0:
+          qacc_out[worldid, dofid] += alpha * ctx_search_in[worldid, dofid]
+          efc_Ma_out[worldid, dofid] += alpha * ctx_mv_in[worldid, dofid]
+      else:
+        qacc_out[worldid, dofid] += alpha * ctx_search_in[worldid, dofid]
+        efc_Ma_out[worldid, dofid] += alpha * ctx_mv_in[worldid, dofid]
 
     # Jaref update
     for efcid in range(tid, nefc, wp.block_dim()):
@@ -1327,8 +1348,9 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
     ctx: SolverContext.
     fuse_jv: Whether jv is computed in-kernel (True) or pre-computed (False).
   """
+  sleep_enabled = _is_sleep_enabled(m) and m.opt.solver == types.SolverType.CG
   wp.launch_tiled(
-    _linesearch_iterative_kernel(m.opt.ls_iterations, m.opt.cone, fuse_jv, m.is_sparse, _use_incremental(m)),
+    _linesearch_iterative_kernel(m.opt.ls_iterations, m.opt.cone, fuse_jv, m.is_sparse, _use_incremental(m), sleep_enabled),
     dim=d.nworld,
     inputs=[
       m.nv,
@@ -1336,9 +1358,12 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
       m.opt.ls_tolerance,
       m.opt.impratio_invsqrt,
       m.stat.meaninertia,
+      m.body_treeid,
+      m.dof_bodyid,
       d.ne,
       d.nf,
       d.nefc,
+      d.tree_awake,
       d.qfrc_smooth,
       d.contact.friction,
       d.contact.dim,
@@ -1615,38 +1640,55 @@ def _solve_init_jaref_kernel(is_sparse: bool, nv: int, dofs_per_thread: int, com
   return kernel
 
 
-@wp.kernel
-def _solve_init_search_cg_tiled(
-  # Model:
-  nv: int,
-  # In:
-  ctx_grad_in: wp.array2d[float],
-  ctx_Mgrad_in: wp.array2d[float],
-  # Out:
-  ctx_search_out: wp.array2d[float],
-  ctx_search_dot_out: wp.array[float],
-  ctx_prev_grad_out: wp.array2d[float],
-  ctx_prev_Mgrad_out: wp.array2d[float],
-):
-  worldid, tid = wp.tid()
+@cache_kernel
+def _solve_init_search_cg_tiled(nv: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
 
-  local_search_dot = float(0.0)
-  BLOCK_DIM = wp.block_dim()
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    body_treeid: wp.array[int],
+    dof_bodyid: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
+    # In:
+    ctx_grad_in: wp.array2d[float],
+    ctx_Mgrad_in: wp.array2d[float],
+    # Out:
+    ctx_search_out: wp.array2d[float],
+    ctx_search_dot_out: wp.array[float],
+    ctx_prev_grad_out: wp.array2d[float],
+    ctx_prev_Mgrad_out: wp.array2d[float],
+  ):
+    worldid, tid = wp.tid()
 
-  for dofid in range(tid, nv, BLOCK_DIM):
-    mgrad = ctx_Mgrad_in[worldid, dofid]
-    search = -1.0 * mgrad
-    ctx_search_out[worldid, dofid] = search
-    local_search_dot += search * search
+    local_search_dot = float(0.0)
+    BLOCK_DIM = wp.block_dim()
 
-    ctx_prev_grad_out[worldid, dofid] = ctx_grad_in[worldid, dofid]
-    ctx_prev_Mgrad_out[worldid, dofid] = mgrad
+    for dofid in range(tid, nv, BLOCK_DIM):
+      if wp.static(SLEEP_ENABLED):
+        treeid = body_treeid[dof_bodyid[dofid]]
+        if tree_awake_in[worldid, treeid] == 0:
+          ctx_search_out[worldid, dofid] = 0.0
+          ctx_prev_grad_out[worldid, dofid] = 0.0
+          ctx_prev_Mgrad_out[worldid, dofid] = 0.0
+          continue
 
-  search_dot_tile = wp.tile(local_search_dot, preserve_type=True)
-  search_dot_sum = wp.tile_reduce(wp.add, search_dot_tile)
+      mgrad = ctx_Mgrad_in[worldid, dofid]
+      search = -1.0 * mgrad
+      ctx_search_out[worldid, dofid] = search
+      local_search_dot += search * search
 
-  if tid == 0:
-    ctx_search_dot_out[worldid] = search_dot_sum[0]
+      ctx_prev_grad_out[worldid, dofid] = ctx_grad_in[worldid, dofid]
+      ctx_prev_Mgrad_out[worldid, dofid] = mgrad
+
+    search_dot_tile = wp.tile(local_search_dot, preserve_type=True)
+    search_dot_sum = wp.tile_reduce(wp.add, search_dot_tile)
+
+    if tid == 0:
+      ctx_search_dot_out[worldid] = search_dot_sum[0]
+
+  return kernel
 
 
 @cache_kernel
@@ -2153,38 +2195,52 @@ def _update_gradient_grad(stable_fast: bool):
   return kernel
 
 
-@wp.kernel
-def _update_gradient_grad_tiled(
-  # Model:
-  nv: int,
-  # Data in:
-  qfrc_smooth_in: wp.array2d[float],
-  qfrc_constraint_in: wp.array2d[float],
-  efc_Ma_in: wp.array2d[float],
-  # In:
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_grad_out: wp.array2d[float],
-  ctx_grad_dot_out: wp.array[float],
-):
-  worldid, tid = wp.tid()
+@cache_kernel
+def _update_gradient_grad_tiled(nv: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    body_treeid: wp.array[int],
+    dof_bodyid: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
+    qfrc_smooth_in: wp.array2d[float],
+    qfrc_constraint_in: wp.array2d[float],
+    efc_Ma_in: wp.array2d[float],
+    # In:
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_grad_out: wp.array2d[float],
+    ctx_grad_dot_out: wp.array[float],
+  ):
+    worldid, tid = wp.tid()
 
-  local_grad_dot = float(0.0)
-  BLOCK_DIM = wp.block_dim()
+    if ctx_done_in[worldid]:
+      return
 
-  for dofid in range(tid, nv, BLOCK_DIM):
-    grad = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - qfrc_constraint_in[worldid, dofid]
-    ctx_grad_out[worldid, dofid] = grad
-    local_grad_dot += grad * grad
+    local_grad_dot = float(0.0)
+    BLOCK_DIM = wp.block_dim()
 
-  grad_dot_tile = wp.tile(local_grad_dot, preserve_type=True)
-  grad_dot_sum = wp.tile_reduce(wp.add, grad_dot_tile)
+    for dofid in range(tid, nv, BLOCK_DIM):
+      if wp.static(SLEEP_ENABLED):
+        treeid = body_treeid[dof_bodyid[dofid]]
+        if tree_awake_in[worldid, treeid] == 0:
+          ctx_grad_out[worldid, dofid] = 0.0
+          continue
 
-  if tid == 0:
-    ctx_grad_dot_out[worldid] = grad_dot_sum[0]
+      grad = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - qfrc_constraint_in[worldid, dofid]
+      ctx_grad_out[worldid, dofid] = grad
+      local_grad_dot += grad * grad
+
+    grad_dot_tile = wp.tile(local_grad_dot, preserve_type=True)
+    grad_dot_sum = wp.tile_reduce(wp.add, grad_dot_tile)
+
+    if tid == 0:
+      ctx_grad_dot_out[worldid] = grad_dot_sum[0]
+
+  return kernel
 
 
 @cache_kernel
@@ -3100,10 +3156,11 @@ def _diag_precond_apply(
 def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = False):
   # grad = Ma - qfrc_smooth - qfrc_constraint
   if m.opt.solver == types.SolverType.CG:
+    sleep_enabled = _is_sleep_enabled(m)
     wp.launch_tiled(
-      _update_gradient_grad_tiled,
+      _update_gradient_grad_tiled(m.nv, sleep_enabled),
       dim=d.nworld,
-      inputs=[m.nv, d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, ctx.done],
+      inputs=[m.body_treeid, m.dof_bodyid, d.tree_awake, d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, ctx.done],
       outputs=[ctx.grad, ctx.grad_dot],
       block_dim=m.block_dim.update_gradient_grad,
     )
@@ -3338,45 +3395,59 @@ def _solve_beta_zero(
   ctx_beta_den_out[worldid] = 0.0
 
 
-@wp.kernel
-def _solve_beta_accumulate_tiled(
-  # Model:
-  nv: int,
-  # In:
-  ctx_grad_in: wp.array2d[float],
-  ctx_Mgrad_in: wp.array2d[float],
-  ctx_prev_grad_in: wp.array2d[float],
-  ctx_prev_Mgrad_in: wp.array2d[float],
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_beta_num_out: wp.array[float],
-  ctx_beta_den_out: wp.array[float],
-):
-  worldid, tid = wp.tid()
+@cache_kernel
+def _solve_beta_accumulate_tiled(nv: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    body_treeid: wp.array[int],
+    dof_bodyid: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
+    # In:
+    ctx_grad_in: wp.array2d[float],
+    ctx_Mgrad_in: wp.array2d[float],
+    ctx_prev_grad_in: wp.array2d[float],
+    ctx_prev_Mgrad_in: wp.array2d[float],
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_beta_num_out: wp.array[float],
+    ctx_beta_den_out: wp.array[float],
+  ):
+    worldid, tid = wp.tid()
 
-  local_num = float(0.0)
-  local_den = float(0.0)
-  BLOCK_DIM = wp.block_dim()
+    if ctx_done_in[worldid]:
+      return
 
-  for dofid in range(tid, nv, BLOCK_DIM):
-    prev_Mgrad = ctx_prev_Mgrad_in[worldid, dofid]
-    num = ctx_grad_in[worldid, dofid] * (ctx_Mgrad_in[worldid, dofid] - prev_Mgrad)
-    den = ctx_prev_grad_in[worldid, dofid] * prev_Mgrad
-    local_num += num
-    local_den += den
+    local_num = float(0.0)
+    local_den = float(0.0)
+    BLOCK_DIM = wp.block_dim()
 
-  num_tile = wp.tile(local_num, preserve_type=True)
-  num_sum = wp.tile_reduce(wp.add, num_tile)
+    for dofid in range(tid, nv, BLOCK_DIM):
+      if wp.static(SLEEP_ENABLED):
+        treeid = body_treeid[dof_bodyid[dofid]]
+        if tree_awake_in[worldid, treeid] == 0:
+          continue
 
-  den_tile = wp.tile(local_den, preserve_type=True)
-  den_sum = wp.tile_reduce(wp.add, den_tile)
+      prev_Mgrad = ctx_prev_Mgrad_in[worldid, dofid]
+      num = ctx_grad_in[worldid, dofid] * (ctx_Mgrad_in[worldid, dofid] - prev_Mgrad)
+      den = ctx_prev_grad_in[worldid, dofid] * prev_Mgrad
+      local_num += num
+      local_den += den
 
-  if tid == 0:
-    ctx_beta_num_out[worldid] = num_sum[0]
-    ctx_beta_den_out[worldid] = den_sum[0]
+    num_tile = wp.tile(local_num, preserve_type=True)
+    num_sum = wp.tile_reduce(wp.add, num_tile)
+
+    den_tile = wp.tile(local_den, preserve_type=True)
+    den_sum = wp.tile_reduce(wp.add, den_tile)
+
+    if tid == 0:
+      ctx_beta_num_out[worldid] = num_sum[0]
+      ctx_beta_den_out[worldid] = den_sum[0]
+
+  return kernel
 
 
 @wp.kernel
@@ -3403,46 +3474,61 @@ def _solve_beta_accumulate(
   wp.atomic_add(ctx_beta_den_out, worldid, den)
 
 
-@wp.kernel
-def _solve_search_update_cg_tiled(
-  # Model:
-  nv: int,
-  # In:
-  ctx_grad_in: wp.array2d[float],
-  ctx_Mgrad_in: wp.array2d[float],
-  ctx_search_in: wp.array2d[float],
-  ctx_beta_in: wp.array[float],
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_search_out: wp.array2d[float],
-  ctx_search_dot_out: wp.array[float],
-  ctx_prev_grad_out: wp.array2d[float],
-  ctx_prev_Mgrad_out: wp.array2d[float],
-):
-  worldid, tid = wp.tid()
+@cache_kernel
+def _solve_search_update_cg_tiled(nv: int, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    body_treeid: wp.array[int],
+    dof_bodyid: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
+    # In:
+    ctx_grad_in: wp.array2d[float],
+    ctx_Mgrad_in: wp.array2d[float],
+    ctx_search_in: wp.array2d[float],
+    ctx_beta_in: wp.array[float],
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_search_out: wp.array2d[float],
+    ctx_search_dot_out: wp.array[float],
+    ctx_prev_grad_out: wp.array2d[float],
+    ctx_prev_Mgrad_out: wp.array2d[float],
+  ):
+    worldid, tid = wp.tid()
 
-  local_search_dot = float(0.0)
-  BLOCK_DIM = wp.block_dim()
-  beta = ctx_beta_in[worldid]
+    if ctx_done_in[worldid]:
+      return
 
-  for dofid in range(tid, nv, BLOCK_DIM):
-    mgrad = ctx_Mgrad_in[worldid, dofid]
-    search = -1.0 * mgrad + beta * ctx_search_in[worldid, dofid]
+    local_search_dot = float(0.0)
+    BLOCK_DIM = wp.block_dim()
+    beta = ctx_beta_in[worldid]
 
-    ctx_search_out[worldid, dofid] = search
-    local_search_dot += search * search
+    for dofid in range(tid, nv, BLOCK_DIM):
+      if wp.static(SLEEP_ENABLED):
+        treeid = body_treeid[dof_bodyid[dofid]]
+        if tree_awake_in[worldid, treeid] == 0:
+          ctx_search_out[worldid, dofid] = 0.0
+          continue
 
-    ctx_prev_grad_out[worldid, dofid] = ctx_grad_in[worldid, dofid]
-    ctx_prev_Mgrad_out[worldid, dofid] = mgrad
+      mgrad = ctx_Mgrad_in[worldid, dofid]
+      search = -1.0 * mgrad + beta * ctx_search_in[worldid, dofid]
 
-  search_dot_tile = wp.tile(local_search_dot, preserve_type=True)
-  search_dot_sum = wp.tile_reduce(wp.add, search_dot_tile)
+      ctx_search_out[worldid, dofid] = search
+      local_search_dot += search * search
 
-  if tid == 0:
-    ctx_search_dot_out[worldid] = search_dot_sum[0]
+      ctx_prev_grad_out[worldid, dofid] = ctx_grad_in[worldid, dofid]
+      ctx_prev_Mgrad_out[worldid, dofid] = mgrad
+
+    search_dot_tile = wp.tile(local_search_dot, preserve_type=True)
+    search_dot_sum = wp.tile_reduce(wp.add, search_dot_tile)
+
+    if tid == 0:
+      ctx_search_dot_out[worldid] = search_dot_sum[0]
+
+  return kernel
 
 
 @wp.kernel
@@ -3588,15 +3674,16 @@ def _solver_iteration(
 
   # polak-ribiere
   if m.opt.solver == types.SolverType.CG:
+    sleep_enabled = _is_sleep_enabled(m)
     wp.launch(
       _solve_beta_zero,
       dim=d.nworld,
       outputs=[ctx.beta, ctx.beta_den],
     )
     wp.launch_tiled(
-      _solve_beta_accumulate_tiled,
+      _solve_beta_accumulate_tiled(m.nv, sleep_enabled),
       dim=d.nworld,
-      inputs=[m.nv, ctx.grad, ctx.Mgrad, ctx.prev_grad, ctx.prev_Mgrad, ctx.done],
+      inputs=[m.body_treeid, m.dof_bodyid, d.tree_awake, ctx.grad, ctx.Mgrad, ctx.prev_grad, ctx.prev_Mgrad, ctx.done],
       outputs=[ctx.beta, ctx.beta_den],
       block_dim=m.block_dim.solve_beta_accumulate,
     )
@@ -3622,9 +3709,9 @@ def _solver_iteration(
       ],
     )
     wp.launch_tiled(
-      _solve_search_update_cg_tiled,
+      _solve_search_update_cg_tiled(m.nv, sleep_enabled),
       dim=d.nworld,
-      inputs=[m.nv, ctx.grad, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
+      inputs=[m.body_treeid, m.dof_bodyid, d.tree_awake, ctx.grad, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
       outputs=[ctx.search, ctx.search_dot, ctx.prev_grad, ctx.prev_Mgrad],
       block_dim=m.block_dim.solve_search_update_cg,
     )
@@ -3713,21 +3800,38 @@ def init_context(m: types.Model, d: types.Data, ctx: SolverContext | InverseCont
 
 @event_scope
 def solve(m: types.Model, d: types.Data):
-  if m.opt.enableflags & types.EnableBit.SLEEP:
+  sleep_enabled = _is_sleep_enabled(m)
+  if sleep_enabled and m.opt.solver == types.SolverType.NEWTON:
     # Self-contained like the island branch below: rebuild the active-DOF mapping from
     # tree_awake so solve() works when called directly (not only via fwd_acceleration).
     island.update_active_dofs(m, d)
     solve_compact(m, d)
-    if m.ntree > 1:
-      island.compute_island_mapping(m, d)
-    return
-
-  if d.njmax == 0 or m.nv == 0:
+  elif d.njmax == 0 or m.nv == 0:
     wp.copy(d.qacc, d.qacc_smooth)
     d.solver_niter.fill_(0)
   else:
     ctx = _create_solver_context(m, d)
     _solve(m, d, ctx)
+
+  if sleep_enabled and m.ntree > 1:
+    island.compute_island_mapping(m, d)
+
+
+@wp.kernel
+def _zero_asleep_qacc(
+  # Model:
+  body_treeid: wp.array[int],
+  dof_bodyid: wp.array[int],
+  # Data in:
+  tree_awake_in: wp.array2d[int],
+  # Data out:
+  qacc_out: wp.array2d[float],
+):
+  worldid, dofid = wp.tid()
+  bodyid = dof_bodyid[dofid]
+  tree = body_treeid[bodyid]
+  if tree >= 0 and tree_awake_in[worldid, tree] == 0:
+    qacc_out[worldid, dofid] = 0.0
 
 
 def _solve(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = False):
@@ -3740,6 +3844,15 @@ def _solve(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = Fa
     outputs=[d.qacc, d.qfrc_constraint],
   )
 
+  sleep_enabled = _is_sleep_enabled(m) and m.opt.solver == types.SolverType.CG
+  if sleep_enabled and not compact:
+    wp.launch(
+      _zero_asleep_qacc,
+      dim=(d.nworld, m.nv),
+      inputs=[m.body_treeid, m.dof_bodyid, d.tree_awake],
+      outputs=[d.qacc],
+    )
+
   #  context
   init_context(m, d, ctx, grad=True, compact=compact)
 
@@ -3750,10 +3863,11 @@ def _solve(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = Fa
 
   # CG search = -Mgrad
   if m.opt.solver == types.SolverType.CG:
+    sleep_enabled = _is_sleep_enabled(m)
     wp.launch_tiled(
-      _solve_init_search_cg_tiled,
+      _solve_init_search_cg_tiled(m.nv, sleep_enabled),
       dim=d.nworld,
-      inputs=[m.nv, ctx.grad, ctx.Mgrad],
+      inputs=[m.body_treeid, m.dof_bodyid, d.tree_awake, ctx.grad, ctx.Mgrad],
       outputs=[ctx.search, ctx.search_dot, ctx.prev_grad, ctx.prev_Mgrad],
       block_dim=m.block_dim.solve_init_search_cg,
     )

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -26,7 +26,9 @@ from mujoco_warp import ConeType
 from mujoco_warp import SolverType
 from mujoco_warp import test_data
 from mujoco_warp._src import island
+from mujoco_warp._src import smooth
 from mujoco_warp._src import solver
+from mujoco_warp._src import support
 from mujoco_warp._src import types
 
 # tolerance for difference between MuJoCo and MJWarp solver calculations - mostly
@@ -1591,6 +1593,255 @@ class CompactSolverTest(absltest.TestCase):
       1e-5,
       f"qfrc_constraint should be zeroed, but got max abs: {np.max(np.abs(qfrc_constraint_post))}",
     )
+
+  def test_cg_sleep_preconditioner(self):
+    """Test smooth.solve_m preconditioner behaves identically when sleep skips asleep trees."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_ARM_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+      },
+    )
+    mjw.forward(m, d)
+
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+
+    y_np = np.random.randn(1, m.nv).astype(np.float32)
+    y_np[0, 2:] = 0.0
+    y = wp.array(y_np, dtype=float)
+
+    x_baseline = wp.zeros_like(y)
+    m.opt.enableflags &= ~types.EnableBit.SLEEP
+    smooth.solve_m(m, d, x_baseline, y)
+
+    x_sleep = wp.zeros_like(y)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+    smooth.solve_m(m, d, x_sleep, y)
+
+    x_baseline_np = x_baseline.numpy()
+    x_sleep_np = x_sleep.numpy()
+
+    np.testing.assert_allclose(x_sleep_np[0, :2], x_baseline_np[0, :2], rtol=1e-5, atol=1e-6)
+    np.testing.assert_array_equal(x_sleep_np[0, 2:], np.zeros(m.nv - 2))
+
+  def test_cg_sleep_matrix_multiplication(self):
+    """Test support.mul_m matrix multiplication skips asleep trees correctly."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_ARM_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+      },
+    )
+    mjw.forward(m, d)
+
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+
+    s_np = np.random.randn(1, m.nv).astype(np.float32)
+    s_np[0, 2:] = 0.0
+    s = wp.array(s_np, dtype=float)
+
+    mv_baseline = wp.zeros_like(s)
+    m.opt.enableflags &= ~types.EnableBit.SLEEP
+    support.mul_m(m, d, mv_baseline, s)
+
+    mv_sleep = wp.zeros_like(s)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+    support.mul_m(m, d, mv_sleep, s)
+
+    mv_baseline_np = mv_baseline.numpy()
+    mv_sleep_np = mv_sleep.numpy()
+
+    np.testing.assert_allclose(mv_sleep_np[0, :2], mv_baseline_np[0, :2], rtol=1e-5, atol=1e-6)
+    np.testing.assert_array_equal(mv_sleep_np[0, 2:], np.zeros(m.nv - 2))
+
+  def test_cg_sleep_solver_correctness(self):
+    """Test end-to-end CG solve outputs match baseline when sleeping is enabled."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+
+    np.testing.assert_allclose(sleep_qacc[0, 0], baseline_qacc[0, 0], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 1:], np.zeros(m.nv - 1))
+
+  def test_cg_sleep_heterogeneous_batch(self):
+    """Test CG sleep with heterogeneous awake/sleep patterns across multiple worlds."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      nworld=4,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    # World 0: Tree 0 awake
+    # World 1: Tree 1 awake
+    # World 2: All trees awake
+    # World 3: All trees asleep
+    d.qacc.zero_()
+    d.tree_awake = wp.array(
+      [
+        [1, 0, 0],
+        [0, 1, 0],
+        [1, 1, 1],
+        [0, 0, 0],
+      ],
+      dtype=int,
+    )
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+
+    # World 0: Tree 0 (dof 0) matches baseline, trees 1 & 2 (dofs 1..12) zero
+    np.testing.assert_allclose(sleep_qacc[0, 0], baseline_qacc[0, 0], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 1:], np.zeros(m.nv - 1))
+
+    # World 1: Tree 1 (dofs 1..6) matches baseline, trees 0 & 2 zero
+    np.testing.assert_array_equal(sleep_qacc[1, :1], np.zeros(1))
+    np.testing.assert_allclose(sleep_qacc[1, 1:7], baseline_qacc[1, 1:7], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[1, 7:], np.zeros(6))
+
+    # World 2: All trees awake match baseline
+    np.testing.assert_allclose(sleep_qacc[2], baseline_qacc[2], rtol=1e-3, atol=1e-4)
+
+    # World 3: All trees asleep are strictly zero
+    np.testing.assert_array_equal(sleep_qacc[3], np.zeros(m.nv))
+
+  def test_cg_sleep_elliptic_cone(self):
+    """Test CG sleep with elliptic friction cone."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      overrides={
+        "opt.cone": ConeType.ELLIPTIC,
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+
+    np.testing.assert_allclose(sleep_qacc[0, 0], baseline_qacc[0, 0], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 1:], np.zeros(m.nv - 1))
+
+  def test_cg_sleep_articulated_chain(self):
+    """Test CG sleep with multi-DOF articulated chain."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_ARM_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    # Case A: Articulated arm (tree 0, 2 DOFs) awake, free bodies asleep
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+    np.testing.assert_allclose(sleep_qacc[0, :2], baseline_qacc[0, :2], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 2:], np.zeros(m.nv - 2))
+
+    # Case B: Articulated arm asleep, ball 0 (tree 1, DOFs 2-7) awake, ball 1 asleep
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[0, 1, 0]], dtype=int)
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+    np.testing.assert_array_equal(sleep_qacc[0, :2], np.zeros(2))
+    np.testing.assert_allclose(sleep_qacc[0, 2:8], baseline_qacc[0, 2:8], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 8:], np.zeros(6))
+
+  def test_cg_sleep_warmstart_transition(self):
+    """Test that warmstart does not pollute asleep tree DOFs."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    m.opt.disableflags &= ~types.DisableBit.WARMSTART
+    d.ctrl = wp.array([[10.0]], dtype=float)
+    mjw.step(m, d)
+
+    # Populate warmstart with non-zero values on all DOFs
+    d.qacc_warmstart = wp.array(np.ones((1, m.nv), dtype=np.float32) * 5.0)
+
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+    self.assertNotEqual(sleep_qacc[0, 0], 0.0)
+    np.testing.assert_array_equal(sleep_qacc[0, 1:], np.zeros(m.nv - 1))
+
+  def test_cg_sleep_island_disable_bit(self):
+    """Test that DisableBit.ISLAND disables sleeping behavior in CG solver."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+    m.opt.disableflags |= types.DisableBit.ISLAND
+
+    solver.solve(m, d)
+
+    qacc_solved = d.qacc.numpy()
+    np.testing.assert_allclose(qacc_solved, baseline_qacc, rtol=1e-3, atol=1e-4)
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -26,7 +26,9 @@ from mujoco_warp import ConeType
 from mujoco_warp import SolverType
 from mujoco_warp import test_data
 from mujoco_warp._src import island
+from mujoco_warp._src import smooth
 from mujoco_warp._src import solver
+from mujoco_warp._src import support
 from mujoco_warp._src import types
 
 # tolerance for difference between MuJoCo and MJWarp solver calculations - mostly
@@ -1485,6 +1487,255 @@ class CompactSolverTest(absltest.TestCase):
       1e-5,
       f"qfrc_constraint should be zeroed, but got max abs: {np.max(np.abs(qfrc_constraint_post))}",
     )
+
+  def test_cg_sleep_preconditioner(self):
+    """Test smooth.solve_m preconditioner behaves identically when sleep skips asleep trees."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_ARM_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+      },
+    )
+    mjw.forward(m, d)
+
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+
+    y_np = np.random.randn(1, m.nv).astype(np.float32)
+    y_np[0, 2:] = 0.0
+    y = wp.array(y_np, dtype=float)
+
+    x_baseline = wp.zeros_like(y)
+    m.opt.enableflags &= ~types.EnableBit.SLEEP
+    smooth.solve_m(m, d, x_baseline, y)
+
+    x_sleep = wp.zeros_like(y)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+    smooth.solve_m(m, d, x_sleep, y)
+
+    x_baseline_np = x_baseline.numpy()
+    x_sleep_np = x_sleep.numpy()
+
+    np.testing.assert_allclose(x_sleep_np[0, :2], x_baseline_np[0, :2], rtol=1e-5, atol=1e-6)
+    np.testing.assert_array_equal(x_sleep_np[0, 2:], np.zeros(m.nv - 2))
+
+  def test_cg_sleep_matrix_multiplication(self):
+    """Test support.mul_m matrix multiplication skips asleep trees correctly."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_ARM_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+      },
+    )
+    mjw.forward(m, d)
+
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+
+    s_np = np.random.randn(1, m.nv).astype(np.float32)
+    s_np[0, 2:] = 0.0
+    s = wp.array(s_np, dtype=float)
+
+    mv_baseline = wp.zeros_like(s)
+    m.opt.enableflags &= ~types.EnableBit.SLEEP
+    support.mul_m(m, d, mv_baseline, s)
+
+    mv_sleep = wp.zeros_like(s)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+    support.mul_m(m, d, mv_sleep, s)
+
+    mv_baseline_np = mv_baseline.numpy()
+    mv_sleep_np = mv_sleep.numpy()
+
+    np.testing.assert_allclose(mv_sleep_np[0, :2], mv_baseline_np[0, :2], rtol=1e-5, atol=1e-6)
+    np.testing.assert_array_equal(mv_sleep_np[0, 2:], np.zeros(m.nv - 2))
+
+  def test_cg_sleep_solver_correctness(self):
+    """Test end-to-end CG solve outputs match baseline when sleeping is enabled."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+
+    np.testing.assert_allclose(sleep_qacc[0, 0], baseline_qacc[0, 0], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 1:], np.zeros(m.nv - 1))
+
+  def test_cg_sleep_heterogeneous_batch(self):
+    """Test CG sleep with heterogeneous awake/sleep patterns across multiple worlds."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      nworld=4,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    # World 0: Tree 0 awake
+    # World 1: Tree 1 awake
+    # World 2: All trees awake
+    # World 3: All trees asleep
+    d.qacc.zero_()
+    d.tree_awake = wp.array(
+      [
+        [1, 0, 0],
+        [0, 1, 0],
+        [1, 1, 1],
+        [0, 0, 0],
+      ],
+      dtype=int,
+    )
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+
+    # World 0: Tree 0 (dof 0) matches baseline, trees 1 & 2 (dofs 1..12) zero
+    np.testing.assert_allclose(sleep_qacc[0, 0], baseline_qacc[0, 0], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 1:], np.zeros(m.nv - 1))
+
+    # World 1: Tree 1 (dofs 1..6) matches baseline, trees 0 & 2 zero
+    np.testing.assert_array_equal(sleep_qacc[1, :1], np.zeros(1))
+    np.testing.assert_allclose(sleep_qacc[1, 1:7], baseline_qacc[1, 1:7], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[1, 7:], np.zeros(6))
+
+    # World 2: All trees awake match baseline
+    np.testing.assert_allclose(sleep_qacc[2], baseline_qacc[2], rtol=1e-3, atol=1e-4)
+
+    # World 3: All trees asleep are strictly zero
+    np.testing.assert_array_equal(sleep_qacc[3], np.zeros(m.nv))
+
+  def test_cg_sleep_elliptic_cone(self):
+    """Test CG sleep with elliptic friction cone."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      overrides={
+        "opt.cone": ConeType.ELLIPTIC,
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+
+    np.testing.assert_allclose(sleep_qacc[0, 0], baseline_qacc[0, 0], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 1:], np.zeros(m.nv - 1))
+
+  def test_cg_sleep_articulated_chain(self):
+    """Test CG sleep with multi-DOF articulated chain."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_ARM_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    # Case A: Articulated arm (tree 0, 2 DOFs) awake, free bodies asleep
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+    np.testing.assert_allclose(sleep_qacc[0, :2], baseline_qacc[0, :2], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 2:], np.zeros(m.nv - 2))
+
+    # Case B: Articulated arm asleep, ball 0 (tree 1, DOFs 2-7) awake, ball 1 asleep
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[0, 1, 0]], dtype=int)
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+    np.testing.assert_array_equal(sleep_qacc[0, :2], np.zeros(2))
+    np.testing.assert_allclose(sleep_qacc[0, 2:8], baseline_qacc[0, 2:8], rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(sleep_qacc[0, 8:], np.zeros(6))
+
+  def test_cg_sleep_warmstart_transition(self):
+    """Test that warmstart does not pollute asleep tree DOFs."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    m.opt.disableflags &= ~types.DisableBit.WARMSTART
+    d.ctrl = wp.array([[10.0]], dtype=float)
+    mjw.step(m, d)
+
+    # Populate warmstart with non-zero values on all DOFs
+    d.qacc_warmstart = wp.array(np.ones((1, m.nv), dtype=np.float32) * 5.0)
+
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+
+    solver.solve(m, d)
+
+    sleep_qacc = d.qacc.numpy()
+    self.assertNotEqual(sleep_qacc[0, 0], 0.0)
+    np.testing.assert_array_equal(sleep_qacc[0, 1:], np.zeros(m.nv - 1))
+
+  def test_cg_sleep_island_disable_bit(self):
+    """Test that DisableBit.ISLAND disables sleeping behavior in CG solver."""
+    _, _, m, d = test_data.fixture(
+      xml=_COMPACT_CONTACT_XML,
+      overrides={
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.solver": types.SolverType.CG,
+        "opt.iterations": 30,
+      },
+    )
+    mjw.forward(m, d)
+
+    baseline_qacc = d.qacc.numpy().copy()
+
+    d.qacc.zero_()
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
+    m.opt.enableflags |= types.EnableBit.SLEEP
+    m.opt.disableflags |= types.DisableBit.ISLAND
+
+    solver.solve(m, d)
+
+    qacc_solved = d.qacc.numpy()
+    np.testing.assert_allclose(qacc_solved, baseline_qacc, rtol=1e-3, atol=1e-4)
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -22,6 +22,7 @@ from mujoco_warp._src.types import MJ_MINVAL
 from mujoco_warp._src.types import ConeType
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import DynType
+from mujoco_warp._src.types import EnableBit
 from mujoco_warp._src.types import JointType
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import State
@@ -151,15 +152,20 @@ def compute_interp_cell_quat(
 
 
 @cache_kernel
-def mul_m_kernel(check_skip: bool):
+def mul_m_kernel(check_skip: bool, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
+
   @wp.kernel(module="unique", grid_stride=False)
   def _mul_m(
     # Model:
+    body_treeid: wp.array[int],
+    dof_bodyid: wp.array[int],
     M_mulm_rowadr: wp.array[int],
     M_mulm_col: wp.array[int],
     M_mulm_madr: wp.array[int],
     # Data in:
     M_in: wp.array2d[float],
+    tree_awake_in: wp.array2d[int],
     # In:
     vec: wp.array2d[float],
     skip: wp.array[bool],
@@ -171,6 +177,12 @@ def mul_m_kernel(check_skip: bool):
 
     if wp.static(check_skip):
       if skip[worldid]:
+        return
+
+    if wp.static(SLEEP_ENABLED):
+      treeid = body_treeid[dof_bodyid[dofid]]
+      if tree_awake_in[worldid, treeid] == 0:
+        res[worldid, dofid] = 0.0
         return
 
     # Gather all contributions (diagonal + off-diagonal).
@@ -248,10 +260,11 @@ def mul_m(
       outputs=[res],
     )
   else:
+    sleep_enabled = bool(m.opt.enableflags & EnableBit.SLEEP)
     wp.launch(
-      mul_m_kernel(check_skip),
+      mul_m_kernel(check_skip, sleep_enabled),
       dim=(d.nworld, m.nv),
-      inputs=[m.M_mulm_rowadr, m.M_mulm_col, m.M_mulm_madr, M, vec, skip],
+      inputs=[m.body_treeid, m.dof_bodyid, m.M_mulm_rowadr, m.M_mulm_col, m.M_mulm_madr, M, d.tree_awake, vec, skip],
       outputs=[res],
     )
 

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -21,7 +21,9 @@ from mujoco_warp._src.math import motion_cross
 from mujoco_warp._src.types import MJ_MINVAL
 from mujoco_warp._src.types import ConeType
 from mujoco_warp._src.types import Data
+from mujoco_warp._src.types import DisableBit
 from mujoco_warp._src.types import DynType
+from mujoco_warp._src.types import EnableBit
 from mujoco_warp._src.types import JointType
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import State
@@ -151,15 +153,19 @@ def compute_interp_cell_quat(
 
 
 @cache_kernel
-def mul_m_kernel(check_skip: bool):
+def mul_m_kernel(check_skip: bool, sleep_enabled: bool = False):
+  SLEEP_ENABLED = sleep_enabled
+
   @wp.kernel(module="unique", grid_stride=False)
   def _mul_m(
     # Model:
+    dof_treeid: wp.array[int],
     M_mulm_rowadr: wp.array[int],
     M_mulm_col: wp.array[int],
     M_mulm_madr: wp.array[int],
     # Data in:
     M_in: wp.array2d[float],
+    tree_awake_in: wp.array2d[int],
     # In:
     vec: wp.array2d[float],
     skip: wp.array[bool],
@@ -171,6 +177,12 @@ def mul_m_kernel(check_skip: bool):
 
     if wp.static(check_skip):
       if skip[worldid]:
+        return
+
+    if wp.static(SLEEP_ENABLED):
+      treeid = dof_treeid[dofid]
+      if tree_awake_in[worldid, treeid] == 0:
+        res[worldid, dofid] = 0.0
         return
 
     # Gather all contributions (diagonal + off-diagonal).
@@ -248,10 +260,11 @@ def mul_m(
       outputs=[res],
     )
   else:
+    sleep_enabled = bool(m.opt.enableflags & EnableBit.SLEEP) and not bool(m.opt.disableflags & DisableBit.ISLAND)
     wp.launch(
-      mul_m_kernel(check_skip),
+      mul_m_kernel(check_skip, sleep_enabled),
       dim=(d.nworld, m.nv),
-      inputs=[m.M_mulm_rowadr, m.M_mulm_col, m.M_mulm_madr, M, vec, skip],
+      inputs=[m.dof_treeid, m.M_mulm_rowadr, m.M_mulm_col, m.M_mulm_madr, M, d.tree_awake, vec, skip],
       outputs=[res],
     )
 


### PR DESCRIPTION
cg solver + sleeping islands

unlike the compact solver that compresses the active islands into dense matrices, this approach simply skips parts of the code for components in islands that are asleep. this enables minimal changes to the source code while enabling sleeping for the cg solver.

one use case for this feature will be to enable sleeping for scenes with flex objects.

---

aloha clutter benchmark

```
uv run mjwarp-testspeed /tmp/benchmark_assets/aloha_clutter/scene_clutter.xml --clear_warp_cache=True --format=short --event_trace=true --memory=true --measure_solver=true --measure_alloc=true --nworld=2048 --nconmax=256 --nccdmax=16 --njmax=384 --nvmax=56 --override=opt.enableflags=SLEEP --override=opt.solver=cg --init_asleep=True --replay=/tmp/benchmark_assets/aloha_clutter/pick_clutter.npz
aloha_clutter.jit_duration: 109.93421121797292
aloha_clutter.run_time: 37.78987904184032
aloha_clutter.steps_per_second: 149088.8074492664
aloha_clutter.converged_worlds: 2048
aloha_clutter.model_memory: 41310126
aloha_clutter.data_memory: 463720464
aloha_clutter.total_memory: 958398464
aloha_clutter.ncon_mean: 7.490419321951109
aloha_clutter.ncon_p95: 18.625732421875
aloha_clutter.nefc_mean: 99.67393675027263
aloha_clutter.nefc_p95: 192.0
aloha_clutter.solver_niter_mean: 41.49668089444747
aloha_clutter.solver_niter_p95: 100.0
aloha_clutter.step: 6700.878753614592
aloha_clutter.step.euler: 153.30552436530377
aloha_clutter.step.euler.sleep: 31.355870659969224
aloha_clutter.step.euler.update_sleep: 6.781534024738371
aloha_clutter.step.euler.fwd_velocity: 81.31424955060463
aloha_clutter.step.euler.fwd_velocity.passive: 29.199928066955234
aloha_clutter.step.euler.fwd_velocity.com_vel: 23.84095582299293
aloha_clutter.step.euler.fwd_velocity.rne: 22.372046826315145
aloha_clutter.step.euler.fwd_velocity.tendon_bias: 0.6913849491813565
aloha_clutter.step.forward: 6545.424725256403
aloha_clutter.step.forward.sensor_pos: 0.686295890670032
aloha_clutter.step.forward.update_sleep: 6.883650281608698
aloha_clutter.step.forward.fwd_position: 1650.9894594267114
aloha_clutter.step.forward.fwd_position.update_sleep[0]: 7.149945479649403
aloha_clutter.step.forward.fwd_position.update_sleep[1]: 6.654125816002429
aloha_clutter.step.forward.fwd_position.collision[0]: 1244.9352988554824
aloha_clutter.step.forward.fwd_position.collision[1]: 165.7304611623494
aloha_clutter.step.forward.fwd_position.collision.convex_narrowphase[0]: 579.9325704209122
aloha_clutter.step.forward.fwd_position.collision.convex_narrowphase[1]: 34.559251176848136
aloha_clutter.step.forward.fwd_position.collision.primitive_narrowphase[0]: 10.16988134909994
aloha_clutter.step.forward.fwd_position.collision.primitive_narrowphase[1]: 6.828789567809858
aloha_clutter.step.forward.fwd_position.collision.nxn_broadphase[0]: 651.2466333601699
aloha_clutter.step.forward.fwd_position.collision.nxn_broadphase[1]: 121.07997070558699
aloha_clutter.step.forward.fwd_position.island: 39.22664498985549
aloha_clutter.step.forward.fwd_position.island.flood_fill: 30.089422646986208
aloha_clutter.step.forward.fwd_position.island.tree_edges: 5.60566613434899
aloha_clutter.step.forward.fwd_position.wake_equality: 2.601962894928208
aloha_clutter.step.forward.fwd_position.transmission: 3.7637223001654334
aloha_clutter.step.forward.fwd_position.wake_collision: 2.5025217842331413
aloha_clutter.step.forward.fwd_position.tendon_armature: 0.6912031970916663
aloha_clutter.step.forward.fwd_position.make_constraint: 49.40948747720089
aloha_clutter.step.forward.fwd_position.fwd_kinematics: 96.21119648388272
aloha_clutter.step.forward.fwd_position.fwd_kinematics.camlight: 5.215376173428538
aloha_clutter.step.forward.fwd_position.fwd_kinematics.com_pos: 35.18593338465984
aloha_clutter.step.forward.fwd_position.fwd_kinematics.tendon: 0.6893856761947648
aloha_clutter.step.forward.fwd_position.fwd_kinematics.flex: 0.6806615758896372
aloha_clutter.step.forward.fwd_position.fwd_kinematics.kinematics: 50.27480799023183
aloha_clutter.step.forward.fwd_position.crb: 21.844965586447152
aloha_clutter.step.forward.sensor_vel: 0.6930207179885679
aloha_clutter.step.forward.fwd_actuation: 5.825154641814393
aloha_clutter.step.forward.wake: 7.952085568815666
aloha_clutter.step.forward.sensor_acc: 8.347146577606317
aloha_clutter.step.forward.fwd_velocity: 81.14991720782925
aloha_clutter.step.forward.fwd_velocity.passive: 29.37622762300661
aloha_clutter.step.forward.fwd_velocity.com_vel: 24.576034709776806
aloha_clutter.step.forward.fwd_velocity.rne: 21.530352611891466
aloha_clutter.step.forward.fwd_velocity.tendon_bias: 0.6924754617194974
aloha_clutter.step.forward.fwd_acceleration: 30.93947611548545
aloha_clutter.step.forward.fwd_acceleration.xfrc_accumulate: 7.737248849041525
aloha_clutter.step.forward.solve: 4743.4429310952655
aloha_clutter.step.forward.solve.mul_m: 4.637586404590394
aloha_clutter.step.forward.solve.solve_m: 7.744820205476586
aloha_clutter.step.forward.solve.compute_island_mapping: 30.969283884261994
```

without enableflags=sleep and init_asleep there are overflows
```
uv run mjwarp-testspeed /tmp/benchmark_assets/aloha_clutter/scene_clutter.xml --format=short --event_trace=true --memory=true --measure_solver=true --measure_alloc=true --nworld=2048 --nconmax=256 --nccdmax=16 --njmax=384 --nvmax=56  --override=opt.solver=cg --replay=/tmp/benchmark
_assets/aloha_clutter/pick_clutter.npz
warning: `VIRTUAL_ENV=env` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead

Simulation aborted: overflow detected in 2048 worlds:
  World 0: BROADPHASE
  World 1: BROADPHASE
  World 2: BROADPHASE
  World 3: BROADPHASE
  World 4: BROADPHASE
  World 5: BROADPHASE
  World 6: BROADPHASE
  World 7: BROADPHASE
  World 8: BROADPHASE
  World 9: BROADPHASE
  ... and 2038 more worlds (reporting truncated to first 10)
```