### PR TITLE
Skip solver work for worlds with stable constraint states

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -87,6 +87,7 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     jv=wp.empty((nworld, njmax), dtype=float),
     quad=wp.empty((nworld, njmax), dtype=wp.vec3),
     alpha=wp.empty((nworld,), dtype=float),
+    grad_scale=wp.empty((nworld,), dtype=float),
     improvement=wp.empty((nworld,), dtype=float),
     prev_grad=wp.empty((nworld, nv), dtype=float),
     prev_Mgrad=wp.empty((nworld, nv), dtype=float),
@@ -839,6 +840,7 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
     ctx_jv_out: wp.array2d[float],
     ctx_quad_out: wp.array2d[wp.vec3],
     ctx_improvement_out: wp.array[float],
+    ctx_alpha_out: wp.array[float],
   ):
     worldid, tid = wp.tid()
 
@@ -1233,6 +1235,7 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
 
     if tid == 0:
       ctx_improvement_out[worldid] = improvement
+      ctx_alpha_out[worldid] = alpha
 
   return kernel
 
@@ -1280,7 +1283,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
       ctx.quad,
       ctx.done,
     ],
-    outputs=[d.qacc, d.efc.Ma, ctx.Jaref, ctx.jv, ctx.quad, ctx.improvement],
+    outputs=[d.qacc, d.efc.Ma, ctx.Jaref, ctx.jv, ctx.quad, ctx.improvement, ctx.alpha],
     block_dim=m.block_dim.linesearch_iterative,
   )
 
