### PR TITLE
Add Newton decrement termination

### DIFF
--- a/mujoco_warp/_src/block_cholesky.py
+++ b/mujoco_warp/_src/block_cholesky.py
@@ -19,6 +19,32 @@ import warp as wp
 
 
 @lru_cache(maxsize=None)
+def _create_solve_epilogue_func(matrix_size_static: int, vector_size_static: int):
+  @wp.func
+  def solve_epilogue_func(
+    # In:
+    solution_tile: wp.tile[float, matrix_size_static, 1],
+    b: wp.array2d[float],
+    thread_idx: int,
+    # Out:
+    search_out: wp.array2d[float],
+  ):
+    local_search_dot = float(0.0)
+    local_decrement = float(0.0)
+    for i in range(thread_idx, vector_size_static, wp.block_dim()):
+      solution = wp.tile_extract(solution_tile, i, 0)
+      search_out[i, 0] = -solution
+      local_search_dot += solution * solution
+      local_decrement += b[i, 0] * solution
+
+    search_dot = wp.tile_reduce(wp.add, wp.tile(local_search_dot, preserve_type=True))[0]
+    decrement = wp.tile_reduce(wp.add, wp.tile(local_decrement, preserve_type=True))[0]
+    return wp.vec2(search_dot, decrement)
+
+  return solve_epilogue_func
+
+
+@lru_cache(maxsize=None)
 def create_blocked_cholesky_factorize_solve_func(block_size: int, matrix_size_static: int):
   @wp.func
   def blocked_cholesky_factorize_solve_func(
@@ -93,7 +119,13 @@ def create_blocked_cholesky_factorize_solve_func(block_size: int, matrix_size_st
 
 
 @lru_cache(maxsize=None)
-def create_blocked_cholesky_augmented_factorize_solve_func(block_size: int, matrix_size_static: int):
+def _create_blocked_cholesky_augmented_factorize_solve_func(
+  block_size: int,
+  matrix_size_static: int,
+  with_newton_epilogue: bool,
+  vector_size_static: int,
+):
+  WITH_NEWTON_EPILOGUE = with_newton_epilogue
   border_size = block_size - 1
 
   @wp.func
@@ -102,9 +134,11 @@ def create_blocked_cholesky_augmented_factorize_solve_func(block_size: int, matr
     A: wp.array2d[float],
     b: wp.array2d[float],
     matrix_size: int,
+    thread_idx: int,
     # Out:
     U: wp.array2d[float],
-    x: wp.array2d[float],
+    # Out:
+    result_out: wp.array2d[float],
   ):
     """Factor A with b as an augmented border and reuse it as the forward solution."""
     rhs_tile = wp.tile_zeros(shape=(matrix_size_static, 1), dtype=float, storage="shared")
@@ -170,21 +204,35 @@ def create_blocked_cholesky_augmented_factorize_solve_func(block_size: int, matr
       )
       wp.tile_upper_solve_inplace(U_tile, tmp_tile)
 
-    wp.tile_store(x, rhs_tile, offset=(0, 0), bounds_check=False)
+    sums = wp.vec2(0.0)
+    if wp.static(WITH_NEWTON_EPILOGUE):
+      sums = wp.static(_create_solve_epilogue_func(matrix_size_static, vector_size_static))(rhs_tile, b, thread_idx, result_out)
+    else:
+      wp.tile_store(result_out, rhs_tile, offset=(0, 0), bounds_check=False)
+
+    return sums
 
   return blocked_cholesky_augmented_factorize_solve_func
 
 
 @lru_cache(maxsize=None)
-def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int):
+def _create_blocked_cholesky_solve_func(
+  block_size: int,
+  matrix_size_static: int,
+  with_newton_epilogue: bool,
+  vector_size_static: int,
+):
+  WITH_NEWTON_EPILOGUE = with_newton_epilogue
+
   @wp.func
   def blocked_cholesky_solve_func(
     # In:
     U: wp.array2d[float],
     b: wp.array2d[float],
     matrix_size: int,
+    thread_idx: int,
     # Out:
-    x: wp.array2d[float],
+    result_out: wp.array2d[float],
   ):
     """Block Cholesky solve.
 
@@ -224,6 +272,30 @@ def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int)
 
       wp.tile_upper_solve_inplace(U_tile, tmp_tile)
 
-    wp.tile_store(x, rhs_tile, offset=(0, 0), bounds_check=False)
+    sums = wp.vec2(0.0)
+    if wp.static(WITH_NEWTON_EPILOGUE):
+      sums = wp.static(_create_solve_epilogue_func(matrix_size_static, vector_size_static))(rhs_tile, b, thread_idx, result_out)
+    else:
+      wp.tile_store(result_out, rhs_tile, offset=(0, 0), bounds_check=False)
+
+    return sums
 
   return blocked_cholesky_solve_func
+
+
+def create_blocked_cholesky_augmented_factorize_solve_func(block_size: int, matrix_size_static: int):
+  return _create_blocked_cholesky_augmented_factorize_solve_func(block_size, matrix_size_static, False, 0)
+
+
+def create_blocked_cholesky_augmented_factorize_solve_newton_func(
+  block_size: int, matrix_size_static: int, vector_size_static: int
+):
+  return _create_blocked_cholesky_augmented_factorize_solve_func(block_size, matrix_size_static, True, vector_size_static)
+
+
+def create_blocked_cholesky_solve_func(block_size: int, matrix_size_static: int):
+  return _create_blocked_cholesky_solve_func(block_size, matrix_size_static, False, 0)
+
+
+def create_blocked_cholesky_solve_newton_func(block_size: int, matrix_size_static: int, vector_size_static: int):
+  return _create_blocked_cholesky_solve_func(block_size, matrix_size_static, True, vector_size_static)

--- a/mujoco_warp/_src/block_cholesky.py
+++ b/mujoco_warp/_src/block_cholesky.py
@@ -18,6 +18,11 @@ from functools import lru_cache
 import warp as wp
 
 
+@wp.func
+def _solve_search_sums(grad: float, solution: float):
+  return wp.vec2(solution * solution, grad * solution)
+
+
 @lru_cache(maxsize=None)
 def _create_solve_epilogue_func(matrix_size_static: int, vector_size_static: int):
   @wp.func
@@ -25,21 +30,13 @@ def _create_solve_epilogue_func(matrix_size_static: int, vector_size_static: int
     # In:
     solution_tile: wp.tile[float, matrix_size_static, 1],
     b: wp.array2d[float],
-    thread_idx: int,
     # Out:
     search_out: wp.array2d[float],
   ):
-    local_search_dot = float(0.0)
-    local_decrement = float(0.0)
-    for i in range(thread_idx, vector_size_static, wp.block_dim()):
-      solution = wp.tile_extract(solution_tile, i, 0)
-      search_out[i, 0] = -solution
-      local_search_dot += solution * solution
-      local_decrement += b[i, 0] * solution
-
-    search_dot = wp.tile_reduce(wp.add, wp.tile(local_search_dot, preserve_type=True))[0]
-    decrement = wp.tile_reduce(wp.add, wp.tile(local_decrement, preserve_type=True))[0]
-    return wp.vec2(search_dot, decrement)
+    grad_tile = wp.tile_load(b, shape=(vector_size_static, 1), offset=(0, 0), bounds_check=False)
+    active_solution = wp.tile_view(solution_tile, shape=(vector_size_static, 1), offset=(0, 0))
+    wp.tile_store(search_out, wp.tile_map(wp.mul, active_solution, -1.0), bounds_check=False)
+    return wp.tile_reduce(wp.add, wp.tile_map(_solve_search_sums, grad_tile, active_solution))[0]
 
   return solve_epilogue_func
 
@@ -134,7 +131,6 @@ def _create_blocked_cholesky_augmented_factorize_solve_func(
     A: wp.array2d[float],
     b: wp.array2d[float],
     matrix_size: int,
-    thread_idx: int,
     # Out:
     U: wp.array2d[float],
     # Out:
@@ -206,7 +202,7 @@ def _create_blocked_cholesky_augmented_factorize_solve_func(
 
     sums = wp.vec2(0.0)
     if wp.static(WITH_NEWTON_EPILOGUE):
-      sums = wp.static(_create_solve_epilogue_func(matrix_size_static, vector_size_static))(rhs_tile, b, thread_idx, result_out)
+      sums = wp.static(_create_solve_epilogue_func(matrix_size_static, vector_size_static))(rhs_tile, b, result_out)
     else:
       wp.tile_store(result_out, rhs_tile, offset=(0, 0), bounds_check=False)
 
@@ -230,7 +226,6 @@ def _create_blocked_cholesky_solve_func(
     U: wp.array2d[float],
     b: wp.array2d[float],
     matrix_size: int,
-    thread_idx: int,
     # Out:
     result_out: wp.array2d[float],
   ):
@@ -274,7 +269,7 @@ def _create_blocked_cholesky_solve_func(
 
     sums = wp.vec2(0.0)
     if wp.static(WITH_NEWTON_EPILOGUE):
-      sums = wp.static(_create_solve_epilogue_func(matrix_size_static, vector_size_static))(rhs_tile, b, thread_idx, result_out)
+      sums = wp.static(_create_solve_epilogue_func(matrix_size_static, vector_size_static))(rhs_tile, b, result_out)
     else:
       wp.tile_store(result_out, rhs_tile, offset=(0, 0), bounds_check=False)
 

--- a/mujoco_warp/_src/block_cholesky.py
+++ b/mujoco_warp/_src/block_cholesky.py
@@ -19,14 +19,14 @@ import warp as wp
 
 
 @wp.func
-def _solve_search_sums(grad: float, solution: float):
+def solve_search_sums(grad: float, solution: float):
   return wp.vec2(solution * solution, grad * solution)
 
 
 @lru_cache(maxsize=None)
-def _create_solve_epilogue_func(matrix_size_static: int, vector_size_static: int):
+def _create_newton_decrement_func(matrix_size_static: int, vector_size_static: int):
   @wp.func
-  def solve_epilogue_func(
+  def newton_decrement_func(
     # In:
     solution_tile: wp.tile[float, matrix_size_static, 1],
     b: wp.array2d[float],
@@ -36,9 +36,9 @@ def _create_solve_epilogue_func(matrix_size_static: int, vector_size_static: int
     grad_tile = wp.tile_load(b, shape=(vector_size_static, 1), offset=(0, 0), bounds_check=False)
     active_solution = wp.tile_view(solution_tile, shape=(vector_size_static, 1), offset=(0, 0))
     wp.tile_store(search_out, wp.tile_map(wp.mul, active_solution, -1.0), bounds_check=False)
-    return wp.tile_reduce(wp.add, wp.tile_map(_solve_search_sums, grad_tile, active_solution))[0]
+    return wp.tile_reduce(wp.add, wp.tile_map(solve_search_sums, grad_tile, active_solution))[0]
 
-  return solve_epilogue_func
+  return newton_decrement_func
 
 
 @lru_cache(maxsize=None)
@@ -119,10 +119,10 @@ def create_blocked_cholesky_factorize_solve_func(block_size: int, matrix_size_st
 def _create_blocked_cholesky_augmented_factorize_solve_func(
   block_size: int,
   matrix_size_static: int,
-  with_newton_epilogue: bool,
+  with_newton_decrement: bool,
   vector_size_static: int,
 ):
-  WITH_NEWTON_EPILOGUE = with_newton_epilogue
+  WITH_NEWTON_DECREMENT = with_newton_decrement
   border_size = block_size - 1
 
   @wp.func
@@ -200,8 +200,8 @@ def _create_blocked_cholesky_augmented_factorize_solve_func(
       wp.tile_upper_solve_inplace(U_tile, tmp_tile)
 
     sums = wp.vec2(0.0)
-    if wp.static(WITH_NEWTON_EPILOGUE):
-      sums = wp.static(_create_solve_epilogue_func(matrix_size_static, vector_size_static))(rhs_tile, b, result_out)
+    if wp.static(WITH_NEWTON_DECREMENT):
+      sums = wp.static(_create_newton_decrement_func(matrix_size_static, vector_size_static))(rhs_tile, b, result_out)
     else:
       wp.tile_store(result_out, rhs_tile, offset=(0, 0), bounds_check=False)
 
@@ -214,10 +214,10 @@ def _create_blocked_cholesky_augmented_factorize_solve_func(
 def _create_blocked_cholesky_solve_func(
   block_size: int,
   matrix_size_static: int,
-  with_newton_epilogue: bool,
+  with_newton_decrement: bool,
   vector_size_static: int,
 ):
-  WITH_NEWTON_EPILOGUE = with_newton_epilogue
+  WITH_NEWTON_DECREMENT = with_newton_decrement
 
   @wp.func
   def blocked_cholesky_solve_func(
@@ -267,8 +267,8 @@ def _create_blocked_cholesky_solve_func(
       wp.tile_upper_solve_inplace(U_tile, tmp_tile)
 
     sums = wp.vec2(0.0)
-    if wp.static(WITH_NEWTON_EPILOGUE):
-      sums = wp.static(_create_solve_epilogue_func(matrix_size_static, vector_size_static))(rhs_tile, b, result_out)
+    if wp.static(WITH_NEWTON_DECREMENT):
+      sums = wp.static(_create_newton_decrement_func(matrix_size_static, vector_size_static))(rhs_tile, b, result_out)
     else:
       wp.tile_store(result_out, rhs_tile, offset=(0, 0), bounds_check=False)
 

--- a/mujoco_warp/_src/block_cholesky.py
+++ b/mujoco_warp/_src/block_cholesky.py
@@ -132,8 +132,7 @@ def _create_blocked_cholesky_augmented_factorize_solve_func(
     b: wp.array2d[float],
     matrix_size: int,
     # Out:
-    U: wp.array2d[float],
-    # Out:
+    U_out: wp.array2d[float],
     result_out: wp.array2d[float],
   ):
     """Factor A with b as an augmented border and reuse it as the forward solution."""
@@ -153,7 +152,7 @@ def _create_blocked_cholesky_augmented_factorize_solve_func(
 
       for j in range(0, k, block_size):
         U_block = wp.tile_load(
-          U, shape=(block_size, block_size), offset=(j, k), storage="shared", bounds_check=False, aligned=True
+          U_out, shape=(block_size, block_size), offset=(j, k), storage="shared", bounds_check=False, aligned=True
         )
         wp.tile_matmul(wp.tile_transpose(U_block), U_block, A_kk_tile, alpha=-1.0)
 
@@ -161,7 +160,7 @@ def _create_blocked_cholesky_augmented_factorize_solve_func(
       diagonal_border = wp.tile_view(A_kk_tile, shape=(border_size, 1), offset=(0, border_size))
       if end == matrix_size:
         wp.tile_assign(rhs_tile, diagonal_border, offset=(k, 0))
-      wp.tile_store(U, A_kk_tile, offset=(k, k), bounds_check=False, aligned=True)
+      wp.tile_store(U_out, A_kk_tile, offset=(k, k), bounds_check=False, aligned=True)
 
       for i in range(end, matrix_size, block_size):
         A_ki_tile = wp.tile_load(
@@ -172,10 +171,10 @@ def _create_blocked_cholesky_augmented_factorize_solve_func(
 
         for j in range(0, k, block_size):
           U_jk_tile = wp.tile_load(
-            U, shape=(block_size, block_size), offset=(j, k), storage="shared", bounds_check=False, aligned=True
+            U_out, shape=(block_size, block_size), offset=(j, k), storage="shared", bounds_check=False, aligned=True
           )
           U_ji_tile = wp.tile_load(
-            U, shape=(block_size, block_size), offset=(j, i), storage="shared", bounds_check=False, aligned=True
+            U_out, shape=(block_size, block_size), offset=(j, i), storage="shared", bounds_check=False, aligned=True
           )
           wp.tile_matmul(wp.tile_transpose(U_jk_tile), U_ji_tile, A_ki_tile, alpha=-1.0)
 
@@ -183,20 +182,20 @@ def _create_blocked_cholesky_augmented_factorize_solve_func(
         panel_border = wp.tile_view(A_ki_tile, shape=(block_size, 1), offset=(0, border_size))
         if i + block_size == matrix_size:
           wp.tile_assign(rhs_tile, panel_border, offset=(k, 0))
-        wp.tile_store(U, A_ki_tile, offset=(k, i), bounds_check=False, aligned=True)
+        wp.tile_store(U_out, A_ki_tile, offset=(k, i), bounds_check=False, aligned=True)
 
     for i in range(matrix_size - block_size, -1, -block_size):
       i_end = i + block_size
       tmp_tile = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(i, 0))
       for j in range(i_end, matrix_size, block_size):
         U_tile = wp.tile_load(
-          U, shape=(block_size, block_size), offset=(i, j), storage="shared", bounds_check=False, aligned=True
+          U_out, shape=(block_size, block_size), offset=(i, j), storage="shared", bounds_check=False, aligned=True
         )
         x_tile = wp.tile_view(rhs_tile, shape=(block_size, 1), offset=(j, 0))
         wp.tile_matmul(U_tile, x_tile, tmp_tile, alpha=-1.0)
 
       U_tile = wp.tile_load(
-        U, shape=(block_size, block_size), offset=(i, i), storage="shared", bounds_check=False, aligned=True
+        U_out, shape=(block_size, block_size), offset=(i, i), storage="shared", bounds_check=False, aligned=True
       )
       wp.tile_upper_solve_inplace(U_tile, tmp_tile)
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -23,6 +23,7 @@ from mujoco_warp._src import math
 from mujoco_warp._src import smooth
 from mujoco_warp._src import support
 from mujoco_warp._src import types
+from mujoco_warp._src.block_cholesky import _solve_search_sums
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_augmented_factorize_solve_newton_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_factorize_solve_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_newton_func
@@ -1583,11 +1584,6 @@ def _solve_init_jaref_kernel(is_sparse: bool, nv: int, dofs_per_thread: int, com
   return kernel
 
 
-@wp.func
-def _solve_search_sums(grad: float, mgrad: float):
-  return wp.vec2(mgrad * mgrad, grad * mgrad)
-
-
 @wp.kernel
 def _solve_init_search_cg_tiled(
   # Model:
@@ -2913,7 +2909,7 @@ def _update_gradient_cholesky_blocked(tile_size: int, matrix_size: int, vector_s
     ctx_search_dot_out: wp.array[float],
     ctx_newton_decrement_out: wp.array[float],
   ):
-    worldid, thread_idx = wp.tid()
+    worldid = wp.tid()
     TILE_SIZE = wp.static(tile_size)
 
     if ctx_done_in[worldid]:
@@ -2928,13 +2924,11 @@ def _update_gradient_cholesky_blocked(tile_size: int, matrix_size: int, vector_s
       ctx_h_in[worldid],
       ctx_grad_in[worldid],
       matrix_size,
-      thread_idx,
       ctx_hfactor[worldid],
       ctx_search_out[worldid],
     )
-    if thread_idx == 0:
-      ctx_search_dot_out[worldid] = sums[0]
-      ctx_newton_decrement_out[worldid] = sums[1]
+    ctx_search_dot_out[worldid] = sums[0]
+    ctx_newton_decrement_out[worldid] = sums[1]
 
   return kernel
 
@@ -2985,7 +2979,7 @@ def _update_gradient_cholesky_blocked_skip_unchanged(
     ctx_search_dot_out: wp.array[float],
     ctx_newton_decrement_out: wp.array[float],
   ):
-    worldid, thread_idx = wp.tid()
+    worldid = wp.tid()
     TILE_SIZE = wp.static(tile_size)
 
     if ctx_done_in[worldid]:
@@ -3002,7 +2996,6 @@ def _update_gradient_cholesky_blocked_skip_unchanged(
         ctx_h_in[worldid],
         ctx_grad_in[worldid],
         matrix_size,
-        thread_idx,
         ctx_hfactor[worldid],
         ctx_search_out[worldid],
       )
@@ -3011,13 +3004,11 @@ def _update_gradient_cholesky_blocked_skip_unchanged(
         ctx_hfactor[worldid],
         ctx_grad_in[worldid],
         matrix_size,
-        thread_idx,
         ctx_search_out[worldid],
       )
 
-    if thread_idx == 0:
-      ctx_search_dot_out[worldid] = sums[0]
-      ctx_newton_decrement_out[worldid] = sums[1]
+    ctx_search_dot_out[worldid] = sums[0]
+    ctx_newton_decrement_out[worldid] = sums[1]
 
   return kernel
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -23,10 +23,10 @@ from mujoco_warp._src import math
 from mujoco_warp._src import smooth
 from mujoco_warp._src import support
 from mujoco_warp._src import types
-from mujoco_warp._src.block_cholesky import _solve_search_sums
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_augmented_factorize_solve_newton_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_factorize_solve_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_newton_func
+from mujoco_warp._src.block_cholesky import solve_search_sums
 from mujoco_warp._src.types import InverseContext
 from mujoco_warp._src.types import SolverContext
 from mujoco_warp._src.warp_util import cache_kernel
@@ -2075,8 +2075,9 @@ def _update_gradient_zero_grad_dot(stable_fast: bool):
         ratio = float(0.0)
         if sigma != 0.0:
           ratio = new_sigma / sigma
-        ctx_grad_dot_out[worldid] *= ratio * ratio
-        ctx_newton_decrement_out[worldid] *= ratio * ratio
+        ratio_sq = ratio * ratio
+        ctx_grad_dot_out[worldid] *= ratio_sq
+        ctx_newton_decrement_out[worldid] *= ratio_sq
         ctx_grad_scale_out[worldid] = new_sigma
         return
 
@@ -2887,7 +2888,7 @@ def _update_gradient_cholesky(tile_size: int, skip_noflip: bool = False):
     wp.tile_cholesky_inplace(mat_tile, fill_mode="upper")
     input_tile = wp.tile_load(ctx_grad_in[worldid], shape=TILE_SIZE)
     output_tile = wp.tile_cholesky_solve(mat_tile, input_tile, fill_mode="upper")
-    sums = wp.tile_reduce(wp.add, wp.tile_map(_solve_search_sums, input_tile, output_tile))[0]
+    sums = wp.tile_reduce(wp.add, wp.tile_map(solve_search_sums, input_tile, output_tile))[0]
     ctx_search_dot_out[worldid] = sums[0]
     ctx_newton_decrement_out[worldid] = sums[1]
     wp.tile_store(ctx_search_out[worldid], wp.tile_map(wp.mul, output_tile, -1.0))

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -23,8 +23,9 @@ from mujoco_warp._src import math
 from mujoco_warp._src import smooth
 from mujoco_warp._src import support
 from mujoco_warp._src import types
-from mujoco_warp._src.block_cholesky import create_blocked_cholesky_augmented_factorize_solve_func
-from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_func
+from mujoco_warp._src.block_cholesky import create_blocked_cholesky_augmented_factorize_solve_newton_func
+from mujoco_warp._src.block_cholesky import create_blocked_cholesky_factorize_solve_func
+from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_newton_func
 from mujoco_warp._src.types import InverseContext
 from mujoco_warp._src.types import SolverContext
 from mujoco_warp._src.warp_util import cache_kernel
@@ -76,6 +77,7 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
 
   alloc_h = m.opt.solver == types.SolverType.NEWTON
   alloc_hfactor = alloc_h and nv > _BLOCK_CHOLESKY_DIM
+  alloc_mgrad = m.opt.solver == types.SolverType.CG
 
   return SolverContext(
     Jaref=wp.empty((nworld, njmax), dtype=float),
@@ -83,7 +85,8 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     done=wp.empty((nworld,), dtype=bool),
     grad=wp.zeros((nworld, nv_pad), dtype=float),
     grad_dot=wp.empty((nworld,), dtype=float),
-    Mgrad=wp.empty((nworld, nv_pad), dtype=float),
+    newton_decrement=wp.empty((nworld,), dtype=float),
+    Mgrad=wp.empty((nworld, nv_pad), dtype=float) if alloc_mgrad else wp.empty((nworld, 0), dtype=float),
     search=wp.empty((nworld, nv), dtype=float),
     mv=wp.empty((nworld, nv), dtype=float),
     jv=wp.empty((nworld, njmax), dtype=float),
@@ -1459,7 +1462,7 @@ def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext):
 
   When state changes are tracked, worlds with ctx.search_unchanged reuse last
   iteration's mv/jv, so a fresh search requires clearing the flag (see the
-  invalidation in _solve and the writer in _solve_search_update).
+  invalidation in _solve and the writer in _update_gradient_zero_grad_dot).
 
   Args:
     m: Model
@@ -1467,8 +1470,8 @@ def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext):
     ctx: SolverContext
   """
   # mv and jv are pure functions of the search direction, and M and J are
-  # constant within a solve: worlds whose search was kept (see
-  # _solve_search_update) reuse last iteration's values.
+  # constant within a solve, so worlds whose search was kept reuse last
+  # iteration's values.
   skip = ctx.search_unchanged if _use_incremental(m) else ctx.done
 
   # mv = M @ search (common to both parallel and iterative)
@@ -1580,18 +1583,9 @@ def _solve_init_jaref_kernel(is_sparse: bool, nv: int, dofs_per_thread: int, com
   return kernel
 
 
-@wp.kernel
-def _solve_init_search(
-  # In:
-  ctx_Mgrad_in: wp.array2d[float],
-  # Out:
-  ctx_search_out: wp.array2d[float],
-  ctx_search_dot_out: wp.array[float],
-):
-  worldid, dofid = wp.tid()
-  search = -1.0 * ctx_Mgrad_in[worldid, dofid]
-  ctx_search_out[worldid, dofid] = search
-  wp.atomic_add(ctx_search_dot_out, worldid, search * search)
+@wp.func
+def _solve_search_sums(grad: float, mgrad: float):
+  return wp.vec2(mgrad * mgrad, grad * mgrad)
 
 
 @wp.kernel
@@ -2061,9 +2055,16 @@ def _update_gradient_zero_grad_dot(stable_fast: bool):
     ctx_done_in: wp.array[bool],
     # Out:
     ctx_grad_dot_out: wp.array[float],
+    ctx_newton_decrement_out: wp.array[float],
     ctx_grad_scale_out: wp.array[float],
+    ctx_search_unchanged_out: wp.array[bool],
   ):
     worldid = wp.tid()
+
+    if wp.static(STABLE_FAST):
+      ctx_search_unchanged_out[worldid] = ctx_done_in[worldid] or state_changed_count_in[worldid] == 0
+    else:
+      ctx_search_unchanged_out[worldid] = False
 
     if ctx_done_in[worldid]:
       return
@@ -2079,10 +2080,12 @@ def _update_gradient_zero_grad_dot(stable_fast: bool):
         if sigma != 0.0:
           ratio = new_sigma / sigma
         ctx_grad_dot_out[worldid] *= ratio * ratio
+        ctx_newton_decrement_out[worldid] *= ratio * ratio
         ctx_grad_scale_out[worldid] = new_sigma
         return
 
     ctx_grad_dot_out[worldid] = 0.0
+    ctx_newton_decrement_out[worldid] = 0.0
     ctx_grad_scale_out[worldid] = 1.0
 
   return kernel
@@ -2869,7 +2872,9 @@ def _update_gradient_cholesky(tile_size: int, skip_noflip: bool = False):
     state_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Out:
-    ctx_Mgrad_out: wp.array2d[float],
+    ctx_search_out: wp.array2d[float],
+    ctx_search_dot_out: wp.array[float],
+    ctx_newton_decrement_out: wp.array[float],
   ):
     worldid = wp.tid()
     TILE_SIZE = wp.static(tile_size)
