### PR TITLE
flex-ellipsoid collisions

### DIFF
--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -81,7 +81,6 @@ MJ_COLLISION_TABLE = {
 
 # TODO(team): Implement narrowphase flex collision support for:
 #             - HFIELD
-#             - ELLIPSOID
 #             - SDF
 MJ_FLEX_COLLISION_TABLE = {
   (GeomType.PLANE, GeomType.FLEX): CollisionType.PRIMITIVE,
@@ -90,6 +89,7 @@ MJ_FLEX_COLLISION_TABLE = {
   (GeomType.BOX, GeomType.FLEX): CollisionType.PRIMITIVE,
   (GeomType.CYLINDER, GeomType.FLEX): CollisionType.PRIMITIVE,
   (GeomType.MESH, GeomType.FLEX): CollisionType.CONVEX,
+  (GeomType.ELLIPSOID, GeomType.FLEX): CollisionType.CONVEX,
 }
 
 

--- a/mujoco_warp/_src/collision_flex.py
+++ b/mujoco_warp/_src/collision_flex.py
@@ -131,6 +131,7 @@ def _flex_triangle_geom_broadphase(
     and gtype != int(GeomType.BOX)
     and gtype != int(GeomType.CYLINDER)
     and gtype != int(GeomType.MESH)
+    and gtype != int(GeomType.ELLIPSOID)
   ):
     return
 
@@ -189,6 +190,8 @@ def _flex_triangle_geom_broadphase(
   elif gtype == int(GeomType.BOX):
     r_extent = wp.length(geom_half_size_local)
   elif gtype == int(GeomType.MESH):
+    r_extent = wp.length(geom_half_size_local)
+  elif gtype == int(GeomType.ELLIPSOID):
     r_extent = wp.length(geom_half_size_local)
 
   if wp.abs(signed_dist) > r_extent + margin + tri_radius:
@@ -827,7 +830,7 @@ def _collide_mesh_triangle(
   geom2.margin = 0.0
   geom2.index = -1
 
-  centroid = (t1 + t2 + t3) * (1.0 / 3.0)
+  centroid = (t1 + t2 + t3) * wp.static(1.0 / 3.0)
   r_geom = wp.length(geom_size_val)
   d1 = wp.length(t1 - centroid)
   d2 = wp.length(t2 - centroid)
@@ -1990,6 +1993,7 @@ def _flex_narrowphase_unified(
     and gtype != int(GeomType.BOX)
     and gtype != int(GeomType.CYLINDER)
     and gtype != int(GeomType.MESH)
+    and gtype != int(GeomType.ELLIPSOID)
   ):
     return
 
@@ -2078,6 +2082,103 @@ def _flex_narrowphase_unified(
         cand_geomcollisionid_out,
         ncand_out,
       )
+  elif gtype == int(GeomType.ELLIPSOID):
+    ccdid = wp.atomic_add(nccd, 0, 1)
+    if ccdid >= naccdmax_in:
+      if opt_warn_overflow:
+        wp.printf("CCD overflow in flex narrowphase - please increase naccdmax to %u\n", ccdid)
+      wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.CCD))
+    else:
+      tolerance = opt_ccd_tolerance[worldid % opt_ccd_tolerance.shape[0]]
+
+      # Construct Ellipsoid Geom (geom1)
+      geom1 = Geom()
+      geom1.pos = geom_pos
+      geom1.rot = geom_rot
+      geom1.size = geom_size_val
+      geom1.margin = 0.0
+      geom1.index = -1
+
+      # Construct Triangle Geom (geom2)
+      geom2 = Geom()
+      geom2.pos = wp.vec3(0.0, 0.0, 0.0)
+      geom2.rot = wp.mat33(t1[0], t1[1], t1[2], t2[0], t2[1], t2[2], t3[0], t3[1], t3[2])
+      geom2.margin = 0.0
+      geom2.index = -1
+
+      centroid = (t1 + t2 + t3) * wp.static(1.0 / 3.0)
+      r_geom = wp.length(geom_size_val)
+      d1 = wp.length(t1 - centroid)
+      d2 = wp.length(t2 - centroid)
+      d3 = wp.length(t3 - centroid)
+      r_tri = wp.max(d1, wp.max(d2, d3))
+
+      if wp.length(centroid - geom_pos) <= r_geom + r_tri + margin + tri_radius + 0.04:
+        dist, ncontact, w1, w2, idx = ccd(
+          tolerance,
+          margin + tri_radius,
+          ccd_iterations,
+          ccd_iterations,
+          geom1,
+          geom2,
+          int(GeomType.ELLIPSOID),
+          int(GeomType.TRIANGLE),
+          geom_pos,
+          centroid,
+          epa_vert[ccdid],
+          epa_vert_index[ccdid],
+          epa_face[ccdid],
+          epa_pr[ccdid],
+          epa_norm2[ccdid],
+          epa_horizon[ccdid],
+        )
+
+        if ncontact > 0 and dist < margin + tri_radius:
+          if _inside_triangle(w2, t1, t2, t3, 0.2):
+            if dist < 0.0:
+              normal = wp.normalize(w1 - w2)
+            else:
+              normal = wp.normalize(w2 - w1)
+
+            # Project triangle vertices onto normal to find deepest penetration
+            dist_v0 = wp.dot(t1 - w1, normal) - tri_radius
+            dist_v1 = wp.dot(t2 - w1, normal) - tri_radius
+            dist_v2 = wp.dot(t3 - w1, normal) - tri_radius
+
+            min_dist = wp.min(dist_v0, wp.min(dist_v1, dist_v2))
+            if min_dist < margin:
+              deepest_vert = v0_local
+              pos = t1 - normal * (tri_radius + 0.5 * dist_v0)
+              if dist_v1 < dist_v0 and dist_v1 < dist_v2:
+                deepest_vert = v1_local
+                pos = t2 - normal * (tri_radius + 0.5 * dist_v1)
+              elif dist_v2 < dist_v0 and dist_v2 < dist_v1:
+                deepest_vert = v2_local
+                pos = t3 - normal * (tri_radius + 0.5 * dist_v2)
+
+              _write_candidate_contact(
+                max_candidates,
+                min_dist,
+                pos,
+                normal,
+                geomid,
+                flexid,
+                local_tri_id,
+                -1,
+                worldid,
+                overflow_out,
+                cand_dist_out,
+                cand_pos_out,
+                cand_nrm_out,
+                cand_geom_out,
+                cand_flex_out,
+                cand_elem_out,
+                cand_vert_out,
+                cand_worldid_out,
+                cand_type_out,
+                cand_geomcollisionid_out,
+                ncand_out,
+              )
   else:
     _collide_geom_triangle_detect(
       max_candidates,
@@ -2517,7 +2618,7 @@ def flex_collision(m: Model, d: Data, ctx):
 
   # EPA workspaces if mesh or self collisions are possible
   epa_iterations = m.opt.ccd_iterations
-  if m.nmesh > 0:
+  if m.nmesh > 0 or m.has_ellipsoid_geom:
     mesh_epa_vert = wp.empty(shape=(d.naccdmax, 10 + 2 * epa_iterations), dtype=wp.vec3)
     mesh_epa_vert_index = wp.empty(shape=(d.naccdmax, 10 + 2 * epa_iterations), dtype=int)
     mesh_epa_face = wp.empty(shape=(d.naccdmax, 6 + MJ_MAX_EPAFACES * epa_iterations), dtype=int)

--- a/mujoco_warp/_src/collision_flex_test.py
+++ b/mujoco_warp/_src/collision_flex_test.py
@@ -15,12 +15,13 @@
 
 import numpy as np
 from absl.testing import absltest
+from absl.testing import parameterized
 
 import mujoco_warp as mjwarp
 from mujoco_warp import test_data
 
 
-class FlexCollisionTest(absltest.TestCase):
+class FlexCollisionTest(parameterized.TestCase):
   """Tests for flex element collision detection."""
 
   def test_sphere_cloth_contact_generated(self):
@@ -618,6 +619,91 @@ class FlexCollisionTest(absltest.TestCase):
 
     nacon = int(d.nacon.numpy()[0])
     self.assertGreater(nacon, 0, "Expected contacts to be generated")
+
+  def test_ellipsoid_cloth_contact_generated(self):
+    """Test that contacts are generated between ellipsoid and cloth."""
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option solver="CG" tolerance="1e-6" timestep=".001"/>
+        <size memory="10M"/>
+
+        <worldbody>
+          <light pos="0 0 3" dir="0 0 -1"/>
+
+          <!-- Ground plane -->
+          <geom type="plane" size="5 5 .1" pos="0 0 0"/>
+
+          <!-- Ellipsoid positioned just above the cloth -->
+          <body pos="0 0 0.12">
+            <freejoint/>
+            <geom type="ellipsoid" size=".1 .15 .08" mass="1"/>
+          </body>
+
+          <!-- Cloth (dim=2 flex) -->
+          <flexcomp type="grid" count="4 4 1" spacing=".2 .2 .1" pos="-.3 -.3 0"
+                    radius=".02" name="cloth" dim="2" mass=".5">
+            <contact condim="3" solref="0.01 1" solimp=".95 .99 .0001"
+                     selfcollide="none" conaffinity="1" contype="1"/>
+            <edge damping="0.01"/>
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """
+    )
+
+    self.assertEqual(mjm.nflex, 1)
+    self.assertEqual(mjm.flex_dim[0], 2)
+
+    self.assertEqual(m.nflex, 1)
+    self.assertGreater(m.flex_elemnum.numpy()[0], 0)
+
+    mjwarp.kinematics(m, d)
+    mjwarp.collision(m, d)
+
+    nacon = int(d.nacon.numpy()[0])
+
+    # Ellipsoid is just above the cloth, so there should be contacts
+    self.assertGreater(nacon, 0, "Expected contacts between ellipsoid and cloth")
+
+  @parameterized.named_parameters(
+    (
+      "hfield",
+      """
+      <mujoco>
+        <asset>
+          <hfield name="terrain" nrow="2" ncol="2" size="1 1 0.1 0.1" elevation="0 0 0 0"/>
+        </asset>
+        <worldbody>
+          <geom type="hfield" hfield="terrain"/>
+          <flexcomp type="grid" count="2 2 1" spacing=".2 .2 .1" pos="0 0 0.1" name="cloth" dim="2"/>
+        </worldbody>
+      </mujoco>
+      """,
+    ),
+    (
+      "sdf",
+      """
+      <mujoco>
+        <asset>
+          <mesh name="cube"
+           vertex="1 1 1  1 1 -1  1 -1 1  1 -1 -1  -1 1 1  -1 1 -1  -1 -1 1  -1 -1 -1"/>
+        </asset>
+        <worldbody>
+          <body pos="0 0 1">
+            <freejoint/>
+            <geom type="sdf" mesh="cube"/>
+          </body>
+          <flexcomp type="grid" count="2 2 1" spacing=".2 .2 .1" pos="0 0 0.1" name="cloth" dim="2"/>
+        </worldbody>
+      </mujoco>
+      """,
+    ),
+  )
+  def test_unsupported_flex_collision_error(self, xml):
+    """Test that loading a model with unsupported geoms and Flex raises NotImplementedError."""
+    with self.assertRaises(NotImplementedError):
+      test_data.fixture(xml=xml)
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -454,9 +454,14 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   condim_arrays = [np.array([0]), mjm.geom_condim, mjm.pair_dim]
   if mjm.nflex > 0:
     condim_arrays.append(mjm.flex_condim)
+    if (mjm.geom_type == mujoco.mjtGeom.mjGEOM_SDF).any():
+      raise NotImplementedError("Flex-SDF collision is not implemented.")
+    if (mjm.geom_type == mujoco.mjtGeom.mjGEOM_HFIELD).any():
+      raise NotImplementedError("Flex-HField collision is not implemented.")
   m.nmaxcondim = np.concatenate(condim_arrays).max()
   m.nmaxpyramid = np.maximum(1, 2 * (m.nmaxcondim - 1))
   m.has_sdf_geom = (mjm.geom_type == mujoco.mjtGeom.mjGEOM_SDF).any()
+  m.has_ellipsoid_geom = (mjm.geom_type == mujoco.mjtGeom.mjGEOM_ELLIPSOID).any()
   m.has_flex_selfcollide = bool(mjm.nflex > 0 and np.any(mjm.flex_selfcollide != 0))
   m.has_trilinear = bool(mjm.nflex > 0 and np.any(mjm.flex_interp == 1))
   m.max_flex_dim = int(np.max(mjm.flex_dim)) if mjm.nflex > 0 else 0
@@ -1079,6 +1084,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
           mujoco.mjtGeom.mjGEOM_BOX,
           mujoco.mjtGeom.mjGEOM_CYLINDER,
           mujoco.mjtGeom.mjGEOM_MESH,
+          mujoco.mjtGeom.mjGEOM_ELLIPSOID,
         ],
       )
       is_pl = mjm.geom_type == mujoco.mjtGeom.mjGEOM_PLANE

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1342,6 +1342,7 @@ class Model:
     has_sdf_geom: whether the model contains SDF geoms
     has_flex_selfcollide: whether any flex has self-collision enabled
     has_trilinear: whether the model contains trilinear flexes
+    has_ellipsoid_geom: whether the model contains ellipsoid geoms
     max_flex_dim: maximum flex dimension in the model
     block_dim: block dim options
     body_tree: list of body ids by tree level
@@ -1822,6 +1823,7 @@ class Model:
   has_sdf_geom: bool
   has_flex_selfcollide: bool
   has_trilinear: bool
+  has_ellipsoid_geom: bool
   max_flex_dim: int
   block_dim: BlockDim
   body_tree: tuple[wp.array[int], ...]


### PR DESCRIPTION
add flex-ellipsoid collisions

```
<mujoco model="Cloth Ellipsoid Collision">
  <compiler autolimits="true"/>
  <option solver="CG" tolerance="1e-6" timestep=".002" jacobian="sparse"/>
  <size njmax="8000" nconmax="2000"/>

  <visual>
    <rgba haze="0.15 0.25 0.35 1"/>
    <quality shadowsize="4096"/>
    <map stiffness="700" shadowscale="0.5" fogstart="1" fogend="15" zfar="40" haze="1"/>
  </visual>

  <asset>
    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="512"/>
  </asset>

  <worldbody>
    <light diffuse=".8 .8 .8" specular="0.2 0.2 0.2" pos="0 0 4" dir="0 0 -1"/>

    <!-- ellipsoid at origin -->
    <geom name="ellipsoid" type="ellipsoid" size=".15 .1 .05" rgba="0.8 0.8 0.8 1"/>

    <!-- Cloth positioned above the mesh sphere -->
    <!-- Extent of cloth: (30-1)*0.014 = 0.406. Centered in x & y, so center is at 0 0.
         Initialized 0.15m above the center of the sphere (sphere radius is 0.1m, so top of sphere is at 0.1m). -->
    <flexcomp name="towel" type="grid" count="30 30 1" spacing="0.014 0.014 0.014"
              radius="0.006" dim="2" rgba="1 0.5 0.5 1" pos="0 0 0.15" mass=".1">
      <edge equality="true"/>
      <elasticity young="3e3" poisson="0" thickness="1e-2" damping="1e-3" elastic2d="bend"/>
      <contact condim="3" solref="0.01 1" solimp=".95 .99 .0001" selfcollide="none"/>
    </flexcomp>
  </worldbody>
</mujoco>
```

```
mjwarp-viewer ../flex_ellipsoid.xml --nconmax=1024 --njmax=4096
```


https://github.com/user-attachments/assets/1b4c8140-7874-4815-ac13-c8ed56cd564f

---

additionally add `NotImplementedError`s in `io.put_model` for unsupported flex collisions with sdf and height field