### PR TITLE
Use 1 thread per constraint for sparse J@v products

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1380,8 +1380,13 @@ def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext):
 
   # jv = J @ search (when not fused into iterative kernel)
   if not fuse_jv:
-    dofs_per_thread = 20 if m.nv > 50 else 50
-    threads_per_efc = ceil(m.nv / dofs_per_thread)
+    if m.is_sparse:
+      # Sparse J has few nonzeros per row, one thread handles them all.
+      dofs_per_thread = m.nv
+      threads_per_efc = 1
+    else:
+      dofs_per_thread = 20 if m.nv > 50 else 50
+      threads_per_efc = ceil(m.nv / dofs_per_thread)
 
     if threads_per_efc > 1:
       wp.launch(
@@ -3400,12 +3405,16 @@ def init_context(m: types.Model, d: types.Data, ctx: SolverContext | InverseCont
   # if we are only using 1 thread, it makes sense to do more dofs as we can also skip the
   # init kernel. For more than 1 thread, dofs_per_thread is lower for better load balancing.
 
-  if m.nv > 50:
+  if m.is_sparse:
+    # Sparse J has few nonzeros per row, one thread handles them all.
+    dofs_per_thread = m.nv
+    threads_per_efc = 1
+  elif m.nv > 50:
     dofs_per_thread = 20
+    threads_per_efc = ceil(m.nv / dofs_per_thread)
   else:
     dofs_per_thread = 50
-
-  threads_per_efc = ceil(m.nv / dofs_per_thread)
+    threads_per_efc = ceil(m.nv / dofs_per_thread)
   # we need to clear the jaref array if we're doing atomic adds.
   if threads_per_efc > 1:
     ctx.Jaref.zero_()


### PR DESCRIPTION
For sparse Jacobians (e.g. cloth), two solver kernels — `_linesearch_jv_fused_kernel` and `_solve_init_jaref_kernel` — were launching `ceil(nv / 20)` threads per constraint row to parallelize the `J @ v` dot product across DOFs. However, in sparse mode each row has very few nonzeros (typically ~6), and:

- **`jv` kernel**: only thread 0 does any work (`if dofstart == 0`); the other 135 threads immediately return
- **`jaref` kernel**: all 136 threads redundantly compute the identical sparse dot product and write to the same output location

For the cloth benchmark (`nv=2706`), this means `ceil(2706/20) = 136` threads per row, with **99.3% thread waste**.

When `is_sparse`, set `threads_per_efc = 1` and `dofs_per_thread = nv`, routing into the existing single-thread sparse code path that efficiently iterates over `rownnz` entries. The dense code path is completely unchanged.

## Benchmarks (RTX A4000)

### cloth (`nworld=32`)

| | Steps/sec | Solver iters |
|--|-----------|-------------|
| `main` | 500 | 27.7 |
| This PR | **812** | 27.5 |
| **Change** | **+63%** | same |

### aloha_cloth (`nworld=32`)

| | Steps/sec | Solver iters |
|--|-----------|-------------|
| `main` | 151 | 64.6 |
| This PR | **242** | 65.0 |
| **Change** | **+60%** | same |