@@ -1645,6 +1648,7 @@ def _update_constraint_init_qfrc_constraint_sparse(
   efc_J_in: wp.array3d[float],
   efc_force_in: wp.array2d[float],
   # In:
+  changed_count_in: wp.array[int],
   ctx_done_in: wp.array[bool],
   # Data out:
   qfrc_constraint_out: wp.array2d[float],
@@ -1652,6 +1656,9 @@ def _update_constraint_init_qfrc_constraint_sparse(
   worldid, efcid = wp.tid()
 
   if ctx_done_in[worldid]:
+    return
+
+  if changed_count_in[worldid] == 0:
     return
 
   if efcid >= nefc_in[worldid]:
@@ -1671,29 +1678,58 @@ def _update_constraint_init_qfrc_constraint_sparse(
 
 
 @wp.kernel
-def _update_constraint_init_qfrc_constraint_dense(
+def _qfrc_constraint_from_grad(
   # Data in:
-  nefc_in: wp.array[int],
-  efc_J_in: wp.array3d[float],
-  efc_force_in: wp.array2d[float],
-  njmax_in: int,
+  qfrc_smooth_in: wp.array2d[float],
+  efc_Ma_in: wp.array2d[float],
   # In:
-  ctx_done_in: wp.array[bool],
+  ctx_grad_in: wp.array2d[float],
+  ctx_grad_scale_in: wp.array[float],
   # Data out:
   qfrc_constraint_out: wp.array2d[float],
 ):
   worldid, dofid = wp.tid()
 
-  if ctx_done_in[worldid]:
-    return
+  grad = ctx_grad_scale_in[worldid] * ctx_grad_in[worldid, dofid]
+  qfrc_constraint_out[worldid, dofid] = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - grad
 
-  sum_qfrc = float(0.0)
-  for efcid in range(min(njmax_in, nefc_in[worldid])):
-    efc_J = efc_J_in[worldid, efcid, dofid]
-    force = efc_force_in[worldid, efcid]
-    sum_qfrc += efc_J * force
 
-  qfrc_constraint_out[worldid, dofid] = sum_qfrc
+@cache_kernel
+def _update_constraint_init_qfrc_constraint_dense(stable_fast: bool):
+  STABLE_FAST = stable_fast
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    nefc_in: wp.array[int],
+    efc_J_in: wp.array3d[float],
+    efc_force_in: wp.array2d[float],
+    njmax_in: int,
+    # In:
+    changed_count_in: wp.array[int],
+    ctx_done_in: wp.array[bool],
+    # Data out:
+    qfrc_constraint_out: wp.array2d[float],
+  ):
+    worldid, dofid = wp.tid()
+
+    if ctx_done_in[worldid]:
+      return
+
+    # Fast path: stale qfrc_constraint is never read; recovered after the solve.
+    if wp.static(STABLE_FAST):
+      if changed_count_in[worldid] == 0:
+        return
+
+    sum_qfrc = float(0.0)
+    for efcid in range(min(njmax_in, nefc_in[worldid])):
+      efc_J = efc_J_in[worldid, efcid, dofid]
+      force = efc_force_in[worldid, efcid]
+      sum_qfrc += efc_J * force
+
+    qfrc_constraint_out[worldid, dofid] = sum_qfrc
+
+  return kernel
 
 
 @wp.kernel
@@ -1796,7 +1832,13 @@ def _update_gradient_h_incremental_sparse(
         wp.atomic_add(ctx_h_out[worldid, colindj], colindi, h)
 
 
-def _update_constraint(m: types.Model, d: types.Data, ctx: SolverContext | InverseContext, track_changes: bool = False):
+def _update_constraint(
+  m: types.Model,
+  d: types.Data,
+  ctx: SolverContext | InverseContext,
+  track_changes: bool = False,
+  stable_fast: bool = False,
+):
   """Update constraint arrays after each solve iteration."""
   efc_inputs = [
     m.opt.impratio_invsqrt,
@@ -1822,59 +1864,97 @@ def _update_constraint(m: types.Model, d: types.Data, ctx: SolverContext | Inver
     outputs=[d.efc.force, d.efc.state, ctx.changed_efc_ids, ctx.changed_efc_count],
   )
 
-  # qfrc_constraint = efc_J.T @ efc_force
+  # qfrc_constraint = efc_J.T @ efc_force. Fast-path worlds with no state flips
+  # skip the rebuild; the public value is recovered after the solve.
+  changed = ctx.changed_efc_count if stable_fast else d.nefc
   if m.is_sparse:
     d.qfrc_constraint.zero_()
     wp.launch(
       _update_constraint_init_qfrc_constraint_sparse,
       dim=(d.nworld, d.njmax),
-      inputs=[d.nefc, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind, d.efc.J, d.efc.force, ctx.done],
+      inputs=[d.nefc, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind, d.efc.J, d.efc.force, changed, ctx.done],
       outputs=[d.qfrc_constraint],
     )
   else:
     wp.launch(
-      _update_constraint_init_qfrc_constraint_dense,
+      _update_constraint_init_qfrc_constraint_dense(stable_fast),
       dim=(d.nworld, m.nv),
-      inputs=[d.nefc, d.efc.J, d.efc.force, d.njmax, ctx.done],
+      inputs=[d.nefc, d.efc.J, d.efc.force, d.njmax, changed, ctx.done],
       outputs=[d.qfrc_constraint],
     )
 
 
-@wp.kernel
-def _update_gradient_zero_grad_dot(
-  # In:
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_grad_dot_out: wp.array[float],
-):
-  worldid = wp.tid()
+@cache_kernel
+def _update_gradient_zero_grad_dot(stable_fast: bool):
+  STABLE_FAST = stable_fast
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # In:
+    changed_count_in: wp.array[int],
+    ctx_alpha_in: wp.array[float],
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_grad_dot_out: wp.array[float],
+    ctx_grad_scale_out: wp.array[float],
+  ):
+    worldid = wp.tid()
 
-  ctx_grad_dot_out[worldid] = 0.0
+    if ctx_done_in[worldid]:
+      return
+
+    # Fast path: grad stays stale at its last rebuilt value g. The true
+    # gradient is grad_scale * g, and a linesearch step t along the (equally
+    # stale) search direction changes it to (grad_scale - t) * g.
+    if wp.static(STABLE_FAST):
+      if changed_count_in[worldid] == 0:
+        sigma = ctx_grad_scale_out[worldid]
+        new_sigma = sigma - ctx_alpha_in[worldid]
+        ratio = float(0.0)
+        if sigma != 0.0:
+          ratio = new_sigma / sigma
+        ctx_grad_dot_out[worldid] *= ratio * ratio
+        ctx_grad_scale_out[worldid] = new_sigma
+        return
+
+    ctx_grad_dot_out[worldid] = 0.0
+    ctx_grad_scale_out[worldid] = 1.0
+
+  return kernel
 
 
-@wp.kernel
-def _update_gradient_grad(
-  # Data in:
-  qfrc_smooth_in: wp.array2d[float],
-  qfrc_constraint_in: wp.array2d[float],
-  efc_Ma_in: wp.array2d[float],
-  # In:
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_grad_out: wp.array2d[float],
-  ctx_grad_dot_out: wp.array[float],
-):
-  worldid, dofid = wp.tid()
+@cache_kernel
+def _update_gradient_grad(stable_fast: bool):
+  STABLE_FAST = stable_fast
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    qfrc_smooth_in: wp.array2d[float],
+    qfrc_constraint_in: wp.array2d[float],
+    efc_Ma_in: wp.array2d[float],
+    # In:
+    changed_count_in: wp.array[int],
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_grad_out: wp.array2d[float],
+    ctx_grad_dot_out: wp.array[float],
+  ):
+    worldid, dofid = wp.tid()
 
-  grad = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - qfrc_constraint_in[worldid, dofid]
-  ctx_grad_out[worldid, dofid] = grad
-  wp.atomic_add(ctx_grad_dot_out, worldid, grad * grad)
+    if ctx_done_in[worldid]:
+      return
+
+    # Fast path: grad stays stale (see _update_gradient_zero_grad_dot).
+    if wp.static(STABLE_FAST):
+      if changed_count_in[worldid] == 0:
+        return
+
+    grad = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - qfrc_constraint_in[worldid, dofid]
+    ctx_grad_out[worldid, dofid] = grad
+    wp.atomic_add(ctx_grad_dot_out, worldid, grad * grad)
+
+  return kernel
 
 
 @wp.kernel
@@ -2596,12 +2676,15 @@ def _update_gradient_JTCJ_dense(
 
 
 @cache_kernel
-def _update_gradient_cholesky(tile_size: int):
+def _update_gradient_cholesky(tile_size: int, skip_noflip: bool = False):
+  SKIP_NOFLIP = skip_noflip
+
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # In:
     ctx_grad_in: wp.array2d[float],
     h_in: wp.array3d[float],
+    changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Out:
     ctx_Mgrad_out: wp.array2d[float],
@@ -2611,6 +2694,11 @@ def _update_gradient_cholesky(tile_size: int):
 
     if ctx_done_in[worldid]:
       return
+
+    # Fast path: skip the solve (see the blocked skip_unchanged variant).
+    if wp.static(SKIP_NOFLIP):
+      if changed_count_in[worldid] == 0:
+        return
 
     mat_tile = wp.tile_load(h_in[worldid], shape=(TILE_SIZE, TILE_SIZE))
     wp.tile_cholesky_inplace(mat_tile, fill_mode="upper")
@@ -2653,8 +2741,9 @@ def _update_gradient_cholesky_blocked(tile_size: int, matrix_size: int, check_sk
 
 
 @cache_kernel
-def _update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size: int):
+def _update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size: int, skip_noflip: bool = False):
   """Blocked Cholesky that skips factorization when no constraints changed."""
+  SKIP_NOFLIP = skip_noflip
 
   @wp.kernel(module="unique", enable_backward=False, module_options={"enable_mathdx_gemm": False})
   def kernel(
@@ -2673,14 +2762,24 @@ def _update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size
     if ctx_done_in[worldid]:
       return
 
-    if changed_count_in[worldid] > 0:
+    # Fast path: skip the solve; Mgrad stays stale on the unchanged ray, and
+    # the linesearch is invariant to the scale of its direction.
+    if wp.static(SKIP_NOFLIP):
+      if changed_count_in[worldid] == 0:
+        return
+
       wp.static(create_blocked_cholesky_factorize_solve_func(TILE_SIZE, matrix_size))(
         ctx_h_in[worldid], ctx_grad_in[worldid], matrix_size, ctx_hfactor[worldid], ctx_Mgrad_out[worldid]
       )
     else:
-      wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
-        ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
-      )
+      if changed_count_in[worldid] > 0:
+        wp.static(create_blocked_cholesky_factorize_solve_func(TILE_SIZE, matrix_size))(
+          ctx_h_in[worldid], ctx_grad_in[worldid], matrix_size, ctx_hfactor[worldid], ctx_Mgrad_out[worldid]
+        )
+      else:
+        wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
+          ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
+        )
 
   return kernel
 
@@ -2696,7 +2795,9 @@ def _padding_h(nv: int, ctx_done_in: wp.array[bool], ctx_h_out: wp.array3d[float
   ctx_h_out[worldid, dofid, dofid] = 1.0
 
 
-def _cholesky_factorize_solve(m: types.Model, d: types.Data, ctx: SolverContext, skip_unchanged: bool = False):
+def _cholesky_factorize_solve(
+  m: types.Model, d: types.Data, ctx: SolverContext, skip_unchanged: bool = False, skip_noflip: bool = False
+):
   """Cholesky factorize ctx.h and solve for Mgrad.
 
   If skip_unchanged is True (blocked path only), worlds where no constraints
@@ -2704,9 +2805,9 @@ def _cholesky_factorize_solve(m: types.Model, d: types.Data, ctx: SolverContext,
   """
   if m.nv <= _BLOCK_CHOLESKY_DIM:
     wp.launch_tiled(
-      _update_gradient_cholesky(m.nv),
+      _update_gradient_cholesky(m.nv, skip_noflip),
       dim=d.nworld,
-      inputs=[ctx.grad, ctx.h, ctx.done],
+      inputs=[ctx.grad, ctx.h, ctx.changed_efc_count if skip_noflip else d.nefc, ctx.done],
       outputs=[ctx.Mgrad],
       block_dim=m.block_dim.update_gradient_cholesky,
     )
@@ -2720,7 +2821,7 @@ def _cholesky_factorize_solve(m: types.Model, d: types.Data, ctx: SolverContext,
 
     if skip_unchanged:
       wp.launch_tiled(
-        _update_gradient_cholesky_blocked_skip_unchanged(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad),
+        _update_gradient_cholesky_blocked_skip_unchanged(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad, skip_noflip),
         dim=d.nworld,
         inputs=[ctx.done, ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)), ctx.h, ctx.changed_efc_count, ctx.hfactor],
         outputs=[ctx.Mgrad.reshape(shape=(d.nworld, ctx.Mgrad.shape[1], 1))],
@@ -2817,11 +2918,16 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
       block_dim=m.block_dim.update_gradient_grad,
     )
   else:
-    wp.launch(_update_gradient_zero_grad_dot, dim=d.nworld, inputs=[ctx.done], outputs=[ctx.grad_dot])
     wp.launch(
-      _update_gradient_grad,
+      _update_gradient_zero_grad_dot(False),
+      dim=d.nworld,
+      inputs=[d.nefc, ctx.alpha, ctx.done],
+      outputs=[ctx.grad_dot, ctx.grad_scale],
+    )
+    wp.launch(
+      _update_gradient_grad(False),
       dim=(d.nworld, m.nv),
-      inputs=[d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, ctx.done],
+      inputs=[d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, d.nefc, ctx.done],
       outputs=[ctx.grad, ctx.grad_dot],
     )
 
@@ -3013,18 +3119,24 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
     raise ValueError(f"Unknown solver type: {m.opt.solver}")
 
 
-def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverContext):
+def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverContext, stable_fast: bool = False):
   """Incremental gradient update: update H for changed constraints + re-factorize.
 
   Skips the full J^T*D*J rebuild by applying only the delta from constraints
   that changed QUADRATIC state, then re-factorizes and solves.
   """
-  wp.launch(_update_gradient_zero_grad_dot, dim=d.nworld, inputs=[ctx.done], outputs=[ctx.grad_dot])
+  changed = ctx.changed_efc_count if stable_fast else d.nefc
+  wp.launch(
+    _update_gradient_zero_grad_dot(stable_fast),
+    dim=d.nworld,
+    inputs=[changed, ctx.alpha, ctx.done],
+    outputs=[ctx.grad_dot, ctx.grad_scale],
+  )
 
   wp.launch(
-    _update_gradient_grad,
+    _update_gradient_grad(stable_fast),
     dim=(d.nworld, m.nv),
-    inputs=[d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, ctx.done],
+    inputs=[d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, changed, ctx.done],
     outputs=[ctx.grad, ctx.grad_dot],
   )
 
@@ -3060,7 +3172,7 @@ def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverConte
       outputs=[ctx.h],
     )
 
