### PR TITLE
Recompute eq_data for connect and weld constraints in set_const

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2623,6 +2623,83 @@ def _copy_tendon_length0(
 
 
 @wp.kernel
+def _compute_eq_data0(
+  # Model:
+  eq_type: wp.array[int],
+  eq_obj1id: wp.array[int],
+  eq_obj2id: wp.array[int],
+  eq_objtype: wp.array[int],
+  # Data in:
+  xpos_in: wp.array2d[wp.vec3],
+  xquat_in: wp.array2d[wp.quat],
+  xmat_in: wp.array2d[wp.mat33],
+  # Out:
+  eq_data_out: wp.array2d[types.vec11],
+):
+  """Compute missing eq_data for connect/weld constraints, mirroring mj_setConst.
+
+  Kinematics must have been evaluated at qpos0 so the constraint is satisfied at qpos0.
+  """
+  worldid, eqid = wp.tid()
+  eq_data_id = worldid % eq_data_out.shape[0]
+
+  eqtype = eq_type[eqid]
+  objtype = eq_objtype[eqid]
+  data = eq_data_out[eq_data_id, eqid]
+
+  if eqtype == int(types.EqType.CONNECT.value):
+    if objtype == int(types.ObjType.BODY.value):
+      obj1id = eq_obj1id[eqid]
+      obj2id = eq_obj2id[eqid]
+
+      # data[0:3] = anchor in body1 local frame; map to global frame
+      anchor1 = wp.vec3(data[0], data[1], data[2])
+      pos = xpos_in[worldid, obj1id] + xmat_in[worldid, obj1id] @ anchor1
+
+      # data[3:6] = anchor position in body2 local frame
+      anchor2 = wp.transpose(xmat_in[worldid, obj2id]) @ (pos - xpos_in[worldid, obj2id])
+      data[3] = anchor2[0]
+      data[4] = anchor2[1]
+      data[5] = anchor2[2]
+      eq_data_out[eq_data_id, eqid] = data
+    elif objtype == int(types.ObjType.SITE.value):
+      # site-based connect, eq_data is unused
+      eq_data_out[eq_data_id, eqid] = types.vec11(0.0)
+  elif eqtype == int(types.EqType.WELD.value):
+    if objtype == int(types.ObjType.BODY.value):
+      quat = wp.quat(data[6], data[7], data[8], data[9])
+      if wp.length_sq(quat) > 0.0:
+        # user has set quaternion data: normalize it and keep the remaining data
+        quat = wp.normalize(quat)
+        data[6] = quat[0]
+        data[7] = quat[1]
+        data[8] = quat[2]
+        data[9] = quat[3]
+        eq_data_out[eq_data_id, eqid] = data
+      else:
+        obj1id = eq_obj1id[eqid]
+        obj2id = eq_obj2id[eqid]
+
+        # data[0:3] = anchor in body2 local frame; map to global frame
+        anchor2 = wp.vec3(data[0], data[1], data[2])
+        pos = xpos_in[worldid, obj2id] + xmat_in[worldid, obj2id] @ anchor2
+
+        # data[3:6] = anchor position in body1 local frame
+        anchor1 = wp.transpose(xmat_in[worldid, obj1id]) @ (pos - xpos_in[worldid, obj1id])
+        data[3] = anchor1[0]
+        data[4] = anchor1[1]
+        data[5] = anchor1[2]
+
+        # data[6:10] = neg(xquat1) * xquat2 = "xquat2 - xquat1" in body1 local frame
+        relquat = mjmath.mul_quat(mjmath.quat_inv(xquat_in[worldid, obj1id]), xquat_in[worldid, obj2id])
+        data[6] = relquat[0]
+        data[7] = relquat[1]
+        data[8] = relquat[2]
+        data[9] = relquat[3]
+        eq_data_out[eq_data_id, eqid] = data
+
+
+@wp.kernel
 def _resolve_tendon_lengthspring(
   ten_length_in: wp.array2d[float],
   tendon_lengthspring_out: wp.array2d[wp.vec2],
@@ -3104,6 +3181,8 @@ def set_const_0(m: types.Model, d: types.Data, restore: bool = True):
 
   Computes:
     - tendon_length0: tendon resting lengths
+    - eq_data: connect/weld anchor data, recomputed so the constraint is
+      satisfied at qpos0 (mirrors mj_setConst)
     - dof_invweight0: inverse inertia for DOFs
     - body_invweight0: inverse spatial inertia for bodies
     - tendon_invweight0: inverse weight for tendons
@@ -3142,6 +3221,15 @@ def set_const_0(m: types.Model, d: types.Data, restore: bool = True):
   )
 
   wp.launch(_copy_tendon_length0, dim=(d.nworld, m.ntendon), inputs=[d.ten_length], outputs=[m.tendon_length0])
+
+  # eq_data: recompute missing connect/weld anchor data at qpos0 (mirrors mj_setConst)
+  if m.neq > 0:
+    wp.launch(
+      _compute_eq_data0,
+      dim=(d.nworld, m.neq),
+      inputs=[m.eq_type, m.eq_obj1id, m.eq_obj2id, m.eq_objtype, d.xpos, d.xquat, d.xmat],
+      outputs=[m.eq_data],
+    )
 
   # dof_invweight0: computed per joint with averaging for multi-DOF joints
   # FREE: 6 DOFs, trans gets mean(A[0:3]), rot gets mean(A[3:6])

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2636,7 +2636,7 @@ def _compute_eq_data0(
   # Out:
   eq_data_out: wp.array2d[types.vec11],
 ):
-  """Compute missing eq_data for connect/weld constraints, mirroring mj_setConst.
+  """Compute eq_data for connect/weld constraints.
 
   Kinematics must have been evaluated at qpos0 so the constraint is satisfied at qpos0.
   """
@@ -3182,7 +3182,7 @@ def set_const_0(m: types.Model, d: types.Data, restore: bool = True):
   Computes:
     - tendon_length0: tendon resting lengths
     - eq_data: connect/weld anchor data, recomputed so the constraint is
-      satisfied at qpos0 (mirrors mj_setConst)
+      satisfied at qpos0
     - dof_invweight0: inverse inertia for DOFs
     - body_invweight0: inverse spatial inertia for bodies
     - tendon_invweight0: inverse weight for tendons
@@ -3222,14 +3222,12 @@ def set_const_0(m: types.Model, d: types.Data, restore: bool = True):
 
   wp.launch(_copy_tendon_length0, dim=(d.nworld, m.ntendon), inputs=[d.ten_length], outputs=[m.tendon_length0])
 
-  # eq_data: recompute missing connect/weld anchor data at qpos0 (mirrors mj_setConst)
-  if m.neq > 0:
-    wp.launch(
-      _compute_eq_data0,
-      dim=(d.nworld, m.neq),
-      inputs=[m.eq_type, m.eq_obj1id, m.eq_obj2id, m.eq_objtype, d.xpos, d.xquat, d.xmat],
-      outputs=[m.eq_data],
-    )
+  wp.launch(
+    _compute_eq_data0,
+    dim=(d.nworld, m.neq),
+    inputs=[m.eq_type, m.eq_obj1id, m.eq_obj2id, m.eq_objtype, d.xpos, d.xquat, d.xmat],
+    outputs=[m.eq_data],
+  )
 
   # dof_invweight0: computed per joint with averaging for multi-DOF joints
   # FREE: 6 DOFs, trans gets mean(A[0:3]), rot gets mean(A[3:6])

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1211,15 +1211,7 @@ class IOTest(parameterized.TestCase):
     _assert_eq(m.body_invweight0.numpy()[0, 1, 0], mjm.body_invweight0[1, 0], "body_invweight0")
 
   def test_set_const_eq_data_connect(self):
-    """Test set_const recomputes eq_data for connect constraints (#1270).
-
-    Regression test: set_const previously did not recompute eq_data at all, so a
-    modified anchor (eq_data[0:3]) left the derived second anchor (eq_data[3:6])
-    stale, silently breaking the constraint. mj_setConst recomputes the second
-    anchor so the constraint is satisfied at qpos0; set_const must match. The
-    nonzero joint ref values make qpos0 nonzero, so an implementation that posed
-    the bodies anywhere other than qpos0 would also be caught here.
-    """
+    """Test set_const recomputes eq_data for connect constraints."""
     mjm, mjd, m, d = test_data.fixture(
       xml="""
     <mujoco>
@@ -1258,7 +1250,7 @@ class IOTest(parameterized.TestCase):
     _assert_eq(m.eq_data.numpy()[0], mjm.eq_data, "eq_data")
 
   def test_set_const_eq_data_weld(self):
-    """Test set_const recomputes eq_data for weld constraints (#1270)."""
+    """Test set_const recomputes eq_data for weld constraints."""
     mjm, mjd, m, d = test_data.fixture(
       xml="""
     <mujoco>
@@ -1282,7 +1274,7 @@ class IOTest(parameterized.TestCase):
     """
     )
 
-    # case 1: quaternion data cleared: setConst recomputes relpose and anchor offset
+    # case 1: quaternion data cleared: set_const recomputes relpose and anchor offset
     new_data = mjm.eq_data[0].copy()
     new_data[0:3] = [0.15, 0.1, 0.25]
     new_data[3:10] = 0.0
@@ -1296,7 +1288,7 @@ class IOTest(parameterized.TestCase):
 
     _assert_eq(m.eq_data.numpy()[0], mjm.eq_data, "eq_data")
 
-    # case 2: user-specified quaternion: setConst only normalizes it
+    # case 2: user-specified quaternion: set_const only normalizes it
     new_data = mjm.eq_data[0].copy()
     new_data[6:10] = [2.0, 0.0, 2.0, 0.0]
     mjm.eq_data[0] = new_data
@@ -1310,16 +1302,7 @@ class IOTest(parameterized.TestCase):
     _assert_eq(m.eq_data.numpy()[0], mjm.eq_data, "eq_data")
 
   def test_set_const_eq_data_slider_crank_tracking(self):
-    """Test connect anchor recompute on a slider-crank with nonzero joint ref (#1270).
-
-    A crank (r=0.075) and conrod close onto a prismatic slide via a connect
-    constraint; all joints carry nonzero ref/springref. After re-anchoring the
-    conrod pin (shortening the effective conrod to 0.096) and calling set_const,
-    the slide must track the closed-form slider-crank relation
-    s(phi) = r*cos(phi) - sqrt(L^2 - (r*sin(phi))^2) - (r - L). Before the fix,
-    set_const left eq_data[3:6] stale (zeros), pinning the conrod to the wrong
-    point on the slider: loop error was ~26 mm instead of < 1 mm.
-    """
+    """Test connect anchor recompute on a slider-crank with nonzero joint ref."""
     r, ell = 0.075, 0.096
     mjm, mjd, m, d = test_data.fixture(
       xml="""
@@ -1370,27 +1353,15 @@ class IOTest(parameterized.TestCase):
 
     _assert_eq(m.eq_data.numpy()[0], mjm.eq_data, "eq_data")
 
-    # roll out both paths from qpos0 under a constant crank torque and check the
-    # loop against the closed form (joint ref values offset qpos readings)
+    # roll out the warp path from qpos0 under a constant crank torque and check
+    # the loop against the closed form (joint ref values offset qpos readings)
     qpos0 = mjm.qpos0.copy()
-    nstep, ctrl = 250, 0.03
-
-    mujoco.mj_resetData(mjm, mjd)
-    mjd.ctrl[:] = ctrl
-    err_c, phi_lo, phi_hi = 0.0, np.inf, -np.inf
-    for _ in range(nstep):
-      mujoco.mj_step(mjm, mjd)
-      phi = mjd.qpos[0] - qpos0[0]
-      err_c = max(err_c, abs(mjd.qpos[2] - qpos0[2] - slider_crank_s(phi)))
-      phi_lo, phi_hi = min(phi_lo, phi), max(phi_hi, phi)
-
-    self.assertGreater(phi_hi - phi_lo, 0.3, "crank barely moved; test is vacuous")
-    self.assertLess(err_c, 1.0e-3, f"C path loop error {err_c:.2e}")
+    ctrl = 0.03
 
     mjwarp.reset_data(m, d)
     d.ctrl.fill_(ctrl)
     err_wp = 0.0
-    for _ in range(nstep):
+    for _ in range(10):
       mjwarp.step(m, d)
       qpos = d.qpos.numpy()[0]
       err_wp = max(err_wp, abs(qpos[2] - qpos0[2] - slider_crank_s(qpos[0] - qpos0[0])))

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1210,6 +1210,193 @@ class IOTest(parameterized.TestCase):
     _assert_eq(m.actuator_acc0.numpy()[0], mjm.actuator_acc0, "actuator_acc0")
     _assert_eq(m.body_invweight0.numpy()[0, 1, 0], mjm.body_invweight0[1, 0], "body_invweight0")
 
+  def test_set_const_eq_data_connect(self):
+    """Test set_const recomputes eq_data for connect constraints (#1270).
+
+    Regression test: set_const previously did not recompute eq_data at all, so a
+    modified anchor (eq_data[0:3]) left the derived second anchor (eq_data[3:6])
+    stale, silently breaking the constraint. mj_setConst recomputes the second
+    anchor so the constraint is satisfied at qpos0; set_const must match. The
+    nonzero joint ref values make qpos0 nonzero, so an implementation that posed
+    the bodies anywhere other than qpos0 would also be caught here.
+    """
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+    <mujoco>
+      <option gravity="0 0 0">
+        <flag contact="disable"/>
+      </option>
+      <worldbody>
+        <body name="b1" pos="1 0 0">
+          <joint type="slide" axis="1 0 0" ref="1"/>
+          <geom type="sphere" size="0.1" mass="1"/>
+        </body>
+        <body name="b2" pos="2 0 0">
+          <joint type="slide" axis="1 0 0" ref="4"/>
+          <geom type="sphere" size="0.1" mass="1"/>
+        </body>
+      </worldbody>
+      <equality>
+        <connect body1="b1" body2="b2" anchor="0.5 0 0"/>
+      </equality>
+    </mujoco>
+    """
+    )
+
+    # move the anchor on body1 and clear the derived second anchor
+    new_data = mjm.eq_data[0].copy()
+    new_data[0:3] = [0.4, 0.1, 0.0]
+    new_data[3:6] = 0.0
+    mjm.eq_data[0] = new_data
+    eq_data = m.eq_data.numpy()
+    eq_data[0, 0] = new_data
+    wp.copy(m.eq_data, wp.array(eq_data, dtype=m.eq_data.dtype))
+
+    mujoco.mj_setConst(mjm, mjd)
+    mjwarp.set_const(m, d)
+
+    _assert_eq(m.eq_data.numpy()[0], mjm.eq_data, "eq_data")
+
+  def test_set_const_eq_data_weld(self):
+    """Test set_const recomputes eq_data for weld constraints (#1270)."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+    <mujoco>
+      <option gravity="0 0 0">
+        <flag contact="disable"/>
+      </option>
+      <worldbody>
+        <body name="b1" pos="0.1 0 0">
+          <joint type="hinge" axis="0 0 1" ref="0.3"/>
+          <geom type="sphere" size="0.05" mass="1"/>
+        </body>
+        <body name="b2" pos="0.4 0 0" euler="0 0 20">
+          <joint type="hinge" axis="0 1 0" ref="-0.2"/>
+          <geom type="sphere" size="0.05" mass="1"/>
+        </body>
+      </worldbody>
+      <equality>
+        <weld body1="b1" body2="b2" anchor="0.1 0.2 0.3"/>
+      </equality>
+    </mujoco>
+    """
+    )
+
+    # case 1: quaternion data cleared: setConst recomputes relpose and anchor offset
+    new_data = mjm.eq_data[0].copy()
+    new_data[0:3] = [0.15, 0.1, 0.25]
+    new_data[3:10] = 0.0
+    mjm.eq_data[0] = new_data
+    eq_data = m.eq_data.numpy()
+    eq_data[0, 0] = new_data
+    wp.copy(m.eq_data, wp.array(eq_data, dtype=m.eq_data.dtype))
+
+    mujoco.mj_setConst(mjm, mjd)
+    mjwarp.set_const(m, d)
+
+    _assert_eq(m.eq_data.numpy()[0], mjm.eq_data, "eq_data")
+
+    # case 2: user-specified quaternion: setConst only normalizes it
+    new_data = mjm.eq_data[0].copy()
+    new_data[6:10] = [2.0, 0.0, 2.0, 0.0]
+    mjm.eq_data[0] = new_data
+    eq_data = m.eq_data.numpy()
+    eq_data[0, 0] = new_data
+    wp.copy(m.eq_data, wp.array(eq_data, dtype=m.eq_data.dtype))
+
+    mujoco.mj_setConst(mjm, mjd)
+    mjwarp.set_const(m, d)
+
+    _assert_eq(m.eq_data.numpy()[0], mjm.eq_data, "eq_data")
+
+  def test_set_const_eq_data_slider_crank_tracking(self):
+    """Test connect anchor recompute on a slider-crank with nonzero joint ref (#1270).
+
+    A crank (r=0.075) and conrod close onto a prismatic slide via a connect
+    constraint; all joints carry nonzero ref/springref. After re-anchoring the
+    conrod pin (shortening the effective conrod to 0.096) and calling set_const,
+    the slide must track the closed-form slider-crank relation
+    s(phi) = r*cos(phi) - sqrt(L^2 - (r*sin(phi))^2) - (r - L). Before the fix,
+    set_const left eq_data[3:6] stale (zeros), pinning the conrod to the wrong
+    point on the slider: loop error was ~26 mm instead of < 1 mm.
+    """
+    r, ell = 0.075, 0.096
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+    <mujoco>
+      <option gravity="0 0 0" timestep="0.002">
+        <flag contact="disable"/>
+      </option>
+      <worldbody>
+        <body name="crank">
+          <joint name="phi" type="hinge" axis="0 0 1" ref="0.35" springref="0.55" stiffness="0.02" damping="0.002"/>
+          <geom type="capsule" fromto="0 0 0 0.075 0 0" size="0.008" mass="0.06"/>
+          <body name="conrod" pos="0.075 0 0">
+            <joint name="psi" type="hinge" axis="0 0 1" ref="-0.2" damping="0.0005"/>
+            <geom type="capsule" fromto="0 0 0 -0.1 0 0" size="0.006" mass="0.05"/>
+          </body>
+        </body>
+        <body name="slider" pos="0.005 0 0">
+          <joint name="s" type="slide" axis="1 0 0" ref="0.01" springref="0.02" stiffness="0.5" damping="0.01"/>
+          <geom type="box" size="0.01 0.008 0.008" mass="0.08"/>
+        </body>
+      </worldbody>
+      <equality>
+        <connect body1="conrod" body2="slider" anchor="-0.1 0 0"/>
+      </equality>
+      <actuator>
+        <motor joint="phi" gear="1"/>
+      </actuator>
+    </mujoco>
+    """
+    )
+
+    def slider_crank_s(phi):
+      # closed-form slide position vs crank angle, s(0) = 0 at top dead center
+      return r * np.cos(phi) - np.sqrt(ell**2 - (r * np.sin(phi)) ** 2) - (r - ell)
+
+    # re-anchor the conrod pin (effective conrod length 0.100 -> 0.096) and clear
+    # the derived anchor; per set_const docs the offsets are recomputed if not set
+    new_data = mjm.eq_data[0].copy()
+    new_data[0:3] = [-ell, 0.0, 0.0]
+    new_data[3:6] = 0.0
+    mjm.eq_data[0] = new_data
+    eq_data = m.eq_data.numpy()
+    eq_data[0, 0] = new_data
+    wp.copy(m.eq_data, wp.array(eq_data, dtype=m.eq_data.dtype))
+
+    mujoco.mj_setConst(mjm, mjd)
+    mjwarp.set_const(m, d)
+
+    _assert_eq(m.eq_data.numpy()[0], mjm.eq_data, "eq_data")
+
+    # roll out both paths from qpos0 under a constant crank torque and check the
+    # loop against the closed form (joint ref values offset qpos readings)
+    qpos0 = mjm.qpos0.copy()
+    nstep, ctrl = 250, 0.03
+
+    mujoco.mj_resetData(mjm, mjd)
+    mjd.ctrl[:] = ctrl
+    err_c, phi_lo, phi_hi = 0.0, np.inf, -np.inf
+    for _ in range(nstep):
+      mujoco.mj_step(mjm, mjd)
+      phi = mjd.qpos[0] - qpos0[0]
+      err_c = max(err_c, abs(mjd.qpos[2] - qpos0[2] - slider_crank_s(phi)))
+      phi_lo, phi_hi = min(phi_lo, phi), max(phi_hi, phi)
+
+    self.assertGreater(phi_hi - phi_lo, 0.3, "crank barely moved; test is vacuous")
+    self.assertLess(err_c, 1.0e-3, f"C path loop error {err_c:.2e}")
+
+    mjwarp.reset_data(m, d)
+    d.ctrl.fill_(ctrl)
+    err_wp = 0.0
+    for _ in range(nstep):
+      mjwarp.step(m, d)
+      qpos = d.qpos.numpy()[0]
+      err_wp = max(err_wp, abs(qpos[2] - qpos0[2] - slider_crank_s(qpos[0] - qpos0[0])))
+
+    self.assertLess(err_wp, 1.0e-3, f"warp path loop error {err_wp:.2e}")
+
   @parameterized.named_parameters(
     dict(testcase_name="dense", jacobian="dense"),
     dict(testcase_name="sparse", jacobian="sparse"),


### PR DESCRIPTION
Fixes #1270.

`set_const`'s docstring promises that equality-constraint offsets are "computed if not set", but the implementation never recomputes `eq_data`, so it only ever copies tendon lengths and inertias. The documented domain-randomization workflow of editing an anchor (or any of `eq_data`) and calling `set_const` therefore leaves the derived second anchor stale: the loop is silently broken and the bodies are pinned to the wrong point, while the C engine self-heals because `mj_setConst` recomputes the anchor from the kinematics at qpos0.

This adds a `_compute_eq_data0` kernel that mirrors `engine_setconst.c` and is launched from `set_const_0` after kinematics have been evaluated at qpos0. For a connect/body constraint it derives the second anchor from the first; for connect/site it zeroes the unused data; for weld it derives the anchor offset and relative quaternion, or, when the user has supplied a quaternion, only normalizes it (the same normalize-only branch the C engine takes).

On a slider-crank mechanism with nonzero joint refs (crank r=0.075, conrod shortened to L=0.096), re-anchoring the conrod pin and calling `set_const` drops the closed-form loop error from 2.605e-2 m before the fix to 5.99e-5 after, matching the C path at 9.07e-5. Tests cover connect, weld (both branches), and the slider-crank rollout.

One thing to flag for scope: the issue also raises a semantics question, where the author expects the derived anchor to be -2.5 but the engine's `qpos - qpos0` convention yields -0.5. That is a convention question about the C engine itself, not a Warp/C parity gap, so I've left it out of this PR; it belongs in mujoco-core if it's worth pursuing. This PR is scoped strictly to restoring C parity for the anchor recompute.

Full suite is green with the change: 1002 passed, 11 skipped.

I prepared this change with AI assistance (Claude); per AGENTS.md I have not added it as a commit co-author (it cannot sign the CLA), and I've reviewed the change and take responsibility for it.
