### PR TITLE
Fix GJK termination and distance reporting for float32

### DIFF
--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -273,8 +273,12 @@ def _linear_combine(n: int, scl: wp.vec4, mat: mat43) -> wp.vec3:
 
 
 @wp.func
-def _almost_equal(v1: wp.vec3, v2: wp.vec3) -> bool:
-  return wp.abs(v1[0] - v2[0]) < MINVAL and wp.abs(v1[1] - v2[1]) < MINVAL and wp.abs(v1[2] - v2[2]) < MINVAL
+def _almost_equal(v1: wp.vec3, v2: wp.vec3, tolerance: float) -> bool:
+  # no-progress check at the caller's tolerance: mjMINVAL (1e-15) is calibrated
+  # for float64 and can only fire on bitwise equality in float32, making
+  # termination depend on reaching an exact fixed point
+  tol = tolerance * wp.max(1.0, wp.max(wp.abs(v1[0]), wp.max(wp.abs(v1[1]), wp.abs(v1[2]))))
+  return wp.abs(v1[0] - v2[0]) < tol and wp.abs(v1[1] - v2[1]) < tol and wp.abs(v1[2] - v2[2]) < tol
 
 
 @wp.func
@@ -708,8 +712,6 @@ def gjk(
 
     # remove vertices from the simplex no longer needed
     n = int(0)
-    lmbdamax = float(-1.0)
-    imax = int(-1)
     for i in range(4):
       if lmbda[i] == 0.0:
         continue
@@ -720,26 +722,17 @@ def gjk(
       simplex_index1[n] = simplex_index1[i]
       simplex_index2[n] = simplex_index2[i]
       lmbda[n] = lmbda[i]
-      imax = wp.where(lmbda[n] > lmbdamax, n, imax)
-      lmbdamax = wp.where(lmbda[n] > lmbdamax, lmbda[n], lmbdamax)
       n += int(1)
 
     # SHOULD NOT OCCUR
     if n < 1:
       break
 
-    lmbda[imax] = 1.0
-    acc = float(0.0)
-    for i in range(n):
-      if i != imax:
-        acc += lmbda[i]
-    lmbda[imax] -= acc
-
     # get the next iteration of x_k
     x_next = _linear_combine(n, lmbda, simplex)
 
     # x_k has converged to minimum
-    if _almost_equal(x_next, x_k):
+    if _almost_equal(x_next, x_k, tolerance):
       break
 
     # copy next iteration into x_k
@@ -757,7 +750,10 @@ def gjk(
   # are the witness points
   result.x1 = wp.where(n == 0, x1_0, _linear_combine(n, lmbda, simplex1))
   result.x2 = wp.where(n == 0, x2_0, _linear_combine(n, lmbda, simplex2))
-  result.dist = xnorm
+  # xnorm can be one iteration stale when the loop exhausts its iterations;
+  # the witness points correspond to the final x_k, so recompute its norm
+  # (n == 4 encloses the origin and forces zero distance)
+  result.dist = wp.where(n == 4, 0.0, wp.norm_l2(x_k))
 
   result.dim = n
   result.simplex1 = simplex1


### PR DESCRIPTION
Since #1503, test_sphere_mesh_margin and test_box_box_ccd fail on CUDA (7.1mm distance error and lost multiccd contacts respectively). CI stays green because the runners are CPU-only. This PR fixes the failures; the mechanism was isolated with per-exit instrumentation on a sphere-mesh case with an exact analytic answer.

Three things interact. First, the no-progress check compares x_next to x_k against mjMINVAL (1e-15), which is calibrated for float64: in float32 it sits below one ulp of any relevant magnitude, so it can only fire on bitwise equality. Since the Frank-Wolfe termination runs with epsilon = 0 for discrete pairs, this check is the only exit for separated discrete geoms, and on CUDA (where FMA contraction leaves a one-ulp oscillation at the fixed point) those pairs run all the way to iteration exhaustion. The CPU backend happens to land on an exact fixed point and terminates at iteration 4, which is why the failures are GPU-only. The check now scales the caller's tolerance by the iterate's magnitude.

Second, on exhaustion the reported distance comes from xnorm, which is assigned before x_k's final update, so it is one iteration staler than the witness points. The distance is now recomputed from the final iterate, keeping the exact zero on the origin-enclosed exit (the loop forces xnorm = 0 there, and the dist > tolerance gate in front of EPA relies on intersecting pairs not reporting a cancellation residual).

Third, the barycentric renormalization added in #1503 redistributes rounding residuals into the largest coordinate every iteration. As far as I can tell the coordinates already sum to one by construction (lambda_i = C4_i / m_det with m_det the cofactor sum), and MuJoCo's subdistance doesn't renormalize, so the block only perturbs lambda at rounding level; doing that every iteration keeps the iterate jiggling, the Frank-Wolfe gap never meets its tolerance, and the sphere-mesh case runs to exhaustion (35 iterations instead of 4). It also isn't neutralized by the other two fixes: with both in place, restoring the renormalization still fails two tests on CUDA. This PR removes it, but I may be missing the case that motivated it, so if there is one, I'm happy to rework this part.

The direction heuristic and termination changes from #1503 are kept. All 24 collision_gjk tests and the full suite pass on both CUDA and CPU, including the MJC-aligned test_box_box_max2 value.