-  _cholesky_factorize_solve(m, d, ctx, skip_unchanged=True)
+  _cholesky_factorize_solve(m, d, ctx, skip_unchanged=True, skip_noflip=stable_fast)
 
 
 @wp.kernel
@@ -3139,46 +3251,70 @@ def _solve_beta_accumulate(
   wp.atomic_add(ctx_beta_den_out, worldid, den)
 
 
-@wp.kernel
-def _solve_zero_search_dot(
-  # In:
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_search_dot_out: wp.array[float],
-):
-  worldid = wp.tid()
+@cache_kernel
+def _solve_zero_search_dot(stable_fast: bool):
+  STABLE_FAST = stable_fast
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # In:
+    changed_count_in: wp.array[int],
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_search_dot_out: wp.array[float],
+  ):
+    worldid = wp.tid()
 
-  ctx_search_dot_out[worldid] = 0.0
+    if ctx_done_in[worldid]:
+      return
+
+    # Fast path: search stays on the same ray; keep search_dot consistent with it.
+    if wp.static(STABLE_FAST):
+      if changed_count_in[worldid] == 0:
+        return
+
+    ctx_search_dot_out[worldid] = 0.0
+
+  return kernel
 
 
-@wp.kernel
-def _solve_search_update(
-  # Model:
-  opt_solver: int,
-  # In:
-  ctx_Mgrad_in: wp.array2d[float],
-  ctx_search_in: wp.array2d[float],
-  ctx_beta_in: wp.array[float],
-  ctx_done_in: wp.array[bool],
-  # Out:
-  ctx_search_out: wp.array2d[float],
-  ctx_search_dot_out: wp.array[float],
-):
-  worldid, dofid = wp.tid()
+@cache_kernel
+def _solve_search_update(stable_fast: bool):
+  STABLE_FAST = stable_fast
 
