### PR TITLE
Newton fast path: rebuild the gradient on friction transitions and linesearch stagnation

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -97,6 +97,7 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     hfactor=wp.empty((nworld, nv_pad, nv_pad), dtype=float) if alloc_hfactor else wp.empty((nworld, 0, 0), dtype=float),
     changed_efc_ids=wp.empty((nworld, njmax), dtype=int) if alloc_h else wp.empty((nworld, 0), dtype=int),
     changed_efc_count=wp.empty((nworld,), dtype=int) if alloc_h else wp.empty((0,), dtype=int),
+    state_changed_count=wp.empty((nworld,), dtype=int) if alloc_h else wp.empty((0,), dtype=int),
   )
 
 
@@ -1553,6 +1554,7 @@ def _update_constraint_efc(track_changes: bool):
     # Out:
     changed_ids_out: wp.array2d[int],
     changed_count_out: wp.array[int],
+    state_changed_count_out: wp.array[int],
   ):
     worldid, efcid = wp.tid()
 
@@ -1562,9 +1564,9 @@ def _update_constraint_efc(track_changes: bool):
     if ctx_done_in[worldid]:
       return
 
-    # Read old QUADRATIC status before overwriting
+    # Read old state before overwriting
     if wp.static(TRACK_CHANGES):
-      old_quad = efc_state_out[worldid, efcid] == types.ConstraintState.QUADRATIC.value
+      old_state = efc_state_out[worldid, efcid]
 
     efc_D = efc_D_in[worldid, efcid]
     Jaref = ctx_Jaref_in[worldid, efcid]
@@ -1630,10 +1632,15 @@ def _update_constraint_efc(track_changes: bool):
     efc_state_out[worldid, efcid] = new_state
 
     if wp.static(TRACK_CHANGES):
+      old_quad = old_state == types.ConstraintState.QUADRATIC.value
       new_quad = new_state == types.ConstraintState.QUADRATIC.value
       if old_quad != new_quad:
         idx = wp.atomic_add(changed_count_out, worldid, 1)
         changed_ids_out[worldid, idx] = efcid
+      # LINEARNEG <-> LINEARPOS friction transitions change the force without
+      # changing the quadratic flag (or H); the fast path must still see them.
+      if old_state != new_state:
+        wp.atomic_add(state_changed_count_out, worldid, 1)
 
   return kernel
 
@@ -1858,12 +1865,12 @@ def _update_constraint(
     _update_constraint_efc(track_changes),
     dim=(d.nworld, d.njmax),
     inputs=efc_inputs,
-    outputs=[d.efc.force, d.efc.state, ctx.changed_efc_ids, ctx.changed_efc_count],
+    outputs=[d.efc.force, d.efc.state, ctx.changed_efc_ids, ctx.changed_efc_count, ctx.state_changed_count],
   )
 
   # qfrc_constraint = efc_J.T @ efc_force. Fast-path worlds with no state flips
   # skip the rebuild; the public value is recovered after the solve.
-  changed = ctx.changed_efc_count if stable_fast else d.nefc
+  changed = ctx.state_changed_count if stable_fast else d.nefc
   if m.is_sparse:
     d.qfrc_constraint.zero_()
     wp.launch(
@@ -2749,6 +2756,7 @@ def _update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size
     ctx_grad_in: wp.array3d[float],
     ctx_h_in: wp.array3d[float],
     changed_count_in: wp.array[int],
+    state_changed_count_in: wp.array[int],
     ctx_hfactor: wp.array3d[float],
     # Out:
     ctx_Mgrad_out: wp.array3d[float],
@@ -2760,23 +2768,22 @@ def _update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size
       return
 
     # Fast path: skip the solve; Mgrad stays stale on the unchanged ray, and
-    # the linesearch is invariant to the scale of its direction.
+    # the linesearch is invariant to the scale of its direction. Worlds whose
+    # only transitions were between friction linear zones (state change but no
+    # quadratic flip) rebuilt grad with H unchanged: solve from the cached
+    # factor.
     if wp.static(SKIP_NOFLIP):
-      if changed_count_in[worldid] == 0:
+      if state_changed_count_in[worldid] == 0:
         return
 
+    if changed_count_in[worldid] > 0:
       wp.static(create_blocked_cholesky_factorize_solve_func(TILE_SIZE, matrix_size))(
         ctx_h_in[worldid], ctx_grad_in[worldid], matrix_size, ctx_hfactor[worldid], ctx_Mgrad_out[worldid]
       )
     else:
-      if changed_count_in[worldid] > 0:
-        wp.static(create_blocked_cholesky_factorize_solve_func(TILE_SIZE, matrix_size))(
-          ctx_h_in[worldid], ctx_grad_in[worldid], matrix_size, ctx_hfactor[worldid], ctx_Mgrad_out[worldid]
-        )
-      else:
-        wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
-          ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
-        )
+      wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
+        ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
+      )
 
   return kernel
 
@@ -2804,7 +2811,7 @@ def _cholesky_factorize_solve(
     wp.launch_tiled(
       _update_gradient_cholesky(m.nv, skip_noflip),
       dim=d.nworld,
-      inputs=[ctx.grad, ctx.h, ctx.changed_efc_count if skip_noflip else d.nefc, ctx.done],
+      inputs=[ctx.grad, ctx.h, ctx.state_changed_count if skip_noflip else d.nefc, ctx.done],
       outputs=[ctx.Mgrad],
       block_dim=m.block_dim.update_gradient_cholesky,
     )
@@ -2820,7 +2827,14 @@ def _cholesky_factorize_solve(
       wp.launch_tiled(
         _update_gradient_cholesky_blocked_skip_unchanged(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad, skip_noflip),
         dim=d.nworld,
-        inputs=[ctx.done, ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)), ctx.h, ctx.changed_efc_count, ctx.hfactor],
+        inputs=[
+          ctx.done,
+          ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)),
+          ctx.h,
+          ctx.changed_efc_count,
+          ctx.state_changed_count if skip_noflip else ctx.changed_efc_count,
+          ctx.hfactor,
+        ],
         outputs=[ctx.Mgrad.reshape(shape=(d.nworld, ctx.Mgrad.shape[1], 1))],
         block_dim=m.block_dim.update_gradient_cholesky_blocked,
       )