@@ -2886,13 +2891,16 @@ def _update_gradient_cholesky(tile_size: int, skip_noflip: bool = False):
     wp.tile_cholesky_inplace(mat_tile, fill_mode="upper")
     input_tile = wp.tile_load(ctx_grad_in[worldid], shape=TILE_SIZE)
     output_tile = wp.tile_cholesky_solve(mat_tile, input_tile, fill_mode="upper")
-    wp.tile_store(ctx_Mgrad_out[worldid], output_tile)
+    sums = wp.tile_reduce(wp.add, wp.tile_map(_solve_search_sums, input_tile, output_tile))[0]
+    ctx_search_dot_out[worldid] = sums[0]
+    ctx_newton_decrement_out[worldid] = sums[1]
+    wp.tile_store(ctx_search_out[worldid], wp.tile_map(wp.mul, output_tile, -1.0))
 
   return kernel
 
 
 @cache_kernel
-def _update_gradient_cholesky_blocked(tile_size: int, matrix_size: int, check_skip: bool = True):
+def _update_gradient_cholesky_blocked(tile_size: int, matrix_size: int, vector_size: int):
   @wp.kernel(module="unique", enable_backward=False, module_options={"enable_mathdx_gemm": False})
   def kernel(
     # In:
@@ -2901,25 +2909,65 @@ def _update_gradient_cholesky_blocked(tile_size: int, matrix_size: int, check_sk
     ctx_h_in: wp.array3d[float],
     ctx_hfactor: wp.array3d[float],
     # Out:
-    ctx_Mgrad_out: wp.array3d[float],
+    ctx_search_out: wp.array3d[float],
+    ctx_search_dot_out: wp.array[float],
+    ctx_newton_decrement_out: wp.array[float],
+  ):
+    worldid, thread_idx = wp.tid()
+    TILE_SIZE = wp.static(tile_size)
+
+    if ctx_done_in[worldid]:
+      return
+
+    # We need matrix size both as a runtime input as well as a static input:
+    # static input is needed to specify the tile sizes for the compiler
+    # runtime input is needed for the loop bounds, otherwise warp will unroll
+    # unconditionally leading to shared memory capacity issues.
+
+    sums = wp.static(create_blocked_cholesky_augmented_factorize_solve_newton_func(TILE_SIZE, matrix_size, vector_size))(
+      ctx_h_in[worldid],
+      ctx_grad_in[worldid],
+      matrix_size,
+      thread_idx,
+      ctx_hfactor[worldid],
+      ctx_search_out[worldid],
+    )
+    if thread_idx == 0:
+      ctx_search_dot_out[worldid] = sums[0]
+      ctx_newton_decrement_out[worldid] = sums[1]
+
+  return kernel
+
+
+@cache_kernel
+def _cholesky_factorize_solve_blocked(tile_size: int, matrix_size: int):
+  @wp.kernel(module="unique", enable_backward=False, module_options={"enable_mathdx_gemm": False})
+  def kernel(
+    # In:
+    A_in: wp.array3d[float],
+    b_in: wp.array3d[float],
+    # Out:
+    U_out: wp.array3d[float],
+    x_out: wp.array3d[float],
   ):
     worldid = wp.tid()
     TILE_SIZE = wp.static(tile_size)
 
-    if wp.static(check_skip):
-      if ctx_done_in[worldid]:
-        return
-
-    # Runtime loop bounds avoid unrolling every panel into shared memory.
-    wp.static(create_blocked_cholesky_augmented_factorize_solve_func(TILE_SIZE, matrix_size))(
-      ctx_h_in[worldid], ctx_grad_in[worldid], matrix_size, ctx_hfactor[worldid], ctx_Mgrad_out[worldid]
+    wp.static(create_blocked_cholesky_factorize_solve_func(TILE_SIZE, matrix_size))(
+      A_in[worldid],
+      b_in[worldid],
+      matrix_size,
+      U_out[worldid],
+      x_out[worldid],
     )
 
   return kernel
 
 
 @cache_kernel
-def _update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size: int, skip_noflip: bool = False):
+def _update_gradient_cholesky_blocked_skip_unchanged(
+  tile_size: int, matrix_size: int, vector_size: int, skip_noflip: bool = False
+):
   """Blocked Cholesky that skips factorization when no constraints changed."""
   SKIP_NOFLIP = skip_noflip
 
@@ -2933,31 +2981,43 @@ def _update_gradient_cholesky_blocked_skip_unchanged(tile_size: int, matrix_size
     state_changed_count_in: wp.array[int],
     ctx_hfactor: wp.array3d[float],
     # Out:
-    ctx_Mgrad_out: wp.array3d[float],
+    ctx_search_out: wp.array3d[float],
+    ctx_search_dot_out: wp.array[float],
+    ctx_newton_decrement_out: wp.array[float],
   ):
-    worldid = wp.tid()
+    worldid, thread_idx = wp.tid()
     TILE_SIZE = wp.static(tile_size)
 
     if ctx_done_in[worldid]:
       return
 
-    # Fast path: skip the solve; Mgrad stays stale on the unchanged ray, and
-    # the linesearch is invariant to the scale of its direction. Worlds whose
-    # only transitions were between friction linear zones (state change but no
-    # quadratic flip) rebuilt grad with H unchanged: solve from the cached
-    # factor.
+    # The linesearch is invariant to direction scale, so an unchanged ray can
+    # keep its previous search direction.
     if wp.static(SKIP_NOFLIP):
       if state_changed_count_in[worldid] == 0:
         return
 
     if quad_changed_count_in[worldid] > 0:
-      wp.static(create_blocked_cholesky_augmented_factorize_solve_func(TILE_SIZE, matrix_size))(
-        ctx_h_in[worldid], ctx_grad_in[worldid], matrix_size, ctx_hfactor[worldid], ctx_Mgrad_out[worldid]
+      sums = wp.static(create_blocked_cholesky_augmented_factorize_solve_newton_func(TILE_SIZE, matrix_size, vector_size))(
+        ctx_h_in[worldid],
+        ctx_grad_in[worldid],
+        matrix_size,
+        thread_idx,
+        ctx_hfactor[worldid],
+        ctx_search_out[worldid],
       )
     else:
-      wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, matrix_size))(
-        ctx_hfactor[worldid], ctx_grad_in[worldid], matrix_size, ctx_Mgrad_out[worldid]
+      sums = wp.static(create_blocked_cholesky_solve_newton_func(TILE_SIZE, matrix_size, vector_size))(
+        ctx_hfactor[worldid],
+        ctx_grad_in[worldid],
+        matrix_size,
+        thread_idx,
+        ctx_search_out[worldid],
       )
+
+    if thread_idx == 0:
+      ctx_search_dot_out[worldid] = sums[0]
+      ctx_newton_decrement_out[worldid] = sums[1]
 
   return kernel
 
@@ -2976,7 +3036,7 @@ def _padding_h(nv: int, ctx_done_in: wp.array[bool], ctx_h_out: wp.array3d[float
 def _cholesky_factorize_solve(
   m: types.Model, d: types.Data, ctx: SolverContext, skip_unchanged: bool = False, skip_noflip: bool = False
 ):
-  """Cholesky factorize ctx.h and solve for Mgrad.
+  """Cholesky factorize ctx.h and form the Newton search direction.
 
   If skip_unchanged is True (blocked path only), worlds where no constraints
   changed reuse the cached factorization in hfactor instead of refactorizing.
@@ -2986,7 +3046,7 @@ def _cholesky_factorize_solve(
       _update_gradient_cholesky(m.nv, skip_noflip),
       dim=d.nworld,
       inputs=[ctx.grad, ctx.h, ctx.state_changed_count if skip_noflip else d.nefc, ctx.done],
-      outputs=[ctx.Mgrad],
+      outputs=[ctx.search, ctx.search_dot, ctx.newton_decrement],
       block_dim=m.block_dim.update_gradient_cholesky,
     )
   else:
@@ -2999,7 +3059,7 @@ def _cholesky_factorize_solve(
 
     if skip_unchanged:
       wp.launch_tiled(
-        _update_gradient_cholesky_blocked_skip_unchanged(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad, skip_noflip),
+        _update_gradient_cholesky_blocked_skip_unchanged(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad, m.nv, skip_noflip),
         dim=d.nworld,
         inputs=[
           ctx.done,
@@ -3009,15 +3069,23 @@ def _cholesky_factorize_solve(
           ctx.state_changed_count if skip_noflip else ctx.quad_changed_count,
           ctx.hfactor,
         ],
-        outputs=[ctx.Mgrad.reshape(shape=(d.nworld, ctx.Mgrad.shape[1], 1))],
+        outputs=[
+          ctx.search.reshape(shape=(d.nworld, m.nv, 1)),
+          ctx.search_dot,
+          ctx.newton_decrement,
+        ],
         block_dim=m.block_dim.update_gradient_cholesky_blocked,
       )
     else:
       wp.launch_tiled(
-        _update_gradient_cholesky_blocked(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad),
+        _update_gradient_cholesky_blocked(types.TILE_SIZE_JTDAJ_DENSE, m.nv_pad, m.nv),
         dim=d.nworld,
         inputs=[ctx.done, ctx.grad.reshape(shape=(d.nworld, ctx.grad.shape[1], 1)), ctx.h, ctx.hfactor],
-        outputs=[ctx.Mgrad.reshape(shape=(d.nworld, ctx.Mgrad.shape[1], 1))],
+        outputs=[
+          ctx.search.reshape(shape=(d.nworld, m.nv, 1)),
+          ctx.search_dot,
+          ctx.newton_decrement,
+        ],
         block_dim=m.block_dim.update_gradient_cholesky_blocked,
       )
 
@@ -3204,7 +3272,7 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
       _update_gradient_zero_grad_dot(False),
       dim=d.nworld,
       inputs=[d.nefc, ctx.alpha, ctx.done],
-      outputs=[ctx.grad_dot, ctx.grad_scale],
+      outputs=[ctx.grad_dot, ctx.newton_decrement, ctx.grad_scale, ctx.search_unchanged],
     )
     wp.launch(
       _update_gradient_grad(False),
@@ -3424,7 +3492,7 @@ def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverConte
     _update_gradient_zero_grad_dot(stable_fast),
     dim=d.nworld,
     inputs=[changed, ctx.alpha, ctx.done],
-    outputs=[ctx.grad_dot, ctx.grad_scale],
+    outputs=[ctx.grad_dot, ctx.newton_decrement, ctx.grad_scale, ctx.search_unchanged],
   )
 
   wp.launch(
@@ -3550,79 +3618,6 @@ def _solve_beta_accumulate(
   wp.atomic_add(ctx_beta_den_out, worldid, den)
 
 
-@cache_kernel
-def _solve_zero_search_dot(stable_fast: bool):
-  STABLE_FAST = stable_fast
-
-  @wp.kernel(module="unique", enable_backward=False)
-  def kernel(
-    # In:
-    state_changed_count_in: wp.array[int],
-    ctx_done_in: wp.array[bool],
-    # Out:
-    ctx_search_dot_out: wp.array[float],
-  ):
-    worldid = wp.tid()
-
-    if ctx_done_in[worldid]:
-      return
-
-    # Fast path: search stays on the same ray; keep search_dot consistent with it.
-    if wp.static(STABLE_FAST):
-      if state_changed_count_in[worldid] == 0:
-        return
-
-    ctx_search_dot_out[worldid] = 0.0
-
-  return kernel
-
-
-@cache_kernel
-def _solve_search_update(stable_fast: bool):
-  STABLE_FAST = stable_fast
-
-  @wp.kernel(module="unique", enable_backward=False)
-  def kernel(
-    # Model:
-    opt_solver: int,
-    # In:
-    state_changed_count_in: wp.array[int],
-    ctx_Mgrad_in: wp.array2d[float],
-    ctx_search_in: wp.array2d[float],
-    ctx_beta_in: wp.array[float],
-    ctx_done_in: wp.array[bool],
-    # Out:
-    ctx_search_out: wp.array2d[float],
-    ctx_search_dot_out: wp.array[float],
-    ctx_search_unchanged_out: wp.array[bool],
-  ):
-    worldid, dofid = wp.tid()
-
-    # Record whether this world keeps its search vector, so the next linesearch
-    # can reuse mv/jv (pure functions of search; done worlds never consume them).
-    if wp.static(STABLE_FAST):
-      if dofid == 0:
-        ctx_search_unchanged_out[worldid] = ctx_done_in[worldid] or state_changed_count_in[worldid] == 0
-
-    if ctx_done_in[worldid]:
-      return
-
-    # Fast path: search stays on the stale ray; the linesearch absorbs its scale.
-    if wp.static(STABLE_FAST):
-      if state_changed_count_in[worldid] == 0:
-        return
-
-    search = -1.0 * ctx_Mgrad_in[worldid, dofid]
-
-    if opt_solver == types.SolverType.CG:
-      search += ctx_beta_in[worldid] * ctx_search_in[worldid, dofid]
-
-    ctx_search_out[worldid, dofid] = search
-    wp.atomic_add(ctx_search_dot_out, worldid, search * search)
-
-  return kernel
-
-
 @wp.kernel
 def _solve_search_update_cg_tiled(
   # Model:
@@ -3717,6 +3712,7 @@ def _solve_done(
   stat_meaninertia: wp.array[float],
   # In:
   ctx_grad_dot_in: wp.array[float],
+  ctx_newton_decrement_in: wp.array[float],
   ctx_improvement_in: wp.array[float],
   ctx_done_in: wp.array[bool],
   # Data out:
@@ -3736,7 +3732,8 @@ def _solve_done(
 
   improvement = _rescale(nv, meaninertia, ctx_improvement_in[worldid])
   gradient = _rescale(nv, meaninertia, wp.sqrt(ctx_grad_dot_in[worldid]))
-  done = (improvement < tolerance) or (gradient < tolerance)
+  model_improvement = _rescale(nv, meaninertia, 0.5 * ctx_newton_decrement_in[worldid])
+  done = (improvement < tolerance) or (gradient < tolerance) or (model_improvement < tolerance)
   if done or solver_niter_out[worldid] == opt_iterations:
     # if the solver has converged or the maximum number of iterations has been reached then
     # mark this world as done and remove it from the number of unconverged worlds
@@ -3805,8 +3802,8 @@ def _solver_iteration(
     )
 
   # The tracking also enables the stable-state fast path: worlds with no state
-  # flips this iteration were exactly quadratic over the step, so grad/Mgrad/
-  # search only changed by a scalar along the same ray. Skip their qfrc/grad/
+  # flips this iteration were exactly quadratic over the step, so grad/search
+  # only changed by a scalar along the same ray. Skip their qfrc/grad/
   # solve/search updates and track the scalar in ctx.grad_scale.
   _update_constraint(m, d, ctx, track_changes=incremental, stable_fast=incremental)
 
@@ -3859,16 +3856,6 @@ def _solver_iteration(
     )
 
   else:
-    changed = ctx.state_changed_count if incremental else d.nefc
-    wp.launch(_solve_zero_search_dot(incremental), dim=d.nworld, inputs=[changed, ctx.done], outputs=[ctx.search_dot])
-
-    wp.launch(
-      _solve_search_update(incremental),
-      dim=(d.nworld, m.nv),
-      inputs=[m.opt.solver, changed, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
-      outputs=[ctx.search, ctx.search_dot, ctx.search_unchanged],
-    )
-
     wp.launch(
       _solve_done,
       dim=d.nworld,
@@ -3878,6 +3865,7 @@ def _solver_iteration(
         m.opt.iterations,
         m.stat.meaninertia,
         ctx.grad_dot,
+        ctx.newton_decrement,
         ctx.improvement,
         ctx.done,
       ],
@@ -3983,7 +3971,7 @@ def _solve(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = Fa
     # left over from the previous solve.
     ctx.search_unchanged.zero_()
 
-  # search = -Mgrad
+  # CG search = -Mgrad
   if m.opt.solver == types.SolverType.CG:
     wp.launch_tiled(
       _solve_init_search_cg_tiled,
@@ -3991,14 +3979,6 @@ def _solve(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = Fa
       inputs=[m.nv, ctx.grad, ctx.Mgrad],
       outputs=[ctx.search, ctx.search_dot, ctx.prev_grad, ctx.prev_Mgrad],
       block_dim=m.block_dim.solve_init_search_cg,
-    )
-
-  else:
-    wp.launch(
-      _solve_init_search,
-      dim=(d.nworld, m.nv),
-      inputs=[ctx.Mgrad],
-      outputs=[ctx.search, ctx.search_dot],
     )
 
   nsolving = wp.full(shape=(1,), value=d.nworld, dtype=int)
@@ -4207,10 +4187,10 @@ def smooth_solve_compact(m: types.Model, d: types.Data):
     outputs=[d.crhs],
   )
   wp.launch_tiled(
-    _update_gradient_cholesky_blocked(types.TILE_SIZE_JTDAJ_DENSE, d.nvmax_pad, False),
+    _cholesky_factorize_solve_blocked(types.TILE_SIZE_JTDAJ_DENSE, d.nvmax_pad),
     dim=d.nworld,
-    inputs=[wp.empty(0, dtype=bool), d.crhs, d.cM, d.cqLD],
-    outputs=[d.cx],
+    inputs=[d.cM, d.crhs],
+    outputs=[d.cqLD, d.cx],
     block_dim=m.block_dim.update_gradient_cholesky_blocked,
   )
   wp.launch(_scatter_solution, dim=(d.nworld, m.nv), inputs=[d.dof_cdof, d.cx], outputs=[d.qacc_smooth])

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -73,6 +73,32 @@ def _eval_elliptic_delta(
 
 
 class SolverTest(parameterized.TestCase):
+  def test_newton_decrement_termination(self):
+    """Newton stops when only its local model predicts convergence."""
+    solver_niter = wp.zeros(1, dtype=int)
+    nsolving = wp.ones(1, dtype=int)
+    done = wp.zeros(1, dtype=bool)
+
+    wp.launch(
+      solver._solve_done,
+      dim=1,
+      inputs=[
+        1,
+        wp.array([1.0e-6], dtype=float),
+        2,
+        wp.array([1.0], dtype=float),
+        wp.array([4.0e-12], dtype=float),
+        wp.array([1.0e-6], dtype=float),
+        wp.array([2.0e-6], dtype=float),
+        done,
+      ],
+      outputs=[solver_niter, nsolving, done],
+    )
+
+    self.assertTrue(done.numpy()[0])
+    self.assertEqual(solver_niter.numpy()[0], 1)
+    self.assertEqual(nsolving.numpy()[0], 0)
+
   # Transition cases use powers of two so the exact delta is below the absolute-cost ulp.
   @parameterized.named_parameters(
     ("middle_zone", 1.0e-4, (0.0, 0.0, 0.0), (0.5, 1.0e-4, 1.0), (0.0, 0.0, 1.0e8), (-0.5, -5000.0, 1.0)),
@@ -743,7 +769,6 @@ class SolverTest(parameterized.TestCase):
         d.efc.force.zero_()
         ctx = solver._create_solver_context(m, d)
         solver.init_context(m, d, ctx, grad=True)
-        wp.launch(solver._solve_init_search, dim=(d.nworld, m.nv), inputs=[ctx.Mgrad], outputs=[ctx.search, ctx.search_dot])
         any_changes = False
         ctx.search_unchanged.fill_(False)
         for _ in range(m.opt.iterations):
@@ -756,18 +781,6 @@ class SolverTest(parameterized.TestCase):
             if np.any(ctx.quad_changed_count.numpy() > 0):
               any_changes = True
           update_fn(m, d, ctx)
-          wp.launch(
-            solver._solve_zero_search_dot(False),
-            dim=(d.nworld),
-            inputs=[ctx.state_changed_count, ctx.done],
-            outputs=[ctx.search_dot],
-          )
-          wp.launch(
-            solver._solve_search_update(False),
-            dim=(d.nworld, m.nv),
-            inputs=[m.opt.solver, ctx.state_changed_count, ctx.Mgrad, ctx.search, ctx.beta, ctx.done],
-            outputs=[ctx.search, ctx.search_dot, ctx.search_unchanged],
-          )
         return d.qacc.numpy().copy(), any_changes
 
       qacc_full, _ = _run_solver(mjw.put_data(mjm, mjd), solver._update_gradient)

--- a/mujoco_warp/_src/support_test.py
+++ b/mujoco_warp/_src/support_test.py
@@ -239,7 +239,7 @@ class SupportTest(parameterized.TestCase):
       search_out: wp.array3d[float],
       sums_out: wp.array[wp.vec2],
     ):
-      worldid, thread_idx = wp.tid()
+      worldid = wp.tid()
       TILE_SIZE = wp.static(16)
 
       if done_in[worldid]:
@@ -249,12 +249,10 @@ class SupportTest(parameterized.TestCase):
         h_in[worldid],
         grad_in[worldid],
         nv_pad,
-        thread_idx,
         hfactor_in[worldid],
         search_out[worldid],
       )
-      if thread_idx == 0:
-        sums_out[worldid] = sums
+      sums_out[worldid] = sums
 
     @wp.kernel(module="unique", enable_backward=False)
     def cholesky_solve_kernel(
@@ -263,18 +261,16 @@ class SupportTest(parameterized.TestCase):
       search_out: wp.array3d[float],
       sums_out: wp.array[wp.vec2],
     ):
-      worldid, thread_idx = wp.tid()
+      worldid = wp.tid()
       TILE_SIZE = wp.static(16)
 
       sums = wp.static(create_blocked_cholesky_solve_newton_func(TILE_SIZE, nv_pad, nv))(
         hfactor_in[worldid],
         grad_in[worldid],
         nv_pad,
-        thread_idx,
         search_out[worldid],
       )
-      if thread_idx == 0:
-        sums_out[worldid] = sums
+      sums_out[worldid] = sums
 
     @wp.kernel(module="unique", enable_backward=False)
     def augmented_cholesky_kernel(
@@ -283,11 +279,11 @@ class SupportTest(parameterized.TestCase):
       hfactor_in: wp.array3d[float],
       Mgrad_out: wp.array3d[float],
     ):
-      worldid, thread_idx = wp.tid()
+      worldid = wp.tid()
       TILE_SIZE = wp.static(16)
 
       wp.static(create_blocked_cholesky_augmented_factorize_solve_func(TILE_SIZE, nv_pad))(
-        h_in[worldid], grad_in[worldid], nv_pad, thread_idx, hfactor_in[worldid], Mgrad_out[worldid]
+        h_in[worldid], grad_in[worldid], nv_pad, hfactor_in[worldid], Mgrad_out[worldid]
       )
 
     @wp.kernel(module="unique", enable_backward=False)
@@ -296,11 +292,11 @@ class SupportTest(parameterized.TestCase):
       hfactor_in: wp.array3d[float],
       Mgrad_out: wp.array3d[float],
     ):
-      worldid, thread_idx = wp.tid()
+      worldid = wp.tid()
       TILE_SIZE = wp.static(16)
 
       wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, nv_pad))(
-        hfactor_in[worldid], grad_in[worldid], nv_pad, thread_idx, Mgrad_out[worldid]
+        hfactor_in[worldid], grad_in[worldid], nv_pad, Mgrad_out[worldid]
       )
 
     # Create test vector and fill the built-in arrays

--- a/mujoco_warp/_src/support_test.py
+++ b/mujoco_warp/_src/support_test.py
@@ -28,8 +28,10 @@ from mujoco_warp import test_data
 from mujoco_warp._src import io
 from mujoco_warp._src import support
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_augmented_factorize_solve_func
+from mujoco_warp._src.block_cholesky import create_blocked_cholesky_augmented_factorize_solve_newton_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_factorize_solve_func
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_func
+from mujoco_warp._src.block_cholesky import create_blocked_cholesky_solve_newton_func
 
 # tolerance for difference between MuJoCo and MJWarp support calculations - mostly
 # due to float precision
@@ -211,7 +213,7 @@ class SupportTest(parameterized.TestCase):
     nworld = d.nworld
 
     @wp.kernel(module="unique", enable_backward=False)
-    def fused_cholesky_kernel(
+    def cholesky_kernel(
       grad_in: wp.array3d[float],
       h_in: wp.array3d[float],
       done_in: wp.array[bool],
@@ -229,17 +231,63 @@ class SupportTest(parameterized.TestCase):
       )
 
     @wp.kernel(module="unique", enable_backward=False)
+    def fused_cholesky_kernel(
+      grad_in: wp.array3d[float],
+      h_in: wp.array3d[float],
+      done_in: wp.array[bool],
+      hfactor_in: wp.array3d[float],
+      search_out: wp.array3d[float],
+      sums_out: wp.array[wp.vec2],
+    ):
+      worldid, thread_idx = wp.tid()
+      TILE_SIZE = wp.static(16)
+
+      if done_in[worldid]:
+        return
+
+      sums = wp.static(create_blocked_cholesky_augmented_factorize_solve_newton_func(TILE_SIZE, nv_pad, nv))(
+        h_in[worldid],
+        grad_in[worldid],
+        nv_pad,
+        thread_idx,
+        hfactor_in[worldid],
+        search_out[worldid],
+      )
+      if thread_idx == 0:
+        sums_out[worldid] = sums
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def cholesky_solve_kernel(
+      grad_in: wp.array3d[float],
+      hfactor_in: wp.array3d[float],
+      search_out: wp.array3d[float],
+      sums_out: wp.array[wp.vec2],
+    ):
+      worldid, thread_idx = wp.tid()
+      TILE_SIZE = wp.static(16)
+
+      sums = wp.static(create_blocked_cholesky_solve_newton_func(TILE_SIZE, nv_pad, nv))(
+        hfactor_in[worldid],
+        grad_in[worldid],
+        nv_pad,
+        thread_idx,
+        search_out[worldid],
+      )
+      if thread_idx == 0:
+        sums_out[worldid] = sums
+
+    @wp.kernel(module="unique", enable_backward=False)
     def augmented_cholesky_kernel(
       grad_in: wp.array3d[float],
       h_in: wp.array3d[float],
       hfactor_in: wp.array3d[float],
       Mgrad_out: wp.array3d[float],
     ):
-      worldid = wp.tid()
+      worldid, thread_idx = wp.tid()
       TILE_SIZE = wp.static(16)
 
       wp.static(create_blocked_cholesky_augmented_factorize_solve_func(TILE_SIZE, nv_pad))(
-        h_in[worldid], grad_in[worldid], nv_pad, hfactor_in[worldid], Mgrad_out[worldid]
+        h_in[worldid], grad_in[worldid], nv_pad, thread_idx, hfactor_in[worldid], Mgrad_out[worldid]
       )
 
     @wp.kernel(module="unique", enable_backward=False)
@@ -248,11 +296,11 @@ class SupportTest(parameterized.TestCase):
       hfactor_in: wp.array3d[float],
       Mgrad_out: wp.array3d[float],
     ):
-      worldid = wp.tid()
+      worldid, thread_idx = wp.tid()
       TILE_SIZE = wp.static(16)
 
       wp.static(create_blocked_cholesky_solve_func(TILE_SIZE, nv_pad))(
-        hfactor_in[worldid], grad_in[worldid], nv_pad, Mgrad_out[worldid]
+        hfactor_in[worldid], grad_in[worldid], nv_pad, thread_idx, Mgrad_out[worldid]
       )
 
     # Create test vector and fill the built-in arrays
@@ -272,7 +320,7 @@ class SupportTest(parameterized.TestCase):
       h_np[0, nv:, nv:] = np.eye(padding_size, dtype=np.float32)
     h = wp.array(h_np, dtype=float)
 
-    # 3. Create inline arrays for grad, Mgrad, and done (no longer in d.efc)
+    # 3. Create inline arrays for grad and done (no longer in d.efc)
     grad_np = np.zeros((nworld, nv_pad))
     grad_np[0, :nv] = b
     grad = wp.array(grad_np, dtype=float)
@@ -282,24 +330,52 @@ class SupportTest(parameterized.TestCase):
     # Initialize padding region to identity
     L_init[0, nv:, nv:] = np.eye(nv_pad - nv, dtype=np.float32)
 
+    hfactor = wp.array(L_init, dtype=float)
+    Mgrad = wp.zeros((nworld, nv_pad), dtype=float)
     hfactor_fused = wp.array(L_init, dtype=float)
 
-    Mgrad_fused = wp.zeros((nworld, nv_pad), dtype=float)
+    search_fused = wp.zeros((nworld, nv), dtype=float)
+    sums_fused = wp.zeros(nworld, dtype=wp.vec2)
+    search_solve = wp.zeros((nworld, nv), dtype=float)
+    sums_solve = wp.zeros(nworld, dtype=wp.vec2)
 
     # Ensure done is False so kernel executes
     done = wp.zeros((nworld,), dtype=bool)
 
     wp.launch_tiled(
+      cholesky_kernel,
+      dim=nworld,
+      inputs=[grad.reshape(shape=(nworld, nv_pad, 1)), h, done, hfactor],
+      outputs=[Mgrad.reshape(shape=(nworld, nv_pad, 1))],
+      block_dim=m.block_dim.update_gradient_cholesky,
+    )
+    wp.launch_tiled(
       fused_cholesky_kernel,
       dim=nworld,
       inputs=[grad.reshape(shape=(nworld, nv_pad, 1)), h, done, hfactor_fused],
-      outputs=[Mgrad_fused.reshape(shape=(nworld, nv_pad, 1))],
+      outputs=[
+        search_fused.reshape(shape=(nworld, nv, 1)),
+        sums_fused,
+      ],
       block_dim=m.block_dim.update_gradient_cholesky,
     )
-    wp.synchronize()
-
-    U_result = hfactor_fused.numpy()[0]
-    x_result = Mgrad_fused.numpy()[0]
+    wp.launch_tiled(
+      cholesky_solve_kernel,
+      dim=nworld,
+      inputs=[grad.reshape(shape=(nworld, nv_pad, 1)), hfactor_fused],
+      outputs=[
+        search_solve.reshape(shape=(nworld, nv, 1)),
+        sums_solve,
+      ],
+      block_dim=m.block_dim.update_gradient_cholesky,
+    )
+    U_result = hfactor.numpy()[0]
+    x_result = Mgrad.numpy()[0]
+    U_fused_result = hfactor_fused.numpy()[0]
+    search_result = search_fused.numpy()[0]
+    sums_result = sums_fused.numpy()[0]
+    search_solve_result = search_solve.numpy()[0]
+    sums_solve_result = sums_solve.numpy()[0]
 
     # Verify padding outside active region doesn't affect active computation
     # Off-diagonal padding should be zero (active region shouldn't touch padding)
@@ -347,15 +423,14 @@ class SupportTest(parameterized.TestCase):
       err_msg="U.T @ U does not equal symmetrized Hessian",
     )
 
-    # Verify solution: A @ x = b using the symmetrized Hessian
+    # Verify the search direction against the symmetrized Hessian solution.
     x_numpy = np.linalg.solve(SPD_active_hessian, b)
-    np.testing.assert_allclose(
-      x_result[:nv],
-      x_numpy,
-      rtol=1e-3,
-      atol=1e-3,
-      err_msg="Solution mismatch with numpy",
-    )
+    np.testing.assert_allclose(x_result[:nv], x_numpy, rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(U_fused_result[:nv, :nv], U_numpy, rtol=1e-4, atol=1e-4)
+    np.testing.assert_allclose(search_result, -x_numpy, rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(sums_result, [x_numpy @ x_numpy, b @ x_numpy], rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(search_solve_result, -x_numpy, rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(sums_solve_result, [x_numpy @ x_numpy, b @ x_numpy], rtol=1e-3, atol=1e-3)
 
     hfactor_augmented = wp.array(L_init, dtype=float)
     Mgrad_augmented = wp.zeros((nworld, nv_pad), dtype=float)
@@ -379,8 +454,6 @@ class SupportTest(parameterized.TestCase):
       outputs=[Mgrad_solve.reshape(shape=(nworld, nv_pad, 1))],
       block_dim=m.block_dim.update_gradient_cholesky,
     )
-    wp.synchronize()
-
     np.testing.assert_allclose(hfactor_augmented.numpy()[0, :nv, :nv], U_numpy, rtol=1e-4, atol=1e-4)
     np.testing.assert_allclose(Mgrad_augmented.numpy()[0, :nv], x_numpy, rtol=1e-3, atol=1e-3)
     np.testing.assert_allclose(Mgrad_solve.numpy()[0, :nv], np.linalg.solve(SPD_active_hessian, solve_b), rtol=1e-3, atol=1e-3)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2378,6 +2378,7 @@ class SolverContext:
   done: wp.array[bool]
   grad: wp.array2d[float]
   grad_dot: wp.array[float]
+  newton_decrement: wp.array[float]
   Mgrad: wp.array2d[float]
   search: wp.array2d[float]
   mv: wp.array2d[float]


### PR DESCRIPTION
## Summary

Add the Newton decrement as an outer convergence criterion for the constraint solver.

After an accepted line-search step, the solver has already rebuilt the gradient and Hessian and computed the next Newton direction. The decrement

$$
\frac{1}{2} g^T H^{-1} g
$$

is the local quadratic model's predicted remaining improvement. Terminating when this value is below the solver tolerance avoids performing another outer Newton iteration solely to observe a correspondingly small actual improvement.

## Motivation

The existing outer termination criteria use the improvement from the previously accepted step and the Euclidean gradient norm. Neither criterion uses the newly computed Newton direction.

Consequently, a solve can reach a point where the remaining model improvement is below tolerance while the previous improvement and gradient norm remain above tolerance. The solver then performs another line search, rebuilds the constraint derivatives, and only afterward terminates based on the resulting actual improvement.

The line-search convergence criteria do not replace this check. They determine whether the one-dimensional minimization along the current direction has converged; they do not determine whether another outer Newton direction is worthwhile.

## Implementation

- Compute `g^T H^-1 g` while producing the Newton search direction.
- Apply the same `nv` and mean-inertia normalization used by the existing outer termination criteria.
- Fuse the search direction, search norm, and decrement reductions into the small and blocked Cholesky solve epilogues.
- Share the blocked Cholesky implementation between ordinary solves and the compile-time Newton epilogue specialization.
- Preserve the cached-factor and unchanged-search fast paths, including rescaling the cached decrement when the gradient changes only by a scalar.
- Stop allocating and writing the intermediate `Mgrad` array for Newton. The CG solver continues to use `Mgrad` unchanged.

## Validation

- Add a unit test where actual improvement and gradient norm are above tolerance but the Newton model improvement is below tolerance.
- Extend blocked Cholesky coverage to validate the ordinary solve, augmented solve, fused Newton epilogue, and cached-factor solve against NumPy.
- Run the complete CUDA solver and support test suites: 86 tests pass.
- Run all pre-commit checks.

## Performance

Measured with `mjwarp-testspeed`, elliptic cones, 8,192 worlds, and 1,000 steps. Results are medians of four interleaved runs, with each variant occupying each ordinal position once. G1 uses `shuffle_dance.npz`; Aloha Clutter uses `pick_clutter.npz`. No prerecorded trajectory is available for the humanoid benchmarks.

| Benchmark | Upstream | Decrement, unfused | Final | Solver iterations, upstream to final | Final vs upstream |
|---|---:|---:|---:|---:|---:|
| Humanoid | 2.542 s | 2.299 s | 2.282 s | 1.644 to 1.345 | -10.2% |
| G1 replay | 4.337 s | 3.950 s | 3.890 s | 4.030 to 3.322 | -10.3% |
| Three humanoids | 15.606 s | 13.742 s | 13.767 s | 3.547 to 2.815 | -11.8% |
| Aloha Clutter replay | 12.094 s | 11.634 s | 11.633 s | 1.106 to 1.104 | -3.8% |

The unfused variant isolates the convergence change by computing the search direction, search norm, and decrement in a separate kernel. Final adds the fused tile epilogue and removes the Newton `Mgrad` workspace. The complete runs behind the medians are:

| Benchmark | Variant | Run 1 | Run 2 | Run 3 | Run 4 | Median |
|---|---|---:|---:|---:|---:|---:|
| Humanoid | Upstream | 2.556676 | 2.527121 | 2.571986 | 2.360423 | 2.541898 |
| Humanoid | Unfused | 2.329163 | 2.344091 | 2.246855 | 2.268954 | 2.299058 |
| Humanoid | Final | 2.278954 | 2.285754 | 2.298831 | 2.246935 | 2.282354 |
| G1 replay | Upstream | 4.377498 | 4.154805 | 4.634156 | 4.296581 | 4.337040 |
| G1 replay | Unfused | 3.940362 | 3.960360 | 4.069016 | 3.926335 | 3.950361 |
| G1 replay | Final | 3.895126 | 3.884735 | 4.237712 | 3.879237 | 3.889930 |
| Three humanoids | Upstream | 15.439896 | 15.631627 | 15.580172 | 15.642628 | 15.605900 |
| Three humanoids | Unfused | 13.707339 | 13.741917 | 13.793112 | 13.741285 | 13.741601 |
| Three humanoids | Final | 13.849973 | 13.677723 | 13.788575 | 13.744602 | 13.766589 |
| Aloha Clutter replay | Upstream | 11.277973 | 12.127685 | 12.059470 | 12.237110 | 12.093578 |
| Aloha Clutter replay | Unfused | 11.307978 | 11.694572 | 11.647998 | 11.620374 | 11.634186 |
| Aloha Clutter replay | Final | 11.399335 | 11.795854 | 11.945521 | 11.470001 | 11.632928 |

CUDA 12.9 Nsight Systems profiles cover the same three variants over 100 steps:

| Benchmark | Upstream GPU time | Unfused | Final | Final vs upstream |
|---|---:|---:|---:|---:|
| Humanoid | 208.8 ms | 188.9 ms | 186.3 ms | -10.8% |
| G1 replay | 518.0 ms | 455.1 ms | 459.9 ms | -11.2% |
| Three humanoids | 1331.1 ms | 1198.0 ms | 1185.4 ms | -10.9% |
| Aloha Clutter replay | 1083.9 ms | 1068.2 ms | 1068.7 ms | -1.4% |

### `Mgrad` ablation

The earlier fused-plus-`Mgrad` measurements used the pre-tile scalar epilogue and therefore did not isolate the `Mgrad` write. The corrected variant is identical to Final except that it allocates `Mgrad` and stores the solved vector to it. Four paired runs, with each variant running first twice, show no resolvable end-to-end effect:

| Benchmark | Tile + `Mgrad` runs | Median | Final runs | Median | Final vs `Mgrad` |
|---|---|---:|---|---:|---:|
| Humanoid | 2.207159 / 2.280833 / 2.311542 / 2.319607 | 2.296187 | 2.294792 / 2.284424 / 2.295558 / 2.284665 | 2.289728 | -0.28% |
| G1 replay | 4.196580 / 4.186073 / 4.228789 / 4.231837 | 4.212684 | 4.240905 / 4.224080 / 4.242891 / 4.209969 | 4.232493 | +0.47% |
| Three humanoids | 13.625806 / 13.707099 / 13.788066 / 13.731764 | 13.719431 | 13.733249 / 13.743454 / 13.665568 / 13.727870 | 13.730560 | +0.08% |
| Aloha Clutter replay | 11.970563 / 12.093601 / 11.887607 / 11.890023 | 11.930293 | 12.047704 / 12.025934 / 11.933399 / 11.935090 | 11.980512 | +0.42% |

Matching Nsight profiles show that removing the write consistently reduces the changed Cholesky kernel, while whole-profile timing remains sensitive to persistent desktop graphics activity:

| Benchmark | `Mgrad` GPU total | Final GPU total | `Mgrad` Cholesky avg | Final Cholesky avg | Final kernel delta |
|---|---:|---:|---:|---:|---:|
| Humanoid | 189.532 ms | 186.004 ms | 26.639 us | 23.948 us | -10.1% |
| G1 replay | 454.826 ms | 419.452 ms | 50.629 us | 49.490 us | -2.3% |
| Three humanoids | 1032.031 ms | 1026.428 ms | 198.085 us | 195.541 us | -1.3% |
| Aloha Clutter replay | 940.726 ms | 939.491 ms | 223.269 us | 221.742 us | -0.7% |

The iteration reduction provides the main end-to-end improvement. Fusion removes the standalone reduction launch. Removing `Mgrad` eliminates an unused Newton workspace and output store; its whole-step effect is below benchmark noise, while the isolated kernel consistently moves in the expected direction.