-  if ctx_done_in[worldid]:
-    return
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Model:
+    opt_solver: int,
+    # In:
+    changed_count_in: wp.array[int],
+    ctx_Mgrad_in: wp.array2d[float],
+    ctx_search_in: wp.array2d[float],
+    ctx_beta_in: wp.array[float],
+    ctx_done_in: wp.array[bool],
+    # Out:
+    ctx_search_out: wp.array2d[float],
+    ctx_search_dot_out: wp.array[float],
+  ):
+    worldid, dofid = wp.tid()
 
-  search = -1.0 * ctx_Mgrad_in[worldid, dofid]
+    if ctx_done_in[worldid]:
+      return
 
-  if opt_solver == types.SolverType.CG:
-    search += ctx_beta_in[worldid] * ctx_search_in[worldid, dofid]
+    # Fast path: search stays on the stale ray; the linesearch absorbs its scale.
+    if wp.static(STABLE_FAST):
+      if changed_count_in[worldid] == 0:
+        return
 
-  ctx_search_out[worldid, dofid] = search
-  wp.atomic_add(ctx_search_dot_out, worldid, search * search)
+    search = -1.0 * ctx_Mgrad_in[worldid, dofid]
+
+    if opt_solver == types.SolverType.CG:
+      search += ctx_beta_in[worldid] * ctx_search_in[worldid, dofid]
+
+    ctx_search_out[worldid, dofid] = search
+    wp.atomic_add(ctx_search_dot_out, worldid, search * search)
+
+  return kernel
 
 
 @wp.kernel
