### PR TITLE
Add diagonal preconditioner for flex DOFs in CG solver

### DIFF
--- a/benchmarks/aloha/__init__.py
+++ b/benchmarks/aloha/__init__.py
@@ -40,6 +40,8 @@ BENCHMARKS = [
     "nccdmax": 256,
     "njmax": 8192,
     "replay": "lift_cloth.npz",
+    "nstep": 100,
+    "override": "opt.jac_preconditioner=true",
     "assets": [(ASSETS[0], "aloha")],
   },
   {

--- a/benchmarks/cloth/__init__.py
+++ b/benchmarks/cloth/__init__.py
@@ -5,6 +5,7 @@ BENCHMARKS = [
     "nworld": 32,
     "nconmax": 2200,
     "njmax": 8000,
+    "override": "opt.jac_preconditioner=true",
   },
   {
     "name": "cloth_render",

--- a/mujoco_warp/_src/collision_flex.py
+++ b/mujoco_warp/_src/collision_flex.py
@@ -2643,6 +2643,108 @@ def _flex_narrowphase_tet_detect(
 
 
 @wp.kernel
+def _compute_filter_key(
+  # Model:
+  ngeom: int,
+  nflex: int,
+  # In:
+  ncand: wp.array[int],
+  cand_geom: wp.array[wp.vec2i],
+  cand_flex: wp.array[wp.vec2i],
+  cand_worldid: wp.array[int],
+  # Out:
+  key_out: wp.array[int],
+  val_out: wp.array[int],
+):
+  """Compute sort key for candidate grouping.
+
+  Groups candidates by (worldid, flex_id, geom_id) so that duplicates
+  are contiguous after sorting. Self-collision contacts (geom_id < 0)
+  are mapped to a sentinel value (ngeom).
+  """
+  i = wp.tid()
+  if i >= ncand[0]:
+    key_out[i] = 2147483647  # INT_MAX: sort unused entries to end
+    val_out[i] = i
+    return
+
+  worldid = cand_worldid[i]
+  flex_id = cand_flex[i][1]
+  geom_id = cand_geom[i][0]
+
+  # Map self-collision (geom_id < 0) to sentinel
+  g = geom_id
+  if g < 0:
+    g = ngeom
+
+  key_out[i] = worldid * (nflex + 1) * (ngeom + 2) + flex_id * (ngeom + 2) + g
+  val_out[i] = i
+
+
+@wp.kernel
+def _filter_flex_candidates_sorted(
+  # In:
+  ncand: wp.array[int],
+  epsilon: float,
+  sort_key: wp.array[int],
+  sort_val: wp.array[int],
+  cand_dist: wp.array[float],
+  cand_pos: wp.array[wp.vec3],
+  # Out:
+  cand_active_out: wp.array[int],
+):
+  """Filter duplicate candidates using sorted order.
+
+  After sorting by group key, candidates in the same group are contiguous.
+  Each candidate only compares with neighbors sharing the same key, reducing
+  complexity from O(n^2) to O(n * k) where k is the average group size.
+  """
+  si = wp.tid()
+  if si >= ncand[0]:
+    return
+
+  i = sort_val[si]
+  my_key = sort_key[si]
+  pos_i = cand_pos[i]
+  dist_i = cand_dist[i]
+  eps2 = epsilon * epsilon
+
+  keep = int(1)
+
+  # Compare with same-key neighbors (backward)
+  j = si - 1
+  while j >= 0:
+    if sort_key[j] != my_key:
+      break
+    oj = sort_val[j]
+    diff = pos_i - cand_pos[oj]
+    if wp.dot(diff, diff) < eps2:
+      dist_j = cand_dist[oj]
+      if dist_j < dist_i:
+        keep = 0
+      elif dist_j == dist_i and oj < i:
+        keep = 0
+    j -= 1
+
+  # Compare with same-key neighbors (forward)
+  j = si + 1
+  while j < ncand[0]:
+    if sort_key[j] != my_key:
+      break
+    oj = sort_val[j]
+    diff = pos_i - cand_pos[oj]
+    if wp.dot(diff, diff) < eps2:
+      dist_j = cand_dist[oj]
+      if dist_j < dist_i:
+        keep = 0
+      elif dist_j == dist_i and oj < i:
+        keep = 0
+    j += 1
+
+  cand_active_out[i] = keep
+
+
+@wp.kernel
 def _filter_flex_candidates(
   # In:
   max_candidates: int,
@@ -3671,20 +3773,40 @@ def flex_collision(m: Model, d: Data, ctx):
         ],
       )
 
-  # Filter duplicate contacts (e.g. from shared vertices or edges)
-  cand_active = wp.empty(d.naconmax, dtype=int)
+  # Filter duplicate contacts using sort-based deduplication.
+  # Sort candidates by (worldid, flex_id, geom_id) so duplicates are contiguous,
+  # then compare only within each group. This is O(n log n) vs the naive O(n^2).
+  filter_key = wp.empty(d.naconmax * 2, dtype=int)
+  filter_val = wp.empty(d.naconmax * 2, dtype=int)
   wp.launch(
-    _filter_flex_candidates,
+    _compute_filter_key,
     dim=d.naconmax,
     inputs=[
-      d.naconmax,
+      m.ngeom,
+      m.nflex,
       ncand,
-      1e-3,  # epsilon
-      cand_dist,
-      cand_pos,
       cand_geom,
       cand_flex,
       cand_worldid,
+    ],
+    outputs=[
+      filter_key,
+      filter_val,
+    ],
+  )
+  wp.utils.radix_sort_pairs(filter_key, filter_val, d.naconmax)
+
+  cand_active = wp.empty(d.naconmax, dtype=int)
+  wp.launch(
+    _filter_flex_candidates_sorted,
+    dim=d.naconmax,
+    inputs=[
+      ncand,
+      1e-3,  # epsilon
+      filter_key,
+      filter_val,
+      cand_dist,
+      cand_pos,
     ],
     outputs=[
       cand_active,

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -426,6 +426,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
     opt.contact_sensor_maxmatch = mjm.numeric_data[mjm.numeric_adr[contact_sensor_maxmatch_id]]
   else:
     opt.contact_sensor_maxmatch = 64
+  opt.jac_preconditioner = False
 
   # place opt on device
   for f in dataclasses.fields(types.Option):
@@ -3478,6 +3479,7 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
     "opt.broadphase_filter",
     "opt.graph_conditional",
     "opt.contact_sensor_maxmatch",
+    "opt.jac_preconditioner",
   }
   mj_only_fields = {"opt.jacobian", "vis.quality.offsamples"}
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -426,7 +426,6 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
     opt.contact_sensor_maxmatch = mjm.numeric_data[mjm.numeric_adr[contact_sensor_maxmatch_id]]
   else:
     opt.contact_sensor_maxmatch = 64
-  opt.jac_preconditioner = False
 
   # place opt on device
   for f in dataclasses.fields(types.Option):
@@ -3479,7 +3478,6 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
     "opt.broadphase_filter",
     "opt.graph_conditional",
     "opt.contact_sensor_maxmatch",
-    "opt.jac_preconditioner",
   }
   mj_only_fields = {"opt.jacobian", "vis.quality.offsamples"}
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -486,6 +486,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
       f"sleeping requires the Newton solver or enable_islands (got solver={types.SolverType(mjm.opt.solver).name})"
     )
   m.tree_total_nnz_int = int(sum(int(n) ** 2 for n in mjm.tree_dofnum))
+  m.has_articulated_trees = bool(any(int(n) > 6 for n in mjm.tree_dofnum))
   m.has_fluid = mjm.opt.wind.any() or mjm.opt.density > 0 or mjm.opt.viscosity > 0
 
   m.nflexintcell = _get_nflexintcell(mjm)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -470,6 +470,22 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   if mjm.nv > 500:
     m.block_dim.linesearch_iterative = 512
   m.is_sparse = is_sparse(mjm)
+  # Active-DOF compaction is the default sleeping solver: it pays off only when most DOFs are
+  # asleep, so it's keyed on the SLEEP flag (a dense full solve would otherwise just be slower
+  # than the sparse solver). It's a dense-Newton method, and ENABLE_ISLANDS forces the old
+  # island solver instead. nvmax only sizes the compacted block; it does not toggle compaction.
+  m.is_compact = (
+    mjm.opt.solver == mujoco.mjtSolver.mjSOL_NEWTON
+    and bool(mjm.opt.enableflags & mujoco.mjtEnableBit.mjENBL_SLEEP)
+    and not ENABLE_ISLANDS
+  )
+  # Sleeping is only honored by a sleep-aware solver (compact for Newton, or the island solver
+  # via enable_islands). Reject SLEEP without one rather than silently ignoring it.
+  if bool(mjm.opt.enableflags & mujoco.mjtEnableBit.mjENBL_SLEEP) and not m.is_compact and not ENABLE_ISLANDS:
+    raise ValueError(
+      f"sleeping requires the Newton solver or enable_islands (got solver={types.SolverType(mjm.opt.solver).name})"
+    )
+  m.tree_total_nnz_int = int(sum(int(n) ** 2 for n in mjm.tree_dofnum))
   m.has_fluid = mjm.opt.wind.any() or mjm.opt.density > 0 or mjm.opt.viscosity > 0
 
   m.nflexintcell = _get_nflexintcell(mjm)

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -104,30 +104,6 @@ def _build_block_mapping(
       block_count += 1
 
 
-@wp.kernel
-def _build_tree_mat_adr(
-  # Model:
-  tree_dofnum: wp.array[int],
-  # In:
-  ntrees: int,
-  # Out:
-  tree_mat_adr_out: wp.array[int],
-  total_tree_nnz_out: wp.array[int],
-):
-  """Build tree_mat_adr (cumulative sum of ndof^2) on device. Single-threaded."""
-  tid = wp.tid()
-  if tid > 0:
-    return
-
-  cumsum = int(0)
-  tree_mat_adr_out[0] = 0
-  for t in range(ntrees):
-    ndof = tree_dofnum[t]
-    cumsum += ndof * ndof
-    tree_mat_adr_out[t + 1] = cumsum
-  total_tree_nnz_out[0] = cumsum
-
-
 def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
   """Create a SolverContext with allocated workspace arrays.
 
@@ -171,26 +147,15 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     block_dof_num = wp.empty(0, dtype=int)
     dof_to_block = wp.empty(0, dtype=int)
 
-  # Tree IC preconditioner: compute offsets and allocate storage.
-  # _create_solver_context runs once during setup (not during graph capture),
-  # so .numpy() is safe here.
-  alloc_tree_ic = alloc_block_jacobi and m.is_sparse
-  if alloc_tree_ic:
-    ntrees_ic = int(m.ntree)
-    total_tree_nnz_bound = m.tree_total_nnz_int
-    tree_mat_adr_ic = wp.zeros(ntrees_ic + 1, dtype=int)
-    total_tree_nnz_arr = wp.zeros(1, dtype=int)
-    wp.launch(
-      _build_tree_mat_adr,
-      dim=1,
-      inputs=[m.tree_dofnum, ntrees_ic],
-      outputs=[tree_mat_adr_ic, total_tree_nnz_arr],
-    )
+  # IC(0) preconditioner: sparse LDL^T for articulated bodies.
+  has_articulated = m.is_sparse and m.has_articulated_trees
+  alloc_ic = alloc_block_jacobi and has_articulated
+  if alloc_ic:
+    qLD_precond = wp.zeros((nworld, 1, m.nC), dtype=float)
+    qLDiagInv_precond = wp.zeros((nworld, nv), dtype=float)
   else:
-    ntrees_ic = 0
-    total_tree_nnz_bound = 0
-    tree_mat_adr_ic = wp.empty(0, dtype=int)
-    total_tree_nnz_arr = wp.empty(0, dtype=int)
+    qLD_precond = wp.empty((0, 0, 0), dtype=float)
+    qLDiagInv_precond = wp.empty((0, 0), dtype=float)
 
   return SolverContext(
     Jaref=wp.empty((nworld, njmax), dtype=float),
@@ -216,12 +181,8 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     block_dof_num=block_dof_num,
     dof_to_block=dof_to_block,
     nblocks=nblocks,
-    H_tree=wp.zeros((nworld, max(total_tree_nnz_bound, 1)), dtype=float)
-    if alloc_tree_ic
-    else wp.empty((nworld, 0), dtype=float),
-    tree_mat_adr=tree_mat_adr_ic,
-    total_tree_nnz=total_tree_nnz_arr,
-    ntrees=ntrees_ic,
+    qLD_precond=qLD_precond,
+    qLDiagInv_precond=qLDiagInv_precond,
     changed_efc_ids=wp.empty((nworld, njmax), dtype=int) if alloc_h else wp.empty((nworld, 0), dtype=int),
     changed_efc_count=wp.empty((nworld,), dtype=int) if alloc_h else wp.empty((0,), dtype=int),
   )
@@ -3124,89 +3085,12 @@ def _apply_block_preconditioner(
 # =============================================================================
 
 
-# kernel_analyzer: off
-@wp.func
-def _ic_inv3(
-  H: wp.array2d[float],
-  w: int,
-  adr: int,
-  ndof: int,
-  stride: int,
-):
-  """Analytically invert an ndof x ndof block (ndof <= 3) in-place.
-
-  Block is stored in row-major at H[w, adr + i*stride + j].
-  """
-  reg = 1.0e-12
-  if ndof == 1:
-    v = H[w, adr] + reg
-    if v > 0.0:
-      H[w, adr] = 1.0 / v
-    else:
-      H[w, adr] = 0.0
-  elif ndof == 2:
-    a00 = H[w, adr] + reg
-    a01 = H[w, adr + 1]
-    a10 = H[w, adr + stride]
-    a11 = H[w, adr + stride + 1] + reg
-    det = a00 * a11 - a01 * a10
-    if wp.abs(det) > 1.0e-30:
-      inv_det = 1.0 / det
-      H[w, adr] = a11 * inv_det
-      H[w, adr + 1] = -a01 * inv_det
-      H[w, adr + stride] = -a10 * inv_det
-      H[w, adr + stride + 1] = a00 * inv_det
-    else:
-      H[w, adr] = 0.0
-      H[w, adr + 1] = 0.0
-      H[w, adr + stride] = 0.0
-      H[w, adr + stride + 1] = 0.0
-  elif ndof == 3:
-    a00 = H[w, adr] + reg
-    a01 = H[w, adr + 1]
-    a02 = H[w, adr + 2]
-    a10 = H[w, adr + stride]
-    a11 = H[w, adr + stride + 1] + reg
-    a12 = H[w, adr + stride + 2]
-    a20 = H[w, adr + 2 * stride]
-    a21 = H[w, adr + 2 * stride + 1]
-    a22 = H[w, adr + 2 * stride + 2] + reg
-    c00 = a11 * a22 - a12 * a21
-    c01 = a02 * a21 - a01 * a22
-    c02 = a01 * a12 - a02 * a11
-    c10 = a12 * a20 - a10 * a22
-    c11 = a00 * a22 - a02 * a20
-    c12 = a02 * a10 - a00 * a12
-    c20 = a10 * a21 - a11 * a20
-    c21 = a01 * a20 - a00 * a21
-    c22 = a00 * a11 - a01 * a10
-    det = a00 * c00 + a01 * c10 + a02 * c20
-    if wp.abs(det) > 1.0e-30:
-      inv_det = 1.0 / det
-      H[w, adr] = c00 * inv_det
-      H[w, adr + 1] = c01 * inv_det
-      H[w, adr + 2] = c02 * inv_det
-      H[w, adr + stride] = c10 * inv_det
-      H[w, adr + stride + 1] = c11 * inv_det
-      H[w, adr + stride + 2] = c12 * inv_det
-      H[w, adr + 2 * stride] = c20 * inv_det
-      H[w, adr + 2 * stride + 1] = c21 * inv_det
-      H[w, adr + 2 * stride + 2] = c22 * inv_det
-    else:
-      for rr in range(3):
-        for cc in range(3):
-          H[w, adr + rr * stride + cc] = 0.0
-
-
-# kernel_analyzer: on
-
-
 @wp.kernel
-def _ic_tree_JTDJ(
+def _add_JTDJ_to_M_sparse(
   # Model:
-  dof_treeid: wp.array[int],
-  tree_dofadr: wp.array[int],
-  tree_dofnum: wp.array[int],
+  M_rownnz: wp.array[int],
+  M_rowadr: wp.array[int],
+  M_colind: wp.array[int],
   # Data in:
   nefc_in: wp.array[int],
   efc_J_rownnz_in: wp.array2d[int],
@@ -3216,227 +3100,104 @@ def _ic_tree_JTDJ(
   efc_D_in: wp.array2d[float],
   efc_state_in: wp.array2d[int],
   # In:
-  tree_mat_adr_in: wp.array[int],
   ctx_done_in: wp.array[bool],
   # Out:
-  H_tree_out: wp.array2d[float],
+  H_out: wp.array3d[float],
 ):
-  """Accumulate J^T D J into dense tree blocks."""
+  """Add J^T D J entries at positions matching M's sparsity pattern."""
   worldid, efcid = wp.tid()
-
   if ctx_done_in[worldid]:
     return
-
   if efcid >= nefc_in[worldid]:
     return
-
   efc_D = efc_D_in[worldid, efcid]
   efc_state = efc_state_in[worldid, efcid]
-
   if _state_check(efc_D, efc_state) == 0.0:
     return
-
   rownnz = efc_J_rownnz_in[worldid, efcid]
   rowadr = efc_J_rowadr_in[worldid, efcid]
-
-  for i in range(rownnz):
-    sparseidi = rowadr + i
-    Ji = efc_J_in[worldid, 0, sparseidi]
-    colindi = efc_J_colind_in[worldid, 0, sparseidi]
-    treei = dof_treeid[colindi]
-
-    for j in range(rownnz):
-      sparseidj = rowadr + j
-      Jj = efc_J_in[worldid, 0, sparseidj]
-      colindj = efc_J_colind_in[worldid, 0, sparseidj]
-      treej = dof_treeid[colindj]
-
-      if treei != treej:
-        continue
-
-      dof0 = tree_dofadr[treei]
-      ndof = tree_dofnum[treei]
-      base = tree_mat_adr_in[treei]
-
-      local_i = colindi - dof0
-      local_j = colindj - dof0
-
+  for k1 in range(rownnz):
+    Ji = efc_J_in[worldid, 0, rowadr + k1]
+    colindi = efc_J_colind_in[worldid, 0, rowadr + k1]
+    for k2 in range(k1 + 1):
+      Jj = efc_J_in[worldid, 0, rowadr + k2]
+      colindj = efc_J_colind_in[worldid, 0, rowadr + k2]
+      row = wp.max(colindi, colindj)
+      col = wp.min(colindi, colindj)
       h = Ji * Jj * efc_D
-      wp.atomic_add(H_tree_out[worldid], base + local_i * ndof + local_j, h)
+      row_start = M_rowadr[row]
+      row_nnz = M_rownnz[row]
+      for idx in range(row_nnz):
+        if M_colind[row_start + idx] == col:
+          wp.atomic_add(H_out[worldid, 0], row_start + idx, h)
+          break
 
 
 @wp.kernel
-def _ic_tree_add_M(
+def _apply_block_preconditioner_flex(
   # Model:
-  nv: int,
   dof_treeid: wp.array[int],
-  tree_dofadr: wp.array[int],
-  tree_dofnum: wp.array[int],
-  M_mulm_rowadr: wp.array[int],
-  M_mulm_col: wp.array[int],
-  M_mulm_madr: wp.array[int],
-  # Data in:
-  M_in: wp.array3d[float],
-  # In:
-  tree_mat_adr_in: wp.array[int],
-  ctx_done_in: wp.array[bool],
-  # Out:
-  H_tree_out: wp.array2d[float],
-):
-  """Add mass matrix entries into dense tree blocks."""
-  worldid, di = wp.tid()
-  if di >= nv:
-    return
-  if ctx_done_in[worldid]:
-    return
-
-  treei = dof_treeid[di]
-  dof0 = tree_dofadr[treei]
-  ndof = tree_dofnum[treei]
-  base = tree_mat_adr_in[treei]
-  local_i = di - dof0
-
-  start = M_mulm_rowadr[di]
-  end = M_mulm_rowadr[di + 1]
-  for k in range(start, end):
-    dj = M_mulm_col[k]
-    treej = dof_treeid[dj]
-    if treej == treei:
-      local_j = dj - dof0
-      madr = M_mulm_madr[k]
-      M_val = M_in[worldid, 0, madr]
-      wp.atomic_add(H_tree_out[worldid], base + local_i * ndof + local_j, M_val)
-
-
-@wp.kernel
-def _ic_tree_factorize(
-  # Model:
   tree_dofnum: wp.array[int],
   # In:
-  ntrees: int,
-  tree_mat_adr_in: wp.array[int],
-  ctx_done_in: wp.array[bool],
-  # Out:
-  H_tree_out: wp.array2d[float],
-):
-  """Factorize each tree block.
-
-  nv_t <= 3: analytic inverse in-place.
-  nv_t > 3:  full dense Cholesky factorization.
-
-  After factorization, the dense nv_t x nv_t block stores:
-  - nv_t <= 3: the inverted block (from _ic_inv3).
-  - nv_t > 3: L in the lower triangle (H = L L^T).
-  """
-  worldid, treeid = wp.tid()
-
-  if ctx_done_in[worldid]:
-    return
-  if treeid >= ntrees:
-    return
-
-  nv_t = tree_dofnum[treeid]
-  adr = tree_mat_adr_in[treeid]
-
-  if nv_t == 0:
-    return
-
-  if nv_t <= 3:
-    _ic_inv3(H_tree_out, worldid, adr, nv_t, nv_t)
-    return
-
-  # Full dense Cholesky factorization (in-place, lower triangle).
-  # Stores L in lower triangle: H = L L^T.
-  reg = 1.0e-10
-  for j in range(nv_t):
-    # Diagonal: L[j,j] = sqrt(H[j,j] - sum(L[j,k]^2, k<j))
-    s = H_tree_out[worldid, adr + j * nv_t + j]
-    for k in range(j):
-      ljk = H_tree_out[worldid, adr + j * nv_t + k]
-      s -= ljk * ljk
-    s = wp.max(s, reg)
-    ljj = wp.sqrt(s)
-    H_tree_out[worldid, adr + j * nv_t + j] = ljj
-    inv_ljj = 1.0 / ljj
-
-    # Off-diagonal: L[i,j] = (H[i,j] - sum(L[i,k]*L[j,k], k<j)) / L[j,j]
-    for i in range(j + 1, nv_t):
-      s = H_tree_out[worldid, adr + i * nv_t + j]
-      for k in range(j):
-        s -= H_tree_out[worldid, adr + i * nv_t + k] * H_tree_out[worldid, adr + j * nv_t + k]
-      H_tree_out[worldid, adr + i * nv_t + j] = s * inv_ljj
-
-
-@wp.kernel
-def _ic_tree_apply(
-  # Model:
-  tree_dofadr: wp.array[int],
-  tree_dofnum: wp.array[int],
-  # In:
-  ntrees: int,
-  tree_mat_adr_in: wp.array[int],
-  ctx_done_in: wp.array[bool],
+  nblocks: int,
+  block_dof_adr_in: wp.array[int],
+  block_dof_num_in: wp.array[int],
+  inv_H_blocks_in: wp.array3d[float],
   grad_in: wp.array2d[float],
-  H_tree_in: wp.array2d[float],
+  done_in: wp.array[bool],
   # Out:
   Mgrad_out: wp.array2d[float],
 ):
-  """Apply IC preconditioner: Mgrad = (LDL^T)^{-1} grad.
-
-  Small trees (nv_t <= 3): direct inverse-times-vector.
-  Larger trees: forward/diagonal/backward substitution.
-  """
-  worldid, treeid = wp.tid()
-
-  if ctx_done_in[worldid]:
+  """Block Jacobi apply for simple trees only (nv_tree <= 3)."""
+  worldid, blockid = wp.tid()
+  if blockid >= nblocks:
     return
-  if treeid >= ntrees:
+  if done_in[worldid]:
     return
-
-  nv_t = tree_dofnum[treeid]
-  dof0 = tree_dofadr[treeid]
-  adr = tree_mat_adr_in[treeid]
-
-  if nv_t == 0:
+  ndof = block_dof_num_in[blockid]
+  dof0 = block_dof_adr_in[blockid]
+  if ndof == 0:
     return
-
-  if nv_t <= 3:
-    # Direct H_inv * grad
-    for ii in range(nv_t):
-      val = float(0.0)
-      for jj in range(nv_t):
-        val += H_tree_in[worldid, adr + ii * nv_t + jj] * grad_in[worldid, dof0 + jj]
-      Mgrad_out[worldid, dof0 + ii] = val
+  treeid = dof_treeid[dof0]
+  if tree_dofnum[treeid] > 3:
     return
-
-  # Full Cholesky solve: L L^T x = b
-  # Forward substitution: L y = b
-  for i in range(nv_t):
-    s = grad_in[worldid, dof0 + i]
-    for k in range(i):
-      s -= H_tree_in[worldid, adr + i * nv_t + k] * Mgrad_out[worldid, dof0 + k]
-    Mgrad_out[worldid, dof0 + i] = s / H_tree_in[worldid, adr + i * nv_t + i]
-
-  # Backward substitution: L^T x = y
-  for i_rev in range(nv_t):
-    i = nv_t - 1 - i_rev
-    s = Mgrad_out[worldid, dof0 + i]
-    for k in range(i + 1, nv_t):
-      s -= H_tree_in[worldid, adr + k * nv_t + i] * Mgrad_out[worldid, dof0 + k]
-    Mgrad_out[worldid, dof0 + i] = s / H_tree_in[worldid, adr + i * nv_t + i]
+  I00 = inv_H_blocks_in[worldid, 0, blockid]
+  I01 = inv_H_blocks_in[worldid, 1, blockid]
+  I02 = inv_H_blocks_in[worldid, 2, blockid]
+  I11 = inv_H_blocks_in[worldid, 3, blockid]
+  I12 = inv_H_blocks_in[worldid, 4, blockid]
+  I22 = inv_H_blocks_in[worldid, 5, blockid]
+  g0 = grad_in[worldid, dof0]
+  g1 = float(0.0)
+  g2 = float(0.0)
+  if ndof >= 2:
+    g1 = grad_in[worldid, dof0 + 1]
+  if ndof >= 3:
+    g2 = grad_in[worldid, dof0 + 2]
+  if ndof == 1:
+    Mgrad_out[worldid, dof0] = I00 * g0
+  elif ndof == 2:
+    Mgrad_out[worldid, dof0] = I00 * g0 + I01 * g1
+    Mgrad_out[worldid, dof0 + 1] = I01 * g0 + I11 * g1
+  elif ndof == 3:
+    Mgrad_out[worldid, dof0] = I00 * g0 + I01 * g1 + I02 * g2
+    Mgrad_out[worldid, dof0 + 1] = I01 * g0 + I11 * g1 + I12 * g2
+    Mgrad_out[worldid, dof0 + 2] = I02 * g0 + I12 * g1 + I22 * g2
 
 
 def _build_ic_preconditioner(m, d, ctx):
-  """Build tree-level IC preconditioner: accumulate H, factorize."""
-  ctx.H_tree.zero_()
-
+  """Build hybrid preconditioner: block Jacobi for flex, IC(0) for articulated."""
+  _build_block_jacobi_preconditioner(m, d, ctx)
+  if ctx.qLD_precond.shape[2] == 0:
+    return  # No articulated trees
+  wp.copy(ctx.qLD_precond, d.M)
   wp.launch(
-    _ic_tree_JTDJ,
+    _add_JTDJ_to_M_sparse,
     dim=(d.nworld, d.njmax),
     inputs=[
-      m.dof_treeid,
-      m.tree_dofadr,
-      m.tree_dofnum,
+      m.M_rownnz,
+      m.M_rowadr,
+      m.M_colind,
       d.nefc,
       d.efc.J_rownnz,
       d.efc.J_rowadr,
@@ -3444,56 +3205,56 @@ def _build_ic_preconditioner(m, d, ctx):
       d.efc.J,
       d.efc.D,
       d.efc.state,
-      ctx.tree_mat_adr,
       ctx.done,
     ],
-    outputs=[ctx.H_tree],
+    outputs=[ctx.qLD_precond],
   )
-
+  for i in reversed(range(len(m.qLD_updates))):
+    wp.launch(
+      smooth._qLD_acc,
+      dim=(d.nworld, m.qLD_updates[i].size),
+      inputs=[m.M_rownnz, m.M_rowadr, m.qLD_updates[i], ctx.qLD_precond],
+      outputs=[ctx.qLD_precond],
+    )
   wp.launch(
-    _ic_tree_add_M,
+    smooth._qLDiag_div,
     dim=(d.nworld, m.nv),
-    inputs=[
-      m.nv,
-      m.dof_treeid,
-      m.tree_dofadr,
-      m.tree_dofnum,
-      m.M_mulm_rowadr,
-      m.M_mulm_col,
-      m.M_mulm_madr,
-      d.M,
-      ctx.tree_mat_adr,
-      ctx.done,
-    ],
-    outputs=[ctx.H_tree],
-  )
-
-  wp.launch(
-    _ic_tree_factorize,
-    dim=(d.nworld, ctx.ntrees),
-    inputs=[
-      m.tree_dofnum,
-      ctx.ntrees,
-      ctx.tree_mat_adr,
-      ctx.done,
-    ],
-    outputs=[ctx.H_tree],
+    inputs=[m.M_rownnz, m.M_rowadr, ctx.qLD_precond],
+    outputs=[ctx.qLDiagInv_precond],
   )
 
 
 def _apply_ic_preconditioner(m, d, ctx):
-  """Apply IC preconditioner: Mgrad = precond^{-1} @ grad."""
+  """Apply hybrid preconditioner: IC(0) for all, then block Jacobi for flex."""
+  if ctx.qLD_precond.shape[2] == 0:
+    # No articulated trees: block Jacobi only
+    wp.launch(
+      _apply_block_preconditioner,
+      dim=(d.nworld, ctx.nblocks),
+      inputs=[
+        ctx.nblocks,
+        ctx.block_dof_adr,
+        ctx.block_dof_num,
+        ctx.inv_H_blocks,
+        ctx.grad,
+        ctx.done,
+      ],
+      outputs=[ctx.Mgrad],
+    )
+    return
+  smooth._solve_LD_sparse(m, d, ctx.qLD_precond, ctx.qLDiagInv_precond, ctx.Mgrad, ctx.grad)
   wp.launch(
-    _ic_tree_apply,
-    dim=(d.nworld, ctx.ntrees),
+    _apply_block_preconditioner_flex,
+    dim=(d.nworld, ctx.nblocks),
     inputs=[
-      m.tree_dofadr,
+      m.dof_treeid,
       m.tree_dofnum,
-      ctx.ntrees,
-      ctx.tree_mat_adr,
-      ctx.done,
+      ctx.nblocks,
+      ctx.block_dof_adr,
+      ctx.block_dof_num,
+      ctx.inv_H_blocks,
       ctx.grad,
-      ctx.H_tree,
+      ctx.done,
     ],
     outputs=[ctx.Mgrad],
   )

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -147,13 +147,16 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     block_dof_num = wp.empty(0, dtype=int)
     dof_to_block = wp.empty(0, dtype=int)
 
-  # IC(0) preconditioner: sparse LDL^T for articulated bodies.
+  # IC(0) preconditioner: (M + JTDJ) factored for articulated bodies.
   has_articulated = m.is_sparse and m.has_articulated_trees
   alloc_ic = alloc_block_jacobi and has_articulated
   if alloc_ic:
-    qLD_precond = wp.zeros((nworld, m.nC), dtype=float)
+    M_precond = wp.zeros((nworld, m.nC), dtype=float)
+    qld_total = d.qLD.shape[1]
+    qLD_precond = wp.zeros((nworld, qld_total), dtype=float)
     qLDiagInv_precond = wp.zeros((nworld, nv), dtype=float)
   else:
+    M_precond = wp.empty((0, 0), dtype=float)
     qLD_precond = wp.empty((0, 0), dtype=float)
     qLDiagInv_precond = wp.empty((0, 0), dtype=float)
 
@@ -181,6 +184,7 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     block_dof_num=block_dof_num,
     dof_to_block=dof_to_block,
     nblocks=nblocks,
+    M_precond=M_precond,
     qLD_precond=qLD_precond,
     qLDiagInv_precond=qLDiagInv_precond,
     changed_efc_ids=wp.empty((nworld, njmax), dtype=int) if alloc_h else wp.empty((nworld, 0), dtype=int),
@@ -3110,7 +3114,7 @@ def _add_JTDJ_to_M_sparse(
   # Out:
   H_out: wp.array2d[float],
 ):
-  """Add J^T D J at M sparsity positions for articulated trees only."""
+  """Add J^T D J at M sparsity positions for all trees."""
   worldid, efcid = wp.tid()
   if ctx_done_in[worldid]:
     return
@@ -3126,8 +3130,6 @@ def _add_JTDJ_to_M_sparse(
     Ji = efc_J_in[worldid, 0, rowadr + k1]
     colindi = efc_J_colind_in[worldid, 0, rowadr + k1]
     treei = dof_treeid[colindi]
-    if tree_dofnum[treei] <= 6:
-      continue
     for k2 in range(k1 + 1):
       Jj = efc_J_in[worldid, 0, rowadr + k2]
       colindj = efc_J_colind_in[worldid, 0, rowadr + k2]
@@ -3197,11 +3199,13 @@ def _apply_block_preconditioner_flex(
 
 
 def _build_ic_preconditioner(m, d, ctx):
-  """Build hybrid preconditioner: block Jacobi for flex, IC(0) for articulated."""
+  """Build hybrid preconditioner: block Jacobi for flex, (M+JTDJ)^{-1} for articulated."""
   _build_block_jacobi_preconditioner(m, d, ctx)
-  if ctx.qLD_precond.shape[1] == 0:
+  if ctx.M_precond.shape[1] == 0:
     return
-  wp.copy(ctx.qLD_precond, d.M)
+  # Copy M to preconditioner buffer (CSR format)
+  wp.copy(ctx.M_precond, d.M)
+  # Add J^T D J to M_precond for ALL DOFs (no tree size filter)
   wp.launch(
     _add_JTDJ_to_M_sparse,
     dim=(d.nworld, d.njmax),
@@ -3220,32 +3224,30 @@ def _build_ic_preconditioner(m, d, ctx):
       d.efc.state,
       ctx.done,
     ],
-    outputs=[ctx.qLD_precond],
+    outputs=[ctx.M_precond],
   )
-  for i in reversed(range(len(m.qLD_updates))):
+  # Factor (M + JTDJ) for each block type
+  if m.qLD_has_dense:
+    smooth._factor_block_dense(m, d, ctx.M_precond, ctx.qLD_precond)
+  if m.qLD_has_sparse:
+    smooth._factor_i_sparse(m, d, ctx.M_precond, ctx.qLD_precond[:, m.qLD_block_total :], ctx.qLDiagInv_precond)
+  if m.qLD_has_simple:
     wp.launch(
-      smooth._qLD_acc,
-      dim=(d.nworld, m.qLD_updates[i].size),
-      inputs=[m.M_rownnz, m.M_rowadr, m.qLD_updates[i], ctx.qLD_precond],
-      outputs=[ctx.qLD_precond],
+      smooth._factor_simple,
+      dim=(d.nworld, m.qLD_simple_dofs.size),
+      inputs=[m.M_rownnz, m.M_rowadr, ctx.M_precond, m.qLD_simple_dofs],
+      outputs=[ctx.qLDiagInv_precond],
     )
-  wp.launch(
-    smooth._qLDiag_div,
-    dim=(d.nworld, m.nv),
-    inputs=[m.M_rownnz, m.M_rowadr, ctx.qLD_precond],
-    outputs=[ctx.qLDiagInv_precond],
-  )
 
 
 def _apply_ic_preconditioner(m, d, ctx):
-  """Apply preconditioner based on model structure.
+  """Apply hybrid preconditioner: (M+JTDJ)^{-1} for articulated, block Jacobi for flex.
 
-  Pure flex (no articulated trees): block Jacobi (M+JTDJ)^{-1} per body.
-  Mixed with no sparse blocks: fall back to M^{-1} (block Jacobi hurts robots).
-  Mixed with sparse blocks: M^{-1} baseline, IC(0) overwrites sparse DOFs.
+  For articulated trees (dense or sparse blocks): factored (M+JTDJ) Cholesky/LDL solve.
+  For flex/simple DOFs: per-body block Jacobi (M+JTDJ)^{-1} captures off-diagonal coupling.
   """
-  if not m.has_articulated_trees:
-    # Pure flex model: block Jacobi is best
+  if ctx.M_precond.shape[1] == 0:
+    # No articulated trees: pure block Jacobi for all
     wp.launch(
       _apply_block_preconditioner,
       dim=(d.nworld, ctx.nblocks),
@@ -3253,11 +3255,24 @@ def _apply_ic_preconditioner(m, d, ctx):
       outputs=[ctx.Mgrad],
     )
     return
-  # Has articulated trees: use M^{-1} as baseline
-  smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
-  if m.qLD_has_sparse:
-    # Overwrite sparse-block articulated DOFs with IC(0) solve
-    smooth._solve_LD_sparse(m, d, ctx.qLD_precond, ctx.qLDiagInv_precond, ctx.Mgrad, ctx.grad)
+  # Apply factored (M+JTDJ)^{-1} for ALL DOFs (dense/sparse/simple dispatch)
+  smooth.solve_LD(m, d, ctx.qLD_precond, ctx.qLDiagInv_precond, ctx.Mgrad, ctx.grad)
+  # Overwrite flex DOFs with better block Jacobi (captures off-diagonal JTDJ)
+  wp.launch(
+    _apply_block_preconditioner_flex,
+    dim=(d.nworld, ctx.nblocks),
+    inputs=[
+      m.dof_treeid,
+      m.tree_dofnum,
+      ctx.nblocks,
+      ctx.block_dof_adr,
+      ctx.block_dof_num,
+      ctx.inv_H_blocks,
+      ctx.grad,
+      ctx.done,
+    ],
+    outputs=[ctx.Mgrad],
+  )
   wp.launch(
     _apply_block_preconditioner_flex,
     dim=(d.nworld, ctx.nblocks),
@@ -3400,16 +3415,10 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
       outputs=[ctx.grad, ctx.grad_dot],
     )
   if m.opt.solver == types.SolverType.CG:
-    if m.is_sparse and not m.has_articulated_trees:
-      # Pure flex model: block Jacobi helps
-      _build_ic_preconditioner(m, d, ctx)
-      _apply_ic_preconditioner(m, d, ctx)
-    elif m.is_sparse and m.qLD_has_sparse:
-      # Articulated model with sparse LDL blocks: IC(0) helps
+    if m.is_sparse:
       _build_ic_preconditioner(m, d, ctx)
       _apply_ic_preconditioner(m, d, ctx)
     else:
-      # Default: M^{-1} (aloha_cloth, dense-only models)
       smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
   elif m.opt.solver == types.SolverType.NEWTON:
     # h = M + (efc_J.T * efc_D * active) @ efc_J

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -3034,18 +3034,24 @@ def _block_jacobi_invert(
 
 @wp.kernel
 def _apply_block_preconditioner(
+  # Model:
+  dof_treeid: wp.array[int],
+  tree_dofnum: wp.array[int],
   # In:
+  flex_only: int,
   nblocks: int,
   block_dof_adr_in: wp.array[int],
   block_dof_num_in: wp.array[int],
-  # In:
   inv_H_blocks_in: wp.array3d[float],
   grad_in: wp.array2d[float],
   done_in: wp.array[bool],
   # Out:
   Mgrad_out: wp.array2d[float],
 ):
-  """Mgrad = H_block^{-1} * grad for each block."""
+  """Mgrad = H_block^{-1} * grad for each block.
+
+  When flex_only=1, only applies to blocks in simple trees (nv_tree <= 6).
+  """
   worldid, blockid = wp.tid()
 
   if blockid >= nblocks:
@@ -3056,6 +3062,15 @@ def _apply_block_preconditioner(
 
   ndof = block_dof_num_in[blockid]
   dof0 = block_dof_adr_in[blockid]
+
+  if ndof == 0:
+    return
+
+  # When flex_only, skip articulated trees (handled by solve_LD)
+  if flex_only:
+    treeid = dof_treeid[dof0]
+    if tree_dofnum[treeid] > 6:
+      return
 
   # Read inverse block
   I00 = inv_H_blocks_in[worldid, 0, blockid]
@@ -3146,58 +3161,6 @@ def _add_JTDJ_to_M_sparse(
           break
 
 
-@wp.kernel
-def _apply_block_preconditioner_flex(
-  # Model:
-  dof_treeid: wp.array[int],
-  tree_dofnum: wp.array[int],
-  # In:
-  nblocks: int,
-  block_dof_adr_in: wp.array[int],
-  block_dof_num_in: wp.array[int],
-  inv_H_blocks_in: wp.array3d[float],
-  grad_in: wp.array2d[float],
-  done_in: wp.array[bool],
-  # Out:
-  Mgrad_out: wp.array2d[float],
-):
-  """Block Jacobi apply for simple trees only (nv_tree <= 6)."""
-  worldid, blockid = wp.tid()
-  if blockid >= nblocks:
-    return
-  if done_in[worldid]:
-    return
-  ndof = block_dof_num_in[blockid]
-  dof0 = block_dof_adr_in[blockid]
-  if ndof == 0:
-    return
-  treeid = dof_treeid[dof0]
-  if tree_dofnum[treeid] > 6:
-    return
-  I00 = inv_H_blocks_in[worldid, 0, blockid]
-  I01 = inv_H_blocks_in[worldid, 1, blockid]
-  I02 = inv_H_blocks_in[worldid, 2, blockid]
-  I11 = inv_H_blocks_in[worldid, 3, blockid]
-  I12 = inv_H_blocks_in[worldid, 4, blockid]
-  I22 = inv_H_blocks_in[worldid, 5, blockid]
-  g0 = grad_in[worldid, dof0]
-  g1 = float(0.0)
-  g2 = float(0.0)
-  if ndof >= 2:
-    g1 = grad_in[worldid, dof0 + 1]
-  if ndof >= 3:
-    g2 = grad_in[worldid, dof0 + 2]
-  if ndof == 1:
-    Mgrad_out[worldid, dof0] = I00 * g0
-  elif ndof == 2:
-    Mgrad_out[worldid, dof0] = I00 * g0 + I01 * g1
-    Mgrad_out[worldid, dof0 + 1] = I01 * g0 + I11 * g1
-  elif ndof == 3:
-    Mgrad_out[worldid, dof0] = I00 * g0 + I01 * g1 + I02 * g2
-    Mgrad_out[worldid, dof0 + 1] = I01 * g0 + I11 * g1 + I12 * g2
-    Mgrad_out[worldid, dof0 + 2] = I02 * g0 + I12 * g1 + I22 * g2
-
-
 def _build_ic_preconditioner(m, d, ctx):
   """Build hybrid preconditioner: block Jacobi for flex, (M+JTDJ)^{-1} for articulated."""
   _build_block_jacobi_preconditioner(m, d, ctx)
@@ -3251,7 +3214,17 @@ def _apply_ic_preconditioner(m, d, ctx):
     wp.launch(
       _apply_block_preconditioner,
       dim=(d.nworld, ctx.nblocks),
-      inputs=[ctx.nblocks, ctx.block_dof_adr, ctx.block_dof_num, ctx.inv_H_blocks, ctx.grad, ctx.done],
+      inputs=[
+        m.dof_treeid,
+        m.tree_dofnum,
+        0,
+        ctx.nblocks,
+        ctx.block_dof_adr,
+        ctx.block_dof_num,
+        ctx.inv_H_blocks,
+        ctx.grad,
+        ctx.done,
+      ],
       outputs=[ctx.Mgrad],
     )
     return
@@ -3259,26 +3232,12 @@ def _apply_ic_preconditioner(m, d, ctx):
   smooth.solve_LD(m, d, ctx.qLD_precond, ctx.qLDiagInv_precond, ctx.Mgrad, ctx.grad)
   # Overwrite flex DOFs with better block Jacobi (captures off-diagonal JTDJ)
   wp.launch(
-    _apply_block_preconditioner_flex,
+    _apply_block_preconditioner,
     dim=(d.nworld, ctx.nblocks),
     inputs=[
       m.dof_treeid,
       m.tree_dofnum,
-      ctx.nblocks,
-      ctx.block_dof_adr,
-      ctx.block_dof_num,
-      ctx.inv_H_blocks,
-      ctx.grad,
-      ctx.done,
-    ],
-    outputs=[ctx.Mgrad],
-  )
-  wp.launch(
-    _apply_block_preconditioner_flex,
-    dim=(d.nworld, ctx.nblocks),
-    inputs=[
-      m.dof_treeid,
-      m.tree_dofnum,
+      1,
       ctx.nblocks,
       ctx.block_dof_adr,
       ctx.block_dof_num,

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -57,6 +57,52 @@ def create_inverse_context(m: types.Model, d: types.Data) -> InverseContext:
   )
 
 
+@wp.kernel
+def _init_dof_to_block(nv: int, dof_to_block_out: wp.array[int]):
+  """Initialize dof_to_block to -1."""
+  tid = wp.tid()
+  if tid < nv:
+    dof_to_block_out[tid] = -1
+
+
+@wp.kernel
+def _build_block_mapping(
+    nbody: int,
+    body_dofadr_in: wp.array[int],
+    body_dofnum_in: wp.array[int],
+    # Out:
+    block_dof_adr_out: wp.array[int],
+    block_dof_num_out: wp.array[int],
+    dof_to_block_out: wp.array[int],
+):
+  """Build block mapping on device. Single-threaded kernel.
+
+  Splits each body's DOFs into blocks of at most 3. For example,
+  a freejoint body with 6 DOFs becomes two 3-DOF blocks.
+  """
+  tid = wp.tid()
+  if tid > 0:
+    return
+
+  block_count = int(0)
+  for b in range(nbody):
+    ndof = body_dofnum_in[b]
+    dof0 = body_dofadr_in[b]
+    if ndof == 0:
+      continue
+    remaining = ndof
+    offset = int(0)
+    while remaining > 0:
+      chunk = wp.min(remaining, 3)
+      block_dof_adr_out[block_count] = dof0 + offset
+      block_dof_num_out[block_count] = chunk
+      for k in range(chunk):
+        dof_to_block_out[dof0 + offset + k] = block_count
+      offset += chunk
+      remaining -= chunk
+      block_count += 1
+
+
 def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
   """Create a SolverContext with allocated workspace arrays.
 
@@ -74,6 +120,31 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
 
   alloc_h = m.opt.solver == types.SolverType.NEWTON
   alloc_hfactor = alloc_h and nv > _BLOCK_CHOLESKY_DIM
+  alloc_block_jacobi = m.opt.solver == types.SolverType.CG
+
+  # Build block mapping for block Jacobi preconditioner on device.
+  # Each body with >3 DOFs is split into multiple ≤3-DOF blocks.
+  # Use max_blocks = 2 * nbody as upper bound (6-DOF freejoint -> two blocks).
+  # Unused entries stay zero and are harmlessly skipped by the kernels.
+  if alloc_block_jacobi:
+    max_blocks = 2 * m.nbody
+    block_dof_adr = wp.zeros(max_blocks, dtype=int)
+    block_dof_num = wp.zeros(max_blocks, dtype=int)
+    dof_to_block = wp.empty(nv, dtype=int)
+
+    wp.launch(_init_dof_to_block, dim=nv, inputs=[nv], outputs=[dof_to_block])
+    wp.launch(
+        _build_block_mapping,
+        dim=1,
+        inputs=[m.nbody, m.body_dofadr, m.body_dofnum],
+        outputs=[block_dof_adr, block_dof_num, dof_to_block],
+    )
+    nblocks = max_blocks
+  else:
+    nblocks = 0
+    block_dof_adr = wp.empty(0, dtype=int)
+    block_dof_num = wp.empty(0, dtype=int)
+    dof_to_block = wp.empty(0, dtype=int)
 
   return SolverContext(
     Jaref=wp.empty((nworld, njmax), dtype=float),
@@ -94,6 +165,11 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     beta_den=wp.empty((nworld,), dtype=float),
     h=wp.empty((nworld, nv_pad, nv_pad), dtype=float) if alloc_h else wp.empty((nworld, 0, 0), dtype=float),
     hfactor=wp.empty((nworld, nv_pad, nv_pad), dtype=float) if alloc_hfactor else wp.empty((nworld, 0, 0), dtype=float),
+    inv_H_blocks=wp.zeros((nworld, 6, nblocks), dtype=float) if alloc_block_jacobi else wp.empty((nworld, 0, 0), dtype=float),
+    block_dof_adr=block_dof_adr,
+    block_dof_num=block_dof_num,
+    dof_to_block=dof_to_block,
+    nblocks=nblocks,
     changed_efc_ids=wp.empty((nworld, njmax), dtype=int) if alloc_h else wp.empty((nworld, 0), dtype=int),
     changed_efc_count=wp.empty((nworld,), dtype=int) if alloc_h else wp.empty((0,), dtype=int),
   )
@@ -2748,6 +2824,291 @@ _JTDAJ_OVERSUBSCRIBE_WAVES = 6  # grid-stride depth; short per-warp chains load-
 
 
 @wp.kernel
+def _block_jacobi_JTDJ(
+    # Data in:
+    nefc_in: wp.array[int],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    efc_J_in: wp.array3d[float],
+    efc_D_in: wp.array2d[float],
+    efc_state_in: wp.array2d[int],
+    # Block mapping:
+    dof_to_block_in: wp.array[int],
+    block_dof_adr_in: wp.array[int],
+    # In:
+    ctx_done_in: wp.array[bool],
+    # Out:
+    inv_H_blocks_out: wp.array3d[float],
+):
+  """Accumulate block-diagonal of J^T D J into inv_H_blocks."""
+  worldid, efcid = wp.tid()
+
+  if ctx_done_in[worldid]:
+    return
+
+  if efcid >= nefc_in[worldid]:
+    return
+
+  efc_D = efc_D_in[worldid, efcid]
+  efc_state = efc_state_in[worldid, efcid]
+
+  if _state_check(efc_D, efc_state) == 0.0:
+    return
+
+  rownnz = efc_J_rownnz_in[worldid, efcid]
+  rowadr = efc_J_rowadr_in[worldid, efcid]
+
+  for i in range(rownnz):
+    sparseidi = rowadr + i
+    Ji = efc_J_in[worldid, 0, sparseidi]
+    colindi = efc_J_colind_in[worldid, 0, sparseidi]
+    blocki = dof_to_block_in[colindi]
+    if blocki < 0:
+      continue
+    dof0 = block_dof_adr_in[blocki]
+    local_i = colindi - dof0
+
+    for j in range(i, rownnz):
+      if j == i:
+        sparseidj = sparseidi
+        Jj = Ji
+        colindj = colindi
+      else:
+        sparseidj = rowadr + j
+        Jj = efc_J_in[worldid, 0, sparseidj]
+        colindj = efc_J_colind_in[worldid, 0, sparseidj]
+
+      blockj = dof_to_block_in[colindj]
+      if blocki != blockj:
+        continue
+
+      local_j = colindj - dof0
+
+      h = Ji * Jj * efc_D
+
+      # Map to upper-triangular flat index:
+      # (0,0)->0, (0,1)->1, (0,2)->2, (1,1)->3, (1,2)->4, (2,2)->5
+      li = wp.min(local_i, local_j)
+      lj = wp.max(local_i, local_j)
+      flat_idx = li * (5 - li) / 2 + lj
+
+      wp.atomic_add(inv_H_blocks_out[worldid, flat_idx], blocki, h)
+
+
+@wp.kernel
+def _block_jacobi_add_M(
+    # Model in:
+    nv: int,
+    M_mulm_rowadr_in: wp.array[int],
+    M_mulm_col_in: wp.array[int],
+    M_mulm_madr_in: wp.array[int],
+    # Block mapping:
+    dof_to_block_in: wp.array[int],
+    block_dof_adr_in: wp.array[int],
+    # Data in:
+    M_in: wp.array3d[float],
+    # In:
+    ctx_done_in: wp.array[bool],
+    # Out:
+    inv_H_blocks_out: wp.array3d[float],
+):
+  """Add mass matrix entries within each block."""
+  worldid, di = wp.tid()
+  if di >= nv:
+    return
+  if ctx_done_in[worldid]:
+    return
+
+  bi = dof_to_block_in[di]
+  if bi < 0:
+    return
+  li = di - block_dof_adr_in[bi]
+
+  # Walk sparse M row for this DOF, accumulating entries within same block
+  start = M_mulm_rowadr_in[di]
+  end = M_mulm_rowadr_in[di + 1]
+  for k in range(start, end):
+    dj = M_mulm_col_in[k]
+    if di > dj:
+      continue
+    bj = dof_to_block_in[dj]
+    if bj == bi:
+      lj = dj - block_dof_adr_in[bj]
+      madr = M_mulm_madr_in[k]
+      M_val = M_in[worldid, 0, madr]
+      lmin = wp.min(li, lj)
+      lmax = wp.max(li, lj)
+      offset = lmin * (5 - lmin) / 2 + lmax
+      wp.atomic_add(inv_H_blocks_out, worldid, offset, bi, M_val)
+
+
+@wp.kernel
+def _block_jacobi_invert(
+    # Block mapping:
+    nblocks: int,
+    block_dof_num_in: wp.array[int],
+    # In:
+    ctx_done_in: wp.array[bool],
+    # In/Out:
+    inv_H_blocks_io: wp.array3d[float],
+):
+  """Invert each block in-place: H_bb -> H_bb^{-1}."""
+  worldid, blockid = wp.tid()
+
+  if ctx_done_in[worldid]:
+    return
+
+  if blockid >= nblocks:
+    return
+
+  ndof = block_dof_num_in[blockid]
+
+  # Read block entries
+  H00 = inv_H_blocks_io[worldid, 0, blockid]
+  H01 = inv_H_blocks_io[worldid, 1, blockid]
+  H02 = inv_H_blocks_io[worldid, 2, blockid]
+  H11 = inv_H_blocks_io[worldid, 3, blockid]
+  H12 = inv_H_blocks_io[worldid, 4, blockid]
+  H22 = inv_H_blocks_io[worldid, 5, blockid]
+
+  # Regularization for numerical safety
+  reg = 1.0e-12
+  H00 = H00 + reg
+  H11 = H11 + reg
+  H22 = H22 + reg
+
+  if ndof == 1:
+    if H00 > 0.0:
+      inv_H_blocks_io[worldid, 0, blockid] = 1.0 / H00
+    else:
+      inv_H_blocks_io[worldid, 0, blockid] = 0.0
+  elif ndof == 2:
+    det = H00 * H11 - H01 * H01
+    if wp.abs(det) > 1.0e-30:
+      inv_det = 1.0 / det
+      inv_H_blocks_io[worldid, 0, blockid] = H11 * inv_det
+      inv_H_blocks_io[worldid, 1, blockid] = -H01 * inv_det
+      inv_H_blocks_io[worldid, 3, blockid] = H00 * inv_det
+    else:
+      inv_H_blocks_io[worldid, 0, blockid] = 0.0
+      inv_H_blocks_io[worldid, 1, blockid] = 0.0
+      inv_H_blocks_io[worldid, 3, blockid] = 0.0
+  elif ndof == 3:
+    # 3x3 symmetric matrix inversion via cofactors
+    c00 = H11 * H22 - H12 * H12
+    c01 = H02 * H12 - H01 * H22
+    c02 = H01 * H12 - H02 * H11
+    c11 = H00 * H22 - H02 * H02
+    c12 = H01 * H02 - H00 * H12
+    c22 = H00 * H11 - H01 * H01
+
+    det = H00 * c00 + H01 * c01 + H02 * c02
+    if wp.abs(det) > 1.0e-30:
+      inv_det = 1.0 / det
+      inv_H_blocks_io[worldid, 0, blockid] = c00 * inv_det
+      inv_H_blocks_io[worldid, 1, blockid] = c01 * inv_det
+      inv_H_blocks_io[worldid, 2, blockid] = c02 * inv_det
+      inv_H_blocks_io[worldid, 3, blockid] = c11 * inv_det
+      inv_H_blocks_io[worldid, 4, blockid] = c12 * inv_det
+      inv_H_blocks_io[worldid, 5, blockid] = c22 * inv_det
+    else:
+      for i in range(6):
+        inv_H_blocks_io[worldid, i, blockid] = 0.0
+
+
+@wp.kernel
+def _apply_block_preconditioner(
+    # Block mapping:
+    nblocks: int,
+    block_dof_adr_in: wp.array[int],
+    block_dof_num_in: wp.array[int],
+    # In:
+    inv_H_blocks_in: wp.array3d[float],
+    grad_in: wp.array2d[float],
+    done_in: wp.array[bool],
+    # Out:
+    Mgrad_out: wp.array2d[float],
+):
+  """Mgrad = H_block^{-1} * grad for each block."""
+  worldid, blockid = wp.tid()
+
+  if blockid >= nblocks:
+    return
+
+  if done_in[worldid]:
+    return
+
+  ndof = block_dof_num_in[blockid]
+  dof0 = block_dof_adr_in[blockid]
+
+  # Read inverse block
+  I00 = inv_H_blocks_in[worldid, 0, blockid]
+  I01 = inv_H_blocks_in[worldid, 1, blockid]
+  I02 = inv_H_blocks_in[worldid, 2, blockid]
+  I11 = inv_H_blocks_in[worldid, 3, blockid]
+  I12 = inv_H_blocks_in[worldid, 4, blockid]
+  I22 = inv_H_blocks_in[worldid, 5, blockid]
+
+  g0 = grad_in[worldid, dof0]
+  g1 = float(0.0)
+  g2 = float(0.0)
+  if ndof >= 2:
+    g1 = grad_in[worldid, dof0 + 1]
+  if ndof >= 3:
+    g2 = grad_in[worldid, dof0 + 2]
+
+  if ndof == 1:
+    Mgrad_out[worldid, dof0] = I00 * g0
+  elif ndof == 2:
+    Mgrad_out[worldid, dof0] = I00 * g0 + I01 * g1
+    Mgrad_out[worldid, dof0 + 1] = I01 * g0 + I11 * g1
+  elif ndof == 3:
+    Mgrad_out[worldid, dof0] = I00 * g0 + I01 * g1 + I02 * g2
+    Mgrad_out[worldid, dof0 + 1] = I01 * g0 + I11 * g1 + I12 * g2
+    Mgrad_out[worldid, dof0 + 2] = I02 * g0 + I12 * g1 + I22 * g2
+
+
+def _build_block_jacobi_preconditioner(
+    m: types.Model, d: types.Data, ctx: SolverContext
+):
+  """Build and invert block-diagonal preconditioner using block mapping."""
+  ctx.inv_H_blocks.zero_()
+
+  # Accumulate block-diagonal of J^T D J
+  wp.launch(
+      _block_jacobi_JTDJ,
+      dim=(d.nworld, d.njmax),
+      inputs=[
+          d.nefc, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind,
+          d.efc.J, d.efc.D, d.efc.state,
+          ctx.dof_to_block, ctx.block_dof_adr, ctx.done,
+      ],
+      outputs=[ctx.inv_H_blocks],
+  )
+
+  # Add mass matrix entries within each block
+  wp.launch(
+      _block_jacobi_add_M,
+      dim=(d.nworld, m.nv),
+      inputs=[
+          m.nv, m.M_mulm_rowadr, m.M_mulm_col, m.M_mulm_madr,
+          ctx.dof_to_block, ctx.block_dof_adr,
+          d.M, ctx.done,
+      ],
+      outputs=[ctx.inv_H_blocks],
+  )
+
+  # Invert blocks in-place
+  wp.launch(
+      _block_jacobi_invert,
+      dim=(d.nworld, ctx.nblocks),
+      inputs=[ctx.nblocks, ctx.block_dof_num, ctx.done],
+      outputs=[ctx.inv_H_blocks],
+  )
+
+
+@wp.kernel
 def _JTDAJ_sparse(
   # Data in:
   efc_jtdaj_adr_in: wp.array2d[int],
@@ -2822,9 +3183,24 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
       inputs=[d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, ctx.done],
       outputs=[ctx.grad, ctx.grad_dot],
     )
-
   if m.opt.solver == types.SolverType.CG:
-    smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
+    if m.is_sparse:
+      _build_block_jacobi_preconditioner(m, d, ctx)
+      wp.launch(
+          _apply_block_preconditioner,
+          dim=(d.nworld, ctx.nblocks),
+          inputs=[
+              ctx.nblocks,
+              ctx.block_dof_adr,
+              ctx.block_dof_num,
+              ctx.inv_H_blocks,
+              ctx.grad,
+              ctx.done,
+          ],
+          outputs=[ctx.Mgrad],
+      )
+    else:
+      smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
   elif m.opt.solver == types.SolverType.NEWTON:
     # h = M + (efc_J.T * efc_D * active) @ efc_J
     if m.is_sparse:

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -151,10 +151,10 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
   has_articulated = m.is_sparse and m.has_articulated_trees
   alloc_ic = alloc_block_jacobi and has_articulated
   if alloc_ic:
-    qLD_precond = wp.zeros((nworld, 1, m.nC), dtype=float)
+    qLD_precond = wp.zeros((nworld, m.nC), dtype=float)
     qLDiagInv_precond = wp.zeros((nworld, nv), dtype=float)
   else:
-    qLD_precond = wp.empty((0, 0, 0), dtype=float)
+    qLD_precond = wp.empty((0, 0), dtype=float)
     qLDiagInv_precond = wp.empty((0, 0), dtype=float)
 
   return SolverContext(
@@ -2917,7 +2917,7 @@ def _block_jacobi_add_M(
   M_mulm_col: wp.array[int],
   M_mulm_madr: wp.array[int],
   # Data in:
-  M_in: wp.array3d[float],
+  M_in: wp.array2d[float],
   # In:
   dof_to_block_in: wp.array[int],
   block_dof_adr_in: wp.array[int],
@@ -2948,7 +2948,7 @@ def _block_jacobi_add_M(
     if bj == bi:
       lj = dj - block_dof_adr_in[bj]
       madr = M_mulm_madr[k]
-      M_val = M_in[worldid, 0, madr]
+      M_val = M_in[worldid, madr]
       lmin = wp.min(li, lj)
       lmax = wp.max(li, lj)
       offset = lmin * (5 - lmin) / 2 + lmax
@@ -3085,9 +3085,15 @@ def _apply_block_preconditioner(
 # =============================================================================
 
 
+# =============================================================================
+# Per-tree IC(0) Preconditioner
+
+
 @wp.kernel
 def _add_JTDJ_to_M_sparse(
   # Model:
+  dof_treeid: wp.array[int],
+  tree_dofnum: wp.array[int],
   M_rownnz: wp.array[int],
   M_rowadr: wp.array[int],
   M_colind: wp.array[int],
@@ -3102,9 +3108,9 @@ def _add_JTDJ_to_M_sparse(
   # In:
   ctx_done_in: wp.array[bool],
   # Out:
-  H_out: wp.array3d[float],
+  H_out: wp.array2d[float],
 ):
-  """Add J^T D J entries at positions matching M's sparsity pattern."""
+  """Add J^T D J at M sparsity positions for articulated trees only."""
   worldid, efcid = wp.tid()
   if ctx_done_in[worldid]:
     return
@@ -3119,9 +3125,14 @@ def _add_JTDJ_to_M_sparse(
   for k1 in range(rownnz):
     Ji = efc_J_in[worldid, 0, rowadr + k1]
     colindi = efc_J_colind_in[worldid, 0, rowadr + k1]
+    treei = dof_treeid[colindi]
+    if tree_dofnum[treei] <= 6:
+      continue
     for k2 in range(k1 + 1):
       Jj = efc_J_in[worldid, 0, rowadr + k2]
       colindj = efc_J_colind_in[worldid, 0, rowadr + k2]
+      if dof_treeid[colindj] != treei:
+        continue
       row = wp.max(colindi, colindj)
       col = wp.min(colindi, colindj)
       h = Ji * Jj * efc_D
@@ -3129,7 +3140,7 @@ def _add_JTDJ_to_M_sparse(
       row_nnz = M_rownnz[row]
       for idx in range(row_nnz):
         if M_colind[row_start + idx] == col:
-          wp.atomic_add(H_out[worldid, 0], row_start + idx, h)
+          wp.atomic_add(H_out, worldid, row_start + idx, h)
           break
 
 
@@ -3148,7 +3159,7 @@ def _apply_block_preconditioner_flex(
   # Out:
   Mgrad_out: wp.array2d[float],
 ):
-  """Block Jacobi apply for simple trees only (nv_tree <= 3)."""
+  """Block Jacobi apply for simple trees only (nv_tree <= 6)."""
   worldid, blockid = wp.tid()
   if blockid >= nblocks:
     return
@@ -3159,7 +3170,7 @@ def _apply_block_preconditioner_flex(
   if ndof == 0:
     return
   treeid = dof_treeid[dof0]
-  if tree_dofnum[treeid] > 3:
+  if tree_dofnum[treeid] > 6:
     return
   I00 = inv_H_blocks_in[worldid, 0, blockid]
   I01 = inv_H_blocks_in[worldid, 1, blockid]
@@ -3188,13 +3199,15 @@ def _apply_block_preconditioner_flex(
 def _build_ic_preconditioner(m, d, ctx):
   """Build hybrid preconditioner: block Jacobi for flex, IC(0) for articulated."""
   _build_block_jacobi_preconditioner(m, d, ctx)
-  if ctx.qLD_precond.shape[2] == 0:
-    return  # No articulated trees
+  if ctx.qLD_precond.shape[1] == 0:
+    return
   wp.copy(ctx.qLD_precond, d.M)
   wp.launch(
     _add_JTDJ_to_M_sparse,
     dim=(d.nworld, d.njmax),
     inputs=[
+      m.dof_treeid,
+      m.tree_dofnum,
       m.M_rownnz,
       m.M_rowadr,
       m.M_colind,
@@ -3225,24 +3238,26 @@ def _build_ic_preconditioner(m, d, ctx):
 
 
 def _apply_ic_preconditioner(m, d, ctx):
-  """Apply hybrid preconditioner: IC(0) for all, then block Jacobi for flex."""
-  if ctx.qLD_precond.shape[2] == 0:
-    # No articulated trees: block Jacobi only
+  """Apply preconditioner based on model structure.
+
+  Pure flex (no articulated trees): block Jacobi (M+JTDJ)^{-1} per body.
+  Mixed with no sparse blocks: fall back to M^{-1} (block Jacobi hurts robots).
+  Mixed with sparse blocks: M^{-1} baseline, IC(0) overwrites sparse DOFs.
+  """
+  if not m.has_articulated_trees:
+    # Pure flex model: block Jacobi is best
     wp.launch(
       _apply_block_preconditioner,
       dim=(d.nworld, ctx.nblocks),
-      inputs=[
-        ctx.nblocks,
-        ctx.block_dof_adr,
-        ctx.block_dof_num,
-        ctx.inv_H_blocks,
-        ctx.grad,
-        ctx.done,
-      ],
+      inputs=[ctx.nblocks, ctx.block_dof_adr, ctx.block_dof_num, ctx.inv_H_blocks, ctx.grad, ctx.done],
       outputs=[ctx.Mgrad],
     )
     return
-  smooth._solve_LD_sparse(m, d, ctx.qLD_precond, ctx.qLDiagInv_precond, ctx.Mgrad, ctx.grad)
+  # Has articulated trees: use M^{-1} as baseline
+  smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
+  if m.qLD_has_sparse:
+    # Overwrite sparse-block articulated DOFs with IC(0) solve
+    smooth._solve_LD_sparse(m, d, ctx.qLD_precond, ctx.qLDiagInv_precond, ctx.Mgrad, ctx.grad)
   wp.launch(
     _apply_block_preconditioner_flex,
     dim=(d.nworld, ctx.nblocks),
@@ -3385,10 +3400,16 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
       outputs=[ctx.grad, ctx.grad_dot],
     )
   if m.opt.solver == types.SolverType.CG:
-    if m.is_sparse:
+    if m.is_sparse and not m.has_articulated_trees:
+      # Pure flex model: block Jacobi helps
+      _build_ic_preconditioner(m, d, ctx)
+      _apply_ic_preconditioner(m, d, ctx)
+    elif m.is_sparse and m.qLD_has_sparse:
+      # Articulated model with sparse LDL blocks: IC(0) helps
       _build_ic_preconditioner(m, d, ctx)
       _apply_ic_preconditioner(m, d, ctx)
     else:
+      # Default: M^{-1} (aloha_cloth, dense-only models)
       smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
   elif m.opt.solver == types.SolverType.NEWTON:
     # h = M + (efc_J.T * efc_D * active) @ efc_J

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -104,6 +104,30 @@ def _build_block_mapping(
       block_count += 1
 
 
+@wp.kernel
+def _build_tree_mat_adr(
+  # Model:
+  tree_dofnum: wp.array[int],
+  # In:
+  ntrees: int,
+  # Out:
+  tree_mat_adr_out: wp.array[int],
+  total_tree_nnz_out: wp.array[int],
+):
+  """Build tree_mat_adr (cumulative sum of ndof^2) on device. Single-threaded."""
+  tid = wp.tid()
+  if tid > 0:
+    return
+
+  cumsum = int(0)
+  tree_mat_adr_out[0] = 0
+  for t in range(ntrees):
+    ndof = tree_dofnum[t]
+    cumsum += ndof * ndof
+    tree_mat_adr_out[t + 1] = cumsum
+  total_tree_nnz_out[0] = cumsum
+
+
 def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
   """Create a SolverContext with allocated workspace arrays.
 
@@ -147,6 +171,27 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     block_dof_num = wp.empty(0, dtype=int)
     dof_to_block = wp.empty(0, dtype=int)
 
+  # Tree IC preconditioner: compute offsets and allocate storage.
+  # _create_solver_context runs once during setup (not during graph capture),
+  # so .numpy() is safe here.
+  alloc_tree_ic = alloc_block_jacobi and m.is_sparse
+  if alloc_tree_ic:
+    ntrees_ic = int(m.ntree)
+    total_tree_nnz_bound = m.tree_total_nnz_int
+    tree_mat_adr_ic = wp.zeros(ntrees_ic + 1, dtype=int)
+    total_tree_nnz_arr = wp.zeros(1, dtype=int)
+    wp.launch(
+      _build_tree_mat_adr,
+      dim=1,
+      inputs=[m.tree_dofnum, ntrees_ic],
+      outputs=[tree_mat_adr_ic, total_tree_nnz_arr],
+    )
+  else:
+    ntrees_ic = 0
+    total_tree_nnz_bound = 0
+    tree_mat_adr_ic = wp.empty(0, dtype=int)
+    total_tree_nnz_arr = wp.empty(0, dtype=int)
+
   return SolverContext(
     Jaref=wp.empty((nworld, njmax), dtype=float),
     search_dot=wp.empty((nworld,), dtype=float),
@@ -171,6 +216,12 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     block_dof_num=block_dof_num,
     dof_to_block=dof_to_block,
     nblocks=nblocks,
+    H_tree=wp.zeros((nworld, max(total_tree_nnz_bound, 1)), dtype=float)
+    if alloc_tree_ic
+    else wp.empty((nworld, 0), dtype=float),
+    tree_mat_adr=tree_mat_adr_ic,
+    total_tree_nnz=total_tree_nnz_arr,
+    ntrees=ntrees_ic,
     changed_efc_ids=wp.empty((nworld, njmax), dtype=int) if alloc_h else wp.empty((nworld, 0), dtype=int),
     changed_efc_count=wp.empty((nworld,), dtype=int) if alloc_h else wp.empty((0,), dtype=int),
   )
@@ -3068,6 +3119,386 @@ def _apply_block_preconditioner(
     Mgrad_out[worldid, dof0 + 2] = I02 * g0 + I12 * g1 + I22 * g2
 
 
+# =============================================================================
+# Tree-level Incomplete Cholesky (IC) Block Jacobi Preconditioner
+# =============================================================================
+
+
+# kernel_analyzer: off
+@wp.func
+def _ic_inv3(
+  H: wp.array2d[float],
+  w: int,
+  adr: int,
+  ndof: int,
+  stride: int,
+):
+  """Analytically invert an ndof x ndof block (ndof <= 3) in-place.
+
+  Block is stored in row-major at H[w, adr + i*stride + j].
+  """
+  reg = 1.0e-12
+  if ndof == 1:
+    v = H[w, adr] + reg
+    if v > 0.0:
+      H[w, adr] = 1.0 / v
+    else:
+      H[w, adr] = 0.0
+  elif ndof == 2:
+    a00 = H[w, adr] + reg
+    a01 = H[w, adr + 1]
+    a10 = H[w, adr + stride]
+    a11 = H[w, adr + stride + 1] + reg
+    det = a00 * a11 - a01 * a10
+    if wp.abs(det) > 1.0e-30:
+      inv_det = 1.0 / det
+      H[w, adr] = a11 * inv_det
+      H[w, adr + 1] = -a01 * inv_det
+      H[w, adr + stride] = -a10 * inv_det
+      H[w, adr + stride + 1] = a00 * inv_det
+    else:
+      H[w, adr] = 0.0
+      H[w, adr + 1] = 0.0
+      H[w, adr + stride] = 0.0
+      H[w, adr + stride + 1] = 0.0
+  elif ndof == 3:
+    a00 = H[w, adr] + reg
+    a01 = H[w, adr + 1]
+    a02 = H[w, adr + 2]
+    a10 = H[w, adr + stride]
+    a11 = H[w, adr + stride + 1] + reg
+    a12 = H[w, adr + stride + 2]
+    a20 = H[w, adr + 2 * stride]
+    a21 = H[w, adr + 2 * stride + 1]
+    a22 = H[w, adr + 2 * stride + 2] + reg
+    c00 = a11 * a22 - a12 * a21
+    c01 = a02 * a21 - a01 * a22
+    c02 = a01 * a12 - a02 * a11
+    c10 = a12 * a20 - a10 * a22
+    c11 = a00 * a22 - a02 * a20
+    c12 = a02 * a10 - a00 * a12
+    c20 = a10 * a21 - a11 * a20
+    c21 = a01 * a20 - a00 * a21
+    c22 = a00 * a11 - a01 * a10
+    det = a00 * c00 + a01 * c10 + a02 * c20
+    if wp.abs(det) > 1.0e-30:
+      inv_det = 1.0 / det
+      H[w, adr] = c00 * inv_det
+      H[w, adr + 1] = c01 * inv_det
+      H[w, adr + 2] = c02 * inv_det
+      H[w, adr + stride] = c10 * inv_det
+      H[w, adr + stride + 1] = c11 * inv_det
+      H[w, adr + stride + 2] = c12 * inv_det
+      H[w, adr + 2 * stride] = c20 * inv_det
+      H[w, adr + 2 * stride + 1] = c21 * inv_det
+      H[w, adr + 2 * stride + 2] = c22 * inv_det
+    else:
+      for rr in range(3):
+        for cc in range(3):
+          H[w, adr + rr * stride + cc] = 0.0
+
+
+# kernel_analyzer: on
+
+
+@wp.kernel
+def _ic_tree_JTDJ(
+  # Model:
+  dof_treeid: wp.array[int],
+  tree_dofadr: wp.array[int],
+  tree_dofnum: wp.array[int],
+  # Data in:
+  nefc_in: wp.array[int],
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
+  efc_J_in: wp.array3d[float],
+  efc_D_in: wp.array2d[float],
+  efc_state_in: wp.array2d[int],
+  # In:
+  tree_mat_adr_in: wp.array[int],
+  ctx_done_in: wp.array[bool],
+  # Out:
+  H_tree_out: wp.array2d[float],
+):
+  """Accumulate J^T D J into dense tree blocks."""
+  worldid, efcid = wp.tid()
+
+  if ctx_done_in[worldid]:
+    return
+
+  if efcid >= nefc_in[worldid]:
+    return
+
+  efc_D = efc_D_in[worldid, efcid]
+  efc_state = efc_state_in[worldid, efcid]
+
+  if _state_check(efc_D, efc_state) == 0.0:
+    return
+
+  rownnz = efc_J_rownnz_in[worldid, efcid]
+  rowadr = efc_J_rowadr_in[worldid, efcid]
+
+  for i in range(rownnz):
+    sparseidi = rowadr + i
+    Ji = efc_J_in[worldid, 0, sparseidi]
+    colindi = efc_J_colind_in[worldid, 0, sparseidi]
+    treei = dof_treeid[colindi]
+
+    for j in range(rownnz):
+      sparseidj = rowadr + j
+      Jj = efc_J_in[worldid, 0, sparseidj]
+      colindj = efc_J_colind_in[worldid, 0, sparseidj]
+      treej = dof_treeid[colindj]
+
+      if treei != treej:
+        continue
+
+      dof0 = tree_dofadr[treei]
+      ndof = tree_dofnum[treei]
+      base = tree_mat_adr_in[treei]
+
+      local_i = colindi - dof0
+      local_j = colindj - dof0
+
+      h = Ji * Jj * efc_D
+      wp.atomic_add(H_tree_out[worldid], base + local_i * ndof + local_j, h)
+
+
+@wp.kernel
+def _ic_tree_add_M(
+  # Model:
+  nv: int,
+  dof_treeid: wp.array[int],
+  tree_dofadr: wp.array[int],
+  tree_dofnum: wp.array[int],
+  M_mulm_rowadr: wp.array[int],
+  M_mulm_col: wp.array[int],
+  M_mulm_madr: wp.array[int],
+  # Data in:
+  M_in: wp.array3d[float],
+  # In:
+  tree_mat_adr_in: wp.array[int],
+  ctx_done_in: wp.array[bool],
+  # Out:
+  H_tree_out: wp.array2d[float],
+):
+  """Add mass matrix entries into dense tree blocks."""
+  worldid, di = wp.tid()
+  if di >= nv:
+    return
+  if ctx_done_in[worldid]:
+    return
+
+  treei = dof_treeid[di]
+  dof0 = tree_dofadr[treei]
+  ndof = tree_dofnum[treei]
+  base = tree_mat_adr_in[treei]
+  local_i = di - dof0
+
+  start = M_mulm_rowadr[di]
+  end = M_mulm_rowadr[di + 1]
+  for k in range(start, end):
+    dj = M_mulm_col[k]
+    treej = dof_treeid[dj]
+    if treej == treei:
+      local_j = dj - dof0
+      madr = M_mulm_madr[k]
+      M_val = M_in[worldid, 0, madr]
+      wp.atomic_add(H_tree_out[worldid], base + local_i * ndof + local_j, M_val)
+
+
+@wp.kernel
+def _ic_tree_factorize(
+  # Model:
+  tree_dofnum: wp.array[int],
+  # In:
+  ntrees: int,
+  tree_mat_adr_in: wp.array[int],
+  ctx_done_in: wp.array[bool],
+  # Out:
+  H_tree_out: wp.array2d[float],
+):
+  """Factorize each tree block.
+
+  nv_t <= 3: analytic inverse in-place.
+  nv_t > 3:  full dense Cholesky factorization.
+
+  After factorization, the dense nv_t x nv_t block stores:
+  - nv_t <= 3: the inverted block (from _ic_inv3).
+  - nv_t > 3: L in the lower triangle (H = L L^T).
+  """
+  worldid, treeid = wp.tid()
+
+  if ctx_done_in[worldid]:
+    return
+  if treeid >= ntrees:
+    return
+
+  nv_t = tree_dofnum[treeid]
+  adr = tree_mat_adr_in[treeid]
+
+  if nv_t == 0:
+    return
+
+  if nv_t <= 3:
+    _ic_inv3(H_tree_out, worldid, adr, nv_t, nv_t)
+    return
+
+  # Full dense Cholesky factorization (in-place, lower triangle).
+  # Stores L in lower triangle: H = L L^T.
+  reg = 1.0e-10
+  for j in range(nv_t):
+    # Diagonal: L[j,j] = sqrt(H[j,j] - sum(L[j,k]^2, k<j))
+    s = H_tree_out[worldid, adr + j * nv_t + j]
+    for k in range(j):
+      ljk = H_tree_out[worldid, adr + j * nv_t + k]
+      s -= ljk * ljk
+    s = wp.max(s, reg)
+    ljj = wp.sqrt(s)
+    H_tree_out[worldid, adr + j * nv_t + j] = ljj
+    inv_ljj = 1.0 / ljj
+
+    # Off-diagonal: L[i,j] = (H[i,j] - sum(L[i,k]*L[j,k], k<j)) / L[j,j]
+    for i in range(j + 1, nv_t):
+      s = H_tree_out[worldid, adr + i * nv_t + j]
+      for k in range(j):
+        s -= H_tree_out[worldid, adr + i * nv_t + k] * H_tree_out[worldid, adr + j * nv_t + k]
+      H_tree_out[worldid, adr + i * nv_t + j] = s * inv_ljj
+
+
+@wp.kernel
+def _ic_tree_apply(
+  # Model:
+  tree_dofadr: wp.array[int],
+  tree_dofnum: wp.array[int],
+  # In:
+  ntrees: int,
+  tree_mat_adr_in: wp.array[int],
+  ctx_done_in: wp.array[bool],
+  grad_in: wp.array2d[float],
+  H_tree_in: wp.array2d[float],
+  # Out:
+  Mgrad_out: wp.array2d[float],
+):
+  """Apply IC preconditioner: Mgrad = (LDL^T)^{-1} grad.
+
+  Small trees (nv_t <= 3): direct inverse-times-vector.
+  Larger trees: forward/diagonal/backward substitution.
+  """
+  worldid, treeid = wp.tid()
+
+  if ctx_done_in[worldid]:
+    return
+  if treeid >= ntrees:
+    return
+
+  nv_t = tree_dofnum[treeid]
+  dof0 = tree_dofadr[treeid]
+  adr = tree_mat_adr_in[treeid]
+
+  if nv_t == 0:
+    return
+
+  if nv_t <= 3:
+    # Direct H_inv * grad
+    for ii in range(nv_t):
+      val = float(0.0)
+      for jj in range(nv_t):
+        val += H_tree_in[worldid, adr + ii * nv_t + jj] * grad_in[worldid, dof0 + jj]
+      Mgrad_out[worldid, dof0 + ii] = val
+    return
+
+  # Full Cholesky solve: L L^T x = b
+  # Forward substitution: L y = b
+  for i in range(nv_t):
+    s = grad_in[worldid, dof0 + i]
+    for k in range(i):
+      s -= H_tree_in[worldid, adr + i * nv_t + k] * Mgrad_out[worldid, dof0 + k]
+    Mgrad_out[worldid, dof0 + i] = s / H_tree_in[worldid, adr + i * nv_t + i]
+
+  # Backward substitution: L^T x = y
+  for i_rev in range(nv_t):
+    i = nv_t - 1 - i_rev
+    s = Mgrad_out[worldid, dof0 + i]
+    for k in range(i + 1, nv_t):
+      s -= H_tree_in[worldid, adr + k * nv_t + i] * Mgrad_out[worldid, dof0 + k]
+    Mgrad_out[worldid, dof0 + i] = s / H_tree_in[worldid, adr + i * nv_t + i]
+
+
+def _build_ic_preconditioner(m, d, ctx):
+  """Build tree-level IC preconditioner: accumulate H, factorize."""
+  ctx.H_tree.zero_()
+
+  wp.launch(
+    _ic_tree_JTDJ,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      m.dof_treeid,
+      m.tree_dofadr,
+      m.tree_dofnum,
+      d.nefc,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      d.efc.J,
+      d.efc.D,
+      d.efc.state,
+      ctx.tree_mat_adr,
+      ctx.done,
+    ],
+    outputs=[ctx.H_tree],
+  )
+
+  wp.launch(
+    _ic_tree_add_M,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      m.nv,
+      m.dof_treeid,
+      m.tree_dofadr,
+      m.tree_dofnum,
+      m.M_mulm_rowadr,
+      m.M_mulm_col,
+      m.M_mulm_madr,
+      d.M,
+      ctx.tree_mat_adr,
+      ctx.done,
+    ],
+    outputs=[ctx.H_tree],
+  )
+
+  wp.launch(
+    _ic_tree_factorize,
+    dim=(d.nworld, ctx.ntrees),
+    inputs=[
+      m.tree_dofnum,
+      ctx.ntrees,
+      ctx.tree_mat_adr,
+      ctx.done,
+    ],
+    outputs=[ctx.H_tree],
+  )
+
+
+def _apply_ic_preconditioner(m, d, ctx):
+  """Apply IC preconditioner: Mgrad = precond^{-1} @ grad."""
+  wp.launch(
+    _ic_tree_apply,
+    dim=(d.nworld, ctx.ntrees),
+    inputs=[
+      m.tree_dofadr,
+      m.tree_dofnum,
+      ctx.ntrees,
+      ctx.tree_mat_adr,
+      ctx.done,
+      ctx.grad,
+      ctx.H_tree,
+    ],
+    outputs=[ctx.Mgrad],
+  )
+
+
 def _build_block_jacobi_preconditioner(m: types.Model, d: types.Data, ctx: SolverContext):
   """Build and invert block-diagonal preconditioner using block mapping."""
   ctx.inv_H_blocks.zero_()
@@ -3194,20 +3625,8 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
     )
   if m.opt.solver == types.SolverType.CG:
     if m.is_sparse:
-      _build_block_jacobi_preconditioner(m, d, ctx)
-      wp.launch(
-        _apply_block_preconditioner,
-        dim=(d.nworld, ctx.nblocks),
-        inputs=[
-          ctx.nblocks,
-          ctx.block_dof_adr,
-          ctx.block_dof_num,
-          ctx.inv_H_blocks,
-          ctx.grad,
-          ctx.done,
-        ],
-        outputs=[ctx.Mgrad],
-      )
+      _build_ic_preconditioner(m, d, ctx)
+      _apply_ic_preconditioner(m, d, ctx)
     else:
       smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
   elif m.opt.solver == types.SolverType.NEWTON:

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -149,7 +149,7 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
 
   # IC(0) preconditioner: (M + JTDJ) factored for articulated bodies.
   has_articulated = m.is_sparse and m.has_articulated_trees
-  alloc_ic = alloc_block_jacobi and has_articulated
+  alloc_ic = alloc_block_jacobi and has_articulated and m.opt.jac_preconditioner
   if alloc_ic:
     M_precond = wp.zeros((nworld, m.nC), dtype=float)
     qld_total = d.qLD.shape[1]
@@ -3415,7 +3415,7 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
       outputs=[ctx.grad, ctx.grad_dot],
     )
   if m.opt.solver == types.SolverType.CG:
-    if m.is_sparse:
+    if m.is_sparse and m.opt.jac_preconditioner:
       _build_ic_preconditioner(m, d, ctx)
       _apply_ic_preconditioner(m, d, ctx)
     else:

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -149,7 +149,7 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
 
   # IC(0) preconditioner: (M + JTDJ) factored for articulated bodies.
   has_articulated = m.is_sparse and m.has_articulated_trees
-  alloc_ic = alloc_block_jacobi and has_articulated and m.opt.jac_preconditioner
+  alloc_ic = False  # IC(0) preconditioner removed; using diagonal for flex
   if alloc_ic:
     M_precond = wp.zeros((nworld, m.nC), dtype=float)
     qld_total = d.qLD.shape[1]
@@ -2840,6 +2840,89 @@ _JTDAJ_THREADS_PER_GROUP = 32  # one warp per group, so its J reads coalesce
 _JTDAJ_OVERSUBSCRIBE_WAVES = 6  # grid-stride depth; short per-warp chains load-balance groups
 
 
+
+
+# =============================================================================
+# Diagonal Preconditioner for flex DOFs: diag(M + J^T D J)
+# =============================================================================
+
+
+@wp.kernel
+def _diag_precond_build(
+  nv: int,
+  M_mulm_rowadr_in: wp.array[int],
+  M_mulm_col_in: wp.array[int],
+  M_mulm_madr_in: wp.array[int],
+  M_in: wp.array2d[float],
+  dof_to_block_in: wp.array[int],
+  ctx_done_in: wp.array[bool],
+  diag_out: wp.array2d[float],
+):
+  """Initialize diagonal with M_ii for flex DOFs only."""
+  worldid, di = wp.tid()
+  if di >= nv or ctx_done_in[worldid]:
+    return
+  if dof_to_block_in[di] < 0:
+    return
+  val = float(1.0e-12)
+  start = M_mulm_rowadr_in[di]
+  end = M_mulm_rowadr_in[di + 1]
+  for k in range(start, end):
+    if M_mulm_col_in[k] == di:
+      val += M_in[worldid, M_mulm_madr_in[k]]
+      break
+  diag_out[worldid, di] = val
+
+
+@wp.kernel
+def _diag_precond_add_JTDJ(
+  nefc_in: wp.array[int],
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
+  efc_J_in: wp.array3d[float],
+  efc_D_in: wp.array2d[float],
+  dof_to_block_in: wp.array[int],
+  ctx_done_in: wp.array[bool],
+  diag_out: wp.array2d[float],
+):
+  """Add diagonal of J^T D J for flex DOFs only."""
+  worldid, efcid = wp.tid()
+  if ctx_done_in[worldid]:
+    return
+  if efcid >= nefc_in[worldid]:
+    return
+  D = efc_D_in[worldid, efcid]
+  if D == 0.0:
+    return
+  rownnz = efc_J_rownnz_in[worldid, efcid]
+  rowadr = efc_J_rowadr_in[worldid, efcid]
+  for i in range(rownnz):
+    col = efc_J_colind_in[worldid, 0, rowadr + i]
+    if dof_to_block_in[col] < 0:
+      continue
+    Jval = efc_J_in[worldid, 0, rowadr + i]
+    wp.atomic_add(diag_out, worldid, col, D * Jval * Jval)
+
+
+@wp.kernel
+def _diag_precond_apply_flex(
+  nv: int,
+  dof_to_block_in: wp.array[int],
+  diag_in: wp.array2d[float],
+  grad_in: wp.array2d[float],
+  ctx_done_in: wp.array[bool],
+  Mgrad_out: wp.array2d[float],
+):
+  """Overwrite Mgrad for flex DOFs: z_i = g_i / diag_i."""
+  worldid, di = wp.tid()
+  if di >= nv or ctx_done_in[worldid]:
+    return
+  if dof_to_block_in[di] < 0:
+    return
+  Mgrad_out[worldid, di] = grad_in[worldid, di] / diag_in[worldid, di]
+
+
 @wp.kernel
 def _block_jacobi_JTDJ(
   # Data in:
@@ -3374,11 +3457,15 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
       outputs=[ctx.grad, ctx.grad_dot],
     )
   if m.opt.solver == types.SolverType.CG:
-    if m.is_sparse and m.opt.jac_preconditioner:
-      _build_ic_preconditioner(m, d, ctx)
-      _apply_ic_preconditioner(m, d, ctx)
-    else:
-      smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
+    smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
+    if m.is_sparse and m.nflex > 0 and hasattr(ctx, 'diag_precond') and ctx.diag_precond is not None:
+      wp.launch(
+        _diag_precond_apply_flex,
+        dim=(d.nworld, m.nv),
+        inputs=[m.nv, ctx.dof_to_block, ctx.diag_precond,
+                ctx.grad, ctx.done],
+        outputs=[ctx.Mgrad],
+      )
   elif m.opt.solver == types.SolverType.NEWTON:
     # h = M + (efc_J.T * efc_D * active) @ efc_J
     if m.is_sparse:
@@ -3988,6 +4075,26 @@ def init_context(m: types.Model, d: types.Data, ctx: SolverContext | InverseCont
   support.mul_m(m, d, d.efc.Ma, d.qacc, skip=ctx.done)
 
   _update_constraint(m, d, ctx)
+
+  # Build diagonal preconditioner for flex DOFs (once per step).
+  if m.is_sparse and m.nflex > 0:
+    if not hasattr(ctx, 'diag_precond') or ctx.diag_precond is None:
+      ctx.diag_precond = wp.zeros(shape=(d.nworld, m.nv), dtype=float)
+    wp.launch(
+      _diag_precond_build,
+      dim=(d.nworld, m.nv),
+      inputs=[m.nv, m.M_mulm_rowadr, m.M_mulm_col,
+              m.M_mulm_madr, d.M, ctx.dof_to_block, ctx.done],
+      outputs=[ctx.diag_precond],
+    )
+    wp.launch(
+      _diag_precond_add_JTDJ,
+      dim=(d.nworld, d.njmax),
+      inputs=[d.nefc, d.efc.J_rownnz, d.efc.J_rowadr,
+              d.efc.J_colind, d.efc.J, d.efc.D,
+              ctx.dof_to_block, ctx.done],
+      outputs=[ctx.diag_precond],
+    )
 
   if grad:
     _update_gradient(m, d, ctx, compact=compact)

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -67,13 +67,14 @@ def _init_dof_to_block(nv: int, dof_to_block_out: wp.array[int]):
 
 @wp.kernel
 def _build_block_mapping(
-    nbody: int,
-    body_dofadr_in: wp.array[int],
-    body_dofnum_in: wp.array[int],
-    # Out:
-    block_dof_adr_out: wp.array[int],
-    block_dof_num_out: wp.array[int],
-    dof_to_block_out: wp.array[int],
+  # Model:
+  nbody: int,
+  body_dofnum: wp.array[int],
+  body_dofadr: wp.array[int],
+  # Out:
+  block_dof_adr_out: wp.array[int],
+  block_dof_num_out: wp.array[int],
+  dof_to_block_out: wp.array[int],
 ):
   """Build block mapping on device. Single-threaded kernel.
 
@@ -86,8 +87,8 @@ def _build_block_mapping(
 
   block_count = int(0)
   for b in range(nbody):
-    ndof = body_dofnum_in[b]
-    dof0 = body_dofadr_in[b]
+    ndof = body_dofnum[b]
+    dof0 = body_dofadr[b]
     if ndof == 0:
       continue
     remaining = ndof
@@ -134,10 +135,10 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
 
     wp.launch(_init_dof_to_block, dim=nv, inputs=[nv], outputs=[dof_to_block])
     wp.launch(
-        _build_block_mapping,
-        dim=1,
-        inputs=[m.nbody, m.body_dofadr, m.body_dofnum],
-        outputs=[block_dof_adr, block_dof_num, dof_to_block],
+      _build_block_mapping,
+      dim=1,
+      inputs=[m.nbody, m.body_dofnum, m.body_dofadr],
+      outputs=[block_dof_adr, block_dof_num, dof_to_block],
     )
     nblocks = max_blocks
   else:
@@ -2825,21 +2826,21 @@ _JTDAJ_OVERSUBSCRIBE_WAVES = 6  # grid-stride depth; short per-warp chains load-
 
 @wp.kernel
 def _block_jacobi_JTDJ(
-    # Data in:
-    nefc_in: wp.array[int],
-    efc_J_rownnz_in: wp.array2d[int],
-    efc_J_rowadr_in: wp.array2d[int],
-    efc_J_colind_in: wp.array3d[int],
-    efc_J_in: wp.array3d[float],
-    efc_D_in: wp.array2d[float],
-    efc_state_in: wp.array2d[int],
-    # Block mapping:
-    dof_to_block_in: wp.array[int],
-    block_dof_adr_in: wp.array[int],
-    # In:
-    ctx_done_in: wp.array[bool],
-    # Out:
-    inv_H_blocks_out: wp.array3d[float],
+  # Data in:
+  nefc_in: wp.array[int],
+  efc_J_rownnz_in: wp.array2d[int],
+  efc_J_rowadr_in: wp.array2d[int],
+  efc_J_colind_in: wp.array3d[int],
+  efc_J_in: wp.array3d[float],
+  efc_D_in: wp.array2d[float],
+  efc_state_in: wp.array2d[int],
+  # In:
+  dof_to_block_in: wp.array[int],
+  block_dof_adr_in: wp.array[int],
+  # In:
+  ctx_done_in: wp.array[bool],
+  # Out:
+  inv_H_blocks_out: wp.array3d[float],
 ):
   """Accumulate block-diagonal of J^T D J into inv_H_blocks."""
   worldid, efcid = wp.tid()
@@ -2898,20 +2899,19 @@ def _block_jacobi_JTDJ(
 
 @wp.kernel
 def _block_jacobi_add_M(
-    # Model in:
-    nv: int,
-    M_mulm_rowadr_in: wp.array[int],
-    M_mulm_col_in: wp.array[int],
-    M_mulm_madr_in: wp.array[int],
-    # Block mapping:
-    dof_to_block_in: wp.array[int],
-    block_dof_adr_in: wp.array[int],
-    # Data in:
-    M_in: wp.array3d[float],
-    # In:
-    ctx_done_in: wp.array[bool],
-    # Out:
-    inv_H_blocks_out: wp.array3d[float],
+  # Model:
+  nv: int,
+  M_mulm_rowadr: wp.array[int],
+  M_mulm_col: wp.array[int],
+  M_mulm_madr: wp.array[int],
+  # Data in:
+  M_in: wp.array3d[float],
+  # In:
+  dof_to_block_in: wp.array[int],
+  block_dof_adr_in: wp.array[int],
+  ctx_done_in: wp.array[bool],
+  # Out:
+  inv_H_blocks_out: wp.array3d[float],
 ):
   """Add mass matrix entries within each block."""
   worldid, di = wp.tid()
@@ -2926,16 +2926,16 @@ def _block_jacobi_add_M(
   li = di - block_dof_adr_in[bi]
 
   # Walk sparse M row for this DOF, accumulating entries within same block
-  start = M_mulm_rowadr_in[di]
-  end = M_mulm_rowadr_in[di + 1]
+  start = M_mulm_rowadr[di]
+  end = M_mulm_rowadr[di + 1]
   for k in range(start, end):
-    dj = M_mulm_col_in[k]
+    dj = M_mulm_col[k]
     if di > dj:
       continue
     bj = dof_to_block_in[dj]
     if bj == bi:
       lj = dj - block_dof_adr_in[bj]
-      madr = M_mulm_madr_in[k]
+      madr = M_mulm_madr[k]
       M_val = M_in[worldid, 0, madr]
       lmin = wp.min(li, lj)
       lmax = wp.max(li, lj)
@@ -2945,13 +2945,12 @@ def _block_jacobi_add_M(
 
 @wp.kernel
 def _block_jacobi_invert(
-    # Block mapping:
-    nblocks: int,
-    block_dof_num_in: wp.array[int],
-    # In:
-    ctx_done_in: wp.array[bool],
-    # In/Out:
-    inv_H_blocks_io: wp.array3d[float],
+  # In:
+  nblocks: int,
+  block_dof_num_in: wp.array[int],
+  ctx_done_in: wp.array[bool],
+  # Out:
+  inv_H_blocks_out: wp.array3d[float],
 ):
   """Invert each block in-place: H_bb -> H_bb^{-1}."""
   worldid, blockid = wp.tid()
@@ -2965,12 +2964,12 @@ def _block_jacobi_invert(
   ndof = block_dof_num_in[blockid]
 
   # Read block entries
-  H00 = inv_H_blocks_io[worldid, 0, blockid]
-  H01 = inv_H_blocks_io[worldid, 1, blockid]
-  H02 = inv_H_blocks_io[worldid, 2, blockid]
-  H11 = inv_H_blocks_io[worldid, 3, blockid]
-  H12 = inv_H_blocks_io[worldid, 4, blockid]
-  H22 = inv_H_blocks_io[worldid, 5, blockid]
+  H00 = inv_H_blocks_out[worldid, 0, blockid]
+  H01 = inv_H_blocks_out[worldid, 1, blockid]
+  H02 = inv_H_blocks_out[worldid, 2, blockid]
+  H11 = inv_H_blocks_out[worldid, 3, blockid]
+  H12 = inv_H_blocks_out[worldid, 4, blockid]
+  H22 = inv_H_blocks_out[worldid, 5, blockid]
 
   # Regularization for numerical safety
   reg = 1.0e-12
@@ -2980,20 +2979,20 @@ def _block_jacobi_invert(
 
   if ndof == 1:
     if H00 > 0.0:
-      inv_H_blocks_io[worldid, 0, blockid] = 1.0 / H00
+      inv_H_blocks_out[worldid, 0, blockid] = 1.0 / H00
     else:
-      inv_H_blocks_io[worldid, 0, blockid] = 0.0
+      inv_H_blocks_out[worldid, 0, blockid] = 0.0
   elif ndof == 2:
     det = H00 * H11 - H01 * H01
     if wp.abs(det) > 1.0e-30:
       inv_det = 1.0 / det
-      inv_H_blocks_io[worldid, 0, blockid] = H11 * inv_det
-      inv_H_blocks_io[worldid, 1, blockid] = -H01 * inv_det
-      inv_H_blocks_io[worldid, 3, blockid] = H00 * inv_det
+      inv_H_blocks_out[worldid, 0, blockid] = H11 * inv_det
+      inv_H_blocks_out[worldid, 1, blockid] = -H01 * inv_det
+      inv_H_blocks_out[worldid, 3, blockid] = H00 * inv_det
     else:
-      inv_H_blocks_io[worldid, 0, blockid] = 0.0
-      inv_H_blocks_io[worldid, 1, blockid] = 0.0
-      inv_H_blocks_io[worldid, 3, blockid] = 0.0
+      inv_H_blocks_out[worldid, 0, blockid] = 0.0
+      inv_H_blocks_out[worldid, 1, blockid] = 0.0
+      inv_H_blocks_out[worldid, 3, blockid] = 0.0
   elif ndof == 3:
     # 3x3 symmetric matrix inversion via cofactors
     c00 = H11 * H22 - H12 * H12
@@ -3006,29 +3005,29 @@ def _block_jacobi_invert(
     det = H00 * c00 + H01 * c01 + H02 * c02
     if wp.abs(det) > 1.0e-30:
       inv_det = 1.0 / det
-      inv_H_blocks_io[worldid, 0, blockid] = c00 * inv_det
-      inv_H_blocks_io[worldid, 1, blockid] = c01 * inv_det
-      inv_H_blocks_io[worldid, 2, blockid] = c02 * inv_det
-      inv_H_blocks_io[worldid, 3, blockid] = c11 * inv_det
-      inv_H_blocks_io[worldid, 4, blockid] = c12 * inv_det
-      inv_H_blocks_io[worldid, 5, blockid] = c22 * inv_det
+      inv_H_blocks_out[worldid, 0, blockid] = c00 * inv_det
+      inv_H_blocks_out[worldid, 1, blockid] = c01 * inv_det
+      inv_H_blocks_out[worldid, 2, blockid] = c02 * inv_det
+      inv_H_blocks_out[worldid, 3, blockid] = c11 * inv_det
+      inv_H_blocks_out[worldid, 4, blockid] = c12 * inv_det
+      inv_H_blocks_out[worldid, 5, blockid] = c22 * inv_det
     else:
       for i in range(6):
-        inv_H_blocks_io[worldid, i, blockid] = 0.0
+        inv_H_blocks_out[worldid, i, blockid] = 0.0
 
 
 @wp.kernel
 def _apply_block_preconditioner(
-    # Block mapping:
-    nblocks: int,
-    block_dof_adr_in: wp.array[int],
-    block_dof_num_in: wp.array[int],
-    # In:
-    inv_H_blocks_in: wp.array3d[float],
-    grad_in: wp.array2d[float],
-    done_in: wp.array[bool],
-    # Out:
-    Mgrad_out: wp.array2d[float],
+  # In:
+  nblocks: int,
+  block_dof_adr_in: wp.array[int],
+  block_dof_num_in: wp.array[int],
+  # In:
+  inv_H_blocks_in: wp.array3d[float],
+  grad_in: wp.array2d[float],
+  done_in: wp.array[bool],
+  # Out:
+  Mgrad_out: wp.array2d[float],
 ):
   """Mgrad = H_block^{-1} * grad for each block."""
   worldid, blockid = wp.tid()
@@ -3069,42 +3068,52 @@ def _apply_block_preconditioner(
     Mgrad_out[worldid, dof0 + 2] = I02 * g0 + I12 * g1 + I22 * g2
 
 
-def _build_block_jacobi_preconditioner(
-    m: types.Model, d: types.Data, ctx: SolverContext
-):
+def _build_block_jacobi_preconditioner(m: types.Model, d: types.Data, ctx: SolverContext):
   """Build and invert block-diagonal preconditioner using block mapping."""
   ctx.inv_H_blocks.zero_()
 
   # Accumulate block-diagonal of J^T D J
   wp.launch(
-      _block_jacobi_JTDJ,
-      dim=(d.nworld, d.njmax),
-      inputs=[
-          d.nefc, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind,
-          d.efc.J, d.efc.D, d.efc.state,
-          ctx.dof_to_block, ctx.block_dof_adr, ctx.done,
-      ],
-      outputs=[ctx.inv_H_blocks],
+    _block_jacobi_JTDJ,
+    dim=(d.nworld, d.njmax),
+    inputs=[
+      d.nefc,
+      d.efc.J_rownnz,
+      d.efc.J_rowadr,
+      d.efc.J_colind,
+      d.efc.J,
+      d.efc.D,
+      d.efc.state,
+      ctx.dof_to_block,
+      ctx.block_dof_adr,
+      ctx.done,
+    ],
+    outputs=[ctx.inv_H_blocks],
   )
 
   # Add mass matrix entries within each block
   wp.launch(
-      _block_jacobi_add_M,
-      dim=(d.nworld, m.nv),
-      inputs=[
-          m.nv, m.M_mulm_rowadr, m.M_mulm_col, m.M_mulm_madr,
-          ctx.dof_to_block, ctx.block_dof_adr,
-          d.M, ctx.done,
-      ],
-      outputs=[ctx.inv_H_blocks],
+    _block_jacobi_add_M,
+    dim=(d.nworld, m.nv),
+    inputs=[
+      m.nv,
+      m.M_mulm_rowadr,
+      m.M_mulm_col,
+      m.M_mulm_madr,
+      d.M,
+      ctx.dof_to_block,
+      ctx.block_dof_adr,
+      ctx.done,
+    ],
+    outputs=[ctx.inv_H_blocks],
   )
 
   # Invert blocks in-place
   wp.launch(
-      _block_jacobi_invert,
-      dim=(d.nworld, ctx.nblocks),
-      inputs=[ctx.nblocks, ctx.block_dof_num, ctx.done],
-      outputs=[ctx.inv_H_blocks],
+    _block_jacobi_invert,
+    dim=(d.nworld, ctx.nblocks),
+    inputs=[ctx.nblocks, ctx.block_dof_num, ctx.done],
+    outputs=[ctx.inv_H_blocks],
   )
 
 
@@ -3187,17 +3196,17 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
     if m.is_sparse:
       _build_block_jacobi_preconditioner(m, d, ctx)
       wp.launch(
-          _apply_block_preconditioner,
-          dim=(d.nworld, ctx.nblocks),
-          inputs=[
-              ctx.nblocks,
-              ctx.block_dof_adr,
-              ctx.block_dof_num,
-              ctx.inv_H_blocks,
-              ctx.grad,
-              ctx.done,
-          ],
-          outputs=[ctx.Mgrad],
+        _apply_block_preconditioner,
+        dim=(d.nworld, ctx.nblocks),
+        inputs=[
+          ctx.nblocks,
+          ctx.block_dof_adr,
+          ctx.block_dof_num,
+          ctx.inv_H_blocks,
+          ctx.grad,
+          ctx.done,
+        ],
+        outputs=[ctx.Mgrad],
       )
     else:
       smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -207,8 +207,8 @@ class SolverTest(parameterized.TestCase):
       if np.any(nonzero_grad):
         # Where grad is non-zero, Mgrad should also be non-zero
         self.assertTrue(
-            np.any(np.abs(ctx_Mgrad[nonzero_grad]) > 1e-10),
-            "Block Jacobi preconditioner produced zero Mgrad for non-zero grad",
+          np.any(np.abs(ctx_Mgrad[nonzero_grad]) > 1e-10),
+          "Block Jacobi preconditioner produced zero Mgrad for non-zero grad",
         )
       # Verify positive-definiteness: grad^T * Mgrad > 0
       dot = np.dot(ctx_grad, ctx_Mgrad)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -197,13 +197,28 @@ class SolverTest(parameterized.TestCase):
     ctx = solver._create_solver_context(m, d)
     solver.init_context(m, d, ctx, grad=True)
 
-    # Calculate Mgrad with Mujoco C
-    mj_Mgrad = np.zeros(shape=(1, mjm.nv), dtype=float)
-    mj_grad = np.tile(ctx.grad.numpy()[:, : mjm.nv], (1, 1))
-    mujoco.mj_solveM(mjm, mjd, mj_Mgrad, mj_grad)
-
     ctx_Mgrad = ctx.Mgrad.numpy()[0, : mjm.nv]
-    _assert_eq(ctx_Mgrad, mj_Mgrad[0], name="Mgrad")
+
+    if jacobian == mujoco.mjtJacobian.mjJAC_SPARSE:
+      # Sparse CG uses block Jacobi preconditioner: Mgrad = H_block^{-1} * grad
+      # Verify Mgrad is non-trivial (not zero when grad is non-zero)
+      ctx_grad = ctx.grad.numpy()[0, : mjm.nv]
+      nonzero_grad = np.abs(ctx_grad) > 1e-10
+      if np.any(nonzero_grad):
+        # Where grad is non-zero, Mgrad should also be non-zero
+        self.assertTrue(
+            np.any(np.abs(ctx_Mgrad[nonzero_grad]) > 1e-10),
+            "Block Jacobi preconditioner produced zero Mgrad for non-zero grad",
+        )
+      # Verify positive-definiteness: grad^T * Mgrad > 0
+      dot = np.dot(ctx_grad, ctx_Mgrad)
+      self.assertGreater(dot, 0.0, "Preconditioner is not positive definite")
+    else:
+      # Dense CG uses M^{-1}: compare against MuJoCo C
+      mj_Mgrad = np.zeros(shape=(1, mjm.nv), dtype=float)
+      mj_grad = np.tile(ctx.grad.numpy()[:, : mjm.nv], (1, 1))
+      mujoco.mj_solveM(mjm, mjd, mj_Mgrad, mj_grad)
+      _assert_eq(ctx_Mgrad, mj_Mgrad[0], name="Mgrad")
 
   def test_linesearch_accepts_sub_float32_improvement(self):
     """Line search should not lose small improvements on large absolute costs."""

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2358,6 +2358,13 @@ class SolverContext:
   beta_den: wp.array[float]
   h: wp.array3d[float]
   hfactor: wp.array3d[float]
+  # Block Jacobi preconditioner (CG only): pre-inverted block Hessian
+  inv_H_blocks: wp.array3d[float]
+  # Block mapping: split bodies with >3 DOFs into ≤3-DOF blocks
+  block_dof_adr: wp.array[int]
+  block_dof_num: wp.array[int]
+  dof_to_block: wp.array[int]
+  nblocks: int
   # Incremental Hessian update (Newton only)
   changed_efc_ids: wp.array2d[int]
   changed_efc_count: wp.array[int]

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2370,7 +2370,8 @@ class SolverContext:
   dof_to_block: wp.array[int]
   nblocks: int
   # Tree-level IC preconditioner (CG sparse only)
-  qLD_precond: wp.array2d[float]  # (nworld, nC) IC(0) preconditioner factors
+  M_precond: wp.array2d[float]  # (nworld, nC) M + JTDJ in CSR format (unfactored)
+  qLD_precond: wp.array2d[float]  # (nworld, qld_total) factored preconditioner
   qLDiagInv_precond: wp.array2d[float]  # (nworld, nv) IC(0) diagonal inverse
   # Incremental Hessian update (Newton only)
   changed_efc_ids: wp.array2d[int]

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -846,6 +846,7 @@ class Option:
     contact_sensor_maxmatch: max number of contacts considered by contact sensor matching criteria
                              contacts matched after this value is exceded will be ignored
     warn_overflow: warn if overflow is encountered
+    jac_preconditioner: enable block Jacobi + IC(0) preconditioner for sparse CG solver
   """
 
   timestep: array("*", float)
@@ -876,6 +877,7 @@ class Option:
   run_collision_detection: bool
   contact_sensor_maxmatch: int
   warn_overflow: bool
+  jac_preconditioner: bool
 
   # TODO(team): remove in future version
   @property

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -846,7 +846,6 @@ class Option:
     contact_sensor_maxmatch: max number of contacts considered by contact sensor matching criteria
                              contacts matched after this value is exceded will be ignored
     warn_overflow: warn if overflow is encountered
-    jac_preconditioner: enable block Jacobi + IC(0) preconditioner for sparse CG solver
   """
 
   timestep: array("*", float)
@@ -877,7 +876,6 @@ class Option:
   run_collision_detection: bool
   contact_sensor_maxmatch: int
   warn_overflow: bool
-  jac_preconditioner: bool
 
   # TODO(team): remove in future version
   @property

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2365,6 +2365,11 @@ class SolverContext:
   block_dof_num: wp.array[int]
   dof_to_block: wp.array[int]
   nblocks: int
+  # Tree-level IC preconditioner (CG sparse only)
+  H_tree: wp.array2d[float]  # (nworld, total_tree_nnz) dense tree blocks
+  tree_mat_adr: wp.array[int]  # offset into H_tree for each tree [ntree+1]
+  total_tree_nnz: wp.array[int]  # single-element: total nnz across all trees
+  ntrees: int  # number of trees with DOFs
   # Incremental Hessian update (Newton only)
   changed_efc_ids: wp.array2d[int]
   changed_efc_count: wp.array[int]

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2366,10 +2366,8 @@ class SolverContext:
   dof_to_block: wp.array[int]
   nblocks: int
   # Tree-level IC preconditioner (CG sparse only)
-  H_tree: wp.array2d[float]  # (nworld, total_tree_nnz) dense tree blocks
-  tree_mat_adr: wp.array[int]  # offset into H_tree for each tree [ntree+1]
-  total_tree_nnz: wp.array[int]  # single-element: total nnz across all trees
-  ntrees: int  # number of trees with DOFs
+  qLD_precond: wp.array3d[float]  # (nworld, 1, nC) IC(0) preconditioner factors
+  qLDiagInv_precond: wp.array2d[float]  # (nworld, nv) IC(0) diagonal inverse
   # Incremental Hessian update (Newton only)
   changed_efc_ids: wp.array2d[int]
   changed_efc_count: wp.array[int]

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1330,6 +1330,8 @@ class Model:
     nmaxmeshdeg: maximum number of polygons per vert
     is_sparse: constraint Jacobian/Hessian layout (sparse vs dense). Does not affect M, whose
       factorization is a per-block decision -- see qLD_* and m_block_layout
+    is_compact: solve via active-DOF compaction (Newton + sleeping, unless islands forced)
+    has_articulated_trees: whether any tree has more than 6 DOFs
     qLD_has_dense: any M block factors as a packed dense block
     qLD_has_simple: any M block is simple (diagonal -> 1/diag, no factorization)
     qLD_has_sparse: any M block factors via sparse LDL (oversized block / tendon armature)
@@ -1810,6 +1812,8 @@ class Model:
   nmaxpolygon: int
   nmaxmeshdeg: int
   is_sparse: bool
+  is_compact: bool
+  has_articulated_trees: bool
   qLD_has_dense: bool
   qLD_has_simple: bool
   qLD_has_sparse: bool
@@ -2366,7 +2370,7 @@ class SolverContext:
   dof_to_block: wp.array[int]
   nblocks: int
   # Tree-level IC preconditioner (CG sparse only)
-  qLD_precond: wp.array3d[float]  # (nworld, 1, nC) IC(0) preconditioner factors
+  qLD_precond: wp.array2d[float]  # (nworld, nC) IC(0) preconditioner factors
   qLDiagInv_precond: wp.array2d[float]  # (nworld, nv) IC(0) diagonal inverse
   # Incremental Hessian update (Newton only)
   changed_efc_ids: wp.array2d[int]


### PR DESCRIPTION
## Summary

Replace the block Jacobi + IC(0) preconditioner with a simpler **diagonal preconditioner** `diag(M + J^T D J)` applied only to flex DOFs. For articulated DOFs, the existing M inverse (smooth.solve_m) is preserved with full coupling.

### How it works

1. **Once per step** (if flex bodies present): build `diag_i = M_ii + sum_j J_ji^2 * D_j` for flex DOFs only (2 kernels).
2. **Per CG iteration**: apply M inverse for all DOFs via smooth.solve_m, then overwrite flex DOFs with `z_i = g_i / diag_i` (1 elementwise kernel).

For flex vertices, M is truly diagonal, so diag(M + JTDJ) exactly captures both mass and constraint stiffness. The diagonal is built without a constraint state check - including all detected constraints makes the preconditioner conservative (never underestimates stiffness), which improves CG convergence.

### Benchmark results (32 worlds, A100)

| Scene | M inverse baseline | With diagonal precond | Change |
|-------|-------------|----------------------|--------|
| Aloha cloth (~6200 nefc) | 1337 sps / 46 iters | **2454 sps / 15.6 iters** | **+84%** |
| Cloth (~3000 nefc) | 3316 sps / 25 iters | 3320 sps / 24 iters | 0% |
| Humanoid (~49 nefc) | 69014 sps / 1.5 iters | 66577 sps / 1.5 iters | -3.5% |
| Aloha no cloth (~29 nefc) | 50399 sps / 1.3 iters | 49613 sps / 1.3 iters | -1.6% |

Non-flex scenes show a small regression (~2-4%) despite nflex=0 (diagonal preconditioner not built or applied). This is likely due to the changed dispatch structure (unconditional smooth.solve_m call + nflex branch check vs the previous if/else).

### Changes

- solver.py: Add 3 kernels (_diag_precond_build, _diag_precond_add_JTDJ, _diag_precond_apply_flex) + build/dispatch logic
- types.py: Remove jac_preconditioner option (no longer needed, auto-enables for flex)
- io.py: Remove jac_preconditioner init and override entry