### PR TITLE
_solve_init_dof

### DIFF
--- a/mujoco_warp/_src/inverse.py
+++ b/mujoco_warp/_src/inverse.py
@@ -119,12 +119,27 @@ def discrete_acc(m: Model, d: Data, qacc: wp.array2d[float]):
   smooth.solve_m(m, d, qacc, qfrc)
 
 
+@wp.kernel
+def _zero_qfrc_constraint_nefc(nefc_in: wp.array[int], qfrc_constraint_out: wp.array2d[float]):
+  worldid, dofid = wp.tid()
+  if nefc_in[worldid] == 0:
+    qfrc_constraint_out[worldid, dofid] = 0.0
+
+
 def inv_constraint(m: Model, d: Data):
   """Inverse constraint solver."""
   # no constraints
   if d.njmax == 0:
     d.qfrc_constraint.zero_()
     return
+
+  if m.is_sparse:
+    wp.launch(
+      _zero_qfrc_constraint_nefc,
+      dim=(d.nworld, m.nv),
+      inputs=[d.nefc],
+      outputs=[d.qfrc_constraint],
+    )
 
   ctx = solver.create_inverse_context(m, d)
   solver.init_context(m, d, ctx, grad=False)

--- a/mujoco_warp/_src/inverse_test.py
+++ b/mujoco_warp/_src/inverse_test.py
@@ -115,6 +115,51 @@ class InverseTest(parameterized.TestCase):
     _assert_eq(d.qfrc_inverse.numpy()[0], qfrc_inverse, "qfrc_inverse")
     _assert_eq(d.qacc.numpy()[0], qacc, "qacc")
 
