### PR TITLE
Fix uninitialized x_I read in _actuator_force dcmotor branch

### DIFF
--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -831,6 +831,7 @@ def _actuator_force(
         adr += 1
 
       # integral
+      x_I = 0.0
       if slots[1] >= 0:
         x_I = act_in[worldid, adr]
         input_mode = int(gainprm[8])


### PR DESCRIPTION
## Bug

In `_actuator_force`'s DCMOTOR act_dot section, `x_I` is assigned only inside the integral-slot conditional but read unconditionally a few lines later by the `dcmotor_voltage` call:

```python
# integral
if slots[1] >= 0:
    x_I = act_in[worldid, adr]   # only assignment
    ...
    adr += 1

# voltage
V = util_misc.dcmotor_voltage(ctrl, ..., x_I, gainprm)  # unconditional read
```

For any dcmotor **without** the integral state this is a use-before-assignment. Warp compiles it into a read of an uninitialized C++ scalar local — undefined behavior (visible in the generated C++: the variable is declared at function scope, assigned only inside the branch, and read unconditionally afterwards).

## Symptom

Observed on **macOS arm64, CPU device** (warp-lang 1.15.0 against this branch; also reproduced with warp-lang 1.14.0 against the mujoco-warp 3.10.0.1 release): the compiled kernel behaves as if the disabled integral branch executes — its `adr += 1` shifts the running activation-slot index, so the temperature and bristle (LuGre) blocks read/write the wrong `act`/`act_dot` slots (out of bounds for bristle-only actuators, reading 0). The stored LuGre bristle derivative becomes the raw actuator velocity instead of `v - sigma0*|v|/g(v)*z`, which injects a spurious `sigma1*v` viscous term into the friction force; the thermal state derivative is corrupted the same way (its act_dot write lands in the wrong slot).

On that platform the existing tests catch it:

```
pytest mujoco_warp/_src/forward_test.py -k dcmotor      # macOS arm64, CPU device
FAILED ...DCMotorTest::test_dcmotor_current_plus_thermal
FAILED ...DCMotorTest::test_dcmotor_lugre_steady_state
FAILED ...DCMotorTest::test_dcmotor_thermal_steady_state
3 failed, 30 passed
```

CI's Linux x86_64 CPU runs and CUDA (verified on an H100, warp-lang 1.15.0: 33/33 pass) happen to produce correct code under the same UB, so the bug is currently invisible to CI — but the source-level use-before-assignment is platform-independent and any compiler/version change could surface it elsewhere.

## Fix

Initialize `x_I = 0.0` before the conditional, mirroring the existing initializer in the GainType.DCMOTOR gain section (`x_I = 0.0` immediately before `if slots[1] >= 0:` there). `0.0` matches the C reference in every reachable configuration: `dcmotor_voltage` uses `x_I` only in its `ki` terms, and the integral slot is enabled exactly when `ki = gainprm[5] > 0`. For the compiler-accepted `ki < 0` corner (slot disabled, velocity mode still evaluates `ki * (x_I - length)`), C MuJoCo's own output equals the `x_I = 0` result — verified numerically. No behavior change for models with the integral state, none on CUDA.

After the change, same macOS arm64 CPU setup: `33 passed` (full forward_test.py: 93 passed, 1 skipped).

## Audit for the same pattern

- `act` in the actearly branch appears to have the same issue for `dyntype="user"` + `actearly="true"`: it is assigned for FILTER/FILTEREXACT/MUSCLE and INTEGRATOR/NONE/DCMOTOR, but for `DynType.USER` the `next_act` call reads it unassigned and returns it as `ctrl_act`. Local repro (macOS arm64 CPU): `<general dyntype="user" actdim="1" actearly="true" gaintype="fixed" gainprm="2 0 0"/>` with `act = 0.25` gives actuator_force 0.0 from mujoco_warp vs 0.5 from C MuJoCo. Happy to fix that here or in a follow-up (include `DynType.USER` in the `act = act_in[...]` condition), whichever you prefer.
- `dynprm` in the gain/bias sections is unassigned when `na == 0`, but warp value-initializes *vector* locals to zero (scalar locals are not initialized), and zero matches stateless-motor semantics — benign; exercised by `test_dcmotor_stateless_steady_state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)