### PR TITLE
Cap large-model linesearch block dim at 256

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -490,7 +490,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   m.block_dim.solve_search_update_cg = _nv_block
   m.block_dim.solve_init_search_cg = _nv_block
   if mjm.nv > 500:
-    m.block_dim.linesearch_iterative = 512
+    m.block_dim.linesearch_iterative = 256
   m.is_sparse = is_sparse(mjm)
   m.has_fluid = mjm.opt.wind.any() or mjm.opt.density > 0 or mjm.opt.viscosity > 0
 


### PR DESCRIPTION
The `nv > 500` heuristic from #1404 launches `_linesearch_iterative` with 512-thread blocks. The elliptic specialization of that kernel now compiles to 153 registers per thread on sm_89 (measured on L40S, CUDA 12.9 toolchain; the pre-#1512 code was already at 113), so a 512-thread launch requires 512 × 153 = 78K registers against the 64K per-block hardware limit and fails at launch with CUDA error 701. This is the cause of the `io_test` `test_get_data_into` failures on Ada CI runners (flex models × elliptic cone × all integrators — the only fixtures with `nv > 500`). The failure is compiler-route-independent (offline ptxas and driver JIT both produce ~153 registers) but architecture-dependent: the same source compiles to 99 registers targeting sm_120, which is why Blackwell development machines never reproduce it.

256 threads is safe by construction: the ISA caps a thread at 255 registers, and 256 × 255 ≤ 65,536, so no future register growth on any architecture or compiler version can make the launch fail again.

Benchmarks show 256 costs nothing relative to 512, including on the workload the heuristic was tuned on. Cloth (`benchmarks/cloth/scene.xml`, L40S, steps/s):

| | block 32 | block 256 | block 512 |
| --- | ---: | ---: | ---: |
| pyramidal, nworld=1, at #1404's commit (53c6a09) | 945 | 1068 | 1068 |
| pyramidal, nworld=32, at #1404's commit | 8211 | 8565 | 8604 |
| pyramidal, nworld=1, main | 568 | 604 | 596 |
| pyramidal, nworld=32, main | 1838 | 1837 | 1770 |
| elliptic, nworld=32, main | — | 1611 | fails (701) |

At the original tuning commit, 256 already delivered the full benefit of the wide block (+13%/+4% over block 32 at nworld 1/32); on current main, 512 has no remaining advantage on pyramidal and cannot launch on elliptic. The wide-block benefit decays with world count (+13% at nworld=1 to noise at nworld≥512) and never inverts on large-`njmax` models, while models below the guard threshold are unaffected by this change.

Alternatives considered and measured: gating 256 on the elliptic cone (rejected — 512 never beats 256 on pyramidal either, and pyramidal's specializations sit near the same register cliff with no contract protecting them); `launch_bounds=512` on the kernel (works — compiler pins 128 registers and spills — but measures slower than the 256 block: 1323 vs 1611 steps/s on elliptic cloth; could still be added independently as insurance against future launch failures); restructuring the kernel to reduce register pressure (a runtime loop bound, serializing the 3-alpha evaluation, and precomputing packed per-row inputs were each prototyped; none moved the kernel below 147 registers).

Verified on L40S: `io_test.py -k test_get_data_into` goes from 4 failed (8× CUDA 701) to 43 passed; cloth and robot benchmark suites run with the numbers above.