@@ -3302,6 +3438,16 @@ def _solve_done(
     wp.atomic_add(nsolving_out, 0, -1)
 
 
+def _use_incremental(m: types.Model) -> bool:
+  """Whether constraint state changes are tracked for incremental H updates."""
+  return m.opt.solver == types.SolverType.NEWTON and m.opt.cone != types.ConeType.ELLIPTIC
+
+
+def _stable_fast(m: types.Model, compact: bool) -> bool:
+  """Stable-state fast path: needs state-change tracking; compact scatters qfrc itself."""
+  return _use_incremental(m) and not compact
+
+
 @event_scope
 def _solver_iteration(
   m: types.Model,
@@ -3316,16 +3462,21 @@ def _solver_iteration(
   # path in _update_constraint_efc has early returns that skip state change
   # tracking, and the additional JTCJ Hessian term depends on Jaref which
   # changes every iteration.
-  incremental = m.opt.solver == types.SolverType.NEWTON and m.opt.cone != types.ConeType.ELLIPTIC
+  incremental = _use_incremental(m)
+  # Stable-state fast path: worlds with no state flips this iteration were
+  # exactly quadratic over the step, so grad/Mgrad/search only changed by a
+  # scalar along the same ray. Skip their qfrc/grad/solve/search updates and
+  # track the scalar in ctx.grad_scale.
+  stable_fast = _stable_fast(m, compact)
 
   if incremental:
     # Must complete before _update_constraint_efc which atomically increments.
     ctx.changed_efc_count.zero_()
 
-  _update_constraint(m, d, ctx, track_changes=incremental)
+  _update_constraint(m, d, ctx, track_changes=incremental, stable_fast=stable_fast)
 
   if incremental:
-    _update_gradient_incremental(m, d, ctx)
+    _update_gradient_incremental(m, d, ctx, stable_fast)
   else:
     _update_gradient(m, d, ctx, compact=compact)
 
@@ -3373,12 +3524,13 @@ def _solver_iteration(
     )
 
   else:
-    wp.launch(_solve_zero_search_dot, dim=d.nworld, inputs=[ctx.done], outputs=[ctx.search_dot])
+    changed = ctx.changed_efc_count if stable_fast else d.nefc
+    wp.launch(_solve_zero_search_dot(stable_fast), dim=d.nworld, inputs=[changed, ctx.done], outputs=[ctx.search_dot])
 
     wp.launch(
-      _solve_search_update,
+      _solve_search_update(stable_fast),
       dim=(d.nworld, m.nv),
-      inputs=[m.opt.solver, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
+      inputs=[m.opt.solver, changed, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
       outputs=[ctx.search, ctx.search_dot],
     )
 
@@ -3504,6 +3656,16 @@ def _solve(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = Fa
     # It should be removed when JAX becomes compatible.
     for _ in range(m.opt.iterations):
       _solver_iteration(m, d, ctx, nsolving, compact=compact)
+
+  # Recover the public qfrc_constraint: the fast path leaves it stale, and the
+  # per-iteration zeroing wiped it for worlds that converged early.
+  if _stable_fast(m, compact):
+    wp.launch(
+      _qfrc_constraint_from_grad,
+      dim=(d.nworld, m.nv),
+      inputs=[d.qfrc_smooth, d.efc.Ma, ctx.grad, ctx.grad_scale],
+      outputs=[d.qfrc_constraint],
+    )
 
 
 # Active-DOF compaction solve (nvmax < nv).

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1658,6 +1658,8 @@ def _update_constraint_init_qfrc_constraint_sparse(
     return
 
   force = efc_force_in[worldid, efcid]
+  if force == 0.0:
+    return
 
   rownnz = efc_J_rownnz_in[worldid, efcid]
   rowadr = efc_J_rowadr_in[worldid, efcid]

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -662,11 +662,16 @@ class SolverTest(parameterized.TestCase):
             if np.any(ctx.changed_efc_count.numpy() > 0):
               any_changes = True
           update_fn(m, d, ctx)
-          wp.launch(solver._solve_zero_search_dot, dim=(d.nworld), inputs=[ctx.done], outputs=[ctx.search_dot])
           wp.launch(
-            solver._solve_search_update,
+            solver._solve_zero_search_dot(False),
+            dim=(d.nworld),
+            inputs=[ctx.changed_efc_count, ctx.done],
+            outputs=[ctx.search_dot],
+          )
+          wp.launch(
+            solver._solve_search_update(False),
             dim=(d.nworld, m.nv),
-            inputs=[m.opt.solver, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
+            inputs=[m.opt.solver, ctx.changed_efc_count, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
             outputs=[ctx.search, ctx.search_dot],
           )
         return d.qacc.numpy().copy(), any_changes

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2351,6 +2351,7 @@ class SolverContext:
   jv: wp.array2d[float]
   quad: wp.array2d[wp.vec3]
   alpha: wp.array[float]
+  grad_scale: wp.array[float]
   improvement: wp.array[float]
   prev_grad: wp.array2d[float]
   prev_Mgrad: wp.array2d[float]


### PR DESCRIPTION
Every Newton solver iteration recomputes qfrc_constraint (a J^T force scatter or gather), the gradient, the Cholesky solve, and the search direction for all unconverged worlds. For a world whose constraint states did not flip during the iteration this work is redundant: the problem was exactly quadratic over the accepted linesearch step, so its gradient changed only by a scalar along an unchanged Newton ray. The solver already tracks state flips per world for the incremental Hessian update, and roughly a third of world-iterations have none on our benchmarks.

This change adds a fast path for those worlds: they skip the qfrc_constraint update, the gradient rebuild, the Cholesky solve, and the search update, leaving those arrays stale. A single scalar per world (ctx.grad_scale) tracks the accumulated gradient scale, updated alongside grad_dot in the existing zeroing kernel so the convergence test stays exact. No vector is rescaled anywhere: the next linesearch minimizes along the same ray and absorbs the scale into its accepted step. Unlike a solve-from-factor skip, no factor cache is required, so there is no store-out cost. Any state flip rebuilds everything through the unchanged baseline path, so staleness never survives a flip. The fast path covers Newton with pyramidal cones for both Jacobian modes and all matrix sizes; elliptic cones and the compact sleep solve keep the existing flow, and their kernels compile identically to before.

Two smaller changes ride along. The sparse scatter now skips rows with exactly zero force, which are common because rows are allocated at margin level but activate at acceleration level (about half the contact rows on unitree_g1_flat carry zero force at any instant). And qfrc_constraint is now materialized once after the solve from the gradient and its scale, which also fixes a pre-existing bug: the per-iteration zeroing wiped qfrc_constraint for every world that converged before the step's last solver iteration and never refilled it, so the public field read as zero for most worlds in multi-world sparse rollouts.

Measured on an RTX PRO 6000 Blackwell with nsys over full testspeed rollouts (8192 worlds, interleaved run orders) against main: end-to-end steps/s +6.7% on three_humanoids, +3.4% on humanoid, +2.3% on unitree_g1_flat, with total GPU kernel time -6.6%, -3.2%, and -2.2% respectively. Solver iteration counts match the baseline on all three models, all worlds converge, and the recovered qfrc_constraint matches a float64 reference to ~2e-6 relative on both Jacobian modes.