+  def test_qfrc_constraint_inverse_initialization(self):
+    """Verify that qfrc_constraint is zeroed in inverse dynamics when nefc==0."""
+    xml = """
+    <mujoco>
+      <option solver="CG" jacobian="sparse"/>
+      <worldbody>
+        <geom type="plane" size="10 10 .001"/>
+        <body name="sphere" pos="0 0 0.04">
+          <freejoint/>
+          <geom type="sphere" size="0.05" mass="1.0"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+    _, _, m, d = test_data.fixture(xml=xml)
+
+    # 1. Position in contact, set some qacc (resisting gravity requires contact force)
+    d.qpos.zero_()
+    qpos_np = d.qpos.numpy()
+    qpos_np[0, 2] = 0.04  # contact
+    wp.copy(d.qpos, wp.array(qpos_np))
+    d.qvel.zero_()
+    d.qacc.zero_()
+
+    mjw.inverse(m, d)
+
+    self.assertGreater(d.nefc.numpy()[0], 0, "Should have active constraints")
+    self.assertGreater(np.max(np.abs(d.qfrc_constraint.numpy()[0])), 1.0, "Should have non-zero constraint forces")
+
+    # 2. Teleport sphere up (no contacts)
+    qpos_np[0, 2] = 1.0
+    wp.copy(d.qpos, wp.array(qpos_np))
+    d.qvel.zero_()
+    d.qacc.zero_()
+
+    mjw.inverse(m, d)
+
+    self.assertEqual(d.nefc.numpy()[0], 0, "Should have no active constraints after teleport")
+    qfrc_constraint_post = d.qfrc_constraint.numpy()[0]
+    self.assertLess(
+      np.max(np.abs(qfrc_constraint_post)),
+      1e-5,
+      f"qfrc_constraint should be zeroed, but got max abs: {np.max(np.abs(qfrc_constraint_post))}",
+    )
+
   def test_discrete_acc_eulerdamp(self):
     _, _, m, d = test_data.fixture(
       xml=_XML,

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1514,6 +1514,35 @@ def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext):
   _linesearch_iterative(m, d, ctx, fuse_jv)
 
 
+@cache_kernel
+def _solve_init_dof(warmstart: bool, sparse: bool):
+  WARMSTART = warmstart
+  SPARSE = sparse
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    nefc_in: wp.array[int],
+    qacc_warmstart_in: wp.array2d[float],
+    qacc_smooth_in: wp.array2d[float],
+    # Data out:
+    qacc_out: wp.array2d[float],
+    qfrc_constraint_out: wp.array2d[float],
+  ):
+    worldid, dofid = wp.tid()
+
+    if wp.static(WARMSTART):
+      qacc_out[worldid, dofid] = qacc_warmstart_in[worldid, dofid]
+    else:
+      qacc_out[worldid, dofid] = qacc_smooth_in[worldid, dofid]
+
+    if wp.static(SPARSE):
+      if nefc_in[worldid] == 0:
+        qfrc_constraint_out[worldid, dofid] = 0.0
+
+  return kernel
+
+
 @wp.kernel
 def _solve_init_efc(
   # Data out:
@@ -3950,10 +3979,13 @@ def solve(m: types.Model, d: types.Data):
 
 def _solve(m: types.Model, d: types.Data, ctx: SolverContext, compact: bool = False):
   """Finds forces that satisfy constraints."""
-  if not (m.opt.disableflags & types.DisableBit.WARMSTART):
-    wp.copy(d.qacc, d.qacc_warmstart)
-  else:
-    wp.copy(d.qacc, d.qacc_smooth)
+  warmstart = not (m.opt.disableflags & types.DisableBit.WARMSTART)
+  wp.launch(
+    _solve_init_dof(warmstart, m.is_sparse),
+    dim=(d.nworld, m.nv),
+    inputs=[d.nefc, d.qacc_warmstart, d.qacc_smooth],
+    outputs=[d.qacc, d.qfrc_constraint],
+  )
 
   #  context
   init_context(m, d, ctx, grad=True, compact=compact)

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -1196,6 +1196,45 @@ class CompactSolverTest(absltest.TestCase):
     np.testing.assert_array_equal(efc_island[:nefc], [2] * nefc)
     np.testing.assert_array_equal(efc_island[nefc:], [-1] * (d.njmax - nefc))
 
+  def test_qfrc_constraint_initialization(self):
+    """Verify that qfrc_constraint is initially zeroed when nefc==0."""
+    xml = """
+    <mujoco>
+      <option solver="CG" jacobian="sparse"/>
+      <worldbody>
+        <geom type="plane" size="10 10 .001"/>
+        <body name="sphere" pos="0 0 0.04">
+          <freejoint/>
+          <geom type="sphere" size="0.05" mass="1.0"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+    _, _, m, d = test_data.fixture(xml=xml)
+
+    # 1. Step once (starts in contact because Z=0.04 < radius=0.05)
+    mjw.step(m, d)
+
+    self.assertGreater(d.nefc.numpy()[0], 0, "Should have active constraints")
+    self.assertGreater(np.max(np.abs(d.qfrc_constraint.numpy()[0])), 1.0, "Should have non-zero constraint forces")
+
+    # 2. Teleport sphere up (no contacts)
+    qpos_np = d.qpos.numpy()
+    qpos_np[0, 2] = 1.0  # Move up to Z=1.0
+    wp.copy(d.qpos, wp.array(qpos_np))
+    d.qvel.zero_()
+
+    # 3. Step again (will update nefc to 0 and should zero qfrc_constraint)
+    mjw.step(m, d)
+
+    self.assertEqual(d.nefc.numpy()[0], 0, "Should have no active constraints after teleport")
+    qfrc_constraint_post = d.qfrc_constraint.numpy()[0]
+    self.assertLess(
+      np.max(np.abs(qfrc_constraint_post)),
+      1e-5,
+      f"qfrc_constraint should be zeroed, but got max abs: {np.max(np.abs(qfrc_constraint_post))}",
+    )
+
 
 if __name__ == "__main__":
   wp.init()


### PR DESCRIPTION
fix bug where `qfrc_constraint` wasn't correctly initialized to zero when `nefc==0` and `nefc>0` at the previous timestep