### PR TITLE
Add reset_data_keyframe to mirror mj_resetDataKeyframe in MuJoCo

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -59,6 +59,7 @@ from mujoco_warp._src.io import make_data as make_data
 from mujoco_warp._src.io import put_data as put_data
 from mujoco_warp._src.io import put_model as put_model
 from mujoco_warp._src.io import reset_data as reset_data
+from mujoco_warp._src.io import reset_data_keyframe as reset_data_keyframe
 from mujoco_warp._src.io import set_const as set_const
 from mujoco_warp._src.io import set_const_0 as set_const_0
 from mujoco_warp._src.io import set_const_fixed as set_const_fixed

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2729,7 +2729,6 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
 
 
 def reset_data_keyframe(
-  mjm: mujoco.MjModel,
   m: types.Model,
   d: types.Data,
   key: int,
@@ -2737,23 +2736,20 @@ def reset_data_keyframe(
 ):
   """Reset data, set fields from specified keyframe; optionally by world.
 
-  Unlike `reset_data`, this function requires the host-side MuJoCo model as an argument
-  becasue the keyframe data are not tracked by `types.Model`.
-
   Args:
-    mjm: The host-side MuJoCo model.
     m: The model containing kinematic and dynamic information (device).
     d: The data object containing the current state and output arrays (device).
-    key: The keyframe index to initialize the data with. An IndexError is raised if
-      key<0 or key>=mjm.nkey.
+    key: The keyframe index to initialize the data with.
     reset: Per-world bitmask. Reset if True.
   """
   reset_data(m, d, reset)
 
   @wp.kernel(module="unique", enable_backward=False)
   def reset_time(
+    # Model:
+    key_time: wp.array[float],
     # In:
-    target_time: float,
+    key: int,
     reset_in: wp.array[bool],
     # Data out:
     time_out: wp.array[float],
@@ -2764,12 +2760,14 @@ def reset_data_keyframe(
       if not reset_in[worldid]:
         return
 
-    time_out[worldid] = target_time
+    time_out[worldid] = key_time[key]
 
   @wp.kernel(module="unique", enable_backward=False)
   def reset_qpos(
+    # Model:
+    key_qpos: wp.array2d[float],
     # In:
-    target_qpos: wp.array[float],
+    key: int,
     reset_in: wp.array[bool],
     # Data out:
     qpos_out: wp.array2d[float],
@@ -2780,12 +2778,14 @@ def reset_data_keyframe(
       if not reset_in[worldid]:
         return
 
-    qpos_out[worldid, qid] = target_qpos[qid]
+    qpos_out[worldid, qid] = key_qpos[key, qid]
 
   @wp.kernel(module="unique", enable_backward=False)
   def reset_qvel(
+    # Model:
+    key_qvel: wp.array2d[float],
     # In:
-    target_qvel: wp.array[float],
+    key: int,
     reset_in: wp.array[bool],
     # Data out:
     qvel_out: wp.array2d[float],
@@ -2796,12 +2796,14 @@ def reset_data_keyframe(
       if not reset_in[worldid]:
         return
 
-    qvel_out[worldid, vid] = target_qvel[vid]
+    qvel_out[worldid, vid] = key_qvel[key, vid]
 
   @wp.kernel(module="unique", enable_backward=False)
   def reset_activation(
+    # Model:
+    key_act: wp.array2d[float],
     # In:
-    target_act: wp.array[float],
+    key: int,
     reset_in: wp.array[bool],
     # Data out:
     act_out: wp.array2d[float],
@@ -2812,16 +2814,16 @@ def reset_data_keyframe(
       if not reset_in[worldid]:
         return
 
-    act_out[worldid, aid] = target_act[aid]
+    act_out[worldid, aid] = key_act[key, aid]
 
   @wp.kernel(module="unique", enable_backward=False)
   def reset_mocap(
     # Model:
     body_mocapid: wp.array[int],
+    key_mpos: wp.array2d[wp.vec3],
+    key_mquat: wp.array2d[wp.quat],
     # In:
-    target_mpos: wp.array[wp.vec3],
-    target_mquat: wp.array[wp.quat],
-    # In:
+    key: int,
     reset_in: wp.array[bool],
     # Data out:
     mocap_pos_out: wp.array2d[wp.vec3],
@@ -2836,13 +2838,15 @@ def reset_data_keyframe(
     mocapid = body_mocapid[bodyid]
 
     if mocapid >= 0:
-      mocap_pos_out[worldid, mocapid] = target_mpos[mocapid]
-      mocap_quat_out[worldid, mocapid] = target_mquat[mocapid]
+      mocap_pos_out[worldid, mocapid] = key_mpos[key, mocapid]
+      mocap_quat_out[worldid, mocapid] = key_mquat[key, mocapid]
 
   @wp.kernel(module="unique", enable_backward=False)
   def reset_control(
+    # Model:
+    key_ctrl: wp.array2d[float],
     # In:
-    target_ctrl: wp.array[float],
+    key: int,
     reset_in: wp.array[bool],
     # Data out:
     ctrl_out: wp.array2d[float],
@@ -2853,61 +2857,55 @@ def reset_data_keyframe(
       if not reset_in[worldid]:
         return
 
-    ctrl_out[worldid, cid] = target_ctrl[cid]
+    ctrl_out[worldid, cid] = key_ctrl[key, cid]
 
   reset_input = reset or wp.ones(d.nworld, dtype=bool)
 
-  target_time = mjm.key_time[key]
   wp.launch(
     reset_time,
     dim=d.nworld,
-    inputs=[target_time, reset_input],
+    inputs=[m.key_time, key, reset_input],
     outputs=[d.time],
   )
 
-  target_qpos = wp.array(mjm.key_qpos[key], dtype=float)
   wp.launch(
     reset_qpos,
     dim=(d.nworld, m.nq),
-    inputs=[target_qpos, reset_input],
+    inputs=[m.key_qpos, key, reset_input],
     outputs=[d.qpos],
   )
 
-  target_qvel = wp.array(mjm.key_qvel[key], dtype=float)
   wp.launch(
     reset_qvel,
     dim=(d.nworld, m.nv),
-    inputs=[target_qvel, reset_input],
+    inputs=[m.key_qvel, key, reset_input],
     outputs=[d.qvel],
   )
 
-  target_act = wp.array(mjm.key_act[key], dtype=float)
   wp.launch(
     reset_activation,
     dim=(d.nworld, m.na),
-    inputs=[target_act, reset_input],
+    inputs=[m.key_act, key, reset_input],
     outputs=[d.act],
   )
 
-  target_mpos = wp.array(mjm.key_mpos[key], dtype=wp.vec3)
-  target_mquat = wp.array(mjm.key_mquat[key], dtype=wp.quat)
   wp.launch(
     reset_mocap,
     dim=(d.nworld, m.nbody),
     inputs=[
       m.body_mocapid,
-      target_mpos,
-      target_mquat,
+      m.key_mpos,
+      m.key_mquat,
+      key,
       reset_input,
     ],
     outputs=[d.mocap_pos, d.mocap_quat],
   )
 
-  target_ctrl = wp.array(mjm.key_ctrl[key], dtype=float)
   wp.launch(
     reset_control,
     dim=(d.nworld, m.nu),
-    inputs=[target_ctrl, reset_input],
+    inputs=[m.key_ctrl, key, reset_input],
     outputs=[d.ctrl],
   )
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2738,37 +2738,30 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     sleep.update_sleep(m, d)
 
 
-def reset_data_keyframe(
-  m: types.Model,
-  d: types.Data,
-  key: int | wp.array,
-  reset: Optional[wp.array] = None,
-):
-  """Reset data, set fields from specified keyframe; optionally by world.
+def reset_data_keyframe(m: types.Model, d: types.Data, key: int | wp.array):
+  """Reset data, set fields from specified keyframe.
 
   Args:
     m: The model containing kinematic and dynamic information (device).
     d: The data object containing the current state and output arrays (device).
-    key: The keyframe index to initialize the data with. Either an int, which
-      sets the same keyframe for every world, or a wp.array(dtype=int) of size
-      nworld, which sets a keyframe per world. In the latter case, worlds with a
-      keyframe index < 0 or >= m.nkey are not reset.
-    reset: Per-world bitmask. Reset if True.
+    key: The keyframe index to initialize the data with. If a plain integer is
+      given, all worlds are reset to that keyframe (in this case, if keyframe
+      index is < 0 or >= m.nkey, a ValueError is raised). If an array of
+      integers is given, each value of the array indicates the target
+      keyframe of the corresponding world (in this case, worlds whose
+      keyframe index is < 0 or >= m.nkey are not reset).
 
   Raises:
     ValueError: If key is an int and key<0 or key>=m.nkey.
-    ValueError: If key is a wp.array but its shape is not (d.nworld,).
+    ValueError: If key is a wp.array but its shape is not (d.nworld,) or its
+      dtype is not int.
   """
-  # Resolve reset world mask
-  if reset is None:
-    reset_input = wp.ones(d.nworld, dtype=bool)
-  else:
-    reset_input = reset
-
   # Resolve target keyframe index
   if isinstance(key, wp.array):
     if key.shape != (d.nworld,):
       raise ValueError(f"key array must have shape ({d.nworld},), got {key.shape}.")
+    if not wp.types.type_is_int(key.dtype):
+      raise ValueError(f"key array must be of integer type, got {key.dtype}.")
     key_input = key
   elif isinstance(key, int):
     if key < 0 or key >= m.nkey:
@@ -2777,31 +2770,30 @@ def reset_data_keyframe(
   else:
     raise ValueError(f"key must be an int or a wp.array, got {type(key)}.")
 
-  # Update reset mask: if key is out of bounds, mark reset mask as False for that world
+  # Worlds whose keyframe index is out of bounds are left untouched.
   @wp.kernel(module="unique", enable_backward=False)
-  def update_mask_for_invalid_keys(
+  def valid_key_mask(
     # Model:
     nkey: int,
     # In:
     key_in: wp.array[int],
-    reset_in: wp.array[bool],
     # Out:
     mask_out: wp.array[bool],
   ):
     worldid = wp.tid()
     key = key_in[worldid]
-    mask_out[worldid] = reset_in[worldid] and key >= 0 and key < nkey
+    mask_out[worldid] = key >= 0 and key < nkey
 
-  reset_input_with_invalid_keys_masked = wp.empty(d.nworld, dtype=bool)
+  reset_mask = wp.empty(d.nworld, dtype=bool)
   wp.launch(
-    update_mask_for_invalid_keys,
+    valid_key_mask,
     dim=d.nworld,
-    inputs=[m.nkey, key_input, reset_input],
-    outputs=[reset_input_with_invalid_keys_masked],
+    inputs=[m.nkey, key_input],
+    outputs=[reset_mask],
   )
 
-  # Call normal reset using updated mask
-  reset_data(m, d, reset_input_with_invalid_keys_masked)
+  # Call normal reset using the mask
+  reset_data(m, d, reset_mask)
 
   # Set time, qpos, qvel, act, mocap_pos, mocap_quat, ctrl from keyframes
   @wp.kernel(module="unique", enable_backward=False)
@@ -2922,28 +2914,28 @@ def reset_data_keyframe(
   wp.launch(
     reset_time,
     dim=d.nworld,
-    inputs=[m.key_time, key_input, reset_input_with_invalid_keys_masked],
+    inputs=[m.key_time, key_input, reset_mask],
     outputs=[d.time],
   )
 
   wp.launch(
     reset_qpos,
     dim=(d.nworld, m.nq),
-    inputs=[m.key_qpos, key_input, reset_input_with_invalid_keys_masked],
+    inputs=[m.key_qpos, key_input, reset_mask],
     outputs=[d.qpos],
   )
 
   wp.launch(
     reset_qvel,
     dim=(d.nworld, m.nv),
-    inputs=[m.key_qvel, key_input, reset_input_with_invalid_keys_masked],
+    inputs=[m.key_qvel, key_input, reset_mask],
     outputs=[d.qvel],
   )
 
   wp.launch(
     reset_activation,
     dim=(d.nworld, m.na),
-    inputs=[m.key_act, key_input, reset_input_with_invalid_keys_masked],
+    inputs=[m.key_act, key_input, reset_mask],
     outputs=[d.act],
   )
 
@@ -2955,7 +2947,7 @@ def reset_data_keyframe(
       m.key_mpos,
       m.key_mquat,
       key_input,
-      reset_input_with_invalid_keys_masked,
+      reset_mask,
     ],
     outputs=[d.mocap_pos, d.mocap_quat],
   )
@@ -2963,7 +2955,7 @@ def reset_data_keyframe(
   wp.launch(
     reset_control,
     dim=(d.nworld, m.nu),
-    inputs=[m.key_ctrl, key_input, reset_input_with_invalid_keys_masked],
+    inputs=[m.key_ctrl, key_input, reset_mask],
     outputs=[d.ctrl],
   )
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2393,6 +2393,9 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     m: The model containing kinematic and dynamic information (device).
     d: The data object containing the current state and output arrays (device).
     reset: Per-world bitmask. Reset if True.
+
+  Raises:
+    ValueError: If reset is specified but its shape is not (d.nworld,).
   """
   sleep_enabled = bool(m.opt.enableflags & types.EnableBit.SLEEP)
 
@@ -2622,7 +2625,14 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     if elemid < nv:
       dof_awake_ind_out[worldid, elemid] = elemid
 
-  reset_input = reset or wp.ones(d.nworld, dtype=bool)
+  if reset is None:
+    reset_input = wp.ones(d.nworld, dtype=bool)
+  elif isinstance(reset, wp.array):
+    if reset.shape != (d.nworld,):
+      raise ValueError(f"reset array must have shape ({d.nworld},), got {reset.shape}.")
+    reset_input = reset
+  else:
+    raise ValueError(f"reset must be None or a wp.array, got {type(reset)}.")
 
   wp.launch(reset_xfrc_applied, dim=(d.nworld, m.nbody, 6), inputs=[reset_input], outputs=[d.xfrc_applied])
   wp.launch(
@@ -2747,6 +2757,7 @@ def reset_data_keyframe(
 
   Raises:
     ValueError: If key is an int and key<0 or key>=m.nkey.
+    ValueError: If key is a wp.array but its shape is not (d.nworld,).
   """
   # Resolve reset world mask
   if reset is None:
@@ -2756,11 +2767,15 @@ def reset_data_keyframe(
 
   # Resolve target keyframe index
   if isinstance(key, wp.array):
+    if key.shape != (d.nworld,):
+      raise ValueError(f"key array must have shape ({d.nworld},), got {key.shape}.")
     key_input = key
-  else:
+  elif isinstance(key, int):
     if key < 0 or key >= m.nkey:
       raise ValueError(f"key ({key}) must be in [0, {m.nkey}).")
     key_input = wp.full(d.nworld, key, dtype=int)
+  else:
+    raise ValueError(f"key must be an int or a wp.array, got {type(key)}.")
 
   # Update reset mask: if key is out of bounds, mark reset mask as False for that world
   @wp.kernel(module="unique", enable_backward=False)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2741,7 +2741,13 @@ def reset_data_keyframe(
     d: The data object containing the current state and output arrays (device).
     key: The keyframe index to initialize the data with.
     reset: Per-world bitmask. Reset if True.
+
+  Raises:
+    ValueError: If key<0 or key>=m.nkey.
   """
+  if key < 0 or key >= m.nkey:
+    raise ValueError(f"key ({key}) must be in [0, {m.nkey}).")
+
   reset_data(m, d, reset)
 
   @wp.kernel(module="unique", enable_backward=False)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2731,7 +2731,7 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
 def reset_data_keyframe(
   m: types.Model,
   d: types.Data,
-  key: int,
+  key: int | wp.array,
   reset: Optional[wp.array] = None,
 ):
   """Reset data, set fields from specified keyframe; optionally by world.
@@ -2739,33 +2739,72 @@ def reset_data_keyframe(
   Args:
     m: The model containing kinematic and dynamic information (device).
     d: The data object containing the current state and output arrays (device).
-    key: The keyframe index to initialize the data with.
+    key: The keyframe index to initialize the data with. Either an int, which
+      sets the same keyframe for every world, or a wp.array(dtype=int) of size
+      nworld, which sets a keyframe per world. In the latter case, worlds with a
+      keyframe index < 0 or >= m.nkey are not reset.
     reset: Per-world bitmask. Reset if True.
 
   Raises:
-    ValueError: If key<0 or key>=m.nkey.
+    ValueError: If key is an int and key<0 or key>=m.nkey.
   """
-  if key < 0 or key >= m.nkey:
-    raise ValueError(f"key ({key}) must be in [0, {m.nkey}).")
+  # Resolve reset world mask
+  if reset is None:
+    reset_input = wp.ones(d.nworld, dtype=bool)
+  else:
+    reset_input = reset
 
-  reset_data(m, d, reset)
+  # Resolve target keyframe index
+  if isinstance(key, wp.array):
+    key_input = key
+  else:
+    if key < 0 or key >= m.nkey:
+      raise ValueError(f"key ({key}) must be in [0, {m.nkey}).")
+    key_input = wp.full(d.nworld, key, dtype=int)
 
+  # Update reset mask: if key is out of bounds, mark reset mask as False for that world
+  @wp.kernel(module="unique", enable_backward=False)
+  def update_mask_for_invalid_keys(
+    # Model:
+    nkey: int,
+    # In:
+    key_in: wp.array[int],
+    reset_in: wp.array[bool],
+    # Out:
+    mask_out: wp.array[bool],
+  ):
+    worldid = wp.tid()
+    key = key_in[worldid]
+    mask_out[worldid] = reset_in[worldid] and key >= 0 and key < nkey
+
+  reset_input_with_invalid_keys_masked = wp.empty(d.nworld, dtype=bool)
+  wp.launch(
+    update_mask_for_invalid_keys,
+    dim=d.nworld,
+    inputs=[m.nkey, key_input, reset_input],
+    outputs=[reset_input_with_invalid_keys_masked],
+  )
+
+  # Call normal reset using updated mask
+  reset_data(m, d, reset_input_with_invalid_keys_masked)
+
+  # Set time, qpos, qvel, act, mocap_pos, mocap_quat, ctrl from keyframes
   @wp.kernel(module="unique", enable_backward=False)
   def reset_time(
     # Model:
     key_time: wp.array[float],
     # In:
-    key: int,
+    key_in: wp.array[int],
     reset_in: wp.array[bool],
     # Data out:
     time_out: wp.array[float],
   ):
     worldid = wp.tid()
 
-    if wp.static(reset is not None):
-      if not reset_in[worldid]:
-        return
+    if not reset_in[worldid]:
+      return
 
+    key = key_in[worldid]
     time_out[worldid] = key_time[key]
 
   @wp.kernel(module="unique", enable_backward=False)
@@ -2773,17 +2812,17 @@ def reset_data_keyframe(
     # Model:
     key_qpos: wp.array2d[float],
     # In:
-    key: int,
+    key_in: wp.array[int],
     reset_in: wp.array[bool],
     # Data out:
     qpos_out: wp.array2d[float],
   ):
     worldid, qid = wp.tid()
 
-    if wp.static(reset is not None):
-      if not reset_in[worldid]:
-        return
+    if not reset_in[worldid]:
+      return
 
+    key = key_in[worldid]
     qpos_out[worldid, qid] = key_qpos[key, qid]
 
   @wp.kernel(module="unique", enable_backward=False)
@@ -2791,17 +2830,17 @@ def reset_data_keyframe(
     # Model:
     key_qvel: wp.array2d[float],
     # In:
-    key: int,
+    key_in: wp.array[int],
     reset_in: wp.array[bool],
     # Data out:
     qvel_out: wp.array2d[float],
   ):
     worldid, vid = wp.tid()
 
-    if wp.static(reset is not None):
-      if not reset_in[worldid]:
-        return
+    if not reset_in[worldid]:
+      return
 
+    key = key_in[worldid]
     qvel_out[worldid, vid] = key_qvel[key, vid]
 
   @wp.kernel(module="unique", enable_backward=False)
@@ -2809,17 +2848,17 @@ def reset_data_keyframe(
     # Model:
     key_act: wp.array2d[float],
     # In:
-    key: int,
+    key_in: wp.array[int],
     reset_in: wp.array[bool],
     # Data out:
     act_out: wp.array2d[float],
   ):
     worldid, aid = wp.tid()
 
-    if wp.static(reset is not None):
-      if not reset_in[worldid]:
-        return
+    if not reset_in[worldid]:
+      return
 
+    key = key_in[worldid]
     act_out[worldid, aid] = key_act[key, aid]
 
   @wp.kernel(module="unique", enable_backward=False)
@@ -2829,7 +2868,7 @@ def reset_data_keyframe(
     key_mpos: wp.array2d[wp.vec3],
     key_mquat: wp.array2d[wp.quat],
     # In:
-    key: int,
+    key_in: wp.array[int],
     reset_in: wp.array[bool],
     # Data out:
     mocap_pos_out: wp.array2d[wp.vec3],
@@ -2837,13 +2876,13 @@ def reset_data_keyframe(
   ):
     worldid, bodyid = wp.tid()
 
-    if wp.static(reset is not None):
-      if not reset_in[worldid]:
-        return
+    if not reset_in[worldid]:
+      return
 
     mocapid = body_mocapid[bodyid]
 
     if mocapid >= 0:
+      key = key_in[worldid]
       mocap_pos_out[worldid, mocapid] = key_mpos[key, mocapid]
       mocap_quat_out[worldid, mocapid] = key_mquat[key, mocapid]
 
@@ -2852,46 +2891,44 @@ def reset_data_keyframe(
     # Model:
     key_ctrl: wp.array2d[float],
     # In:
-    key: int,
+    key_in: wp.array[int],
     reset_in: wp.array[bool],
     # Data out:
     ctrl_out: wp.array2d[float],
   ):
     worldid, cid = wp.tid()
 
-    if wp.static(reset is not None):
-      if not reset_in[worldid]:
-        return
+    if not reset_in[worldid]:
+      return
 
+    key = key_in[worldid]
     ctrl_out[worldid, cid] = key_ctrl[key, cid]
-
-  reset_input = reset or wp.ones(d.nworld, dtype=bool)
 
   wp.launch(
     reset_time,
     dim=d.nworld,
-    inputs=[m.key_time, key, reset_input],
+    inputs=[m.key_time, key_input, reset_input_with_invalid_keys_masked],
     outputs=[d.time],
   )
 
   wp.launch(
     reset_qpos,
     dim=(d.nworld, m.nq),
-    inputs=[m.key_qpos, key, reset_input],
+    inputs=[m.key_qpos, key_input, reset_input_with_invalid_keys_masked],
     outputs=[d.qpos],
   )
 
   wp.launch(
     reset_qvel,
     dim=(d.nworld, m.nv),
-    inputs=[m.key_qvel, key, reset_input],
+    inputs=[m.key_qvel, key_input, reset_input_with_invalid_keys_masked],
     outputs=[d.qvel],
   )
 
   wp.launch(
     reset_activation,
     dim=(d.nworld, m.na),
-    inputs=[m.key_act, key, reset_input],
+    inputs=[m.key_act, key_input, reset_input_with_invalid_keys_masked],
     outputs=[d.act],
   )
 
@@ -2902,8 +2939,8 @@ def reset_data_keyframe(
       m.body_mocapid,
       m.key_mpos,
       m.key_mquat,
-      key,
-      reset_input,
+      key_input,
+      reset_input_with_invalid_keys_masked,
     ],
     outputs=[d.mocap_pos, d.mocap_quat],
   )
@@ -2911,7 +2948,7 @@ def reset_data_keyframe(
   wp.launch(
     reset_control,
     dim=(d.nworld, m.nu),
-    inputs=[m.key_ctrl, key, reset_input],
+    inputs=[m.key_ctrl, key_input, reset_input_with_invalid_keys_masked],
     outputs=[d.ctrl],
   )
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2392,11 +2392,11 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
   Args:
     m: The model containing kinematic and dynamic information (device).
     d: The data object containing the current state and output arrays (device).
-    reset: Per-world bitmask. Reset if True.
+    reset: Per-world bitmask (bool or integer array). Reset if nonzero/True.
 
   Raises:
     ValueError: If reset is specified but its shape is not (d.nworld,) or its
-      dtype is not bool.
+      dtype is not bool or integer.
   """
   sleep_enabled = bool(m.opt.enableflags & types.EnableBit.SLEEP)
 
@@ -2631,9 +2631,13 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
   elif isinstance(reset, wp.array):
     if reset.shape != (d.nworld,):
       raise ValueError(f"reset array must have shape ({d.nworld},), got {reset.shape}.")
-    if reset.dtype != wp.bool:
-      raise ValueError(f"reset array must be of bool type, got {reset.dtype}.")
-    reset_input = reset
+    if reset.dtype == wp.bool:
+      reset_input = reset
+    elif wp.types.type_is_int(reset.dtype):
+      reset_input = wp.empty(d.nworld, dtype=bool)
+      wp.utils.array_cast(reset, reset_input)
+    else:
+      raise ValueError(f"reset array must be of bool or integer type, got {reset.dtype}.")
   else:
     raise ValueError(f"reset must be None or a wp.array, got {type(reset)}.")
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2395,7 +2395,8 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     reset: Per-world bitmask. Reset if True.
 
   Raises:
-    ValueError: If reset is specified but its shape is not (d.nworld,).
+    ValueError: If reset is specified but its shape is not (d.nworld,) or its
+      dtype is not bool.
   """
   sleep_enabled = bool(m.opt.enableflags & types.EnableBit.SLEEP)
 
@@ -2630,6 +2631,8 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
   elif isinstance(reset, wp.array):
     if reset.shape != (d.nworld,):
       raise ValueError(f"reset array must have shape ({d.nworld},), got {reset.shape}.")
+    if reset.dtype != wp.bool:
+      raise ValueError(f"reset array must be of bool type, got {reset.dtype}.")
     reset_input = reset
   else:
     raise ValueError(f"reset must be None or a wp.array, got {type(reset)}.")
@@ -2763,7 +2766,8 @@ def reset_data_keyframe(m: types.Model, d: types.Data, key: int | wp.array):
     if not wp.types.type_is_int(key.dtype):
       raise ValueError(f"key array must be of integer type, got {key.dtype}.")
     key_input = key
-  elif isinstance(key, int):
+  elif isinstance(key, (int, np.integer)):
+    key = int(key)
     if key < 0 or key >= m.nkey:
       raise ValueError(f"key ({key}) must be in [0, {m.nkey}).")
     key_input = wp.full(d.nworld, key, dtype=int)
@@ -2795,16 +2799,33 @@ def reset_data_keyframe(m: types.Model, d: types.Data, key: int | wp.array):
   # Call normal reset using the mask
   reset_data(m, d, reset_mask)
 
-  # Set time, qpos, qvel, act, mocap_pos, mocap_quat, ctrl from keyframes
+  # Set time, qpos, qvel, act, ctrl, mocap_pos, mocap_quat from the keyframe.
   @wp.kernel(module="unique", enable_backward=False)
-  def reset_time(
+  def reset_keyframe_data(
     # Model:
+    nq: int,
+    nv: int,
+    nu: int,
+    na: int,
+    nmocap: int,
     key_time: wp.array[float],
+    key_qpos: wp.array2d[float],
+    key_qvel: wp.array2d[float],
+    key_act: wp.array2d[float],
+    key_mpos: wp.array2d[wp.vec3],
+    key_mquat: wp.array2d[wp.quat],
+    key_ctrl: wp.array2d[float],
     # In:
     key_in: wp.array[int],
     reset_in: wp.array[bool],
     # Data out:
     time_out: wp.array[float],
+    qpos_out: wp.array2d[float],
+    qvel_out: wp.array2d[float],
+    act_out: wp.array2d[float],
+    ctrl_out: wp.array2d[float],
+    mocap_pos_out: wp.array2d[wp.vec3],
+    mocap_quat_out: wp.array2d[wp.quat],
   ):
     worldid = wp.tid()
 
@@ -2813,150 +2834,46 @@ def reset_data_keyframe(m: types.Model, d: types.Data, key: int | wp.array):
 
     key = key_in[worldid]
     time_out[worldid] = key_time[key]
-
-  @wp.kernel(module="unique", enable_backward=False)
-  def reset_qpos(
-    # Model:
-    key_qpos: wp.array2d[float],
-    # In:
-    key_in: wp.array[int],
-    reset_in: wp.array[bool],
-    # Data out:
-    qpos_out: wp.array2d[float],
-  ):
-    worldid, qid = wp.tid()
-
-    if not reset_in[worldid]:
-      return
-
-    key = key_in[worldid]
-    qpos_out[worldid, qid] = key_qpos[key, qid]
-
-  @wp.kernel(module="unique", enable_backward=False)
-  def reset_qvel(
-    # Model:
-    key_qvel: wp.array2d[float],
-    # In:
-    key_in: wp.array[int],
-    reset_in: wp.array[bool],
-    # Data out:
-    qvel_out: wp.array2d[float],
-  ):
-    worldid, vid = wp.tid()
-
-    if not reset_in[worldid]:
-      return
-
-    key = key_in[worldid]
-    qvel_out[worldid, vid] = key_qvel[key, vid]
-
-  @wp.kernel(module="unique", enable_backward=False)
-  def reset_activation(
-    # Model:
-    key_act: wp.array2d[float],
-    # In:
-    key_in: wp.array[int],
-    reset_in: wp.array[bool],
-    # Data out:
-    act_out: wp.array2d[float],
-  ):
-    worldid, aid = wp.tid()
-
-    if not reset_in[worldid]:
-      return
-
-    key = key_in[worldid]
-    act_out[worldid, aid] = key_act[key, aid]
-
-  @wp.kernel(module="unique", enable_backward=False)
-  def reset_mocap(
-    # Model:
-    body_mocapid: wp.array[int],
-    key_mpos: wp.array2d[wp.vec3],
-    key_mquat: wp.array2d[wp.quat],
-    # In:
-    key_in: wp.array[int],
-    reset_in: wp.array[bool],
-    # Data out:
-    mocap_pos_out: wp.array2d[wp.vec3],
-    mocap_quat_out: wp.array2d[wp.quat],
-  ):
-    worldid, bodyid = wp.tid()
-
-    if not reset_in[worldid]:
-      return
-
-    mocapid = body_mocapid[bodyid]
-
-    if mocapid >= 0:
-      key = key_in[worldid]
-      mocap_pos_out[worldid, mocapid] = key_mpos[key, mocapid]
-      mocap_quat_out[worldid, mocapid] = key_mquat[key, mocapid]
-
-  @wp.kernel(module="unique", enable_backward=False)
-  def reset_control(
-    # Model:
-    key_ctrl: wp.array2d[float],
-    # In:
-    key_in: wp.array[int],
-    reset_in: wp.array[bool],
-    # Data out:
-    ctrl_out: wp.array2d[float],
-  ):
-    worldid, cid = wp.tid()
-
-    if not reset_in[worldid]:
-      return
-
-    key = key_in[worldid]
-    ctrl_out[worldid, cid] = key_ctrl[key, cid]
+    for i in range(nq):
+      qpos_out[worldid, i] = key_qpos[key, i]
+    for i in range(nv):
+      qvel_out[worldid, i] = key_qvel[key, i]
+    for i in range(na):
+      act_out[worldid, i] = key_act[key, i]
+    for i in range(nmocap):
+      mocap_pos_out[worldid, i] = key_mpos[key, i]
+      mocap_quat_out[worldid, i] = key_mquat[key, i]
+    for i in range(nu):
+      ctrl_out[worldid, i] = key_ctrl[key, i]
 
   wp.launch(
-    reset_time,
+    reset_keyframe_data,
     dim=d.nworld,
-    inputs=[m.key_time, key_input, reset_mask],
-    outputs=[d.time],
-  )
-
-  wp.launch(
-    reset_qpos,
-    dim=(d.nworld, m.nq),
-    inputs=[m.key_qpos, key_input, reset_mask],
-    outputs=[d.qpos],
-  )
-
-  wp.launch(
-    reset_qvel,
-    dim=(d.nworld, m.nv),
-    inputs=[m.key_qvel, key_input, reset_mask],
-    outputs=[d.qvel],
-  )
-
-  wp.launch(
-    reset_activation,
-    dim=(d.nworld, m.na),
-    inputs=[m.key_act, key_input, reset_mask],
-    outputs=[d.act],
-  )
-
-  wp.launch(
-    reset_mocap,
-    dim=(d.nworld, m.nbody),
     inputs=[
-      m.body_mocapid,
+      m.nq,
+      m.nv,
+      m.nu,
+      m.na,
+      m.nmocap,
+      m.key_time,
+      m.key_qpos,
+      m.key_qvel,
+      m.key_act,
       m.key_mpos,
       m.key_mquat,
+      m.key_ctrl,
       key_input,
       reset_mask,
     ],
-    outputs=[d.mocap_pos, d.mocap_quat],
-  )
-
-  wp.launch(
-    reset_control,
-    dim=(d.nworld, m.nu),
-    inputs=[m.key_ctrl, key_input, reset_mask],
-    outputs=[d.ctrl],
+    outputs=[
+      d.time,
+      d.qpos,
+      d.qvel,
+      d.act,
+      d.ctrl,
+      d.mocap_pos,
+      d.mocap_quat,
+    ],
   )
 
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2728,6 +2728,190 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     sleep.update_sleep(m, d)
 
 
+def reset_data_keyframe(
+  mjm: mujoco.MjModel,
+  m: types.Model,
+  d: types.Data,
+  key: int,
+  reset: Optional[wp.array] = None,
+):
+  """Reset data, set fields from specified keyframe; optionally by world.
+
+  Unlike `reset_data`, this function requires the host-side MuJoCo model as an argument
+  becasue the keyframe data are not tracked by `types.Model`.
+
+  Args:
+    mjm: The host-side MuJoCo model.
+    m: The model containing kinematic and dynamic information (device).
+    d: The data object containing the current state and output arrays (device).
+    key: The keyframe index to initialize the data with. An IndexError is raised if
+      key<0 or key>=mjm.nkey.
+    reset: Per-world bitmask. Reset if True.
+  """
+  reset_data(m, d, reset)
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def reset_time(
+    # In:
+    target_time: float,
+    reset_in: wp.array[bool],
+    # Data out:
+    time_out: wp.array[float],
+  ):
+    worldid = wp.tid()
+
+    if wp.static(reset is not None):
+      if not reset_in[worldid]:
+        return
+
+    time_out[worldid] = target_time
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def reset_qpos(
+    # In:
+    target_qpos: wp.array[float],
+    reset_in: wp.array[bool],
+    # Data out:
+    qpos_out: wp.array2d[float],
+  ):
+    worldid, qid = wp.tid()
+
+    if wp.static(reset is not None):
+      if not reset_in[worldid]:
+        return
+
+    qpos_out[worldid, qid] = target_qpos[qid]
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def reset_qvel(
+    # In:
+    target_qvel: wp.array[float],
+    reset_in: wp.array[bool],
+    # Data out:
+    qvel_out: wp.array2d[float],
+  ):
+    worldid, vid = wp.tid()
+
+    if wp.static(reset is not None):
+      if not reset_in[worldid]:
+        return
+
+    qvel_out[worldid, vid] = target_qvel[vid]
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def reset_activation(
+    # In:
+    target_act: wp.array[float],
+    reset_in: wp.array[bool],
+    # Data out:
+    act_out: wp.array2d[float],
+  ):
+    worldid, aid = wp.tid()
+
+    if wp.static(reset is not None):
+      if not reset_in[worldid]:
+        return
+
+    act_out[worldid, aid] = target_act[aid]
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def reset_mocap(
+    # Model:
+    body_mocapid: wp.array[int],
+    # In:
+    target_mpos: wp.array[wp.vec3],
+    target_mquat: wp.array[wp.quat],
+    # In:
+    reset_in: wp.array[bool],
+    # Data out:
+    mocap_pos_out: wp.array2d[wp.vec3],
+    mocap_quat_out: wp.array2d[wp.quat],
+  ):
+    worldid, bodyid = wp.tid()
+
+    if wp.static(reset is not None):
+      if not reset_in[worldid]:
+        return
+
+    mocapid = body_mocapid[bodyid]
+
+    if mocapid >= 0:
+      mocap_pos_out[worldid, mocapid] = target_mpos[mocapid]
+      mocap_quat_out[worldid, mocapid] = target_mquat[mocapid]
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def reset_control(
+    # In:
+    target_ctrl: wp.array[float],
+    reset_in: wp.array[bool],
+    # Data out:
+    ctrl_out: wp.array2d[float],
+  ):
+    worldid, cid = wp.tid()
+
+    if wp.static(reset is not None):
+      if not reset_in[worldid]:
+        return
+
+    ctrl_out[worldid, cid] = target_ctrl[cid]
+
+  reset_input = reset or wp.ones(d.nworld, dtype=bool)
+
+  target_time = mjm.key_time[key]
+  wp.launch(
+    reset_time,
+    dim=d.nworld,
+    inputs=[target_time, reset_input],
+    outputs=[d.time],
+  )
+
+  target_qpos = wp.array(mjm.key_qpos[key], dtype=float)
+  wp.launch(
+    reset_qpos,
+    dim=(d.nworld, m.nq),
+    inputs=[target_qpos, reset_input],
+    outputs=[d.qpos],
+  )
+
+  target_qvel = wp.array(mjm.key_qvel[key], dtype=float)
+  wp.launch(
+    reset_qvel,
+    dim=(d.nworld, m.nv),
+    inputs=[target_qvel, reset_input],
+    outputs=[d.qvel],
+  )
+
+  target_act = wp.array(mjm.key_act[key], dtype=float)
+  wp.launch(
+    reset_activation,
+    dim=(d.nworld, m.na),
+    inputs=[target_act, reset_input],
+    outputs=[d.act],
+  )
+
+  target_mpos = wp.array(mjm.key_mpos[key], dtype=wp.vec3)
+  target_mquat = wp.array(mjm.key_mquat[key], dtype=wp.quat)
+  wp.launch(
+    reset_mocap,
+    dim=(d.nworld, m.nbody),
+    inputs=[
+      m.body_mocapid,
+      target_mpos,
+      target_mquat,
+      reset_input,
+    ],
+    outputs=[d.mocap_pos, d.mocap_quat],
+  )
+
+  target_ctrl = wp.array(mjm.key_ctrl[key], dtype=float)
+  wp.launch(
+    reset_control,
+    dim=(d.nworld, m.nu),
+    inputs=[target_ctrl, reset_input],
+    outputs=[d.ctrl],
+  )
+
+
 # kernel_analyzer: off
 @wp.kernel
 def _init_subtreemass(

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1071,6 +1071,15 @@ class IOTest(parameterized.TestCase):
     _assert_eq(d.qvel.numpy()[0], 1.0, "qvel[0]")
     _assert_eq(d.qvel.numpy()[1], 2.0, "qvel[1]")
 
+    wp.copy(d.qvel, qvel)
+
+    # int arrays are tolerated as a reset mask (nonzero means reset)
+    reset10_int = wp.array(np.array([1, 0]), dtype=int)
+    mjwarp.reset_data(m, d, reset=reset10_int)
+
+    _assert_eq(d.qvel.numpy()[0], 0.0, "qvel[0]")
+    _assert_eq(d.qvel.numpy()[1], 2.0, "qvel[1]")
+
   def test_reset_data_reset_invalid(self):
     """Tests that reset_data validates the reset argument."""
     _, _, m, d = test_data.fixture(
@@ -1090,10 +1099,7 @@ class IOTest(parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, "reset array must have shape"):
       mjwarp.reset_data(m, d, reset=wp.array(np.array([True, False, True]), dtype=bool))
 
-    with self.assertRaisesRegex(ValueError, "reset array must be of bool type"):
-      mjwarp.reset_data(m, d, reset=wp.array(np.array([1, 0]), dtype=int))
-
-    with self.assertRaisesRegex(ValueError, "reset array must be of bool type"):
+    with self.assertRaisesRegex(ValueError, "reset array must be of bool or integer type"):
       mjwarp.reset_data(m, d, reset=wp.array(np.array([1.0, 0.0]), dtype=float))
 
     with self.assertRaisesRegex(ValueError, "reset must be None or a wp.array"):

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1072,6 +1072,96 @@ class IOTest(parameterized.TestCase):
     _assert_eq(d.qvel.numpy()[0], 1.0, "qvel[0]")
     _assert_eq(d.qvel.numpy()[1], 2.0, "qvel[1]")
 
+  def test_reset_data_keyframe(self):
+    """Tests that reset_data_keyframe matches mj_resetDataKeyframe."""
+    _MJCF = """
+    <mujoco>
+      <worldbody>
+        <body name="mocap1" mocap="true">
+          <geom type="sphere" size="0.1"/>
+        </body>
+        <body>
+          <joint type="slide" name="slide1"/>
+          <geom type="sphere" size="1"/>
+        </body>
+      </worldbody>
+      <actuator>
+        <general joint="slide1" dyntype="integrator" dynprm="1" gaintype="fixed" gainprm="1" biastype="none"/>
+      </actuator>
+      <keyframe>
+        <key name="k0" time="0.5" qpos="0.3" qvel="0.4" act="0.6" ctrl="0.7"
+             mpos="0.1 0.2 0.3" mquat="0.7071068 0.7071068 0 0"/>
+      </keyframe>
+    </mujoco>
+    """
+    reset_datafield = ["time", "qpos", "qvel", "act", "ctrl", "mocap_pos", "mocap_quat"]
+    key = 0
+
+    mjm, mjd, m, d = test_data.fixture(xml=_MJCF)
+
+    # corrupt data
+    for arr in reset_datafield:
+      attr = getattr(d, arr)
+      if attr.dtype == float:
+        attr.fill_(wp.nan)
+      else:
+        attr.fill_(-1)
+
+    mujoco.mj_resetDataKeyframe(mjm, mjd, key)
+    mjwarp.reset_data_keyframe(mjm, m, d, key)
+
+    for arr in reset_datafield:
+      _assert_eq(getattr(d, arr).numpy()[0], getattr(mjd, arr), arr)
+
+  def test_reset_data_keyframe_world(self):
+    """Tests per-world reset for reset_data_keyframe."""
+    _MJCF = """
+    <mujoco>
+      <worldbody>
+        <body>
+          <geom type="sphere" size="1"/>
+          <joint type="slide"/>
+        </body>
+      </worldbody>
+      <keyframe>
+        <key name="k0" qpos="0.5"/>
+      </keyframe>
+    </mujoco>
+    """
+    key = 0
+    mjm = mujoco.MjModel.from_xml_string(_MJCF)
+    m = mjwarp.put_model(mjm)
+    d = mjwarp.make_data(mjm, nworld=2)
+
+    # nonzero values
+    qpos = wp.array(np.array([[1.0], [2.0]]), dtype=float)
+
+    wp.copy(d.qpos, qpos)
+
+    # reset both worlds
+    mjwarp.reset_data_keyframe(mjm, m, d, key)
+
+    _assert_eq(d.qpos.numpy()[0], 0.5, "qpos[0]")
+    _assert_eq(d.qpos.numpy()[1], 0.5, "qpos[1]")
+
+    wp.copy(d.qpos, qpos)
+
+    # don't reset second world
+    reset10 = wp.array(np.array([True, False]), dtype=bool)
+    mjwarp.reset_data_keyframe(mjm, m, d, key, reset=reset10)
+
+    _assert_eq(d.qpos.numpy()[0], 0.5, "qpos[0]")
+    _assert_eq(d.qpos.numpy()[1], 2.0, "qpos[1]")
+
+    wp.copy(d.qpos, qpos)
+
+    # don't reset both worlds
+    reset00 = wp.array(np.array([False, False], dtype=bool))
+    mjwarp.reset_data_keyframe(mjm, m, d, key, reset=reset00)
+
+    _assert_eq(d.qpos.numpy()[0], 1.0, "qpos[0]")
+    _assert_eq(d.qpos.numpy()[1], 2.0, "qpos[1]")
+
   def test_sdf(self):
     """Tests that an SDF can be loaded."""
     mjm, mjd, m, d = test_data.fixture("collision_sdf/cow.xml")

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1097,7 +1097,7 @@ class IOTest(parameterized.TestCase):
     reset_datafield = ["time", "qpos", "qvel", "act", "ctrl", "mocap_pos", "mocap_quat"]
     key = 0
 
-    mjm, mjd, m, d = test_data.fixture(xml=_MJCF)
+    mjm, mjd, m, d = test_data.fixture(xml=_MJCF, keyframe=key)
 
     # corrupt data
     for arr in reset_datafield:
@@ -1107,8 +1107,7 @@ class IOTest(parameterized.TestCase):
       else:
         attr.fill_(-1)
 
-    mujoco.mj_resetDataKeyframe(mjm, mjd, key)
-    mjwarp.reset_data_keyframe(mjm, m, d, key)
+    mjwarp.reset_data_keyframe(m, d, key)
 
     for arr in reset_datafield:
       _assert_eq(getattr(d, arr).numpy()[0], getattr(mjd, arr), arr)
@@ -1139,7 +1138,7 @@ class IOTest(parameterized.TestCase):
     wp.copy(d.qpos, qpos)
 
     # reset both worlds
-    mjwarp.reset_data_keyframe(mjm, m, d, key)
+    mjwarp.reset_data_keyframe(m, d, key)
 
     _assert_eq(d.qpos.numpy()[0], 0.5, "qpos[0]")
     _assert_eq(d.qpos.numpy()[1], 0.5, "qpos[1]")
@@ -1148,7 +1147,7 @@ class IOTest(parameterized.TestCase):
 
     # don't reset second world
     reset10 = wp.array(np.array([True, False]), dtype=bool)
-    mjwarp.reset_data_keyframe(mjm, m, d, key, reset=reset10)
+    mjwarp.reset_data_keyframe(m, d, key, reset=reset10)
 
     _assert_eq(d.qpos.numpy()[0], 0.5, "qpos[0]")
     _assert_eq(d.qpos.numpy()[1], 2.0, "qpos[1]")
@@ -1157,7 +1156,7 @@ class IOTest(parameterized.TestCase):
 
     # don't reset both worlds
     reset00 = wp.array(np.array([False, False], dtype=bool))
-    mjwarp.reset_data_keyframe(mjm, m, d, key, reset=reset00)
+    mjwarp.reset_data_keyframe(m, d, key, reset=reset00)
 
     _assert_eq(d.qpos.numpy()[0], 1.0, "qpos[0]")
     _assert_eq(d.qpos.numpy()[1], 2.0, "qpos[1]")

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1135,7 +1135,7 @@ class IOTest(parameterized.TestCase):
       _assert_eq(getattr(d, arr).numpy()[0], getattr(mjd, arr), arr)
 
   def test_reset_data_keyframe_world(self):
-    """Tests per-world reset for reset_data_keyframe."""
+    """Tests per-world reset for reset_data_keyframe, skipping worlds via an invalid key."""
     _MJCF = """
     <mujoco>
       <worldbody>
@@ -1167,18 +1167,18 @@ class IOTest(parameterized.TestCase):
 
     wp.copy(d.qpos, qpos)
 
-    # don't reset second world
-    reset10 = wp.array(np.array([True, False]), dtype=bool)
-    mjwarp.reset_data_keyframe(m, d, key, reset=reset10)
+    # don't reset second world: give it an out-of-range key
+    key10 = wp.array(np.array([0, -1]), dtype=int)
+    mjwarp.reset_data_keyframe(m, d, key10)
 
     _assert_eq(d.qpos.numpy()[0], 0.5, "qpos[0]")
     _assert_eq(d.qpos.numpy()[1], 2.0, "qpos[1]")
 
     wp.copy(d.qpos, qpos)
 
-    # don't reset both worlds
-    reset00 = wp.array(np.array([False, False], dtype=bool))
-    mjwarp.reset_data_keyframe(m, d, key, reset=reset00)
+    # don't reset either world
+    key00 = wp.array(np.array([-1, -1]), dtype=int)
+    mjwarp.reset_data_keyframe(m, d, key00)
 
     _assert_eq(d.qpos.numpy()[0], 1.0, "qpos[0]")
     _assert_eq(d.qpos.numpy()[1], 2.0, "qpos[1]")
@@ -1243,6 +1243,8 @@ class IOTest(parameterized.TestCase):
       mjwarp.reset_data_keyframe(m, d, 1)
     with self.assertRaisesRegex(ValueError, "key array must have shape"):
       mjwarp.reset_data_keyframe(m, d, wp.array(np.array([0, 0, 0]), dtype=int))
+    with self.assertRaisesRegex(ValueError, "key array must be of integer type"):
+      mjwarp.reset_data_keyframe(m, d, wp.array(np.array([0.0, 0.0]), dtype=float))
     with self.assertRaisesRegex(ValueError, "key must be an int or a wp.array"):
       mjwarp.reset_data_keyframe(m, d, 0.5)
 

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1029,7 +1029,7 @@ class IOTest(parameterized.TestCase):
 
   def test_reset_data_world(self):
     """Tests per-world reset."""
-    _MJCF = """
+    mjm = mujoco.MjModel.from_xml_string("""
     <mujoco>
       <worldbody>
         <body>
@@ -1038,8 +1038,7 @@ class IOTest(parameterized.TestCase):
         </body>
       </worldbody>
     </mujoco>
-    """
-    mjm = mujoco.MjModel.from_xml_string(_MJCF)
+    """)
     m = mjwarp.put_model(mjm)
     d = mjwarp.make_data(mjm, nworld=2)
 
@@ -1074,7 +1073,8 @@ class IOTest(parameterized.TestCase):
 
   def test_reset_data_reset_invalid(self):
     """Tests that reset_data validates the reset argument."""
-    _MJCF = """
+    _, _, m, d = test_data.fixture(
+      xml="""
     <mujoco>
       <worldbody>
         <body>
@@ -1083,20 +1083,29 @@ class IOTest(parameterized.TestCase):
         </body>
       </worldbody>
     </mujoco>
-    """
-    mjm = mujoco.MjModel.from_xml_string(_MJCF)
-    m = mjwarp.put_model(mjm)
-    d = mjwarp.make_data(mjm, nworld=2)
+    """,
+      nworld=2,
+    )
 
     with self.assertRaisesRegex(ValueError, "reset array must have shape"):
       mjwarp.reset_data(m, d, reset=wp.array(np.array([True, False, True]), dtype=bool))
+
+    with self.assertRaisesRegex(ValueError, "reset array must be of bool type"):
+      mjwarp.reset_data(m, d, reset=wp.array(np.array([1, 0]), dtype=int))
+
+    with self.assertRaisesRegex(ValueError, "reset array must be of bool type"):
+      mjwarp.reset_data(m, d, reset=wp.array(np.array([1.0, 0.0]), dtype=float))
 
     with self.assertRaisesRegex(ValueError, "reset must be None or a wp.array"):
       mjwarp.reset_data(m, d, reset=[True, False])
 
   def test_reset_data_keyframe(self):
     """Tests that reset_data_keyframe matches mj_resetDataKeyframe."""
-    _MJCF = """
+    reset_datafield = ["time", "qpos", "qvel", "act", "mocap_pos", "mocap_quat", "ctrl"]
+    key = 0
+
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
     <mujoco>
       <worldbody>
         <body name="mocap1" mocap="true">
@@ -1108,18 +1117,16 @@ class IOTest(parameterized.TestCase):
         </body>
       </worldbody>
       <actuator>
-        <general joint="slide1" dyntype="integrator" dynprm="1" gaintype="fixed" gainprm="1" biastype="none"/>
+        <general joint="slide1" dyntype="integrator"/>
       </actuator>
       <keyframe>
         <key name="k0" time="0.5" qpos="0.3" qvel="0.4" act="0.6" ctrl="0.7"
              mpos="0.1 0.2 0.3" mquat="0.7071068 0.7071068 0 0"/>
       </keyframe>
     </mujoco>
-    """
-    reset_datafield = ["time", "qpos", "qvel", "act", "ctrl", "mocap_pos", "mocap_quat"]
-    key = 0
-
-    mjm, mjd, m, d = test_data.fixture(xml=_MJCF, keyframe=key)
+    """,
+      keyframe=key,
+    )
 
     # corrupt data
     for arr in reset_datafield:
@@ -1136,7 +1143,10 @@ class IOTest(parameterized.TestCase):
 
   def test_reset_data_keyframe_world(self):
     """Tests per-world reset for reset_data_keyframe, skipping worlds via an invalid key."""
-    _MJCF = """
+    key = 0
+
+    _, _, m, d = test_data.fixture(
+      xml="""
     <mujoco>
       <worldbody>
         <body>
@@ -1148,11 +1158,9 @@ class IOTest(parameterized.TestCase):
         <key name="k0" qpos="0.5"/>
       </keyframe>
     </mujoco>
-    """
-    key = 0
-    mjm = mujoco.MjModel.from_xml_string(_MJCF)
-    m = mjwarp.put_model(mjm)
-    d = mjwarp.make_data(mjm, nworld=2)
+    """,
+      nworld=2,
+    )
 
     # nonzero values
     qpos = wp.array(np.array([[1.0], [2.0]]), dtype=float)
@@ -1185,26 +1193,43 @@ class IOTest(parameterized.TestCase):
 
   def test_reset_data_keyframe_per_world(self):
     """Tests reset_data_keyframe with a per-world keyframe array."""
-    _MJCF = """
+    reset_datafield = ["time", "qpos", "qvel", "act", "mocap_pos", "mocap_quat", "ctrl"]
+
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
     <mujoco>
       <worldbody>
+        <body name="mocap1" mocap="true">
+          <geom type="sphere" size="0.1"/>
+        </body>
         <body>
+          <joint type="slide" name="slide1"/>
           <geom type="sphere" size="1"/>
-          <joint type="slide"/>
         </body>
       </worldbody>
+      <actuator>
+        <general joint="slide1" dyntype="integrator"/>
+      </actuator>
       <keyframe>
-        <key name="k0" qpos="0.5"/>
-        <key name="k1" qpos="0.6"/>
+        <key name="k0" time="0.1" qpos="0.2" qvel="0.3" act="0.4" ctrl="0.5"
+             mpos="0.1 0 0" mquat="1 0 0 0"/>
+        <key name="k1" time="0.6" qpos="0.7" qvel="0.8" act="0.9" ctrl="1.0"
+             mpos="0 0.2 0" mquat="0.7071068 0.7071068 0 0"/>
       </keyframe>
     </mujoco>
-    """
-    mjm = mujoco.MjModel.from_xml_string(_MJCF)
-    m = mjwarp.put_model(mjm)
-    d = mjwarp.make_data(mjm, nworld=4)
+    """,
+      nworld=4,
+    )
 
-    qpos = wp.array(np.array([[1.0], [2.0], [3.0], [4.0]]), dtype=float)
-    wp.copy(d.qpos, qpos)
+    # get reference values using the plain mujoco API
+    mjd0 = mujoco.MjData(mjm)
+    mujoco.mj_resetDataKeyframe(mjm, mjd0, 0)
+    mjd1 = mujoco.MjData(mjm)
+    mujoco.mj_resetDataKeyframe(mjm, mjd1, 1)
+
+    # corrupt data
+    for arr in reset_datafield:
+      getattr(d, arr).fill_(-1.0)
 
     # world 0 -> key 0
     # world 1 -> key 1
@@ -1213,14 +1238,50 @@ class IOTest(parameterized.TestCase):
     key = wp.array(np.array([0, 1, -1, 2]), dtype=int)
     mjwarp.reset_data_keyframe(m, d, key)
 
-    _assert_eq(d.qpos.numpy()[0], 0.5, "qpos[0]")
-    _assert_eq(d.qpos.numpy()[1], 0.6, "qpos[1]")
-    _assert_eq(d.qpos.numpy()[2], 3.0, "qpos[2]")
-    _assert_eq(d.qpos.numpy()[3], 4.0, "qpos[3]")
+    for arr in reset_datafield:
+      d_arr = getattr(d, arr).numpy()
+      expected = [
+        getattr(mjd0, arr),  # reference value for world 0
+        getattr(mjd1, arr),  # reference value for world 1
+        -1.0,  # corrupted value
+        -1.0,  # corrupted value
+      ]
+      for worldid, exp in enumerate(expected):
+        _assert_eq(d_arr[worldid], exp, f"{arr}[{worldid}]")
+
+  def test_reset_data_keyframe_no_keyframes(self):
+    """Tests reset_data_keyframe on a model without keyframes (nkey == 0)."""
+    _, _, m, d = test_data.fixture(
+      xml="""
+    <mujoco>
+      <worldbody>
+        <body>
+          <geom type="sphere" size="1"/>
+          <joint type="slide"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """,
+      nworld=2,
+    )
+    self.assertEqual(m.nkey, 0)
+
+    with self.assertRaisesRegex(ValueError, r"key \(0\) must be in \[0, 0\)"):
+      mjwarp.reset_data_keyframe(m, d, 0)
+
+    qpos = wp.array(np.array([[1.0], [2.0]]), dtype=float)
+    wp.copy(d.qpos, qpos)
+
+    # every world has an out-of-range key, so nothing is reset
+    mjwarp.reset_data_keyframe(m, d, wp.array(np.array([0, 0]), dtype=int))
+
+    _assert_eq(d.qpos.numpy()[0], 1.0, "qpos[0]")
+    _assert_eq(d.qpos.numpy()[1], 2.0, "qpos[1]")
 
   def test_reset_data_keyframe_key_invalid(self):
     """Tests that reset_data_keyframe validates the key argument."""
-    _MJCF = """
+    _, _, m, d = test_data.fixture(
+      xml="""
     <mujoco>
       <worldbody>
         <body>
@@ -1232,10 +1293,9 @@ class IOTest(parameterized.TestCase):
         <key name="k0" qpos="0.5"/>
       </keyframe>
     </mujoco>
-    """
-    mjm = mujoco.MjModel.from_xml_string(_MJCF)
-    m = mjwarp.put_model(mjm)
-    d = mjwarp.make_data(mjm, nworld=2)
+    """,
+      nworld=2,
+    )
 
     with self.assertRaisesRegex(ValueError, r"key \(-1\) must be in \[0, 1\)"):
       mjwarp.reset_data_keyframe(m, d, -1)
@@ -1247,6 +1307,29 @@ class IOTest(parameterized.TestCase):
       mjwarp.reset_data_keyframe(m, d, wp.array(np.array([0.0, 0.0]), dtype=float))
     with self.assertRaisesRegex(ValueError, "key must be an int or a wp.array"):
       mjwarp.reset_data_keyframe(m, d, 0.5)
+
+  def test_reset_data_keyframe_numpy_int(self):
+    """Tests that reset_data_keyframe accepts numpy integer scalars."""
+    _, _, m, d = test_data.fixture(
+      xml="""
+    <mujoco>
+      <worldbody>
+        <body>
+          <geom type="sphere" size="1"/>
+          <joint type="slide"/>
+        </body>
+      </worldbody>
+      <keyframe>
+        <key name="k0" qpos="0.5"/>
+      </keyframe>
+    </mujoco>
+    """
+    )
+
+    for key in (np.int32(0), np.int64(0)):
+      d.qpos.fill_(0.0)
+      mjwarp.reset_data_keyframe(m, d, key)
+      _assert_eq(d.qpos.numpy()[0], 0.5, "qpos")
 
   def test_sdf(self):
     """Tests that an SDF can be loaded."""

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1072,6 +1072,28 @@ class IOTest(parameterized.TestCase):
     _assert_eq(d.qvel.numpy()[0], 1.0, "qvel[0]")
     _assert_eq(d.qvel.numpy()[1], 2.0, "qvel[1]")
 
+  def test_reset_data_reset_invalid(self):
+    """Tests that reset_data validates the reset argument."""
+    _MJCF = """
+    <mujoco>
+      <worldbody>
+        <body>
+          <geom type="sphere" size="1"/>
+          <joint type="slide"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+    mjm = mujoco.MjModel.from_xml_string(_MJCF)
+    m = mjwarp.put_model(mjm)
+    d = mjwarp.make_data(mjm, nworld=2)
+
+    with self.assertRaisesRegex(ValueError, "reset array must have shape"):
+      mjwarp.reset_data(m, d, reset=wp.array(np.array([True, False, True]), dtype=bool))
+
+    with self.assertRaisesRegex(ValueError, "reset must be None or a wp.array"):
+      mjwarp.reset_data(m, d, reset=[True, False])
+
   def test_reset_data_keyframe(self):
     """Tests that reset_data_keyframe matches mj_resetDataKeyframe."""
     _MJCF = """
@@ -1195,6 +1217,34 @@ class IOTest(parameterized.TestCase):
     _assert_eq(d.qpos.numpy()[1], 0.6, "qpos[1]")
     _assert_eq(d.qpos.numpy()[2], 3.0, "qpos[2]")
     _assert_eq(d.qpos.numpy()[3], 4.0, "qpos[3]")
+
+  def test_reset_data_keyframe_key_invalid(self):
+    """Tests that reset_data_keyframe validates the key argument."""
+    _MJCF = """
+    <mujoco>
+      <worldbody>
+        <body>
+          <geom type="sphere" size="1"/>
+          <joint type="slide"/>
+        </body>
+      </worldbody>
+      <keyframe>
+        <key name="k0" qpos="0.5"/>
+      </keyframe>
+    </mujoco>
+    """
+    mjm = mujoco.MjModel.from_xml_string(_MJCF)
+    m = mjwarp.put_model(mjm)
+    d = mjwarp.make_data(mjm, nworld=2)
+
+    with self.assertRaisesRegex(ValueError, r"key \(-1\) must be in \[0, 1\)"):
+      mjwarp.reset_data_keyframe(m, d, -1)
+    with self.assertRaisesRegex(ValueError, r"key \(1\) must be in \[0, 1\)"):
+      mjwarp.reset_data_keyframe(m, d, 1)
+    with self.assertRaisesRegex(ValueError, "key array must have shape"):
+      mjwarp.reset_data_keyframe(m, d, wp.array(np.array([0, 0, 0]), dtype=int))
+    with self.assertRaisesRegex(ValueError, "key must be an int or a wp.array"):
+      mjwarp.reset_data_keyframe(m, d, 0.5)
 
   def test_sdf(self):
     """Tests that an SDF can be loaded."""

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -1161,6 +1161,41 @@ class IOTest(parameterized.TestCase):
     _assert_eq(d.qpos.numpy()[0], 1.0, "qpos[0]")
     _assert_eq(d.qpos.numpy()[1], 2.0, "qpos[1]")
 
+  def test_reset_data_keyframe_per_world(self):
+    """Tests reset_data_keyframe with a per-world keyframe array."""
+    _MJCF = """
+    <mujoco>
+      <worldbody>
+        <body>
+          <geom type="sphere" size="1"/>
+          <joint type="slide"/>
+        </body>
+      </worldbody>
+      <keyframe>
+        <key name="k0" qpos="0.5"/>
+        <key name="k1" qpos="0.6"/>
+      </keyframe>
+    </mujoco>
+    """
+    mjm = mujoco.MjModel.from_xml_string(_MJCF)
+    m = mjwarp.put_model(mjm)
+    d = mjwarp.make_data(mjm, nworld=4)
+
+    qpos = wp.array(np.array([[1.0], [2.0], [3.0], [4.0]]), dtype=float)
+    wp.copy(d.qpos, qpos)
+
+    # world 0 -> key 0
+    # world 1 -> key 1
+    # world 2 -> key < 0 (reset skipped)
+    # world 3 -> key >= nkey (reset skipped)
+    key = wp.array(np.array([0, 1, -1, 2]), dtype=int)
+    mjwarp.reset_data_keyframe(m, d, key)
+
+    _assert_eq(d.qpos.numpy()[0], 0.5, "qpos[0]")
+    _assert_eq(d.qpos.numpy()[1], 0.6, "qpos[1]")
+    _assert_eq(d.qpos.numpy()[2], 3.0, "qpos[2]")
+    _assert_eq(d.qpos.numpy()[3], 4.0, "qpos[3]")
+
   def test_sdf(self):
     """Tests that an SDF can be loaded."""
     mjm, mjd, m, d = test_data.fixture("collision_sdf/cow.xml")

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1025,6 +1025,7 @@ class Model:
     nJten: number of non-zeros in sparse tendon Jacobian
     nwrap: number of wrap objects in all tendon paths
     nsensor: number of sensors
+    nkey: number of keyframes
     nmocap: number of mocap bodies
     nplugin: number of plugin instances
     nJmom: number of non-zeros in actuator_moment
@@ -1323,6 +1324,13 @@ class Model:
     sensor_interval: sensor interval and phase               (nsensor, 2)
     plugin: globally registered plugin slot number           (nplugin,)
     plugin_attr: config attributes of geom plugin            (nplugin, _NPLUGINATTR)
+    key_time: keyframe time                                  (nkey,)
+    key_qpos: keyframe qpos                                  (nkey, nq)
+    key_qvel: keyframe qvel                                  (nkey, nv)
+    key_act: keyframe act                                    (nkey, na)
+    key_mpos: keyframe mocap pos                             (nkey, nmocap, 3)
+    key_mquat: keyframe mocap quat                           (nkey, nmocap, 4)
+    key_ctrl: keyframe ctrl                                   (nkey, nu)
     M_rownnz: number of non-zeros in each row of M           (nv,)
     M_rowadr: index of each row in M                         (nv,)
     M_colind: column indices of non-zeros in M               (nC,)
@@ -1510,6 +1518,7 @@ class Model:
   nJten: int
   nwrap: int
   nsensor: int
+  nkey: int
   nmocap: int
   nplugin: int
   nJmom: int
@@ -1807,6 +1816,13 @@ class Model:
   sensor_interval: array("nsensor", wp.vec2)
   plugin: array("nplugin", int)
   plugin_attr: array("nplugin", vec_pluginattr)
+  key_time: array("nkey", float)
+  key_qpos: array("nkey", "nq", float)
+  key_qvel: array("nkey", "nv", float)
+  key_act: array("nkey", "na", float)
+  key_mpos: array("nkey", "nmocap", wp.vec3)
+  key_mquat: array("nkey", "nmocap", wp.quat)
+  key_ctrl: array("nkey", "nu", float)
   M_rownnz: array("nv", int)
   M_rowadr: array("nv", int)
   M_colind: array("nC", int)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1330,7 +1330,7 @@ class Model:
     key_act: keyframe act                                    (nkey, na)
     key_mpos: keyframe mocap pos                             (nkey, nmocap, 3)
     key_mquat: keyframe mocap quat                           (nkey, nmocap, 4)
-    key_ctrl: keyframe ctrl                                   (nkey, nu)
+    key_ctrl: keyframe ctrl                                  (nkey, nu)
     M_rownnz: number of non-zeros in each row of M           (nv,)
     M_rowadr: index of each row in M                         (nv,)
     M_colind: column indices of non-zeros in M               (nC,)


### PR DESCRIPTION
Currently, `mujoco_warp.reset_data` mirrors `mujoco.mj_resetData`, but there's no `mujoco_warp.reset_data_keyframe` that mirrors `mujoco.mj_resetDataKeyframe`.

This PR aims to implement it by repeating exactly what `mj_resetDataKeyframe` does on the CPU: calling `mj_resetData`, then re-setting values defined in the keyframe.

The complication is that `nkey` and `key_{time,qpos,qvel,act,mpos,mquat,ctrl}` are not currently included in `mujoco_warp.Model`. Therefore, the reset-to-keypoint function would have to either
- receive the `MjModel` object as an additional input (this is the state after d599780), or
- rely on keyframe-related attributes being added to `Model` (this is the current state of this PR). The dynamic attribute setting logic in `put_model` automatically populates these fields, so we don't need to touch `put_model`.

Would this be something useful?

PS. I guess we could in principle also allow different worlds to be reset to different keyframes, but IDK if this is a "real" use case.