### PR TITLE
Simplify dense elliptic Hessian contraction

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2737,6 +2737,28 @@ def _update_gradient_JTCJ_compact(
     wp.atomic_add(ctx_h_out[worldid, c_dof1], c_dof2, h)
 
 
+@wp.func
+def _elliptic_hessian_entry_from_projections(
+  # In:
+  dm: float,
+  mu_over_t: float,
+  mu_n_over_ttt: float,
+  tangent_diag: float,
+  z01: float,
+  z02: float,
+  projection1: float,
+  projection2: float,
+  tangent_dot: float,
+) -> float:
+  # Contract the diagonal-plus-rank-one curvature without materializing the cone Hessian.
+  return dm * (
+    z01 * z02
+    - mu_over_t * (z01 * projection2 + z02 * projection1)
+    + mu_n_over_ttt * projection1 * projection2
+    + tangent_diag * tangent_dot
+  )
+
+
 @wp.kernel
 def _update_gradient_JTCJ_dense(
   # Model:
@@ -2803,85 +2825,37 @@ def _update_gradient_JTCJ_dense(
       continue
 
     n = ctx_Jaref_in[worldid, efcid0] * mu
-    u = types.vec6(n, 0.0, 0.0, 0.0, 0.0, 0.0)
-
+    z01 = mu * efc_J_in[worldid, efcid0, dof1id]
+    z02 = mu * efc_J_in[worldid, efcid0, dof2id]
     tt = float(0.0)
-    for j in range(1, condim):
-      efcidj = contact_efc_address_in[conid, j]
-      if efcidj >= 0:
-        uj = ctx_Jaref_in[worldid, efcidj] * fri[j - 1]
-      else:
-        uj = 0.0
-      tt += uj * uj
-      u[j] = uj
+    projection1 = float(0.0)
+    projection2 = float(0.0)
+    tangent_dot = float(0.0)
+    for dim in range(1, condim):
+      efcid = contact_efc_address_in[conid, dim]
+      if efcid >= 0:
+        scale = fri[dim - 1]
+        u = ctx_Jaref_in[worldid, efcid] * scale
+        z1 = scale * efc_J_in[worldid, efcid, dof1id]
+        z2 = scale * efc_J_in[worldid, efcid, dof2id]
+        tt += u * u
+        projection1 += u * z1
+        projection2 += u * z2
+        tangent_dot += z1 * z2
 
-    if tt <= 0.0:
-      t = 0.0
-    else:
-      t = wp.sqrt(tt)
-    t = wp.max(t, types.MJ_MINVAL)
+    t = wp.max(wp.sqrt(tt), types.MJ_MINVAL)
     ttt = wp.max(t * t * t, types.MJ_MINVAL)
-
-    h = float(0.0)
-
-    for dim1id in range(condim):
-      if dim1id == 0:
-        efcid1 = efcid0
-      else:
-        efcid1 = contact_efc_address_in[conid, dim1id]
-        if efcid1 < 0:
-          continue
-
-      efc_J11 = efc_J_in[worldid, efcid1, dof1id]
-      efc_J12 = efc_J_in[worldid, efcid1, dof2id]
-
-      ui = u[dim1id]
-
-      for dim2id in range(0, dim1id + 1):
-        if dim2id == 0:
-          efcid2 = efcid0
-        else:
-          efcid2 = contact_efc_address_in[conid, dim2id]
-          if efcid2 < 0:
-            continue
-
-        efc_J21 = efc_J_in[worldid, efcid2, dof1id]
-        efc_J22 = efc_J_in[worldid, efcid2, dof2id]
-
-        uj = u[dim2id]
-
-        # set first row/column: (1, -mu/t * u)
-        if dim1id == 0 and dim2id == 0:
-          hcone = 1.0
-        elif dim1id == 0:
-          hcone = -math.safe_div(mu, t) * uj
-        elif dim2id == 0:
-          hcone = -math.safe_div(mu, t) * ui
-        else:
-          hcone = mu * math.safe_div(n, ttt) * ui * uj
-
-          # add to diagonal: mu^2 - mu * n / t
-          if dim1id == dim2id:
-            hcone += mu2 - mu * math.safe_div(n, t)
-
-        # pre and post multiply by diag(mu, friction) scale by dm
-        if dim1id == 0:
-          fri1 = mu
-        else:
-          fri1 = fri[dim1id - 1]
-
-        if dim2id == 0:
-          fri2 = mu
-        else:
-          fri2 = fri[dim2id - 1]
-
-        hcone *= dm * fri1 * fri2
-
-        if hcone != 0.0:
-          h += hcone * efc_J11 * efc_J22
-
-          if dim1id != dim2id:
-            h += hcone * efc_J12 * efc_J21
+    h = _elliptic_hessian_entry_from_projections(
+      dm,
+      math.safe_div(mu, t),
+      mu * math.safe_div(n, ttt),
+      mu2 - mu * math.safe_div(n, t),
+      z01,
+      z02,
+      projection1,
+      projection2,
+      tangent_dot,
+    )
 
     ctx_h_out[worldid, dof1id, dof2id] += h
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2845,11 +2845,12 @@ def _update_gradient_JTCJ_dense(
 
     t = wp.max(wp.sqrt(tt), types.MJ_MINVAL)
     ttt = wp.max(t * t * t, types.MJ_MINVAL)
+    mu_tinv = math.safe_div(mu, t)
     h = _elliptic_hessian_entry_from_projections(
       dm,
-      math.safe_div(mu, t),
+      mu_tinv,
       mu * math.safe_div(n, ttt),
-      mu2 - mu * math.safe_div(n, t),
+      mu2 - n * mu_tinv,
       z01,
       z02,
       projection1,

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -40,6 +40,72 @@ def _assert_eq(a, b, name):
   np.testing.assert_allclose(a, b, err_msg=err_msg, atol=tol, rtol=tol)
 
 
+def _elliptic_dense_hessian_reference(m, d, ctx):
+  contact_dim = d.contact.dim.numpy()
+  contact_dist = d.contact.dist.numpy()
+  contact_efc_address = d.contact.efc_address.numpy()
+  contact_friction = d.contact.friction.numpy()
+  contact_includemargin = d.contact.includemargin.numpy()
+  contact_worldid = d.contact.worldid.numpy()
+  efc_D = d.efc.D.numpy()
+  efc_J = d.efc.J.numpy()
+  efc_state = d.efc.state.numpy()
+  impratio_invsqrt = m.opt.impratio_invsqrt.numpy()
+  jaref = ctx.Jaref.numpy()
+  h = np.zeros((d.nworld, m.nv, m.nv), dtype=np.float64)
+
+  for conid in range(d.nacon.numpy()[0]):
+    if contact_dist[conid] - contact_includemargin[conid] >= 0.0:
+      continue
+    worldid = contact_worldid[conid]
+    efcid0 = contact_efc_address[conid, 0]
+    if efcid0 < 0 or efc_state[worldid, efcid0] != types.ConstraintState.CONE.value:
+      continue
+
+    condim = contact_dim[conid]
+    friction = contact_friction[conid]
+    mu = friction[0] * impratio_invsqrt[worldid % impratio_invsqrt.shape[0]]
+    mu2 = mu * mu
+    dm = efc_D[worldid, efcid0] / (mu2 * (1.0 + mu2))
+    if dm == 0.0:
+      continue
+
+    u = np.zeros(condim)
+    scale = np.zeros(condim)
+    u[0] = jaref[worldid, efcid0] * mu
+    scale[0] = mu
+    jac = np.zeros((condim, m.nv))
+    for dim in range(condim):
+      efcid = contact_efc_address[conid, dim]
+      if efcid < 0:
+        continue
+      if dim > 0:
+        scale[dim] = friction[dim - 1]
+        u[dim] = jaref[worldid, efcid] * scale[dim]
+      jac[dim] = efc_J[worldid, efcid, : m.nv]
+
+    t = max(np.linalg.norm(u[1:]), types.MJ_MINVAL)
+    ttt = max(t * t * t, types.MJ_MINVAL)
+    cone = np.zeros((condim, condim))
+    for dim1 in range(condim):
+      for dim2 in range(dim1 + 1):
+        if dim1 == 0 and dim2 == 0:
+          value = 1.0
+        elif dim2 == 0:
+          value = -mu / t * u[dim1]
+        else:
+          value = mu * u[0] / ttt * u[dim1] * u[dim2]
+          if dim1 == dim2:
+            value += mu2 - mu * u[0] / t
+        value *= dm * scale[dim1] * scale[dim2]
+        cone[dim1, dim2] = value
+        cone[dim2, dim1] = value
+
+    h[worldid] += np.triu(jac.T @ cone @ jac)
+
+  return h
+
+
 @wp.kernel
 def _eval_elliptic_delta(
   # In:
@@ -522,6 +588,74 @@ class SolverTest(parameterized.TestCase):
     qacc = d.qacc.numpy()[0]
     self.assertTrue(np.all(np.isfinite(qacc)), "Newton solve produced non-finite qacc")
     _assert_eq(qacc, mjd.qacc, "qacc")
+
+  def test_elliptic_dense_hessian(self):
+    """Structured dense cone contraction matches the reference Hessian."""
+    condims = (3, 4, 6)
+    bodies = "".join(
+      f'<body pos="{i * 0.25 - 0.25:.3f} 0 0.020">'
+      f'<freejoint/><geom type="box" size="0.04 0.05 0.03" mass="0.5" condim="{condim}"/></body>'
+      for i, condim in enumerate(condims)
+    )
+    xml = f"""
+    <mujoco>
+      <option cone="elliptic" solver="Newton" jacobian="dense" iterations="20" ls_iterations="20"/>
+      <worldbody>
+        <geom type="plane" size="5 5 .1" friction="1 0.01 0.001" condim="1"/>
+        {bodies}
+      </worldbody>
+    </mujoco>
+    """
+    mjm, mjd, m, _ = test_data.fixture(xml=xml)
+    self.assertFalse(m.is_sparse)
+
+    mjd.qvel[0::6] = 1.5
+    mujoco.mj_forward(mjm, mjd)
+    self.assertEqual(set(mjd.contact.dim[: mjd.ncon]), set(condims))
+
+    d = mjw.put_data(mjm, mjd)
+    ctx = solver._create_solver_context(m, d)
+    solver.init_context(m, d, ctx, grad=True)
+    ctx.h.zero_()
+    ctx.done.fill_(False)
+
+    if wp.get_device().is_cuda:
+      dim_block = (wp.get_device().sm_count * 6 * 256 + m.dof_tri_row.size - 1) // m.dof_tri_row.size
+    else:
+      dim_block = d.naconmax
+    nblocks_perblock = (d.naconmax + dim_block - 1) // dim_block
+    wp.launch(
+      solver._update_gradient_JTCJ_dense,
+      dim=(dim_block, m.dof_tri_row.size),
+      inputs=[
+        m.opt.impratio_invsqrt,
+        m.dof_tri_row,
+        m.dof_tri_col,
+        d.contact.dist,
+        d.contact.includemargin,
+        d.contact.friction,
+        d.contact.dim,
+        d.contact.efc_address,
+        d.contact.worldid,
+        d.efc.J,
+        d.efc.D,
+        d.efc.state,
+        d.naconmax,
+        d.nacon,
+        ctx.Jaref,
+        ctx.done,
+        nblocks_perblock,
+        dim_block,
+      ],
+      outputs=[ctx.h],
+    )
+
+    np.testing.assert_allclose(
+      ctx.h.numpy()[:, : m.nv, : m.nv],
+      _elliptic_dense_hessian_reference(m, d, ctx),
+      rtol=1e-5,
+      atol=1e-6,
+    )
 
   @parameterized.parameters(
     (ConeType.PYRAMIDAL, SolverType.CG, 25, 5),


### PR DESCRIPTION
Dense Newton currently materializes every entry of the elliptic cone curvature matrix and then performs a quadratic contraction over the contact dimensions for each generalized-coordinate pair.

This change uses the curvature's diagonal-plus-rank-one structure directly. It computes two projections and a tangent dot product for each Hessian entry, then evaluates the resulting scalar contraction. Work per entry falls from quadratic to linear in the contact dimension without storing the intermediate cone Hessian. Mixed 3-, 4-, and 6-dimensional contacts continue to dispatch at runtime.

The dense regression test constructs a mixed 3/4/6 contact model and compares the generated Hessian with an independent NumPy construction of `J^T C J`.

Performance was measured on an RTX PRO 6000 Blackwell with 8,192 worlds and 1,000 steps. Values are medians of five interleaved runs after unmeasured warmups, comparing `upstream/main` (`63d25e44`) with this PR (`90191e81`). Both benchmarks force Newton, elliptic cones, and dense Jacobians. G1 uses the prerecorded `shuffle_dance.npz` trajectory; Humanoid uses its standard keyframe rollout. Every run converged all 8,192 worlds with unchanged solver iteration distributions.

| Benchmark | `upstream/main` | This PR | Difference |
|---|---:|---:|---:|
| Humanoid, dense elliptic | 2.271 s | 2.078 s | 8.5% faster |
| G1 flat, dense elliptic, prerecorded | 5.229 s | 4.539 s | 13.2% faster |

The focused mixed-contact dense test passes on CUDA. CI is green, including pre-commit and kernel-analyzer.
