### PR TITLE
Add fast math and clear fill optimization

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -3854,6 +3854,7 @@ def create_render_context(
   render_depth: list[bool] | bool | None = None,
   render_seg: list[bool] | bool | None = None,
   use_textures: bool = True,
+  use_fast_math: bool = True,
   use_shadows: bool = False,
   use_ambient_lighting: bool = True,
   enabled_geom_groups: list[int] = [0, 1, 2],
@@ -3879,6 +3880,7 @@ def create_render_context(
     render_seg: Whether to render segmentation (per-pixel object ID/type pairs).
       If None, uses the MuJoCo model values.
     use_textures: Whether to use textures.
+    use_fast_math: Whether to enable fast math for the render kernel.
     use_shadows: Whether to use shadows.
     use_ambient_lighting: Top-level ambient switch. When False, skips all
                           ambient contributions, including headlight ambient,
@@ -4101,6 +4103,7 @@ def create_render_context(
     cam_res=cam_res_arr,
     cam_id_map=wp.array(active_cam_indices, dtype=int),
     use_textures=use_textures,
+    use_fast_math=use_fast_math,
     use_shadows=use_shadows,
     use_ambient_lighting=use_ambient_lighting,
     background_color=render_util.pack_rgba_to_uint32(

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -551,8 +551,6 @@ def render(m: Model, d: Data, rc: RenderContext):
     d: The data on device.
     rc: The render context on device.
   """
-  rc.rgb_data.fill_(rc.background_color)
-  rc.depth_data.fill_(0.0)
   rc.seg_data.fill_(wp.vec2i(-1, -1))
 
   # Specialize the ray-cast helpers to the geom types present in the scene so the
@@ -566,8 +564,9 @@ def render(m: Model, d: Data, rc: RenderContext):
   rc_static = {f.name: getattr(rc, f.name) for f in dataclasses.fields(rc) if f.type in (int, bool, float, wp.vec3)}
   rc_static["enable_specular_or_emission"] = rc.enable_specular or rc.enable_emission
   M_NLIGHT = m.nlight
+  background_color = rc.background_color
 
-  @wp.kernel(module="unique", enable_backward=False)
+  @wp.kernel(module="unique", enable_backward=False, module_options={"fast_math": True})
   def _render_megakernel(
     # Model:
     geom_type: wp.array[int],
@@ -722,6 +721,8 @@ def render(m: Model, d: Data, rc: RenderContext):
 
     # Early Out
     if geom_id == -1:
+      if render_depth[camid]:
+        depth_out[worldid, depth_adr[camid] + rayid_local] = 0.0
       if wp.static(rc_static["render_skybox"]) and render_rgb[camid]:
         skybox_id = skybox_tex_id[worldid % skybox_tex_id.shape[0]]
         skybox_color = sample_skybox(
@@ -735,6 +736,8 @@ def render(m: Model, d: Data, rc: RenderContext):
           skybox_color[2] * 255.0,
           255.0,
         )
+      elif render_rgb[camid]:
+        rgb_out[worldid, rgb_adr[camid] + rayid_local] = background_color
       return
 
     if render_depth[camid]:

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -561,10 +561,9 @@ def render(m: Model, d: Data, rc: RenderContext):
   compute_lighting = _make_compute_lighting(cast_ray_first_hit)
 
   # Static parameters extracted for JAX FFI closure.
-  rc_static = {f.name: getattr(rc, f.name) for f in dataclasses.fields(rc) if f.type in (int, bool, float, wp.vec3)}
+  rc_static = {f.name: getattr(rc, f.name) for f in dataclasses.fields(rc) if f.type in (int, wp.uint32, bool, float, wp.vec3)}
   rc_static["enable_specular_or_emission"] = rc.enable_specular or rc.enable_emission
   M_NLIGHT = m.nlight
-  background_color = rc.background_color
 
   @wp.kernel(module="unique", enable_backward=False, module_options={"fast_math": rc.use_fast_math})
   def _render_megakernel(
@@ -737,7 +736,7 @@ def render(m: Model, d: Data, rc: RenderContext):
           255.0,
         )
       elif render_rgb[camid]:
-        rgb_out[worldid, rgb_adr[camid] + rayid_local] = background_color
+        rgb_out[worldid, rgb_adr[camid] + rayid_local] = wp.static(rc_static["background_color"])
       return
 
     if render_depth[camid]:

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -566,7 +566,7 @@ def render(m: Model, d: Data, rc: RenderContext):
   M_NLIGHT = m.nlight
   background_color = rc.background_color
 
-  @wp.kernel(module="unique", enable_backward=False, module_options={"fast_math": True})
+  @wp.kernel(module="unique", enable_backward=False, module_options={"fast_math": rc.use_fast_math})
   def _render_megakernel(
     # Model:
     geom_type: wp.array[int],

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2404,6 +2404,7 @@ class RenderContext:
     cam_res: camera resolution for actively rendering cameras
     cam_id_map: camera id map
     use_textures: whether to use textures
+    use_fast_math: whether to enable fast math for the render kernel
     use_shadows: whether to use shadows
     use_ambient_lighting: top-level switch for ambient contributions
     background_color: color used for missed rays when no skybox is rendered
@@ -2491,6 +2492,7 @@ class RenderContext:
   cam_res: array("ncam", wp.vec2i)
   cam_id_map: array("ncam", int)
   use_textures: bool
+  use_fast_math: bool
   use_shadows: bool
   use_ambient_lighting: bool
   background_color: wp.uint32


### PR DESCRIPTION
Enable fast math for the render megakernel and avoid clearing RGB and depth output buffers before every render. 

| Scene | Before | After | Change |
| --- | ---: | ---: | ---: |
| Primitives (2,048 worlds) | 1.090M FPS | 1.376M FPS | +26.2% |
| Humanoid (2,048 worlds) | 427k FPS | 479k FPS | +12.2% |

The attached before-after compares a 512×512 lit, shadowed frame before and after fast math. Only 98 of 262,144 pixels differ, by at most one 8-bit channel value.

<img width="1536" height="554" alt="image" src="https://github.com/user-attachments/assets/242dd081-d691-49a9-92ff-7131ead7d38a" />
