### PR TITLE
Gate the EPA horizon warning behind warn_overflow and record it in Data.overflow

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -475,6 +475,8 @@ def ccd_hfield_kernel_builder(
             epa_norm2,
             epa_horizon,
             wp.static(warn_overflow),
+            worldid,
+            overflow_out,
           )
 
           if ncontact == 0:
@@ -835,6 +837,8 @@ def ccd_kernel_builder(
         epa_norm2_in[ccdid],
         epa_horizon_in[ccdid],
         wp.static(warn_overflow),
+        worldid,
+        overflow_out,
       )
 
     if dist >= gap and not is_collision_sensor:

--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -474,6 +474,7 @@ def ccd_hfield_kernel_builder(
             epa_pr,
             epa_norm2,
             epa_horizon,
+            wp.static(warn_overflow),
           )
 
           if ncontact == 0:
@@ -833,6 +834,7 @@ def ccd_kernel_builder(
         epa_pr_in[ccdid],
         epa_norm2_in[ccdid],
         epa_horizon_in[ccdid],
+        wp.static(warn_overflow),
       )
 
     if dist >= gap and not is_collision_sensor:

--- a/mujoco_warp/_src/collision_flex.py
+++ b/mujoco_warp/_src/collision_flex.py
@@ -863,6 +863,8 @@ def _collide_mesh_triangle(
       epa_norm2,
       epa_horizon,
       warn_overflow,
+      worldid,
+      overflow_out,
     )
 
     if ncontact > 0 and dist < margin + tri_radius:
@@ -2019,6 +2021,8 @@ def _flex_selfcollision_narrowphase(
       epa_norm2_out[pairid],
       epa_horizon_out[pairid],
       opt_warn_overflow,
+      worldid,
+      overflow_out,
     )
 
     phys_dist = dist
@@ -2240,6 +2244,8 @@ def _flex_active_element_collisions_detect(
         epa_norm2_out[unique_thread_id],
         epa_horizon_out[unique_thread_id],
         opt_warn_overflow,
+        worldid,
+        overflow_out,
       )
 
       phys_dist = dist
@@ -2515,6 +2521,8 @@ def _flex_narrowphase_unified(
           epa_norm2[ccdid],
           epa_horizon[ccdid],
           opt_warn_overflow,
+          worldid,
+          overflow_out,
         )
 
         if ncontact > 0 and dist < margin + tri_radius:

