### PR TITLE
update _equality_weld

### DIFF
--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -1098,7 +1098,7 @@ def _equality_weld(is_sparse: bool, newton: bool):
       qfull1 = math.mul_quat(xquat_in[worldid, body2], site_quat[site_quat_id, obj2id])
       qdot1 = math.mul_quat(omega2_q, qfull1) * 0.5
 
-      negqdot1 = wp.quat(-qdot1[0], -qdot1[1], -qdot1[2], -qdot1[3])
+      negqdot1 = math.quat_inv(qdot1)
       negq1 = wp.quat(qfull1[0], -qfull1[1], -qfull1[2], -qfull1[3])
 
     else:
@@ -1109,7 +1109,7 @@ def _equality_weld(is_sparse: bool, newton: bool):
       q1_non_site = xquat_in[worldid, body2]
       qdot1 = math.mul_quat(omega2_q, q1_non_site) * 0.5
 
-      negqdot1 = wp.quat(-qdot1[0], -qdot1[1], -qdot1[2], -qdot1[3])
+      negqdot1 = math.quat_inv(qdot1)
       negq1 = wp.quat(q1_non_site[0], -q1_non_site[1], -q1_non_site[2], -q1_non_site[3])
 
     # compute Jacobian difference (opposite of contact: 0 - 1)

--- a/mujoco_warp/_src/constraint_test.py
+++ b/mujoco_warp/_src/constraint_test.py
@@ -453,6 +453,36 @@ class ConstraintTest(parameterized.TestCase):
     self.assertEqual(d.nefc.numpy()[0], mjd.nefc, "nefc mismatch")
     _assert_efc_eq(mjm, m, d, mjd, mjd.nefc, f"efc_flex_interpolated_trilinear", m.nv)
 
+  def test_weld_coriolis(self):
+    """Test weld Coriolis term Jdotv_r with default torquescale and high velocity."""
+    xml = """
+      <mujoco>
+        <worldbody>
+          <body name="body1" pos="0 0 0">
+            <freejoint/>
+            <geom type="box" size=".1 .1 .1"/>
+          </body>
+          <body name="body2" pos="0 0 1">
+            <freejoint/>
+            <geom type="box" size=".1 .1 .1"/>
+          </body>
+        </worldbody>
+        <equality>
+          <weld body1="body1" body2="body2"/>
+        </equality>
+        <keyframe>
+          <key qpos="0.1 0.2 0.3 0.5940885257860046 0.3960590171906697 0.49507377148833714 0.49507377148833714
+                     -0.1 0.5 0.8 0.502518907629606 -0.30151134457776363 0.8040302522073697 0.10050378152592121"
+               qvel="1.0 -2.0 3.0 5.0 10.0 -8.0 -3.0 2.0 1.0 -7.0 4.0 6.0"/>
+        </keyframe>
+      </mujoco>
+    """
+    mjm, mjd, m, d = test_data.fixture(xml=xml, keyframe=0)
+
+    mjw.make_constraint(m, d)
+
+    _assert_efc_eq(mjm, m, d, mjd, mjd.nefc, "weld_coriolis", m.nv, tol=1e-3)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
fix weld constraint: "negative quaternion" should be quaternion conjugate not all elements *-1

mujoco reference
https://github.com/google-deepmind/mujoco/blob/40feb498a193b016b51887596566823a7658a25b/src/engine/engine_core_constraint.c#L690
https://github.com/google-deepmind/mujoco/blob/main/src/engine/engine_util_spatial.c#L57

