### PR TITLE
Preserve small elliptic line-search deltas

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -260,97 +260,52 @@ def _eval_frictionloss_pt_3alphas(
 
 
 @wp.func
-def _eval_elliptic(
-  # In:
-  mu: float,
-  quad: wp.vec3,
-  quad1: wp.vec3,
-  quad2: wp.vec3,
-  alpha: float,
-) -> wp.vec3:
-  u0 = quad1[0]
-  v0 = quad1[1]
-  uu = quad1[2]
-  uv = quad2[0]
-  vv = quad2[1]
-  dm = quad2[2]
-
-  # compute N, Tsqr
-  N = u0 + alpha * v0
-  Tsqr = uu + alpha * (2.0 * uv + alpha * vv)
-
-  # no tangential force: top or bottom zone
-  if Tsqr <= 0.0:
-    # bottom zone: quadratic cost
-    if N < 0.0:
-      return _eval_pt(quad, alpha)
-
-    # top zone: nothing to do
-  # otherwise regular processing
-  else:
-    # tangential force
-    T = wp.sqrt(Tsqr)
-
-    # N >= mu * T : top zone
-    if N >= mu * T:
-      # nothing to do
-      pass
-    # mu * N + T <= 0 : bottom zone
-    elif mu * N + T <= 0.0:
-      return _eval_pt(quad, alpha)
-
-    # otherwise middle zone
-    else:
-      # derivatives
-      N1 = v0
-      T1 = (uv + alpha * vv) / T
-      T2 = vv / T - (uv + alpha * vv) * T1 / (T * T)
-
-      # add to cost
-      cost = wp.vec3(
-        0.5 * dm * (N - mu * T) * (N - mu * T),
-        dm * (N - mu * T) * (N1 - mu * T1),
-        dm * ((N1 - mu * T1) * (N1 - mu * T1) + (N - mu * T) * (-mu * T2)),
-      )
-
-      return cost
-
-  return wp.vec3(0.0, 0.0, 0.0)
-
-
-@wp.func
 def _eval_elliptic_reference(
   # In:
   mu: float,
   quad: wp.vec3,
   quad1: wp.vec3,
   quad2: wp.vec3,
-) -> tuple[float, float, int]:
+) -> tuple[float, float, float, int]:
   u0 = quad1[0]
   uu = quad1[2]
   dm = quad2[2]
 
   if uu <= 0.0:
     if u0 < 0.0:
-      return quad[0], 0.0, int(types.ConstraintState.QUADRATIC)
-    return 0.0, 0.0, int(types.ConstraintState.SATISFIED)
+      return quad[0], 0.0, 0.0, int(types.ConstraintState.QUADRATIC)
+    return 0.0, 0.0, 0.0, int(types.ConstraintState.SATISFIED)
 
   T0 = wp.sqrt(uu)
   if u0 >= mu * T0:
-    return 0.0, T0, int(types.ConstraintState.SATISFIED)
+    return 0.0, T0, 0.0, int(types.ConstraintState.SATISFIED)
   if mu * u0 + T0 <= 0.0:
-    return quad[0], T0, int(types.ConstraintState.QUADRATIC)
+    return quad[0], T0, 0.0, int(types.ConstraintState.QUADRATIC)
 
   r0 = u0 - mu * T0
-  return 0.5 * dm * r0 * r0, T0, int(types.ConstraintState.CONE)
+  return 0.5 * dm * r0 * r0, T0, r0, int(types.ConstraintState.CONE)
+
+
+@wp.func
+def _eval_elliptic_alpha_zero(mu: float, quad: wp.vec3, quad1: wp.vec3, quad2: wp.vec3) -> wp.vec3:
+  cost0, T0, r0, state0 = _eval_elliptic_reference(mu, quad, quad1, quad2)
+  if state0 == int(types.ConstraintState.QUADRATIC):
+    return _eval_pt(quad, 0.0)
+  if state0 == int(types.ConstraintState.CONE):
+    T1 = quad2[0] / T0
+    T2 = (quad2[1] - T1 * T1) / T0
+    r1 = quad1[1] - mu * T1
+    dm = quad2[2]
+    return wp.vec3(cost0, dm * r0 * r1, dm * (r1 * r1 - mu * r0 * T2))
+  return wp.vec3(0.0)
 
 
 @wp.func
 def _eval_elliptic_quadratic_shifted(quad: wp.vec3, alpha: float, cost0: float, state0: int) -> wp.vec3:
   aq2 = alpha * quad[2]