--- a/mujoco_warp/_src/collision_flex.py
+++ b/mujoco_warp/_src/collision_flex.py
@@ -796,6 +796,7 @@ def _collide_mesh_triangle(
   epa_horizon: wp.array[int],
   tolerance: float,
   ccd_iterations: int,
+  warn_overflow: bool,
   # Data out:
   overflow_out: wp.array[int],
   # Out:
@@ -861,6 +862,7 @@ def _collide_mesh_triangle(
       epa_pr,
       epa_norm2,
       epa_horizon,
+      warn_overflow,
     )
 
     if ncontact > 0 and dist < margin + tri_radius:
@@ -1840,6 +1842,7 @@ def _flex_selfcollision_narrowphase(
   # Model:
   nflex: int,
   opt_ccd_tolerance: wp.array[float],
+  opt_warn_overflow: bool,
   flex_dim: wp.array[int],
   flex_vertadr: wp.array[int],
   flex_elemadr: wp.array[int],
@@ -2015,6 +2018,7 @@ def _flex_selfcollision_narrowphase(
       epa_pr_out[pairid],
       epa_norm2_out[pairid],
       epa_horizon_out[pairid],
+      opt_warn_overflow,
     )
 
     phys_dist = dist
@@ -2060,6 +2064,7 @@ def _flex_active_element_collisions_detect(
   # Model:
   nflex: int,
   opt_ccd_tolerance: wp.array[float],
+  opt_warn_overflow: bool,
   flex_selfcollide: wp.array[int],
   flex_dim: wp.array[int],
   flex_vertadr: wp.array[int],
@@ -2234,6 +2239,7 @@ def _flex_active_element_collisions_detect(
         epa_pr_out[unique_thread_id],
         epa_norm2_out[unique_thread_id],
         epa_horizon_out[unique_thread_id],
+        opt_warn_overflow,
       )
 
       phys_dist = dist
@@ -2445,6 +2451,7 @@ def _flex_narrowphase_unified(
         epa_horizon[ccdid],
         tolerance,
         ccd_iterations,
+        opt_warn_overflow,
         overflow_out,
         cand_dist_out,
         cand_pos_out,
@@ -2507,6 +2514,7 @@ def _flex_narrowphase_unified(
           epa_pr[ccdid],
           epa_norm2[ccdid],
           epa_horizon[ccdid],
+          opt_warn_overflow,
         )
 
         if ncontact > 0 and dist < margin + tri_radius:
@@ -3650,6 +3658,7 @@ def flex_collision(m: Model, d: Data, ctx):
         inputs=[
           m.nflex,
           m.opt.ccd_tolerance,
+          m.opt.warn_overflow,
           m.flex_dim,
           m.flex_vertadr,
           m.flex_elemadr,
@@ -3716,6 +3725,7 @@ def flex_collision(m: Model, d: Data, ctx):
         inputs=[
           m.nflex,
           m.opt.ccd_tolerance,
+          m.opt.warn_overflow,
           m.flex_selfcollide,
           m.flex_dim,
           m.flex_vertadr,

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -20,6 +20,7 @@ import warp as wp
 
 from mujoco_warp._src.collision_core import Geom
 from mujoco_warp._src.types import GeomType
+from mujoco_warp._src.types import OverflowType
 from mujoco_warp._src.types import mat43
 from mujoco_warp._src.types import mat63
 
@@ -1288,6 +1289,9 @@ def _epa(
   geomtype2: int,
   is_discrete: bool,
   warn_overflow: bool,
+  worldid: int,
+  # Data out:
+  overflow_out: wp.array[int],
 ) -> Tuple[float, wp.vec3, wp.vec3, int]:
   """Recover penetration data from two geoms in contact given an initial polytope."""
   upper = FLOAT_MAX
@@ -1359,6 +1363,7 @@ def _epa(
     if pt.nhorizon == -1:
       if warn_overflow:
         wp.printf("Warning: EPA horizon = %d isn't large enough.\n", pt.horizon.shape[0])
+      wp.atomic_or(overflow_out, worldid, OverflowType.EPA_HORIZON)
       idx = -1
       break
 
@@ -1377,6 +1382,7 @@ def _epa(
         if pt.nhorizon == -1:
           if warn_overflow:
             wp.printf("Warning: EPA horizon = %d isn't large enough.\n", pt.horizon.shape[0])
+          wp.atomic_or(overflow_out, worldid, OverflowType.EPA_HORIZON)
           idx = -1
           break
 
@@ -2386,6 +2392,9 @@ def epa_phase(
   face_norm2: wp.array[float],
   horizon: wp.array[int],
   warn_overflow: bool,
+  worldid: int,
+  # Data out:
+  overflow_out: wp.array[int],
 ) -> Tuple[float, int, wp.vec3, wp.vec3, int]:
   """Run EPA given GJK result. Returns (dist, ncontact, x1, x2, multiccd_idx)."""
   pt = Polytope()
@@ -2457,7 +2466,9 @@ def epa_phase(
     return result.dist, 1, result.x1, result.x2, -1
 
   is_discrete = _discrete_geoms(geomtype1, geomtype2) and (geom1.margin == 0.0 and geom2.margin == 0.0)
-  dist, x1, x2, idx = _epa(tolerance, epa_iterations, pt, geom1, geom2, geomtype1, geomtype2, is_discrete, warn_overflow)
+  dist, x1, x2, idx = _epa(
+    tolerance, epa_iterations, pt, geom1, geom2, geomtype1, geomtype2, is_discrete, warn_overflow, worldid, overflow_out
+  )
   if idx == -1:
     return FLOAT_MAX, 0, wp.vec3(), wp.vec3(), -1
 
@@ -2492,6 +2503,9 @@ def ccd(
   face_norm2: wp.array[float],
   horizon: wp.array[int],
   warn_overflow: bool,
+  worldid: int,
+  # Data out:
+  overflow_out: wp.array[int],
 ) -> Tuple[float, int, wp.vec3, wp.vec3, int]:
   """General convex collision detection via GJK/EPA."""
   needs_epa, dist, ncontact, x1, x2, result, geom1, geom2 = gjk_phase(
@@ -2514,4 +2528,6 @@ def ccd(
     face_norm2,
     horizon,
     warn_overflow,
+    worldid,
+    overflow_out,
   )

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -1287,6 +1287,7 @@ def _epa(
   geomtype1: int,
   geomtype2: int,
   is_discrete: bool,
+  warn_overflow: bool,
 ) -> Tuple[float, wp.vec3, wp.vec3, int]:
   """Recover penetration data from two geoms in contact given an initial polytope."""
   upper = FLOAT_MAX
@@ -1356,7 +1357,8 @@ def _epa(
     pt.nhorizon = _add_edge(pt, face[1], face[2])
     pt.nhorizon = _add_edge(pt, face[2], face[0])
     if pt.nhorizon == -1:
-      wp.printf("Warning: EPA horizon = %d isn't large enough.\n", pt.horizon.shape[0])
+      if warn_overflow:
+        wp.printf("Warning: EPA horizon = %d isn't large enough.\n", pt.horizon.shape[0])
       idx = -1
       break
 
@@ -1373,7 +1375,8 @@ def _epa(
         pt.nhorizon = _add_edge(pt, face[1], face[2])
         pt.nhorizon = _add_edge(pt, face[2], face[0])
         if pt.nhorizon == -1:
-          wp.printf("Warning: EPA horizon = %d isn't large enough.\n", pt.horizon.shape[0])
+          if warn_overflow:
+            wp.printf("Warning: EPA horizon = %d isn't large enough.\n", pt.horizon.shape[0])
           idx = -1
           break
 
@@ -2382,6 +2385,7 @@ def epa_phase(
   face_pr: wp.array[wp.vec3],
   face_norm2: wp.array[float],
   horizon: wp.array[int],
+  warn_overflow: bool,
 ) -> Tuple[float, int, wp.vec3, wp.vec3, int]:
   """Run EPA given GJK result. Returns (dist, ncontact, x1, x2, multiccd_idx)."""
   pt = Polytope()
@@ -2453,7 +2457,7 @@ def epa_phase(
     return result.dist, 1, result.x1, result.x2, -1
 
   is_discrete = _discrete_geoms(geomtype1, geomtype2) and (geom1.margin == 0.0 and geom2.margin == 0.0)
-  dist, x1, x2, idx = _epa(tolerance, epa_iterations, pt, geom1, geom2, geomtype1, geomtype2, is_discrete)
+  dist, x1, x2, idx = _epa(tolerance, epa_iterations, pt, geom1, geom2, geomtype1, geomtype2, is_discrete, warn_overflow)
   if idx == -1:
     return FLOAT_MAX, 0, wp.vec3(), wp.vec3(), -1
 
@@ -2487,6 +2491,7 @@ def ccd(
   face_pr: wp.array[wp.vec3],
   face_norm2: wp.array[float],
   horizon: wp.array[int],
+  warn_overflow: bool,
 ) -> Tuple[float, int, wp.vec3, wp.vec3, int]:
   """General convex collision detection via GJK/EPA."""
   needs_epa, dist, ncontact, x1, x2, result, geom1, geom2 = gjk_phase(
@@ -2508,4 +2513,5 @@ def ccd(
     face_pr,
     face_norm2,
     horizon,
+    warn_overflow,
   )

--- a/mujoco_warp/_src/collision_gjk_test.py
+++ b/mujoco_warp/_src/collision_gjk_test.py
@@ -750,7 +750,7 @@ class GJKTest(parameterized.TestCase):
       mat1=rot1,
       pos2=pos2,
       mat2=rot2,
-      horizon_size=8,
+      horizon_size=5,
       warn_overflow=False,
       overflow_out=overflow,
     )

--- a/mujoco_warp/_src/collision_gjk_test.py
+++ b/mujoco_warp/_src/collision_gjk_test.py
@@ -28,6 +28,7 @@ from mujoco_warp._src.collision_gjk import multicontact
 from mujoco_warp._src.collision_gjk import support
 from mujoco_warp._src.types import MJ_MAX_EPAFACES
 from mujoco_warp._src.types import MJ_MAX_EPAHORIZON
+from mujoco_warp._src.types import OverflowType
 from mujoco_warp._src.types import mat63
 
 
@@ -42,6 +43,9 @@ def _geom_dist(
   pos2: wp.vec3 | None = None,
   mat1: wp.mat33 | None = None,
   mat2: wp.mat33 | None = None,
+  horizon_size: int | None = None,
+  warn_overflow: bool = True,
+  overflow_out: wp.array | None = None,
 ):
   # we run multiccd on static scenes so these need to be initialized
   nmaxpolygon = 10 if multiccd else 0
@@ -51,7 +55,9 @@ def _geom_dist(
   epa_face = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=int)
   epa_pr = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=wp.vec3)
   epa_norm2 = wp.empty(6 + MJ_MAX_EPAFACES * m.opt.ccd_iterations, dtype=float)
-  epa_horizon = wp.empty(MJ_MAX_EPAHORIZON, dtype=int)
+  epa_horizon = wp.empty(MJ_MAX_EPAHORIZON if horizon_size is None else horizon_size, dtype=int)
+  if overflow_out is None:
+    overflow_out = wp.zeros(1, dtype=int)
   multiccd_polygon = wp.empty(2 * nmaxpolygon, dtype=wp.vec3)
   multiccd_clipped = wp.empty(2 * nmaxpolygon, dtype=wp.vec3)
   multiccd_pnormal = wp.empty(nmaxpolygon, dtype=wp.vec3)
@@ -107,6 +113,8 @@ def _geom_dist(
     endvert: wp.array[wp.vec3],
     face1: wp.array[wp.vec3],
     face2: wp.array[wp.vec3],
+    # Data out:
+    overflow_out: wp.array[int],
     # Out:
     dist_out: wp.array[float],
     ncon_out: wp.array[int],
@@ -199,7 +207,9 @@ def _geom_dist(
       face_pr,
       face_norm2,
       horizon,
-      True,
+      wp.static(warn_overflow),
+      worldid,
+      overflow_out,
     )
 
     if multiccd and idx >= 0:
@@ -282,6 +292,7 @@ def _geom_dist(
       multiccd_face2,
     ],
     outputs=[
+      overflow_out,
       dist_out,
       ncon_out,
       pos_out,
@@ -726,6 +737,24 @@ class GJKTest(parameterized.TestCase):
 
     dist, _, _, _ = _geom_dist(m, d, 0, 1, multiccd=False, pos1=pos1, mat1=rot1, pos2=pos2, mat2=rot2)
     self.assertAlmostEqual(dist, -0.00011578822, 6)  # dist = -0.00011579410621457821 - MJC 64 bit precision
+
+    # same configuration with an undersized horizon buffer sets the overflow bit
+    overflow = wp.zeros(1, dtype=int)
+    _geom_dist(
+      m,
+      d,
+      0,
+      1,
+      multiccd=False,
+      pos1=pos1,
+      mat1=rot1,
+      pos2=pos2,
+      mat2=rot2,
+      horizon_size=8,
+      warn_overflow=False,
+      overflow_out=overflow,
+    )
+    self.assertTrue(overflow.numpy()[0] & OverflowType.EPA_HORIZON)
 
   def test_box_box_rotation(self):
     """Test box-box with slight rotation which should give 4 contacts."""

--- a/mujoco_warp/_src/collision_gjk_test.py
+++ b/mujoco_warp/_src/collision_gjk_test.py
@@ -199,6 +199,7 @@ def _geom_dist(
       face_pr,
       face_norm2,
       horizon,
+      True,
     )
 
     if multiccd and idx >= 0:

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -158,6 +158,7 @@ class OverflowType(enum.IntFlag):
     HFIELD: height field collision overflow
     CONTACT_MATCH: contact match sensor overflow
     NVMAX: nvmax overflow (islands)
+    EPA_HORIZON: EPA horizon buffer overflow
   """
 
   NEFC = 1 << 0
@@ -168,6 +169,7 @@ class OverflowType(enum.IntFlag):
   HFIELD = 1 << 5
   CONTACT_MATCH = 1 << 6
   NVMAX = 1 << 7
+  EPA_HORIZON = 1 << 8
 
 
 class CamLightType(enum.IntEnum):


### PR DESCRIPTION
#1461 added the warn_overflow option to control the legacy in-kernel stdout warnings, routing overflow events to the per-world Data.overflow bitmask instead. The EPA horizon warning in collision_gjk.py was not covered, so it still prints even when warn_overflow is disabled, and the event leaves no record in Data.overflow.

This change threads warn_overflow through ccd, epa_phase and _epa to gate the printf, and adds an EPA_HORIZON bit to OverflowType that is set whenever the horizon buffer runs out of space, matching the other overflow warnings. The box-box horizon test now also runs with an undersized horizon buffer to check the new bit.