@@ -3215,7 +3229,7 @@ def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverConte
   Skips the full J^T*D*J rebuild by applying only the delta from constraints
   that changed QUADRATIC state, then re-factorizes and solves.
   """
-  changed = ctx.changed_efc_count if stable_fast else d.nefc
+  changed = ctx.state_changed_count if stable_fast else d.nefc
   wp.launch(
     _update_gradient_zero_grad_dot(stable_fast),
     dim=d.nworld,
@@ -3564,6 +3578,7 @@ def _solver_iteration(
   if incremental:
     # Must complete before _update_constraint_efc which atomically increments.
     ctx.changed_efc_count.zero_()
+    ctx.state_changed_count.zero_()
 
   _update_constraint(m, d, ctx, track_changes=incremental, stable_fast=stable_fast)
 
@@ -3616,7 +3631,7 @@ def _solver_iteration(
     )
 
   else:
-    changed = ctx.changed_efc_count if stable_fast else d.nefc
+    changed = ctx.state_changed_count if stable_fast else d.nefc
     wp.launch(_solve_zero_search_dot(stable_fast), dim=d.nworld, inputs=[changed, ctx.done], outputs=[ctx.search_dot])
 
     wp.launch(

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -949,10 +949,8 @@ def _linesearch_iterative_kernel(
     scale = meaninertia * wp.float(nv)
     gtol = wp.max(tolerance * ls_tolerance * snorm * scale, 1e-6)
 
-    # p0 via parallel reduction; also accumulate the gross derivative-term
-    # magnitude, which sets the arithmetic noise floor of the bracketing search
+    # p0 via parallel reduction
     local_p0 = wp.vec3(0.0)
-    local_q1_abs = float(0.0)
     for efcid in range(tid, nefc, wp.block_dim()):
       if wp.static(IS_ELLIPTIC):
         efc_type = efc_type_in[worldid, efcid]
@@ -973,7 +971,7 @@ def _linesearch_iterative_kernel(
           quad1 = ctx_quad_in[worldid, efc_addr1]
           quad2 = ctx_quad_in[worldid, efc_addr2]
 
-        pt = _compute_efc_eval_pt_alpha_zero(
+        local_p0 += _compute_efc_eval_pt_alpha_zero(
           efcid,
           ne,
           nf,
@@ -989,12 +987,9 @@ def _linesearch_iterative_kernel(
           quad1,
           quad2,
         )
-        local_p0 += pt
-        if wp.static(TRACK_EXHAUSTION):
-          local_q1_abs += wp.abs(pt[1])
       else:
         # direct evaluation for pyramidal cones (no intermediate quad)
-        pt = _compute_efc_eval_pt_alpha_zero(
+        local_p0 += _compute_efc_eval_pt_alpha_zero(
           efcid,
           ne,
           nf,
@@ -1003,20 +998,12 @@ def _linesearch_iterative_kernel(
           ctx_Jaref_in[worldid, efcid],
           ctx_jv_in[worldid, efcid],
         )
-        local_p0 += pt
-        if wp.static(TRACK_EXHAUSTION):
-          local_q1_abs += wp.abs(pt[1])
 
     # at this point, every thread has computed some contributions to p0 in local_p0
     # we now create a tile of all local_p0 contributions and reduce them to a single value
     # this is done in parallel using a tile reduction
     p0_tile = wp.tile(local_p0, preserve_type=True)
     p0_sum = wp.tile_reduce(wp.add, p0_tile)
-    q1_abs = float(0.0)
-    if wp.static(TRACK_EXHAUSTION):
-      q1_abs_tile = wp.tile(local_q1_abs)
-      q1_abs_sum = wp.tile_reduce(wp.add, q1_abs_tile)
-      q1_abs = q1_abs_sum[0]
 
     # quad_gauss = [0, search.T @ Ma - search.T @ qfrc_smooth, 0.5 * search.T @ mv]
     local_gauss = wp.vec2(0.0)
@@ -1035,6 +1022,20 @@ def _linesearch_iterative_kernel(
     # add quad_gauss contribution to p0
     p0 = wp.vec3(ctx_quad_gauss[0], ctx_quad_gauss[1], 2.0 * ctx_quad_gauss[2]) + p0_sum[0]
     p0_delta = wp.vec3(0.0, p0[1], p0[2])
+
+    # The bracketing search reads derivative sums whose rounding noise is ~eps
+    # times their gross magnitude, so roots below eps * |q1| / p0[2] (and never
+    # below 8 ulps of the unit ray anchor) are noise, not descent: an accepted
+    # step under this floor means the stale ray is exhausted and the fast path
+    # must rebuild the world. Per quadratic row |q1| = sqrt(2 * cost * hessian),
+    # so Cauchy-Schwarz bounds the row total by sums already reduced for p0; the
+    # smooth term is added exactly. Friction linear rows fall outside the bound,
+    # which only lowers the floor toward the fixed 8-ulp base.
+    noise_floor = float(0.0)
+    if wp.static(TRACK_EXHAUSTION):
+      rows = p0_sum[0]
+      q1_abs = wp.sqrt(2.0 * wp.max(rows[0], 0.0) * wp.max(rows[2], 0.0)) + wp.abs(ctx_quad_gauss[1])
+      noise_floor = _ALPHA_NOISE_EPS * wp.max(1.0, math.safe_div(q1_abs, p0[2]))
 
     # lo_in at lo_alpha_in = -p0[1] / p0[2]
     lo_alpha_in = -math.safe_div(p0[1], p0[2])
@@ -1258,13 +1259,7 @@ def _linesearch_iterative_kernel(
     if tid == 0:
       ctx_improvement_out[worldid] = improvement
       ctx_alpha_out[worldid] = alpha
-      # The bracketing search reads derivative sums whose rounding noise is
-      # ~eps * q1_abs, so roots below eps * q1_abs / p0[2] (and never below
-      # 8 ulps of the unit ray anchor) are noise, not descent: the stale ray
-      # is exhausted and the fast path must rebuild this world.
       if wp.static(TRACK_EXHAUSTION):
-        total_q1_abs = q1_abs + wp.abs(ctx_quad_gauss[1])
-        noise_floor = _ALPHA_NOISE_EPS * wp.max(1.0, math.safe_div(total_q1_abs, p0[2]))
         ctx_ray_exhausted_out[worldid] = wp.abs(alpha) < noise_floor
 
   return kernel

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -54,6 +54,7 @@ def create_inverse_context(m: types.Model, d: types.Data) -> InverseContext:
     done=wp.empty((nworld,), dtype=bool),
     quad_changed_ids=wp.empty((nworld, 0), dtype=int),
     quad_changed_count=wp.empty((0,), dtype=int),
+    state_changed_count=wp.empty((0,), dtype=int),
   )
 
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1663,7 +1663,7 @@ def _update_constraint_init_qfrc_constraint_sparse(
   efc_J_in: wp.array3d[float],
   efc_force_in: wp.array2d[float],
   # In:
-  quad_changed_count_in: wp.array[int],
+  state_changed_count_in: wp.array[int],
   ctx_done_in: wp.array[bool],
   # Data out:
   qfrc_constraint_out: wp.array2d[float],
@@ -1673,7 +1673,7 @@ def _update_constraint_init_qfrc_constraint_sparse(
   if ctx_done_in[worldid]:
     return
 
-  if quad_changed_count_in[worldid] == 0:
+  if state_changed_count_in[worldid] == 0:
     return
 
   if efcid >= nefc_in[worldid]:
@@ -1721,7 +1721,7 @@ def _update_constraint_init_qfrc_constraint_dense(stable_fast: bool):
     efc_force_in: wp.array2d[float],
     njmax_in: int,
     # In:
-    quad_changed_count_in: wp.array[int],
+    state_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Data out:
     qfrc_constraint_out: wp.array2d[float],
@@ -1733,7 +1733,7 @@ def _update_constraint_init_qfrc_constraint_dense(stable_fast: bool):
 
     # Fast path: stale qfrc_constraint is never read; recovered after the solve.
     if wp.static(STABLE_FAST):
-      if quad_changed_count_in[worldid] == 0:
+      if state_changed_count_in[worldid] == 0:
         return
 
     sum_qfrc = float(0.0)
@@ -1904,7 +1904,7 @@ def _update_gradient_zero_grad_dot(stable_fast: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # In:
-    quad_changed_count_in: wp.array[int],
+    state_changed_count_in: wp.array[int],
     ctx_alpha_in: wp.array[float],
     ctx_done_in: wp.array[bool],
     # Out:
@@ -1920,7 +1920,7 @@ def _update_gradient_zero_grad_dot(stable_fast: bool):
     # gradient is grad_scale * g, and a linesearch step t along the (equally
     # stale) search direction changes it to (grad_scale - t) * g.
     if wp.static(STABLE_FAST):
-      if quad_changed_count_in[worldid] == 0:
+      if state_changed_count_in[worldid] == 0:
         sigma = ctx_grad_scale_out[worldid]
         new_sigma = sigma - ctx_alpha_in[worldid]
         ratio = float(0.0)
@@ -1947,7 +1947,7 @@ def _update_gradient_grad(stable_fast: bool):
     qfrc_constraint_in: wp.array2d[float],
     efc_Ma_in: wp.array2d[float],
     # In:
-    quad_changed_count_in: wp.array[int],
+    state_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Out:
     ctx_grad_out: wp.array2d[float],
@@ -1960,7 +1960,7 @@ def _update_gradient_grad(stable_fast: bool):
 
     # Fast path: grad stays stale (see _update_gradient_zero_grad_dot).
     if wp.static(STABLE_FAST):
-      if quad_changed_count_in[worldid] == 0:
+      if state_changed_count_in[worldid] == 0:
         return
 
     grad = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - qfrc_constraint_in[worldid, dofid]
@@ -2697,7 +2697,7 @@ def _update_gradient_cholesky(tile_size: int, skip_noflip: bool = False):
     # In:
     ctx_grad_in: wp.array2d[float],
     h_in: wp.array3d[float],
-    quad_changed_count_in: wp.array[int],
+    state_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Out:
     ctx_Mgrad_out: wp.array2d[float],
@@ -2710,7 +2710,7 @@ def _update_gradient_cholesky(tile_size: int, skip_noflip: bool = False):
 
     # Fast path: skip the solve (see the blocked skip_unchanged variant).
     if wp.static(SKIP_NOFLIP):
-      if quad_changed_count_in[worldid] == 0:
+      if state_changed_count_in[worldid] == 0:
         return
 
     mat_tile = wp.tile_load(h_in[worldid], shape=(TILE_SIZE, TILE_SIZE))
@@ -3373,7 +3373,7 @@ def _solve_zero_search_dot(stable_fast: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # In:
-    quad_changed_count_in: wp.array[int],
+    state_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Out:
     ctx_search_dot_out: wp.array[float],
@@ -3385,7 +3385,7 @@ def _solve_zero_search_dot(stable_fast: bool):
 
     # Fast path: search stays on the same ray; keep search_dot consistent with it.
     if wp.static(STABLE_FAST):
-      if quad_changed_count_in[worldid] == 0:
+      if state_changed_count_in[worldid] == 0:
         return
 
     ctx_search_dot_out[worldid] = 0.0
@@ -3402,7 +3402,7 @@ def _solve_search_update(stable_fast: bool):
     # Model:
     opt_solver: int,
     # In:
-    quad_changed_count_in: wp.array[int],
+    state_changed_count_in: wp.array[int],
     ctx_Mgrad_in: wp.array2d[float],
     ctx_search_in: wp.array2d[float],
     ctx_beta_in: wp.array[float],
@@ -3418,7 +3418,7 @@ def _solve_search_update(stable_fast: bool):
 
     # Fast path: search stays on the stale ray; the linesearch absorbs its scale.
     if wp.static(STABLE_FAST):
-      if quad_changed_count_in[worldid] == 0:
+      if state_changed_count_in[worldid] == 0:
         return
 
     search = -1.0 * ctx_Mgrad_in[worldid, dofid]

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -55,6 +55,7 @@ def create_inverse_context(m: types.Model, d: types.Data) -> InverseContext:
     quad_changed_ids=wp.empty((nworld, 0), dtype=int),
     quad_changed_count=wp.empty((0,), dtype=int),
     state_changed_count=wp.empty((0,), dtype=int),
+    ray_exhausted=wp.empty((0,), dtype=bool),
   )
 
 
@@ -90,6 +91,7 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     alpha=wp.empty((nworld,), dtype=float),
     grad_scale=wp.empty((nworld,), dtype=float),
     improvement=wp.empty((nworld,), dtype=float),
+    ray_exhausted=wp.zeros((nworld,), dtype=bool),
     prev_grad=wp.empty((nworld, nv), dtype=float),
     prev_Mgrad=wp.empty((nworld, nv), dtype=float),
     beta=wp.empty((nworld,), dtype=float),
@@ -843,6 +845,7 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
     ctx_quad_out: wp.array2d[wp.vec3],
     ctx_improvement_out: wp.array[float],
     ctx_alpha_out: wp.array[float],
+    ctx_ray_exhausted_out: wp.array[bool],
   ):
     worldid, tid = wp.tid()
 
@@ -942,8 +945,10 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
     scale = meaninertia * wp.float(nv)
     gtol = wp.max(tolerance * ls_tolerance * snorm * scale, 1e-6)
 
-    # p0 via parallel reduction
+    # p0 via parallel reduction; also accumulate the gross derivative-term
+    # magnitude, which sets the arithmetic noise floor of the bracketing search
     local_p0 = wp.vec3(0.0)
+    local_q1_abs = float(0.0)
     for efcid in range(tid, nefc, wp.block_dim()):
       if wp.static(IS_ELLIPTIC):
         efc_type = efc_type_in[worldid, efcid]
@@ -964,7 +969,7 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
           quad1 = ctx_quad_in[worldid, efc_addr1]
           quad2 = ctx_quad_in[worldid, efc_addr2]
 
-        local_p0 += _compute_efc_eval_pt_alpha_zero(
+        pt = _compute_efc_eval_pt_alpha_zero(
           efcid,
           ne,
           nf,
@@ -980,9 +985,11 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
           quad1,
           quad2,
         )
+        local_p0 += pt
+        local_q1_abs += wp.abs(pt[1])
       else:
         # direct evaluation for pyramidal cones (no intermediate quad)
-        local_p0 += _compute_efc_eval_pt_alpha_zero(
+        pt = _compute_efc_eval_pt_alpha_zero(
           efcid,
           ne,
           nf,
@@ -991,12 +998,16 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
           ctx_Jaref_in[worldid, efcid],
           ctx_jv_in[worldid, efcid],
         )
+        local_p0 += pt
+        local_q1_abs += wp.abs(pt[1])
 
     # at this point, every thread has computed some contributions to p0 in local_p0
     # we now create a tile of all local_p0 contributions and reduce them to a single value
     # this is done in parallel using a tile reduction
     p0_tile = wp.tile(local_p0, preserve_type=True)
     p0_sum = wp.tile_reduce(wp.add, p0_tile)
+    q1_abs_tile = wp.tile(local_q1_abs)
+    q1_abs_sum = wp.tile_reduce(wp.add, q1_abs_tile)
 
     # quad_gauss = [0, search.T @ Ma - search.T @ qfrc_smooth, 0.5 * search.T @ mv]
     local_gauss = wp.vec2(0.0)
@@ -1015,6 +1026,7 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
     # add quad_gauss contribution to p0
     p0 = wp.vec3(ctx_quad_gauss[0], ctx_quad_gauss[1], 2.0 * ctx_quad_gauss[2]) + p0_sum[0]
     p0_delta = wp.vec3(0.0, p0[1], p0[2])
+    q1_abs = q1_abs_sum[0] + wp.abs(ctx_quad_gauss[1])
 
     # lo_in at lo_alpha_in = -p0[1] / p0[2]
     lo_alpha_in = -math.safe_div(p0[1], p0[2])
@@ -1238,6 +1250,12 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
     if tid == 0:
       ctx_improvement_out[worldid] = improvement
       ctx_alpha_out[worldid] = alpha
+      # The bracketing search reads derivative sums whose rounding noise is
+      # ~eps * q1_abs, so roots below eps * q1_abs / p0[2] (and never below
+      # 8 ulps of the unit ray anchor) are noise, not descent: the stale ray
+      # is exhausted and the fast path must rebuild this world.
+      noise_floor = _ALPHA_NOISE_EPS * wp.max(1.0, math.safe_div(q1_abs, p0[2]))
+      ctx_ray_exhausted_out[worldid] = wp.abs(alpha) < noise_floor
 
   return kernel
 
@@ -1285,7 +1303,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
       ctx.quad,
       ctx.done,
     ],
-    outputs=[d.qacc, d.efc.Ma, ctx.Jaref, ctx.jv, ctx.quad, ctx.improvement, ctx.alpha],
+    outputs=[d.qacc, d.efc.Ma, ctx.Jaref, ctx.jv, ctx.quad, ctx.improvement, ctx.alpha, ctx.ray_exhausted],
     block_dim=m.block_dim.linesearch_iterative,
   )
 
@@ -1548,7 +1566,7 @@ def _update_constraint_efc(track_changes: bool):
     nacon_in: wp.array[int],
     # In:
     ctx_Jaref_in: wp.array2d[float],
-    ctx_alpha_in: wp.array[float],
+    ctx_ray_exhausted_in: wp.array[bool],
     ctx_done_in: wp.array[bool],
     # Data out:
     efc_force_out: wp.array2d[float],
@@ -1563,10 +1581,10 @@ def _update_constraint_efc(track_changes: bool):
     if ctx_done_in[worldid]:
       return
 
-    # A vanishing linesearch step means the stale search ray is exhausted;
-    # count it as a state change so the fast path rebuilds this world.
+    # The linesearch flags worlds whose accepted step was rounding noise (stale
+    # ray exhausted); count it as a state change so the fast path rebuilds them.
     if wp.static(TRACK_CHANGES):
-      if efcid == 0 and wp.abs(ctx_alpha_in[worldid]) < _STABLE_FAST_MIN_ALPHA:
+      if efcid == 0 and ctx_ray_exhausted_in[worldid]:
         wp.atomic_add(state_changed_count_out, worldid, 1)
 
     if efcid >= nefc_in[worldid]:
@@ -1866,7 +1884,7 @@ def _update_constraint(
     d.efc.frictionloss,
     d.nacon,
     ctx.Jaref,
-    ctx.alpha if isinstance(ctx, SolverContext) else d.time,
+    ctx.ray_exhausted,
     ctx.done,
   ]
 
@@ -3553,14 +3571,13 @@ def _solve_done(
     wp.atomic_add(nsolving_out, 0, -1)
 
 
-# For a world with no state flips the problem is quadratic and the exact
-# linesearch step along the stale Newton ray equals the remaining ray fraction
-# (t* = grad_scale, with the minimizer at grad_scale = 0). Steps below ~8 ulp
-# of the unit ray anchor are float32 rounding noise: the ray's reachable
-# gradient is floored at ~eps * |grad at rebuild|, and if the tolerance sits
-# below that floor the world could never terminate on this ray. Rebuilding
-# re-anchors the arithmetic at the current (much smaller) gradient scale.
-_STABLE_FAST_MIN_ALPHA = 8.0 * 1.1920929e-07  # 8 * float32 eps
+# The linesearch runs in ray units anchored at the last gradient rebuild, and
+# its bracketing arithmetic cannot resolve steps below ~eps times the gross
+# derivative-term magnitude over the curvature (see _linesearch_iterative_kernel).
+# A world whose tolerance sits below that floor could never terminate on the
+# stale ray; rebuilding re-anchors the arithmetic at the current (much smaller)
+# gradient scale. The 8 is an allowance for the reduction depth of the sums.
+_ALPHA_NOISE_EPS = 8.0 * 1.1920929e-07  # 8 * float32 eps
 
 
 def _use_incremental(m: types.Model) -> bool:

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -55,7 +55,7 @@ def create_inverse_context(m: types.Model, d: types.Data) -> InverseContext:
     quad_changed_ids=wp.empty((nworld, 0), dtype=int),
     quad_changed_count=wp.empty((0,), dtype=int),
     state_changed_count=wp.empty((0,), dtype=int),
-    ray_exhausted=wp.empty((0,), dtype=bool),
+    ls_exhausted=wp.empty((0,), dtype=bool),
   )
 
 
@@ -91,7 +91,7 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     alpha=wp.empty((nworld,), dtype=float),
     grad_scale=wp.empty((nworld,), dtype=float),
     improvement=wp.empty((nworld,), dtype=float),
-    ray_exhausted=wp.zeros((nworld,), dtype=bool),
+    ls_exhausted=wp.zeros((nworld,), dtype=bool),
     prev_grad=wp.empty((nworld, nv), dtype=float),
     prev_Mgrad=wp.empty((nworld, nv), dtype=float),
     beta=wp.empty((nworld,), dtype=float),
@@ -849,7 +849,7 @@ def _linesearch_iterative_kernel(
     ctx_quad_out: wp.array2d[wp.vec3],
     ctx_improvement_out: wp.array[float],
     ctx_alpha_out: wp.array[float],
-    ctx_ray_exhausted_out: wp.array[bool],
+    ctx_ls_exhausted_out: wp.array[bool],
   ):
     worldid, tid = wp.tid()
 
@@ -1260,7 +1260,7 @@ def _linesearch_iterative_kernel(
       ctx_improvement_out[worldid] = improvement
       ctx_alpha_out[worldid] = alpha
       if wp.static(TRACK_EXHAUSTION):
-        ctx_ray_exhausted_out[worldid] = wp.abs(alpha) < noise_floor
+        ctx_ls_exhausted_out[worldid] = wp.abs(alpha) < noise_floor
 
   return kernel
 
@@ -1308,7 +1308,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
       ctx.quad,
       ctx.done,
     ],
-    outputs=[d.qacc, d.efc.Ma, ctx.Jaref, ctx.jv, ctx.quad, ctx.improvement, ctx.alpha, ctx.ray_exhausted],
+    outputs=[d.qacc, d.efc.Ma, ctx.Jaref, ctx.jv, ctx.quad, ctx.improvement, ctx.alpha, ctx.ls_exhausted],
     block_dim=m.block_dim.linesearch_iterative,
   )
 
@@ -1571,7 +1571,7 @@ def _update_constraint_efc(track_changes: bool):
     nacon_in: wp.array[int],
     # In:
     ctx_Jaref_in: wp.array2d[float],
-    ctx_ray_exhausted_in: wp.array[bool],
+    ctx_ls_exhausted_in: wp.array[bool],
     ctx_done_in: wp.array[bool],
     # Data out:
     efc_force_out: wp.array2d[float],
@@ -1589,7 +1589,7 @@ def _update_constraint_efc(track_changes: bool):
     # The linesearch flags worlds whose accepted step was rounding noise (stale
     # ray exhausted); count it as a state change so the fast path rebuilds them.
     if wp.static(TRACK_CHANGES):
-      if efcid == 0 and ctx_ray_exhausted_in[worldid]:
+      if efcid == 0 and ctx_ls_exhausted_in[worldid]:
         wp.atomic_add(state_changed_count_out, worldid, 1)
 
     if efcid >= nefc_in[worldid]:
@@ -1889,7 +1889,7 @@ def _update_constraint(
     d.efc.frictionloss,
     d.nacon,
     ctx.Jaref,
-    ctx.ray_exhausted,
+    ctx.ls_exhausted,
     ctx.done,
   ]
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -52,8 +52,8 @@ def create_inverse_context(m: types.Model, d: types.Data) -> InverseContext:
     Jaref=wp.empty((nworld, njmax), dtype=float),
     search_dot=wp.empty((nworld,), dtype=float),
     done=wp.empty((nworld,), dtype=bool),
-    changed_efc_ids=wp.empty((nworld, 0), dtype=int),
-    changed_efc_count=wp.empty((0,), dtype=int),
+    quad_changed_ids=wp.empty((nworld, 0), dtype=int),
+    quad_changed_count=wp.empty((0,), dtype=int),
   )
 
 
@@ -95,8 +95,8 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     beta_den=wp.empty((nworld,), dtype=float),
     h=wp.empty((nworld, nv_pad, nv_pad), dtype=float) if alloc_h else wp.empty((nworld, 0, 0), dtype=float),
     hfactor=wp.empty((nworld, nv_pad, nv_pad), dtype=float) if alloc_hfactor else wp.empty((nworld, 0, 0), dtype=float),
-    changed_efc_ids=wp.empty((nworld, njmax), dtype=int) if alloc_h else wp.empty((nworld, 0), dtype=int),
-    changed_efc_count=wp.empty((nworld,), dtype=int) if alloc_h else wp.empty((0,), dtype=int),
+    quad_changed_ids=wp.empty((nworld, njmax), dtype=int) if alloc_h else wp.empty((nworld, 0), dtype=int),
+    quad_changed_count=wp.empty((nworld,), dtype=int) if alloc_h else wp.empty((0,), dtype=int),
     state_changed_count=wp.empty((nworld,), dtype=int) if alloc_h else wp.empty((0,), dtype=int),
   )
 
@@ -1552,8 +1552,8 @@ def _update_constraint_efc(track_changes: bool):
     efc_force_out: wp.array2d[float],
     efc_state_out: wp.array2d[int],
     # Out:
-    changed_ids_out: wp.array2d[int],
-    changed_count_out: wp.array[int],
+    quad_changed_ids_out: wp.array2d[int],
+    quad_changed_count_out: wp.array[int],
     state_changed_count_out: wp.array[int],
   ):
     worldid, efcid = wp.tid()
@@ -1635,8 +1635,8 @@ def _update_constraint_efc(track_changes: bool):
       old_quad = old_state == types.ConstraintState.QUADRATIC.value
       new_quad = new_state == types.ConstraintState.QUADRATIC.value
       if old_quad != new_quad:
-        idx = wp.atomic_add(changed_count_out, worldid, 1)
-        changed_ids_out[worldid, idx] = efcid
+        idx = wp.atomic_add(quad_changed_count_out, worldid, 1)
+        quad_changed_ids_out[worldid, idx] = efcid
       # LINEARNEG <-> LINEARPOS friction transitions change the force without
       # changing the quadratic flag (or H); the fast path must still see them.
       if old_state != new_state:
@@ -1655,7 +1655,7 @@ def _update_constraint_init_qfrc_constraint_sparse(
   efc_J_in: wp.array3d[float],
   efc_force_in: wp.array2d[float],
   # In:
-  changed_count_in: wp.array[int],
+  quad_changed_count_in: wp.array[int],
   ctx_done_in: wp.array[bool],
   # Data out:
   qfrc_constraint_out: wp.array2d[float],
@@ -1665,7 +1665,7 @@ def _update_constraint_init_qfrc_constraint_sparse(
   if ctx_done_in[worldid]:
     return
 
-  if changed_count_in[worldid] == 0:
+  if quad_changed_count_in[worldid] == 0:
     return
 
   if efcid >= nefc_in[worldid]:
@@ -1713,7 +1713,7 @@ def _update_constraint_init_qfrc_constraint_dense(stable_fast: bool):
     efc_force_in: wp.array2d[float],
     njmax_in: int,
     # In:
-    changed_count_in: wp.array[int],
+    quad_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Data out:
     qfrc_constraint_out: wp.array2d[float],
@@ -1725,7 +1725,7 @@ def _update_constraint_init_qfrc_constraint_dense(stable_fast: bool):
 
     # Fast path: stale qfrc_constraint is never read; recovered after the solve.
     if wp.static(STABLE_FAST):
-      if changed_count_in[worldid] == 0:
+      if quad_changed_count_in[worldid] == 0:
         return
 
     sum_qfrc = float(0.0)
@@ -1746,8 +1746,8 @@ def _update_gradient_h_incremental(
   efc_D_in: wp.array2d[float],
   efc_state_in: wp.array2d[int],
   # In:
-  changed_ids_in: wp.array2d[int],
-  changed_count_in: wp.array[int],
+  quad_changed_ids_in: wp.array2d[int],
+  quad_changed_count_in: wp.array[int],
   # Out:
   ctx_h_out: wp.array3d[float],
 ):
@@ -1758,7 +1758,7 @@ def _update_gradient_h_incremental(
   """
   worldid, elementid = wp.tid()
 