-  cost = alpha * aq2 + alpha * quad[1] + quad[0] - cost0
-  if state0 == int(types.ConstraintState.QUADRATIC):
-    cost = alpha * (aq2 + quad[1])
+  cost = alpha * (aq2 + quad[1])
+  if state0 != int(types.ConstraintState.QUADRATIC):
+    cost += quad[0] - cost0
   return wp.vec3(cost, 2.0 * aq2 + quad[1], 2.0 * quad[2])
 
 
@@ -364,6 +319,7 @@ def _eval_elliptic_shifted(
   alpha: float,
   cost0: float,
   T0: float,
+  r0: float,
   state0: int,
 ) -> wp.vec3:
   u0 = quad1[0]
@@ -387,19 +343,18 @@ def _eval_elliptic_shifted(
     elif mu * N + T <= 0.0:
       return _eval_elliptic_quadratic_shifted(quad, alpha, cost0, state0)
     else:
-      N1 = v0
       T1 = (uv + alpha * vv) / T
-      T2 = vv / T - (uv + alpha * vv) * T1 / (T * T)
+      T2 = (vv - T1 * T1) / T
       r = N - mu * T
-      r1 = N1 - mu * T1
+      r1 = v0 - mu * T1
 
-      cost = 0.5 * dm * r * r - cost0
       if state0 == int(types.ConstraintState.CONE):
         # Rationalize T - T0 before forming the small cone residual change.
         T_delta = Tsqr_delta / (T + T0)
         r_delta = alpha * v0 - mu * T_delta
-        r0 = u0 - mu * T0
         cost = 0.5 * dm * r_delta * (2.0 * r0 + r_delta)
+      else:
+        cost = 0.5 * dm * r * r - cost0
 
       return wp.vec3(
         cost,
@@ -543,8 +498,8 @@ def _compute_efc_eval_pt_elliptic(
       if efcid != efc_address0:  # Not primary row
         return wp.vec3(0.0)
       mu = contact_friction[0] * impratio_invsqrt
-      cost0, T0, state0 = _eval_elliptic_reference(mu, ctx_quad, quad1, quad2)
-      return _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, alpha, cost0, T0, state0)
+      cost0, T0, r0, state0 = _eval_elliptic_reference(mu, ctx_quad, quad1, quad2)
+      return _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, alpha, cost0, T0, r0, state0)
 
     # Limit/other constraint — direct eval (no quad read)
     x = ctx_Jaref + alpha * ctx_jv
@@ -624,7 +579,7 @@ def _compute_efc_eval_pt_alpha_zero_elliptic(
       if efcid != efc_address0:  # Not primary row
         return wp.vec3(0.0)
       mu = contact_friction[0] * impratio_invsqrt
-      return _eval_elliptic(mu, ctx_quad, quad1, quad2, 0.0)
+      return _eval_elliptic_alpha_zero(mu, ctx_quad, quad1, quad2)
 
     # Limit/other constraint — direct eval (no quad read)
     if ctx_Jaref < 0.0:
@@ -720,11 +675,6 @@ def _compute_efc_eval_pt_3alphas_elliptic(
   Returns a tuple of 3 vec3s for (lo_alpha, hi_alpha, mid_alpha).
   Constraint types checked in order: contact elliptic/limit/other -> friction -> equality.
   """
-  # x = search point, needed for friction and limit constraints
-  x_lo = ctx_Jaref + lo_alpha * ctx_jv
-  x_hi = ctx_Jaref + hi_alpha * ctx_jv
-  x_mid = ctx_Jaref + mid_alpha * ctx_jv
-
   # Contact/limit/other constraints
   if efcid >= ne + nf:
     # Contact elliptic: uses special elliptic cone evaluation
@@ -732,14 +682,17 @@ def _compute_efc_eval_pt_3alphas_elliptic(
       if efcid != efc_address0:  # secondary rows contribute nothing
         return (wp.vec3(0.0), wp.vec3(0.0), wp.vec3(0.0))
       mu = contact_friction[0] * impratio_invsqrt
-      cost0, T0, state0 = _eval_elliptic_reference(mu, ctx_quad, quad1, quad2)
+      cost0, T0, r0, state0 = _eval_elliptic_reference(mu, ctx_quad, quad1, quad2)
       return (
-        _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, lo_alpha, cost0, T0, state0),
-        _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, hi_alpha, cost0, T0, state0),
-        _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, mid_alpha, cost0, T0, state0),
+        _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, lo_alpha, cost0, T0, r0, state0),
+        _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, hi_alpha, cost0, T0, r0, state0),
+        _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, mid_alpha, cost0, T0, r0, state0),
       )
 
     # Limit/other constraints — direct eval (no quad read)
+    x_lo = ctx_Jaref + lo_alpha * ctx_jv
+    x_hi = ctx_Jaref + hi_alpha * ctx_jv
+    x_mid = ctx_Jaref + mid_alpha * ctx_jv
     efc_D = efc_D_in[efcid]
     quad0 = _eval_pt_direct_cost_alpha_zero(ctx_Jaref, efc_D)
     cost0 = wp.where(ctx_Jaref < 0.0, quad0, 0.0)
@@ -755,6 +708,9 @@ def _compute_efc_eval_pt_3alphas_elliptic(
 
   # Friction constraint - load D and frictionloss only here
   if efcid >= ne:
+    x_lo = ctx_Jaref + lo_alpha * ctx_jv
+    x_hi = ctx_Jaref + hi_alpha * ctx_jv
+    x_mid = ctx_Jaref + mid_alpha * ctx_jv
     efc_D = efc_D_in[efcid]
     f = efc_frictionloss[efcid]
     rf = math.safe_div(f, efc_D)

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -292,8 +292,9 @@ def _eval_elliptic_alpha_zero(mu: float, quad: wp.vec3, quad1: wp.vec3, quad2: w
   if state0 == int(types.ConstraintState.QUADRATIC):
     return _eval_pt(quad, 0.0)
   if state0 == int(types.ConstraintState.CONE):
-    T1 = quad2[0] / T0
-    T2 = (quad2[1] - T1 * T1) / T0
+    T0_inv = 1.0 / T0
+    T1 = quad2[0] * T0_inv
+    T2 = (quad2[1] - T1 * T1) * T0_inv
     r1 = quad1[1] - mu * T1
     dm = quad2[2]
     return wp.vec3(cost0, dm * r0 * r1, dm * (r1 * r1 - mu * r0 * T2))
@@ -363,8 +364,9 @@ def _eval_elliptic_shifted(
     elif mu * N + T <= 0.0:
       return _eval_elliptic_quadratic_shifted(mu, quad, alpha, N, Tsqr, u0, T0, dm, state0)
     else:
-      T1 = (uv + alpha * vv) / T
-      T2 = (vv - T1 * T1) / T
+      T_inv = 1.0 / T
+      T1 = (uv + alpha * vv) * T_inv
+      T2 = (vv - T1 * T1) * T_inv
       r = N - mu * T
       r1 = v0 - mu * T1
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -301,11 +301,31 @@ def _eval_elliptic_alpha_zero(mu: float, quad: wp.vec3, quad1: wp.vec3, quad2: w
 
 
 @wp.func
-def _eval_elliptic_quadratic_shifted(quad: wp.vec3, alpha: float, cost0: float, state0: int) -> wp.vec3:
+def _eval_elliptic_quadratic_cone_gap(mu: float, N: float, T: float, dm: float) -> float:
+  """Return quadratic cost minus cone cost at the same point."""
+  boundary = mu * N + T
+  return 0.5 * dm * boundary * boundary
+
+
+@wp.func
+def _eval_elliptic_quadratic_shifted(
+  # In:
+  mu: float,
+  quad: wp.vec3,
+  alpha: float,
+  N: float,
+  Tsqr: float,
+  u0: float,
+  T0: float,
+  dm: float,
+  state0: int,
+) -> wp.vec3:
   aq2 = alpha * quad[2]
   cost = alpha * (aq2 + quad[1])
-  if state0 != int(types.ConstraintState.QUADRATIC):
-    cost += quad[0] - cost0
+  if state0 == int(types.ConstraintState.CONE):
+    cost += _eval_elliptic_quadratic_cone_gap(mu, u0, T0, dm)
+  elif state0 == int(types.ConstraintState.SATISFIED):
+    cost = 0.5 * dm * (1.0 + mu * mu) * (N * N + wp.max(Tsqr, 0.0))
   return wp.vec3(cost, 2.0 * aq2 + quad[1], 2.0 * quad[2])
 
 
@@ -335,13 +355,13 @@ def _eval_elliptic_shifted(
 
   if Tsqr <= 0.0:
     if N < 0.0:
-      return _eval_elliptic_quadratic_shifted(quad, alpha, cost0, state0)
+      return _eval_elliptic_quadratic_shifted(mu, quad, alpha, N, Tsqr, u0, T0, dm, state0)
   else:
     T = wp.sqrt(Tsqr)
     if N >= mu * T:
       pass
     elif mu * N + T <= 0.0:
-      return _eval_elliptic_quadratic_shifted(quad, alpha, cost0, state0)
+      return _eval_elliptic_quadratic_shifted(mu, quad, alpha, N, Tsqr, u0, T0, dm, state0)
     else:
       T1 = (uv + alpha * vv) / T
       T2 = (vv - T1 * T1) / T
@@ -353,8 +373,11 @@ def _eval_elliptic_shifted(
         T_delta = Tsqr_delta / (T + T0)
         r_delta = alpha * v0 - mu * T_delta
         cost = 0.5 * dm * r_delta * (2.0 * r0 + r_delta)
+      elif state0 == int(types.ConstraintState.QUADRATIC):
+        aq2 = alpha * quad[2]
+        cost = alpha * (aq2 + quad[1]) - _eval_elliptic_quadratic_cone_gap(mu, N, T, dm)
       else:
-        cost = 0.5 * dm * r * r - cost0
+        cost = 0.5 * dm * r * r
 
       return wp.vec3(
         cost,

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -319,14 +319,53 @@ def _eval_elliptic(
 
 
 @wp.func
-def _eval_elliptic_cost(
+def _eval_elliptic_reference(
+  # In:
+  mu: float,
+  quad: wp.vec3,
+  quad1: wp.vec3,
+  quad2: wp.vec3,
+) -> tuple[float, float, int]:
+  u0 = quad1[0]
+  uu = quad1[2]
+  dm = quad2[2]
+
+  if uu <= 0.0:
+    if u0 < 0.0:
+      return quad[0], 0.0, int(types.ConstraintState.QUADRATIC)
+    return 0.0, 0.0, int(types.ConstraintState.SATISFIED)
+
+  T0 = wp.sqrt(uu)
+  if u0 >= mu * T0:
+    return 0.0, T0, int(types.ConstraintState.SATISFIED)
+  if mu * u0 + T0 <= 0.0:
+    return quad[0], T0, int(types.ConstraintState.QUADRATIC)
+
+  r0 = u0 - mu * T0
+  return 0.5 * dm * r0 * r0, T0, int(types.ConstraintState.CONE)
+
+
+@wp.func
+def _eval_elliptic_quadratic_shifted(quad: wp.vec3, alpha: float, cost0: float, state0: int) -> wp.vec3:
+  aq2 = alpha * quad[2]
+  cost = alpha * aq2 + alpha * quad[1] + quad[0] - cost0
+  if state0 == int(types.ConstraintState.QUADRATIC):
+    cost = alpha * (aq2 + quad[1])
+  return wp.vec3(cost, 2.0 * aq2 + quad[1], 2.0 * quad[2])
+
+
+@wp.func
+def _eval_elliptic_shifted(
   # In:
   mu: float,
   quad: wp.vec3,
   quad1: wp.vec3,
   quad2: wp.vec3,
   alpha: float,
-) -> float:
+  cost0: float,
+  T0: float,
+  state0: int,
+) -> wp.vec3:
   u0 = quad1[0]
   v0 = quad1[1]
   uu = quad1[2]
@@ -335,21 +374,40 @@ def _eval_elliptic_cost(
   dm = quad2[2]
 
   N = u0 + alpha * v0
-  Tsqr = uu + alpha * (2.0 * uv + alpha * vv)
+  Tsqr_delta = alpha * (2.0 * uv + alpha * vv)
+  Tsqr = uu + Tsqr_delta
 
   if Tsqr <= 0.0:
     if N < 0.0:
-      return _eval_cost(quad, alpha)
+      return _eval_elliptic_quadratic_shifted(quad, alpha, cost0, state0)
   else:
     T = wp.sqrt(Tsqr)
     if N >= mu * T:
       pass
     elif mu * N + T <= 0.0:
-      return _eval_cost(quad, alpha)
+      return _eval_elliptic_quadratic_shifted(quad, alpha, cost0, state0)
     else:
-      return 0.5 * dm * (N - mu * T) * (N - mu * T)
+      N1 = v0
+      T1 = (uv + alpha * vv) / T
+      T2 = vv / T - (uv + alpha * vv) * T1 / (T * T)
+      r = N - mu * T
+      r1 = N1 - mu * T1
 
-  return 0.0
+      cost = 0.5 * dm * r * r - cost0
+      if state0 == int(types.ConstraintState.CONE):
+        # Rationalize T - T0 before forming the small cone residual change.
+        T_delta = Tsqr_delta / (T + T0)
+        r_delta = alpha * v0 - mu * T_delta
+        r0 = u0 - mu * T0
+        cost = 0.5 * dm * r_delta * (2.0 * r0 + r_delta)
+
+      return wp.vec3(
+        cost,
+        dm * r * r1,
+        dm * (r1 * r1 + r * (-mu * T2)),
+      )
+
+  return wp.vec3(-cost0, 0.0, 0.0)
 
 
 @wp.func
@@ -485,8 +543,8 @@ def _compute_efc_eval_pt_elliptic(
       if efcid != efc_address0:  # Not primary row
         return wp.vec3(0.0)
       mu = contact_friction[0] * impratio_invsqrt
-      cost0 = _eval_elliptic_cost(mu, ctx_quad, quad1, quad2, 0.0)
-      return _shift_cost(_eval_elliptic(mu, ctx_quad, quad1, quad2, alpha), cost0)
+      cost0, T0, state0 = _eval_elliptic_reference(mu, ctx_quad, quad1, quad2)
+      return _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, alpha, cost0, T0, state0)
 
     # Limit/other constraint — direct eval (no quad read)
     x = ctx_Jaref + alpha * ctx_jv
@@ -674,11 +732,12 @@ def _compute_efc_eval_pt_3alphas_elliptic(
       if efcid != efc_address0:  # secondary rows contribute nothing
         return (wp.vec3(0.0), wp.vec3(0.0), wp.vec3(0.0))
       mu = contact_friction[0] * impratio_invsqrt
-      cost0 = _eval_elliptic_cost(mu, ctx_quad, quad1, quad2, 0.0)
-      lo = _eval_elliptic(mu, ctx_quad, quad1, quad2, lo_alpha)
-      hi = _eval_elliptic(mu, ctx_quad, quad1, quad2, hi_alpha)
-      mid = _eval_elliptic(mu, ctx_quad, quad1, quad2, mid_alpha)
-      return (_shift_cost(lo, cost0), _shift_cost(hi, cost0), _shift_cost(mid, cost0))
+      cost0, T0, state0 = _eval_elliptic_reference(mu, ctx_quad, quad1, quad2)
+      return (
+        _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, lo_alpha, cost0, T0, state0),
+        _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, hi_alpha, cost0, T0, state0),
+        _eval_elliptic_shifted(mu, ctx_quad, quad1, quad2, mid_alpha, cost0, T0, state0),
+      )
 
     # Limit/other constraints — direct eval (no quad read)
     efc_D = efc_D_in[efcid]

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -27,6 +27,7 @@ from mujoco_warp import SolverType
 from mujoco_warp import test_data
 from mujoco_warp._src import island
 from mujoco_warp._src import solver
+from mujoco_warp._src import types
 
 # tolerance for difference between MuJoCo and MJWarp solver calculations - mostly
 # due to float precision
@@ -39,7 +40,63 @@ def _assert_eq(a, b, name):
   np.testing.assert_allclose(a, b, err_msg=err_msg, atol=tol, rtol=tol)
 
 
+@wp.kernel
+def _eval_elliptic_delta(
+  # In:
+  alpha: float,
+  d_values: wp.array[float],
+  frictionloss_values: wp.array[float],
+  quad: wp.vec3,
+  quad1: wp.vec3,
+  quad2: wp.vec3,
+  friction: types.vec5,
+  # Out:
+  result_out: wp.array[wp.vec3],
+):
+  result_out[0] = solver._compute_efc_eval_pt_elliptic(
+    0,
+    alpha,
+    0,
+    0,
+    1.0,
+    int(types.ConstraintType.CONTACT_ELLIPTIC),
+    d_values,
+    frictionloss_values,
+    0.0,
+    0.0,
+    quad,
+    friction,
+    0,
+    quad1,
+    quad2,
+  )
+
+
 class SolverTest(parameterized.TestCase):
+  @parameterized.named_parameters(
+    ("middle_zone", (0.0, 0.0, 0.0), (0.5, 1.0e-4, 1.0), (0.0, 0.0, 1.0e8)),
+    ("quadratic_zone", (1.25e7, -5000.0, 0.5), (-2.0, 0.0, 1.0), (0.0, 0.0, 1.0)),
+  )
+  def test_elliptic_shifted_cost_preserves_small_delta(self, quad, quad1, quad2):
+    """Elliptic cost deltas remain visible below the absolute-cost ulp."""
+    result = wp.empty(1, dtype=wp.vec3)
+    wp.launch(
+      _eval_elliptic_delta,
+      dim=1,
+      inputs=[
+        1.0e-4,
+        wp.zeros(1, dtype=float),
+        wp.zeros(1, dtype=float),
+        wp.vec3(*quad),
+        wp.vec3(*quad1),
+        wp.vec3(*quad2),
+        types.vec5(1.0, 0.0, 0.0, 0.0, 0.0),
+      ],
+      outputs=[result],
+    )
+
+    np.testing.assert_allclose(result.numpy()[0], [-0.5, -5000.0, 1.0], rtol=1.0e-6, atol=1.0e-6)
+
   def test_M_fullm_upper_indices_are_row_sorted(self):
     """Sparse M seeding uses upper-triangle row-sorted writes."""
     _, _, m, _ = test_data.fixture("humanoid/humanoid.xml")

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -73,18 +73,50 @@ def _eval_elliptic_delta(
 
 
 class SolverTest(parameterized.TestCase):
+  # Transition cases use powers of two so the exact delta is below the absolute-cost ulp.
   @parameterized.named_parameters(
-    ("middle_zone", (0.0, 0.0, 0.0), (0.5, 1.0e-4, 1.0), (0.0, 0.0, 1.0e8)),
-    ("quadratic_zone", (1.25e7, -5000.0, 0.5), (-2.0, 0.0, 1.0), (0.0, 0.0, 1.0)),
+    ("middle_zone", 1.0e-4, (0.0, 0.0, 0.0), (0.5, 1.0e-4, 1.0), (0.0, 0.0, 1.0e8), (-0.5, -5000.0, 1.0)),
+    (
+      "quadratic_zone",
+      1.0e-4,
+      (1.25e7, -5000.0, 0.5),
+      (-2.0, 0.0, 1.0),
+      (0.0, 0.0, 1.0),
+      (-0.5, -5000.0, 1.0),
+    ),
+    (
+      "cone_to_quadratic",
+      2.44140625e-4,
+      (33546241.0, -8192.0, 33554432.0),
+      (-0.999755859375, -1.0, 1.0),
+      (-1.0, 1.0, 16777216.0),
+      (0.5, 8192.0, 67108864.0),
+    ),
+    (
+      "quadratic_to_cone",
+      2.44140625e-4,
+      (33546241.0, -8192.0, 33554432.0),
+      (-1.0, 1.0, 0.9995117783546448),
+      (0.999755859375, 1.0, 16777216.0),
+      (-0.5, 0.0, 0.0),
+    ),
+    (
+      "satisfied_to_quadratic",
+      2.44140625e-4,
+      (1.0, -16384.0, 67108864.0),
+      (2.44140625e-4, -2.0, 0.0),
+      (0.0, 0.0, 16777216.0),
+      (1.0, 16384.0, 134217728.0),
+    ),
   )
-  def test_elliptic_shifted_cost_preserves_small_delta(self, quad, quad1, quad2):
+  def test_elliptic_shifted_cost_preserves_small_delta(self, alpha, quad, quad1, quad2, expected):
     """Elliptic cost deltas remain visible below the absolute-cost ulp."""
     result = wp.empty(1, dtype=wp.vec3)
     wp.launch(
       _eval_elliptic_delta,
       dim=1,
       inputs=[
-        1.0e-4,
+        alpha,
         wp.zeros(1, dtype=float),
         wp.zeros(1, dtype=float),
         wp.vec3(*quad),
@@ -95,7 +127,7 @@ class SolverTest(parameterized.TestCase):
       outputs=[result],
     )
 
-    np.testing.assert_allclose(result.numpy()[0], [-0.5, -5000.0, 1.0], rtol=1.0e-6, atol=1.0e-6)
+    np.testing.assert_allclose(result.numpy()[0], expected, rtol=1.0e-6, atol=1.0e-6)
 
   def test_M_fullm_upper_indices_are_row_sorted(self):
     """Sparse M seeding uses upper-triangle row-sorted writes."""


### PR DESCRIPTION
Newton line search compares candidate costs against the cost at alpha zero. For elliptic contacts, this was implemented by evaluating both absolute costs independently in float32 and then subtracting them. When the absolute cone cost is large, a valid improvement can be smaller than its float32 unit in the last place, causing the subtraction to round to zero. The line search can then treat an improving step as unchanged, which caused unstable convergence in the friction-ramp scenario.

Compute elliptic cost changes directly from the piecewise cone objective instead of subtracting nearly equal absolute values. The alpha-zero evaluation classifies the reference zone once and returns the reference cost, tangential norm, cone residual, and constraint state. Within the quadratic zone, the change is `delta_C = alpha * (q1 + alpha * q2)`. Within the middle cone, the tangential norm change is rationalized as `delta_T = delta_T_squared / (T + T0)`, followed by `delta_r = alpha * v0 - mu * delta_T` and `delta_C = 0.5 * dm * delta_r * (2 * r0 + delta_r)`.

Crossings between the middle cone and quadratic zone use the exact identity `Q - C = 0.5 * dm * (mu * N + T)^2`. A cone-to-quadratic step adds this gap at alpha zero to the shifted quadratic, while a quadratic-to-cone step subtracts the gap at the candidate point. A step from the satisfied zone into the quadratic zone evaluates the candidate quadratic as a scaled sum of squares. These forms cover the full piecewise surface without subtracting large absolute costs.

The candidate gradient and Hessian continue to use the original piecewise elliptic-cone equations. The alpha-zero derivative path reuses the same classification, and the batched three-alpha path computes the reference terms once. Computations used only by limit and friction constraints remain inside those branches so elliptic contacts and equality constraints avoid unnecessary arithmetic.

The regression test uses binary-exact inputs whose absolute costs round to the same float32 value while their true changes are `0.5` or `-0.5`. It covers same-zone middle-cone and quadratic evaluation, both cone/quadratic transition directions, and the satisfied-to-quadratic path, together with the expected gradients and Hessians. The solver tests and Newton friction-ramp regression continue to pass, and fixed-work profiling shows no line-search performance regression.

Performance was measured in a fresh A/B against merge base `eb35c2d8` and PR head `ca5113fa`. Values are medians of three interleaved runs, with the GPU idle before every sample. All workloads used their recorded trajectories (`lift_pot.npz`, `pick_clutter.npz`, and `shuffle_dance.npz`), and the Unitree workloads explicitly set `opt.cone=elliptic`. All configured worlds converged.

| Benchmark | Worlds | Base step (us) | PR step (us) | Step change | Base solve (us) | PR solve (us) | Solve change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `aloha_pot` | 8192 | 355.1 | 351.1 | -1.12% | 149.8 | 145.5 | -2.86% |
| `aloha_clutter` | 2048 | 4157.7 | 3898.0 | -6.25% | 1636.8 | 1488.8 | -9.04% |
| `unitree_g1_flat` | 8192 | 544.6 | 536.2 | -1.54% | 406.8 | 399.6 | -1.78% |
| `unitree_g1_hfield` | 8192 | 765.7 | 777.3 | +1.52% | 461.5 | 459.5 | -0.43% |

The solver time improves in all four workloads. The 1.52% hfield end-to-end change is outside the solver and within the observed total-step variability.

The flaky Newton ANymal elliptic reset failure was also reproduced against the exact Newton PR revision from [this CI job](https://github.com/newton-physics/newton/actions/runs/29086153345/job/86340621655). The MuJoCo Warp merge base failed 7 of 30 runs at the same post-reset 100-iteration assertion, while the PR head passed 30 of 30 runs under the same Newton revision and dependencies. Newton's locked `mujoco-warp==3.10.0.1` release reproduced the failure in 1 of 10 runs.
