### PR TITLE
extract elliptic-cone middle-zone force/cost into a helper

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -400,6 +400,25 @@ def _eval_elliptic_shifted(
 
 
 @wp.func
+def _eval_elliptic_middle(
+  # In:
+  N: float,
+  T: float,
+  D0: float,
+  mu: float,
+  ufrictionj: float,
+  is_normal: bool,
+) -> wp.vec2:
+  """Computes the elliptic-cone middle-zone (force, cost) for one row (cost 0 on tangent rows)."""
+  dm = math.safe_div(D0, mu * mu * (1.0 + mu * mu))
+  nmt = N - mu * T
+  force_normal = -dm * nmt * mu
+  if is_normal:
+    return wp.vec2(force_normal, 0.5 * dm * nmt * nmt)
+  return wp.vec2(-math.safe_div(force_normal, T) * ufrictionj, 0.0)
+
+
+@wp.func
 def _eval_constraint(
   # In:
   is_equality: bool,
@@ -445,16 +464,9 @@ def _eval_constraint(
       return wp.vec3(-D * jaref, float(types.ConstraintState.QUADRATIC.value), 0.5 * D * jaref * jaref)
     # Middle zone
     else:
-      dm = math.safe_div(D0, mu * mu * (1.0 + mu * mu))
-      nmt = N - mu * T
-      force_normal = -dm * nmt * mu
-
-      if efcid == efcid0:
-        return wp.vec3(force_normal, float(types.ConstraintState.CONE.value), 0.5 * dm * nmt * nmt)
-      else:
-        force_tangent = -math.safe_div(force_normal, T) * ufrictionj
-
-      return wp.vec3(force_tangent, float(types.ConstraintState.CONE.value), 0.0)
+      is_normal = efcid == efcid0
+      fc = _eval_elliptic_middle(N, T, D0, mu, ufrictionj, is_normal)
+      return wp.vec3(fc[0], float(types.ConstraintState.CONE.value), fc[1])
 
   if jaref >= 0.0:
     return wp.vec3(0.0, float(types.ConstraintState.SATISFIED.value), 0.0)

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -403,6 +403,25 @@ def _eval_elliptic_shifted(
 
 
 @wp.func
+def _eval_elliptic_middle(
+  # In:
+  N: float,
+  T: float,
+  D0: float,
+  mu: float,
+  ufrictionj: float,
+  is_normal: bool,
+) -> wp.vec2:
+  """Computes the elliptic-cone middle-zone (force, cost) for one row (cost 0 on tangent rows)."""
+  dm = math.safe_div(D0, mu * mu * (1.0 + mu * mu))
+  nmt = N - mu * T
+  force_normal = -dm * nmt * mu
+  if is_normal:
+    return wp.vec2(force_normal, 0.5 * dm * nmt * nmt)
+  return wp.vec2(-math.safe_div(force_normal, T) * ufrictionj, 0.0)
+
+
+@wp.func
 def _eval_constraint(
   # In:
   is_equality: bool,
@@ -448,16 +467,9 @@ def _eval_constraint(
       return wp.vec3(-D * jaref, float(types.ConstraintState.QUADRATIC.value), 0.5 * D * jaref * jaref)
     # Middle zone
     else:
-      dm = math.safe_div(D0, mu * mu * (1.0 + mu * mu))
-      nmt = N - mu * T
-      force_normal = -dm * nmt * mu
-
-      if efcid == efcid0:
-        return wp.vec3(force_normal, float(types.ConstraintState.CONE.value), 0.5 * dm * nmt * nmt)
-      else:
-        force_tangent = -math.safe_div(force_normal, T) * ufrictionj
-
-      return wp.vec3(force_tangent, float(types.ConstraintState.CONE.value), 0.0)
+      is_normal = efcid == efcid0
+      fc = _eval_elliptic_middle(N, T, D0, mu, ufrictionj, is_normal)
+      return wp.vec3(fc[0], float(types.ConstraintState.CONE.value), fc[1])
 
   if jaref >= 0.0:
     return wp.vec3(0.0, float(types.ConstraintState.SATISFIED.value), 0.0)


### PR DESCRIPTION
Pull the middle-zone force and cost math out of _eval_constraint into a reusable `_eval_elliptic_middle` helper. No behavior change; this just makes the elliptic-cone force available as a single source of truth instead of inlined in the constraint eval.

---

Performance was measured on an NVIDIA RTX PRO 5000 Blackwell with 8,192 worlds and 1,000 steps. Values are means over 10 interleaved runs after unmeasured warmups, comparing `origin/main` (`d28130a`) with this PR (`a74cf9d`). The only model override is `opt.cone=elliptic`, since both models default to pyramidal cones and would never reach the changed code; the solver stays on its default (Newton) and the Jacobian stays on auto, which resolves to dense for Humanoid (nv=27) and sparse for G1 (nv=35). Contact and constraint limits come from the benchmark definitions in `benchmarks/*/__init__.py`. G1 uses the prerecorded `shuffle_dance.npz` trajectory; Humanoid uses its standard keyframe rollout. Every run converged all 8,192 worlds with unchanged solver iteration distributions.

| Benchmark | `origin/main` | This PR | Difference |
|---|---:|---:|---:|
| Humanoid, elliptic | 3.093 s | 3.093 s | -0.01% |
| G1 flat, elliptic, prerecorded | 6.001 s | 5.999 s | +0.02% |

A positive difference means this PR is faster. Both are an order of magnitude below run-to-run variation, so this is parity rather than a change in either direction. That is the expected result: the middle-zone arithmetic is unchanged and Warp inlines the extracted `wp.func`, so the generated kernel is equivalent. The benchmarks are here to show the refactor costs nothing, not to claim a speedup.
