### PR TITLE
Minor renaming in GJK

### DIFF
--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -570,8 +570,7 @@ def _S1D(s1: wp.vec3, s2: wp.vec3) -> wp.vec2:
   p_o = _project_origin_line(s1, s2)
 
   # find the axis with the largest projection "shadow" of the simplex
-  mu = s1[0] - s2[0]
-  mu_max = mu
+  mu_max = s1[0] - s2[0]
   index = 0
 
   mu = s1[1] - s2[1]

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -262,17 +262,14 @@ def _epa_support(
 
 
 @wp.func
-def _linear_combine(n: int, coefs: wp.vec4, mat: mat43) -> wp.vec3:
-  v = wp.vec3(0.0)
+def _linear_combine(n: int, scl: wp.vec4, mat: mat43) -> wp.vec3:
   if n == 1:
-    v = coefs[0] * mat[0]
-  elif n == 2:
-    v = coefs[0] * mat[0] + coefs[1] * mat[1]
-  elif n == 3:
-    v = coefs[0] * mat[0] + coefs[1] * mat[1] + coefs[2] * mat[2]
-  else:
-    v = coefs[0] * mat[0] + coefs[1] * mat[1] + coefs[2] * mat[2] + coefs[3] * mat[3]
-  return v
+    return scl[0] * mat[0]
+  if n == 2:
+    return scl[0] * mat[0] + scl[1] * mat[1]
+  if n == 3:
+    return scl[0] * mat[0] + scl[1] * mat[1] + scl[2] * mat[2]
+  return scl[0] * mat[0] + scl[1] * mat[1] + scl[2] * mat[2] + scl[3] * mat[3]
 
 
 @wp.func
@@ -374,52 +371,52 @@ def _S3D(s1: wp.vec3, s2: wp.vec3, s3: wp.vec3, s4: wp.vec3) -> wp.vec4:
   if comp1 and comp2 and comp3 and comp4:
     return wp.vec4(C41 / m_det, C42 / m_det, C43 / m_det, C44 / m_det)
 
-  # find the smallest distance, and use the corresponding barycentric coordinates
-  coordinates = wp.vec4(0.0, 0.0, 0.0, 0.0)
+  # find the smallest distance, and use the corresponding barycentric coordinates (weights)
+  wts = wp.vec4(0.0, 0.0, 0.0, 0.0)
   dmin = FLOAT_MAX
 
   if not comp1:
-    subcoord = _S2D(s2, s3, s4)
-    x = subcoord[0] * s2 + subcoord[1] * s3 + subcoord[2] * s4
+    subwts = _S2D(s2, s3, s4)
+    x = subwts[0] * s2 + subwts[1] * s3 + subwts[2] * s4
     d = wp.dot(x, x)
-    coordinates[0] = 0.0
-    coordinates[1] = subcoord[0]
-    coordinates[2] = subcoord[1]
-    coordinates[3] = subcoord[2]
+    wts[0] = 0.0
+    wts[1] = subwts[0]
+    wts[2] = subwts[1]
+    wts[3] = subwts[2]
     dmin = d
 
   if not comp2:
-    subcoord = _S2D(s1, s3, s4)
-    x = subcoord[0] * s1 + subcoord[1] * s3 + subcoord[2] * s4
+    subwts = _S2D(s1, s3, s4)
+    x = subwts[0] * s1 + subwts[1] * s3 + subwts[2] * s4
     d = wp.dot(x, x)
     if d < dmin:
-      coordinates[0] = subcoord[0]
-      coordinates[1] = 0.0
-      coordinates[2] = subcoord[1]
-      coordinates[3] = subcoord[2]
+      wts[0] = subwts[0]
+      wts[1] = 0.0
+      wts[2] = subwts[1]
+      wts[3] = subwts[2]
       dmin = d
 
   if not comp3:
-    subcoord = _S2D(s1, s2, s4)
-    x = subcoord[0] * s1 + subcoord[1] * s2 + subcoord[2] * s4
+    subwts = _S2D(s1, s2, s4)
+    x = subwts[0] * s1 + subwts[1] * s2 + subwts[2] * s4
     d = wp.dot(x, x)
     if d < dmin:
-      coordinates[0] = subcoord[0]
-      coordinates[1] = subcoord[1]
-      coordinates[2] = 0.0
-      coordinates[3] = subcoord[2]
+      wts[0] = subwts[0]
+      wts[1] = subwts[1]
+      wts[2] = 0.0
+      wts[3] = subwts[2]
       dmin = d
 
   if not comp4:
-    subcoord = _S2D(s1, s2, s3)
-    x = subcoord[0] * s1 + subcoord[1] * s2 + subcoord[2] * s3
+    subwts = _S2D(s1, s2, s3)
+    x = subwts[0] * s1 + subwts[1] * s2 + subwts[2] * s3
     d = wp.dot(x, x)
     if d < dmin:
-      coordinates[0] = subcoord[0]
-      coordinates[1] = subcoord[1]
-      coordinates[2] = subcoord[2]
-      coordinates[3] = 0.0
-  return coordinates
+      wts[0] = subwts[0]
+      wts[1] = subwts[1]
+      wts[2] = subwts[2]
+      wts[3] = 0.0
+  return wts
 
 
 @wp.func
@@ -533,38 +530,38 @@ def _S2D(s1: wp.vec3, s2: wp.vec3, s3: wp.vec3) -> wp.vec3:
   if comp1 and comp2 and comp3:
     return wp.vec3(C31 / M_max, C32 / M_max, C33 / M_max)
 
-  # find the smallest distance, and use the corresponding barycentric coordinates
+  # find the smallest distance, and use the corresponding barycentric coordinates (weights)
   dmin = FLOAT_MAX
-  coordinates = wp.vec3(0.0, 0.0, 0.0)
+  wts = wp.vec3(0.0, 0.0, 0.0)
 
   if not comp1:
-    subcoord = _S1D(s2, s3)
-    x = subcoord[0] * s2 + subcoord[1] * s3
+    subwts = _S1D(s2, s3)
+    x = subwts[0] * s2 + subwts[1] * s3
     d = wp.dot(x, x)
-    coordinates[0] = 0.0
-    coordinates[1] = subcoord[0]
-    coordinates[2] = subcoord[1]
+    wts[0] = 0.0
+    wts[1] = subwts[0]
+    wts[2] = subwts[1]
     dmin = d
 
   if not comp2:
-    subcoord = _S1D(s1, s3)
-    x = subcoord[0] * s1 + subcoord[1] * s3
+    subwts = _S1D(s1, s3)
+    x = subwts[0] * s1 + subwts[1] * s3
     d = wp.dot(x, x)
     if d < dmin:
-      coordinates[0] = subcoord[0]
-      coordinates[1] = 0.0
-      coordinates[2] = subcoord[1]
+      wts[0] = subwts[0]
+      wts[1] = 0.0
+      wts[2] = subwts[1]
       dmin = d
 
   if not comp3:
-    subcoord = _S1D(s1, s2)
-    x = subcoord[0] * s1 + subcoord[1] * s2
+    subwts = _S1D(s1, s2)
+    x = subwts[0] * s1 + subwts[1] * s2
     d = wp.dot(x, x)
     if d < dmin:
-      coordinates[0] = subcoord[0]
-      coordinates[1] = subcoord[1]
-      coordinates[2] = 0.0
-  return coordinates
+      wts[0] = subwts[0]
+      wts[1] = subwts[1]
+      wts[2] = 0.0
+  return wts
 
 
 @wp.func
@@ -573,13 +570,19 @@ def _S1D(s1: wp.vec3, s2: wp.vec3) -> wp.vec2:
   p_o = _project_origin_line(s1, s2)
 
   # find the axis with the largest projection "shadow" of the simplex
-  mu_max = 0.0
+  mu = s1[0] - s2[0]
+  mu_max = mu
   index = 0
-  for i in range(3):
-    mu = s1[i] - s2[i]
-    if wp.abs(mu) >= wp.abs(mu_max):
-      mu_max = mu
-      index = i
+
+  mu = s1[1] - s2[1]
+  if wp.abs(mu) >= wp.abs(mu_max):
+    mu_max = mu
+    index = 1
+
+  mu = s1[2] - s2[2]
+  if wp.abs(mu) >= wp.abs(mu_max):
+    mu_max = mu
+    index = 2
 
   C1 = p_o[index] - s2[index]
   C2 = s1[index] - p_o[index]
@@ -612,21 +615,21 @@ def gjk(
   simplex_index1 = wp.vec4i()
   simplex_index2 = wp.vec4i()
   n = int(0)
-  coordinates = wp.vec4()  # barycentric coordinates
+  wts = wp.vec4()  # barycentric coordinates (weights)
   tol2 = tolerance * tolerance
   epsilon = wp.where(is_discrete, 0.0, 0.5 * tol2)
 
   # set initial guess
   x_k = x1_0 - x2_0
-  xnorm_old = FLOAT_MAX
+  xnorm2_old = FLOAT_MAX
 
   for _ in range(gjk_iterations):
-    xnorm = wp.dot(x_k, x_k)
+    xnorm2 = wp.dot(x_k, x_k)
     # TODO(kbayes): determine new constant here
-    if xnorm < tol2 or wp.abs(xnorm_old - xnorm) < tol2:
+    if xnorm2 < tol2 or wp.abs(xnorm2_old - xnorm2) < tol2:
       break
-    xnorm_old = xnorm
-    dir_neg = x_k / wp.sqrt(xnorm)
+    xnorm2_old = xnorm2
+    dir_neg = x_k / wp.sqrt(xnorm2)
 
     # compute kth support point in geom1
     sp = support(geom1, geomtype1, -dir_neg)
@@ -643,6 +646,11 @@ def gjk(
     # compute the kth support point
     simplex[n] = simplex1[n] - simplex2[n]
 
+    # stopping criteria using the Frank-Wolfe duality gap given by
+    #  |f(x_k) - f(x_min)|^2 <= < grad f(x_k), (x_k - simplex[n]) >
+    if wp.dot(x_k, x_k - simplex[n]) < epsilon:
+      break
+
     if cutoff == 0.0:
       if wp.dot(x_k, simplex[n]) > 0.0:
         result = GJKResult()
@@ -651,25 +659,20 @@ def gjk(
         return result
     elif cutoff < FLOAT_MAX:
       vs = wp.dot(x_k, simplex[n])
-      if wp.dot(x_k, simplex[n]) > 0.0 and (vs * vs / xnorm) >= cutoff2:
+      if wp.dot(x_k, simplex[n]) > 0.0 and (vs * vs / xnorm2) >= cutoff2:
         result = GJKResult()
         result.dim = 0
         result.dist = FLOAT_MAX
         return result
 
-    # stopping criteria using the Frank-Wolfe duality gap given by
-    #  |f(x_k) - f(x_min)|^2 <= < grad f(x_k), (x_k - simplex[n]) >
-    if wp.dot(x_k, x_k - simplex[n]) < epsilon:
-      break
-
     # run the distance subalgorithm to compute the barycentric coordinates
     # of the closest point to the origin in the simplex
-    coordinates = _subdistance(n + 1, simplex)
+    wts = _subdistance(n + 1, simplex)
 
     # remove vertices from the simplex no longer needed
     n = int(0)
     for i in range(4):
-      if coordinates[i] == 0.0:
+      if wts[i] == 0.0:
         continue
 
       simplex[n] = simplex[i]
@@ -677,7 +680,7 @@ def gjk(
       simplex2[n] = simplex2[i]
       simplex_index1[n] = simplex_index1[i]
       simplex_index2[n] = simplex_index2[i]
-      coordinates[n] = coordinates[i]
+      wts[n] = wts[i]
       n += int(1)
 
     # SHOULD NOT OCCUR
@@ -685,7 +688,7 @@ def gjk(
       break
 
     # get the next iteration of x_k
-    x_next = _linear_combine(n, coordinates, simplex)
+    x_next = _linear_combine(n, wts, simplex)
 
     # x_k has converged to minimum
     if _almost_equal(x_next, x_k):
@@ -703,8 +706,8 @@ def gjk(
   # compute the approximate witness points
   # if n is zero, then there was an immediate return meaning the initial points
   # are the witness points
-  result.x1 = wp.where(n == 0, x1_0, _linear_combine(n, coordinates, simplex1))
-  result.x2 = wp.where(n == 0, x2_0, _linear_combine(n, coordinates, simplex2))
+  result.x1 = wp.where(n == 0, x1_0, _linear_combine(n, wts, simplex1))
+  result.x2 = wp.where(n == 0, x2_0, _linear_combine(n, wts, simplex2))
   result.dist = wp.norm_l2(x_k)
 
   result.dim = n

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -282,11 +282,11 @@ def _subdistance(n: int, simplex: mat43) -> wp.vec4:
   if n == 4:
     return _S3D(simplex[0], simplex[1], simplex[2], simplex[3])
   if n == 3:
-    coordinates3 = _S2D(simplex[0], simplex[1], simplex[2])
-    return wp.vec4(coordinates3[0], coordinates3[1], coordinates3[2], 0.0)
+    wts3 = _S2D(simplex[0], simplex[1], simplex[2])
+    return wp.vec4(wts3[0], wts3[1], wts3[2], 0.0)
   if n == 2:
-    coordinates2 = _S1D(simplex[0], simplex[1])
-    return wp.vec4(coordinates2[0], coordinates2[1], 0.0, 0.0)
+    wts2 = _S1D(simplex[0], simplex[1])
+    return wp.vec4(wts2[0], wts2[1], 0.0, 0.0)
   return wp.vec4(1.0, 0.0, 0.0, 0.0)
 
 

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -282,11 +282,11 @@ def _subdistance(n: int, simplex: mat43) -> wp.vec4:
   if n == 4:
     return _S3D(simplex[0], simplex[1], simplex[2], simplex[3])
   if n == 3:
-    wts3 = _S2D(simplex[0], simplex[1], simplex[2])
-    return wp.vec4(wts3[0], wts3[1], wts3[2], 0.0)
+    lmbda3 = _S2D(simplex[0], simplex[1], simplex[2])
+    return wp.vec4(lmbda3[0], lmbda3[1], lmbda3[2], 0.0)
   if n == 2:
-    wts2 = _S1D(simplex[0], simplex[1])
-    return wp.vec4(wts2[0], wts2[1], 0.0, 0.0)
+    lmbda2 = _S1D(simplex[0], simplex[1])
+    return wp.vec4(lmbda2[0], lmbda2[1], 0.0, 0.0)
   return wp.vec4(1.0, 0.0, 0.0, 0.0)
 
 
@@ -371,52 +371,52 @@ def _S3D(s1: wp.vec3, s2: wp.vec3, s3: wp.vec3, s4: wp.vec3) -> wp.vec4:
   if comp1 and comp2 and comp3 and comp4:
     return wp.vec4(C41 / m_det, C42 / m_det, C43 / m_det, C44 / m_det)
 
-  # find the smallest distance, and use the corresponding barycentric coordinates (weights)
-  wts = wp.vec4(0.0, 0.0, 0.0, 0.0)
+  # find the smallest distance, and use the corresponding barycentric coordinates
+  lmbda = wp.vec4(0.0, 0.0, 0.0, 0.0)
   dmin = FLOAT_MAX
 
   if not comp1:
-    subwts = _S2D(s2, s3, s4)
-    x = subwts[0] * s2 + subwts[1] * s3 + subwts[2] * s4
+    sublmbda = _S2D(s2, s3, s4)
+    x = sublmbda[0] * s2 + sublmbda[1] * s3 + sublmbda[2] * s4
     d = wp.dot(x, x)
-    wts[0] = 0.0
-    wts[1] = subwts[0]
-    wts[2] = subwts[1]
-    wts[3] = subwts[2]
+    lmbda[0] = 0.0
+    lmbda[1] = sublmbda[0]
+    lmbda[2] = sublmbda[1]
+    lmbda[3] = sublmbda[2]
     dmin = d
 
   if not comp2:
-    subwts = _S2D(s1, s3, s4)
-    x = subwts[0] * s1 + subwts[1] * s3 + subwts[2] * s4
+    sublmbda = _S2D(s1, s3, s4)
+    x = sublmbda[0] * s1 + sublmbda[1] * s3 + sublmbda[2] * s4
     d = wp.dot(x, x)
     if d < dmin:
-      wts[0] = subwts[0]
-      wts[1] = 0.0
-      wts[2] = subwts[1]
-      wts[3] = subwts[2]
+      lmbda[0] = sublmbda[0]
+      lmbda[1] = 0.0
+      lmbda[2] = sublmbda[1]
+      lmbda[3] = sublmbda[2]
       dmin = d
 
   if not comp3:
-    subwts = _S2D(s1, s2, s4)
-    x = subwts[0] * s1 + subwts[1] * s2 + subwts[2] * s4
+    sublmbda = _S2D(s1, s2, s4)
+    x = sublmbda[0] * s1 + sublmbda[1] * s2 + sublmbda[2] * s4
     d = wp.dot(x, x)
     if d < dmin:
-      wts[0] = subwts[0]
-      wts[1] = subwts[1]
-      wts[2] = 0.0
-      wts[3] = subwts[2]
+      lmbda[0] = sublmbda[0]
+      lmbda[1] = sublmbda[1]
+      lmbda[2] = 0.0
+      lmbda[3] = sublmbda[2]
       dmin = d
 
   if not comp4:
-    subwts = _S2D(s1, s2, s3)
-    x = subwts[0] * s1 + subwts[1] * s2 + subwts[2] * s3
+    sublmbda = _S2D(s1, s2, s3)
+    x = sublmbda[0] * s1 + sublmbda[1] * s2 + sublmbda[2] * s3
     d = wp.dot(x, x)
     if d < dmin:
-      wts[0] = subwts[0]
-      wts[1] = subwts[1]
-      wts[2] = subwts[2]
-      wts[3] = 0.0
-  return wts
+      lmbda[0] = sublmbda[0]
+      lmbda[1] = sublmbda[1]
+      lmbda[2] = sublmbda[2]
+      lmbda[3] = 0.0
+  return lmbda
 
 
 @wp.func
@@ -530,38 +530,38 @@ def _S2D(s1: wp.vec3, s2: wp.vec3, s3: wp.vec3) -> wp.vec3:
   if comp1 and comp2 and comp3:
     return wp.vec3(C31 / M_max, C32 / M_max, C33 / M_max)
 
-  # find the smallest distance, and use the corresponding barycentric coordinates (weights)
+  # find the smallest distance, and use the corresponding barycentric coordinates
   dmin = FLOAT_MAX
-  wts = wp.vec3(0.0, 0.0, 0.0)
+  lmbda = wp.vec3(0.0, 0.0, 0.0)
 
   if not comp1:
-    subwts = _S1D(s2, s3)
-    x = subwts[0] * s2 + subwts[1] * s3
+    sublmbda = _S1D(s2, s3)
+    x = sublmbda[0] * s2 + sublmbda[1] * s3
     d = wp.dot(x, x)
-    wts[0] = 0.0
-    wts[1] = subwts[0]
-    wts[2] = subwts[1]
+    lmbda[0] = 0.0
+    lmbda[1] = sublmbda[0]
+    lmbda[2] = sublmbda[1]
     dmin = d
 
   if not comp2:
-    subwts = _S1D(s1, s3)
-    x = subwts[0] * s1 + subwts[1] * s3
+    sublmbda = _S1D(s1, s3)
+    x = sublmbda[0] * s1 + sublmbda[1] * s3
     d = wp.dot(x, x)
     if d < dmin:
-      wts[0] = subwts[0]
-      wts[1] = 0.0
-      wts[2] = subwts[1]
+      lmbda[0] = sublmbda[0]
+      lmbda[1] = 0.0
+      lmbda[2] = sublmbda[1]
       dmin = d
 
   if not comp3:
-    subwts = _S1D(s1, s2)
-    x = subwts[0] * s1 + subwts[1] * s2
+    sublmbda = _S1D(s1, s2)
+    x = sublmbda[0] * s1 + sublmbda[1] * s2
     d = wp.dot(x, x)
     if d < dmin:
-      wts[0] = subwts[0]
-      wts[1] = subwts[1]
-      wts[2] = 0.0
-  return wts
+      lmbda[0] = sublmbda[0]
+      lmbda[1] = sublmbda[1]
+      lmbda[2] = 0.0
+  return lmbda
 
 
 @wp.func
@@ -615,7 +615,7 @@ def gjk(
   simplex_index1 = wp.vec4i()
   simplex_index2 = wp.vec4i()
   n = int(0)
-  wts = wp.vec4()  # barycentric coordinates (weights)
+  lmbda = wp.vec4()  # barycentric coordinates
   tol2 = tolerance * tolerance
   epsilon = wp.where(is_discrete, 0.0, 0.5 * tol2)
 
@@ -667,12 +667,12 @@ def gjk(
 
     # run the distance subalgorithm to compute the barycentric coordinates
     # of the closest point to the origin in the simplex
-    wts = _subdistance(n + 1, simplex)
+    lmbda = _subdistance(n + 1, simplex)
 
     # remove vertices from the simplex no longer needed
     n = int(0)
     for i in range(4):
-      if wts[i] == 0.0:
+      if lmbda[i] == 0.0:
         continue
 
       simplex[n] = simplex[i]
@@ -680,7 +680,7 @@ def gjk(
       simplex2[n] = simplex2[i]
       simplex_index1[n] = simplex_index1[i]
       simplex_index2[n] = simplex_index2[i]
-      wts[n] = wts[i]
+      lmbda[n] = lmbda[i]
       n += int(1)
 
     # SHOULD NOT OCCUR
@@ -688,7 +688,7 @@ def gjk(
       break
 
     # get the next iteration of x_k
-    x_next = _linear_combine(n, wts, simplex)
+    x_next = _linear_combine(n, lmbda, simplex)
 
     # x_k has converged to minimum
     if _almost_equal(x_next, x_k):
@@ -706,8 +706,8 @@ def gjk(
   # compute the approximate witness points
   # if n is zero, then there was an immediate return meaning the initial points
   # are the witness points
-  result.x1 = wp.where(n == 0, x1_0, _linear_combine(n, wts, simplex1))
-  result.x2 = wp.where(n == 0, x2_0, _linear_combine(n, wts, simplex2))
+  result.x1 = wp.where(n == 0, x1_0, _linear_combine(n, lmbda, simplex1))
+  result.x2 = wp.where(n == 0, x2_0, _linear_combine(n, lmbda, simplex2))
   result.dist = wp.norm_l2(x_k)
 
   result.dim = n


### PR DESCRIPTION
* Improved S1D and linear_combine a little
* Rename xnorm -> xnorm2 as it's the x_k normal squared
* Rename coordinates to lmbda (lambda is a Python keyword) to reflect C MuJoCo and the literature naming convention. Coordinates is too vague and long of a name.
* Move convergence check before the cut off check. This is now same as C MuJoCo and rationally makes more sense. 