-  n_changes = changed_count_in[worldid]
+  n_changes = quad_changed_count_in[worldid]
   if n_changes == 0:
     return
 
@@ -1768,7 +1768,7 @@ def _update_gradient_h_incremental(
 
   delta = float(0.0)
   for change_idx in range(n_changes):
-    efcid = changed_ids_in[worldid, change_idx]
+    efcid = quad_changed_ids_in[worldid, change_idx]
     Jrow = efc_J_in[worldid, efcid, row]
     if Jrow == 0.0:
       continue
@@ -1796,8 +1796,8 @@ def _update_gradient_h_incremental_sparse(
   efc_D_in: wp.array2d[float],
   efc_state_in: wp.array2d[int],
   # In:
-  changed_ids_in: wp.array2d[int],
-  changed_count_in: wp.array[int],
+  quad_changed_ids_in: wp.array2d[int],
+  quad_changed_count_in: wp.array[int],
   slots_per_world: int,
   # Out:
   ctx_h_out: wp.array3d[float],
@@ -1810,9 +1810,9 @@ def _update_gradient_h_incremental_sparse(
   """
   worldid, slot, lane = wp.tid()
 
-  n_changes = changed_count_in[worldid]
+  n_changes = quad_changed_count_in[worldid]
   for change_idx in range(slot, n_changes, slots_per_world):
-    efcid = changed_ids_in[worldid, change_idx]
+    efcid = quad_changed_ids_in[worldid, change_idx]
     D = efc_D_in[worldid, efcid]
     sign = float(0.0)
     if efc_state_in[worldid, efcid] == types.ConstraintState.QUADRATIC.value:
@@ -1865,7 +1865,7 @@ def _update_constraint(
     _update_constraint_efc(track_changes),
     dim=(d.nworld, d.njmax),
     inputs=efc_inputs,
-    outputs=[d.efc.force, d.efc.state, ctx.changed_efc_ids, ctx.changed_efc_count, ctx.state_changed_count],
+    outputs=[d.efc.force, d.efc.state, ctx.quad_changed_ids, ctx.quad_changed_count, ctx.state_changed_count],
   )
 
   # qfrc_constraint = efc_J.T @ efc_force. Fast-path worlds with no state flips
@@ -1895,7 +1895,7 @@ def _update_gradient_zero_grad_dot(stable_fast: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # In:
-    changed_count_in: wp.array[int],
+    quad_changed_count_in: wp.array[int],
     ctx_alpha_in: wp.array[float],
     ctx_done_in: wp.array[bool],
     # Out:
@@ -1911,7 +1911,7 @@ def _update_gradient_zero_grad_dot(stable_fast: bool):
     # gradient is grad_scale * g, and a linesearch step t along the (equally
     # stale) search direction changes it to (grad_scale - t) * g.
     if wp.static(STABLE_FAST):
-      if changed_count_in[worldid] == 0:
+      if quad_changed_count_in[worldid] == 0:
         sigma = ctx_grad_scale_out[worldid]
         new_sigma = sigma - ctx_alpha_in[worldid]
         ratio = float(0.0)
@@ -1938,7 +1938,7 @@ def _update_gradient_grad(stable_fast: bool):
     qfrc_constraint_in: wp.array2d[float],
     efc_Ma_in: wp.array2d[float],
     # In:
-    changed_count_in: wp.array[int],
+    quad_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Out:
     ctx_grad_out: wp.array2d[float],
@@ -1951,7 +1951,7 @@ def _update_gradient_grad(stable_fast: bool):
 
     # Fast path: grad stays stale (see _update_gradient_zero_grad_dot).
     if wp.static(STABLE_FAST):
-      if changed_count_in[worldid] == 0:
+      if quad_changed_count_in[worldid] == 0:
         return
 
     grad = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - qfrc_constraint_in[worldid, dofid]
@@ -2688,7 +2688,7 @@ def _update_gradient_cholesky(tile_size: int, skip_noflip: bool = False):
     # In:
     ctx_grad_in: wp.array2d[float],
     h_in: wp.array3d[float],
-    changed_count_in: wp.array[int],
+    quad_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Out:
     ctx_Mgrad_out: wp.array2d[float],
@@ -2701,7 +2701,7 @@ def _update_gradient_cholesky(tile_size: int, skip_noflip: bool = False):
 
     # Fast path: skip the solve (see the blocked skip_unchanged variant).
     if wp.static(SKIP_NOFLIP):
-      if changed_count_in[worldid] == 0:
+      if quad_changed_count_in[worldid] == 0:
         return
 
     mat_tile = wp.tile_load(h_in[worldid], shape=(TILE_SIZE, TILE_SIZE))
@@ -2755,7 +2755,7 @@ def _update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size
     ctx_done_in: wp.array[bool],
     ctx_grad_in: wp.array3d[float],
     ctx_h_in: wp.array3d[float],
-    changed_count_in: wp.array[int],
+    quad_changed_count_in: wp.array[int],
     state_changed_count_in: wp.array[int],
     ctx_hfactor: wp.array3d[float],
     # Out:
@@ -2776,7 +2776,7 @@ def _update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size
       if state_changed_count_in[worldid] == 0:
         return
 
-    if changed_count_in[worldid] > 0:
+    if quad_changed_count_in[worldid] > 0:
       wp.static(create_blocked_cholesky_factorize_solve_func(TILE_SIZE, matrix_size))(
         ctx_h_in[worldid], ctx_grad_in[worldid], matrix_size, ctx_hfactor[worldid], ctx_Mgrad_out[worldid]
       )
@@ -2831,8 +2831,8 @@ def _cholesky_factorize_solve(
           ctx.done,
           ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)),
           ctx.h,
-          ctx.changed_efc_count,
-          ctx.state_changed_count if skip_noflip else ctx.changed_efc_count,
+          ctx.quad_changed_count,
+          ctx.state_changed_count if skip_noflip else ctx.quad_changed_count,
           ctx.hfactor,
         ],
         outputs=[ctx.Mgrad.reshape(shape=(d.nworld, ctx.Mgrad.shape[1], 1))],
@@ -3246,7 +3246,7 @@ def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverConte
 
   # Update upper triangle of H with delta from changed constraints.
   if m.is_sparse:
-    slots = _jtdaj_groups_per_world(d.nworld, ctx.changed_efc_ids.shape[1])
+    slots = _jtdaj_groups_per_world(d.nworld, ctx.quad_changed_ids.shape[1])
     wp.launch(
       _update_gradient_h_incremental_sparse,
       dim=(d.nworld, slots, _JTDAJ_THREADS_PER_GROUP),
@@ -3257,8 +3257,8 @@ def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverConte
         d.efc.J,
         d.efc.D,
         d.efc.state,
-        ctx.changed_efc_ids,
-        ctx.changed_efc_count,
+        ctx.quad_changed_ids,
+        ctx.quad_changed_count,
         slots,
       ],
       outputs=[ctx.h],
@@ -3272,8 +3272,8 @@ def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverConte
         d.efc.J,
         d.efc.D,
         d.efc.state,
-        ctx.changed_efc_ids,
-        ctx.changed_efc_count,
+        ctx.quad_changed_ids,
+        ctx.quad_changed_count,
       ],
       outputs=[ctx.h],
     )
@@ -3364,7 +3364,7 @@ def _solve_zero_search_dot(stable_fast: bool):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # In:
-    changed_count_in: wp.array[int],
+    quad_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Out:
     ctx_search_dot_out: wp.array[float],
@@ -3376,7 +3376,7 @@ def _solve_zero_search_dot(stable_fast: bool):
 
     # Fast path: search stays on the same ray; keep search_dot consistent with it.
     if wp.static(STABLE_FAST):
-      if changed_count_in[worldid] == 0:
+      if quad_changed_count_in[worldid] == 0:
         return
 
     ctx_search_dot_out[worldid] = 0.0
@@ -3393,7 +3393,7 @@ def _solve_search_update(stable_fast: bool):
     # Model:
     opt_solver: int,
     # In:
-    changed_count_in: wp.array[int],
+    quad_changed_count_in: wp.array[int],
     ctx_Mgrad_in: wp.array2d[float],
     ctx_search_in: wp.array2d[float],
     ctx_beta_in: wp.array[float],
@@ -3409,7 +3409,7 @@ def _solve_search_update(stable_fast: bool):
 
     # Fast path: search stays on the stale ray; the linesearch absorbs its scale.
     if wp.static(STABLE_FAST):
-      if changed_count_in[worldid] == 0:
+      if quad_changed_count_in[worldid] == 0:
         return
 
     search = -1.0 * ctx_Mgrad_in[worldid, dofid]
@@ -3577,7 +3577,7 @@ def _solver_iteration(
 
   if incremental:
     # Must complete before _update_constraint_efc which atomically increments.
-    ctx.changed_efc_count.zero_()
+    ctx.quad_changed_count.zero_()
     ctx.state_changed_count.zero_()
 
   _update_constraint(m, d, ctx, track_changes=incremental, stable_fast=stable_fast)

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -773,7 +773,9 @@ def _compute_efc_eval_pt_3alphas_elliptic(
 
 
 @cache_kernel
-def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, fuse_jv: bool, is_sparse: bool):
+def _linesearch_iterative_kernel(
+  ls_iterations: int, cone_type: types.ConeType, fuse_jv: bool, is_sparse: bool, track_exhaustion: bool
+):
   """Factory for iterative linesearch kernel.
 
   Args:
@@ -781,10 +783,12 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
     cone_type: Friction cone type (PYRAMIDAL or ELLIPTIC) for compile-time optimization.
     fuse_jv: Whether to compute jv = J @ search in-kernel (efficient for small nv).
     is_sparse: Use sparse matrix representation for constraint Jacobian.
+    track_exhaustion: Flag exhausted search rays (only useful when the fast path is on).
   """
   LS_ITERATIONS = ls_iterations
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
   FUSE_JV = fuse_jv
+  TRACK_EXHAUSTION = track_exhaustion
   IS_SPARSE = is_sparse
 
   # Native snippet for CUDA __syncthreads()
@@ -986,7 +990,8 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
           quad2,
         )
         local_p0 += pt
-        local_q1_abs += wp.abs(pt[1])
+        if wp.static(TRACK_EXHAUSTION):
+          local_q1_abs += wp.abs(pt[1])
       else:
         # direct evaluation for pyramidal cones (no intermediate quad)
         pt = _compute_efc_eval_pt_alpha_zero(
@@ -999,15 +1004,19 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
           ctx_jv_in[worldid, efcid],
         )
         local_p0 += pt
-        local_q1_abs += wp.abs(pt[1])
+        if wp.static(TRACK_EXHAUSTION):
+          local_q1_abs += wp.abs(pt[1])
 
     # at this point, every thread has computed some contributions to p0 in local_p0
     # we now create a tile of all local_p0 contributions and reduce them to a single value
     # this is done in parallel using a tile reduction
     p0_tile = wp.tile(local_p0, preserve_type=True)
     p0_sum = wp.tile_reduce(wp.add, p0_tile)
-    q1_abs_tile = wp.tile(local_q1_abs)
-    q1_abs_sum = wp.tile_reduce(wp.add, q1_abs_tile)
+    q1_abs = float(0.0)
+    if wp.static(TRACK_EXHAUSTION):
+      q1_abs_tile = wp.tile(local_q1_abs)
+      q1_abs_sum = wp.tile_reduce(wp.add, q1_abs_tile)
+      q1_abs = q1_abs_sum[0]
 
     # quad_gauss = [0, search.T @ Ma - search.T @ qfrc_smooth, 0.5 * search.T @ mv]
     local_gauss = wp.vec2(0.0)
@@ -1026,7 +1035,6 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
     # add quad_gauss contribution to p0
     p0 = wp.vec3(ctx_quad_gauss[0], ctx_quad_gauss[1], 2.0 * ctx_quad_gauss[2]) + p0_sum[0]
     p0_delta = wp.vec3(0.0, p0[1], p0[2])
-    q1_abs = q1_abs_sum[0] + wp.abs(ctx_quad_gauss[1])
 
     # lo_in at lo_alpha_in = -p0[1] / p0[2]
     lo_alpha_in = -math.safe_div(p0[1], p0[2])
@@ -1254,8 +1262,10 @@ def _linesearch_iterative_kernel(ls_iterations: int, cone_type: types.ConeType, 
       # ~eps * q1_abs, so roots below eps * q1_abs / p0[2] (and never below
       # 8 ulps of the unit ray anchor) are noise, not descent: the stale ray
       # is exhausted and the fast path must rebuild this world.
-      noise_floor = _ALPHA_NOISE_EPS * wp.max(1.0, math.safe_div(q1_abs, p0[2]))
-      ctx_ray_exhausted_out[worldid] = wp.abs(alpha) < noise_floor
+      if wp.static(TRACK_EXHAUSTION):
+        total_q1_abs = q1_abs + wp.abs(ctx_quad_gauss[1])
+        noise_floor = _ALPHA_NOISE_EPS * wp.max(1.0, math.safe_div(total_q1_abs, p0[2]))
+        ctx_ray_exhausted_out[worldid] = wp.abs(alpha) < noise_floor
 
   return kernel
 
@@ -1270,7 +1280,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
     fuse_jv: Whether jv is computed in-kernel (True) or pre-computed (False).
   """
   wp.launch_tiled(
-    _linesearch_iterative_kernel(m.opt.ls_iterations, m.opt.cone, fuse_jv, m.is_sparse),
+    _linesearch_iterative_kernel(m.opt.ls_iterations, m.opt.cone, fuse_jv, m.is_sparse, _use_incremental(m)),
     dim=d.nworld,
     inputs=[
       m.nv,

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -3590,6 +3590,17 @@ def _stable_fast(m: types.Model, compact: bool) -> bool:
   return _use_incremental(m) and not compact
 
 
+@wp.kernel
+def _zero_change_counters(
+  # Out:
+  quad_changed_count_out: wp.array[int],
+  state_changed_count_out: wp.array[int],
+):
+  worldid = wp.tid()
+  quad_changed_count_out[worldid] = 0
+  state_changed_count_out[worldid] = 0
+
+
 @event_scope
 def _solver_iteration(
   m: types.Model,
@@ -3613,8 +3624,11 @@ def _solver_iteration(
 
   if incremental:
     # Must complete before _update_constraint_efc which atomically increments.
-    ctx.quad_changed_count.zero_()
-    ctx.state_changed_count.zero_()
+    wp.launch(
+      _zero_change_counters,
+      dim=d.nworld,
+      outputs=[ctx.quad_changed_count, ctx.state_changed_count],
+    )
 
   _update_constraint(m, d, ctx, track_changes=incremental, stable_fast=stable_fast)
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1548,6 +1548,7 @@ def _update_constraint_efc(track_changes: bool):
     nacon_in: wp.array[int],
     # In:
     ctx_Jaref_in: wp.array2d[float],
+    ctx_alpha_in: wp.array[float],
     ctx_done_in: wp.array[bool],
     # Data out:
     efc_force_out: wp.array2d[float],
@@ -1559,10 +1560,16 @@ def _update_constraint_efc(track_changes: bool):
   ):
     worldid, efcid = wp.tid()
 
-    if efcid >= nefc_in[worldid]:
+    if ctx_done_in[worldid]:
       return
 
-    if ctx_done_in[worldid]:
+    # A vanishing linesearch step means the stale search ray is exhausted;
+    # count it as a state change so the fast path rebuilds this world.
+    if wp.static(TRACK_CHANGES):
+      if efcid == 0 and wp.abs(ctx_alpha_in[worldid]) < _STABLE_FAST_MIN_ALPHA:
+        wp.atomic_add(state_changed_count_out, worldid, 1)
+
+    if efcid >= nefc_in[worldid]:
       return
 
     # Read old state before overwriting
@@ -1859,6 +1866,7 @@ def _update_constraint(
     d.efc.frictionloss,
     d.nacon,
     ctx.Jaref,
+    ctx.alpha if isinstance(ctx, SolverContext) else d.time,
     ctx.done,
   ]
 
@@ -3543,6 +3551,16 @@ def _solve_done(
     # mark this world as done and remove it from the number of unconverged worlds
     ctx_done_out[worldid] = True
     wp.atomic_add(nsolving_out, 0, -1)
+
+
+# For a world with no state flips the problem is quadratic and the exact
+# linesearch step along the stale Newton ray equals the remaining ray fraction
+# (t* = grad_scale, with the minimizer at grad_scale = 0). Steps below ~8 ulp
+# of the unit ray anchor are float32 rounding noise: the ray's reachable
+# gradient is floored at ~eps * |grad at rebuild|, and if the tolerance sits
+# below that floor the world could never terminate on this ray. Rebuilding
+# re-anchors the arithmetic at the current (much smaller) gradient scale.
+_STABLE_FAST_MIN_ALPHA = 8.0 * 1.1920929e-07  # 8 * float32 eps
 
 
 def _use_incremental(m: types.Model) -> bool:

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -726,8 +726,10 @@ class SolverFastPathTest(parameterized.TestCase):
     wp.copy(d.qvel, wp.array(qvel, dtype=float))
 
     max_rel = 0.0
+    cap_steps = 0
     for _ in range(100):
       mjw.step(m, d)
+      cap_steps += int(d.solver_niter.numpy().max() >= mjm.opt.iterations)
       nefc = d.nefc.numpy()
       J = d.efc.J.numpy()
       force = d.efc.force.numpy()
@@ -740,6 +742,10 @@ class SolverFastPathTest(parameterized.TestCase):
         scale = max(np.abs(ref).max(), 1.0)
         max_rel = max(max_rel, np.abs(ref - got[w]).max() / scale)
     self.assertLess(max_rel, 1e-4, f"qfrc_constraint inconsistent with J^T f: rel {max_rel:.3e}")
+    # Friction chatter legitimately caps a couple of steps here even with full
+    # per-iteration rebuilds; an exhausted stale ray that never re-anchors spins
+    # to the cap on most steps (warmstart is off, so every solve starts far away).
+    self.assertLess(cap_steps, 20, f"solver stalled: {cap_steps}/100 steps hit the iteration cap")
 
 
 # Basic weld constraint model.

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -685,6 +685,63 @@ class SolverTest(parameterized.TestCase):
     self.assertTrue(total_any_changes, "no state changes detected across any keyframe")
 
 
+_FRICTION_CHAIN_XML = """
+<mujoco>
+  <option timestep="0.01" solver="Newton" cone="pyramidal" jacobian="dense">
+    <flag warmstart="disable"/>
+  </option>
+  <worldbody>
+    <body>
+      <joint type="hinge" axis="0 1 0" frictionloss="1.5"/>
+      <geom type="capsule" size="0.02" fromto="0 0 0 0.2 0 0" mass="1"/>
+      <body pos="0.2 0 0">
+        <joint type="hinge" axis="0 1 0" frictionloss="0.8"/>
+        <geom type="capsule" size="0.02" fromto="0 0 0 0.2 0 0" mass="0.5"/>
+        <body pos="0.2 0 0">
+          <joint type="hinge" axis="1 0 0" frictionloss="2.0"/>
+          <geom type="capsule" size="0.02" fromto="0 0 0 0.15 0 0" mass="0.3"/>
+          <body pos="0.15 0 0">
+            <joint type="hinge" axis="0 1 0" frictionloss="0.5"/>
+            <geom type="capsule" size="0.02" fromto="0 0 0 0.1 0 0" mass="0.2"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+class SolverFastPathTest(parameterized.TestCase):
+  def test_fast_path_friction_transitions(self):
+    """qfrc_constraint must stay consistent when friction rows cross linear zones."""
+    mjm = mujoco.MjModel.from_xml_string(_FRICTION_CHAIN_XML)
+    mjd = mujoco.MjData(mjm)
+    mujoco.mj_forward(mjm, mjd)
+    m = mjw.put_model(mjm)
+    nworld = 64
+    d = mjw.put_data(mjm, mjd, nworld=nworld)
+    rng = np.random.default_rng(3)
+    qvel = rng.uniform(-8.0, 8.0, size=(nworld, mjm.nv)).astype(np.float32)
+    wp.copy(d.qvel, wp.array(qvel, dtype=float))
+
+    max_rel = 0.0
+    for _ in range(100):
+      mjw.step(m, d)
+      nefc = d.nefc.numpy()
+      J = d.efc.J.numpy()
+      force = d.efc.force.numpy()
+      got = d.qfrc_constraint.numpy()
+      for w in range(nworld):
+        n = nefc[w]
+        if n == 0:
+          continue
+        ref = J[w, :n, : mjm.nv].astype(np.float64).T @ force[w, :n].astype(np.float64)
+        scale = max(np.abs(ref).max(), 1.0)
+        max_rel = max(max_rel, np.abs(ref - got[w]).max() / scale)
+    self.assertLess(max_rel, 1e-4, f"qfrc_constraint inconsistent with J^T f: rel {max_rel:.3e}")
+
+
 # Basic weld constraint model.
 _WELD_XML = """
 <mujoco>

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -655,23 +655,23 @@ class SolverTest(parameterized.TestCase):
         for _ in range(m.opt.iterations):
           solver._linesearch(m, d, ctx)
           if track:
-            ctx.changed_efc_count.zero_()
+            ctx.quad_changed_count.zero_()
           solver._update_constraint(m, d, ctx, track_changes=track)
           if track:
             wp.synchronize()
-            if np.any(ctx.changed_efc_count.numpy() > 0):
+            if np.any(ctx.quad_changed_count.numpy() > 0):
               any_changes = True
           update_fn(m, d, ctx)
           wp.launch(
             solver._solve_zero_search_dot(False),
             dim=(d.nworld),
-            inputs=[ctx.changed_efc_count, ctx.done],
+            inputs=[ctx.quad_changed_count, ctx.done],
             outputs=[ctx.search_dot],
           )
           wp.launch(
             solver._solve_search_update(False),
             dim=(d.nworld, m.nv),
-            inputs=[m.opt.solver, ctx.changed_efc_count, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
+            inputs=[m.opt.solver, ctx.quad_changed_count, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
             outputs=[ctx.search, ctx.search_dot],
           )
         return d.qacc.numpy().copy(), any_changes

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -727,7 +727,7 @@ class SolverFastPathTest(parameterized.TestCase):
 
     max_rel = 0.0
     cap_steps = 0
-    for _ in range(100):
+    for _ in range(20):
       mjw.step(m, d)
       cap_steps += int(d.solver_niter.numpy().max() >= mjm.opt.iterations)
       nefc = d.nefc.numpy()
@@ -745,7 +745,7 @@ class SolverFastPathTest(parameterized.TestCase):
     # Friction chatter legitimately caps a couple of steps here even with full
     # per-iteration rebuilds; an exhausted stale ray that never re-anchors spins
     # to the cap on most steps (warmstart is off, so every solve starts far away).
-    self.assertLess(cap_steps, 20, f"solver stalled: {cap_steps}/100 steps hit the iteration cap")
+    self.assertLess(cap_steps, 5, f"solver stalled: {cap_steps}/20 steps hit the iteration cap")
 
 
 # Basic weld constraint model.

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -665,13 +665,13 @@ class SolverTest(parameterized.TestCase):
           wp.launch(
             solver._solve_zero_search_dot(False),
             dim=(d.nworld),
-            inputs=[ctx.quad_changed_count, ctx.done],
+            inputs=[ctx.state_changed_count, ctx.done],
             outputs=[ctx.search_dot],
           )
           wp.launch(
             solver._solve_search_update(False),
             dim=(d.nworld, m.nv),
-            inputs=[m.opt.solver, ctx.quad_changed_count, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
+            inputs=[m.opt.solver, ctx.state_changed_count, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
             outputs=[ctx.search, ctx.search_dot],
           )
         return d.qacc.numpy().copy(), any_changes

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2334,8 +2334,8 @@ class InverseContext:
   Jaref: wp.array2d[float]
   search_dot: wp.array[float]
   done: wp.array[bool]
-  changed_efc_ids: wp.array2d[int]
-  changed_efc_count: wp.array[int]
+  quad_changed_ids: wp.array2d[int]
+  quad_changed_count: wp.array[int]
 
 
 @dataclasses.dataclass
@@ -2354,6 +2354,7 @@ class SolverContext:
   quad: wp.array2d[wp.vec3]
   alpha: wp.array[float]
   grad_scale: wp.array[float]
+  # rows with any piecewise-state change this iteration (gradient rebuild needed)
   state_changed_count: wp.array[int]
   improvement: wp.array[float]
   prev_grad: wp.array2d[float]
@@ -2363,8 +2364,9 @@ class SolverContext:
   h: wp.array3d[float]
   hfactor: wp.array3d[float]
   # Incremental Hessian update (Newton only)
-  changed_efc_ids: wp.array2d[int]
-  changed_efc_count: wp.array[int]
+  # rows whose QUADRATIC membership flipped this iteration (Hessian delta needed)
+  quad_changed_ids: wp.array2d[int]
+  quad_changed_count: wp.array[int]
 
 
 @dataclasses.dataclass

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2337,7 +2337,7 @@ class InverseContext:
   quad_changed_ids: wp.array2d[int]
   quad_changed_count: wp.array[int]
   state_changed_count: wp.array[int]
-  ray_exhausted: wp.array[bool]
+  ls_exhausted: wp.array[bool]
 
 
 @dataclasses.dataclass
@@ -2356,19 +2356,15 @@ class SolverContext:
   quad: wp.array2d[wp.vec3]
   alpha: wp.array[float]
   grad_scale: wp.array[float]
-  # rows with any piecewise-state change this iteration (gradient rebuild needed)
   state_changed_count: wp.array[int]
   improvement: wp.array[float]
-  # accepted linesearch step was below its arithmetic noise floor (stale ray exhausted)
-  ray_exhausted: wp.array[bool]
+  ls_exhausted: wp.array[bool]
   prev_grad: wp.array2d[float]
   prev_Mgrad: wp.array2d[float]
   beta: wp.array[float]
   beta_den: wp.array[float]
   h: wp.array3d[float]
   hfactor: wp.array3d[float]
-  # Incremental Hessian update (Newton only)
-  # rows whose QUADRATIC membership flipped this iteration (Hessian delta needed)
   quad_changed_ids: wp.array2d[int]
   quad_changed_count: wp.array[int]
 

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2337,6 +2337,7 @@ class InverseContext:
   quad_changed_ids: wp.array2d[int]
   quad_changed_count: wp.array[int]
   state_changed_count: wp.array[int]
+  ray_exhausted: wp.array[bool]
 
 
 @dataclasses.dataclass
@@ -2358,6 +2359,8 @@ class SolverContext:
   # rows with any piecewise-state change this iteration (gradient rebuild needed)
   state_changed_count: wp.array[int]
   improvement: wp.array[float]
+  # accepted linesearch step was below its arithmetic noise floor (stale ray exhausted)
+  ray_exhausted: wp.array[bool]
   prev_grad: wp.array2d[float]
   prev_Mgrad: wp.array2d[float]
   beta: wp.array[float]

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2354,6 +2354,7 @@ class SolverContext:
   quad: wp.array2d[wp.vec3]
   alpha: wp.array[float]
   grad_scale: wp.array[float]
+  state_changed_count: wp.array[int]
   improvement: wp.array[float]
   prev_grad: wp.array2d[float]
   prev_Mgrad: wp.array2d[float]

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2336,6 +2336,7 @@ class InverseContext:
   done: wp.array[bool]
   quad_changed_ids: wp.array2d[int]
   quad_changed_count: wp.array[int]
+  state_changed_count: wp.array[int]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
The stable-state fast path from #1493 skips recomputing the gradient, search direction, and Cholesky solve for worlds whose constraint states did not change during an iteration, on the premise that such a step stayed exactly quadratic and the cached quantities remain valid up to a scalar. Two kinds of change escaped that detection, so the affected worlds kept iterating with a stale gradient.

First, friction transitions. The fast path watched only the counter of rows whose QUADRATIC state flipped, which is the right set for the incremental Hessian update but not for the gradient: a frictionloss row crossing between its two linear force zones changes its force by 2*frictionloss while the quadratic flag and the Hessian stay put. The stale gradient desyncs qfrc_constraint from J^T efc_force and can leave worlds unable to converge. The fix tracks any per-row state change in a second per-world counter and gates all gradient/search/solve skips on it, while the quadratic-flip list keeps driving the incremental Hessian update; worlds whose only transitions were between the friction linear zones rebuild the gradient but reuse the cached factorization. The two counters coincide on models without friction rows.

Second, linesearch stagnation. After skipped iterations the search direction is still the one computed at the last rebuild, and the linesearch's float32 bracketing arithmetic cannot resolve steps below eps times its gross derivative magnitude over the ray curvature. A world whose tolerance lies below that floor accepts noise-sized steps forever and runs to the iteration cap, and since the solver iterates under one conditional graph, that world holds the whole batch for all 100 iterations. This could not happen before the fast path existed, because rebuilding every iteration re-anchors the arithmetic at the current gradient scale. The linesearch now computes its per-world noise floor (eps * |q1| / p''(0), never below 8 ulps of the unit step, with the gross derivative magnitude bounded via Cauchy-Schwarz from sums the linesearch already reduces, so no per-row work is added) and flags a world whose accepted step falls below it; the flag counts as a state change, so the next iteration rebuilds from the actual constraint state and either resumes real progress or terminates through the normal convergence criteria. The trigger can only add a rebuild, never end a solve early. The easiest reproduction is friction plus disabled warmstart at default tolerance: every solve then starts far from the solution, and without the fix the friction-chain regression test spins to the cap on 79 of 100 steps (2 of 100 with it, matching what full per-iteration rebuilds also produce through ordinary friction chatter). The tracking is compiled out of configurations that never skip rebuilds (elliptic, CG), whose linesearch is unchanged.

The regression test rolls out a friction chain with warmstart disabled and asserts both properties: qfrc_constraint stays consistent with J^T efc_force each step (fails at relative error 1.07 without the transition fix), and the number of cap-hitting steps stays bounded. The change also renames the change counters so the two sets are self-documenting, and fuses the per-iteration counter zeroing into one kernel.

Benchmarks on RTX PRO 6000: total GPU kernel time under nsys (CUDA 12.9) over 1000-step mjwarp-testspeed rollouts, main da4d7ba6 vs this PR measured back to back per benchmark:

| benchmark | total GPU time | solver iterations/step |
|---|---|---|
| three_humanoids | 4854 -> 4755 ms (-2.0%) | 2.58195 -> 2.58156 |
| unitree_g1_flat | 2223 -> 2243 ms (+0.9%) | 4.36732 -> 4.36736 |
| humanoid | 964 -> 965 ms (+0.05%) | 1.94396 -> 1.94421 |
| aloha_pot | 2793 -> 2732 ms (-2.2%) | 1.44555 -> 1.44552 |
| aloha_clutter | 20756 -> 20786 ms (+0.1%) | 1.06712 -> 1.06712 |

Solver iteration statistics are identical to four decimals everywhere. The aloha_pot row is a built-in control: its two builds compile identical kernels (elliptic disables the fast path), so its -2.2% is pure per-pair scatter — on trajectory-sensitive benchmarks the conditional solver graph re-rolls its iteration count from run to run (pot executed the linesearch 6833 vs 6702 times), and total GPU time inherits that, which also covers three_humanoids' -2.0%. The trajectory-stable benchmarks read +0.05% (humanoid) and +0.1% (aloha_clutter), and unitree_g1_flat's repeated pairs across the day (-0.4%, -0.1%, +0.9%) bracket zero. The only per-kernel residuals attributable to the change are +0.1us on the linesearch median (noise-floor epilogue) and +0.4us on the incremental-Cholesky gate median (the second counter read).