### PR TITLE
Replace quadratic island discovery with a linear-memory GPU DSU

### DIFF
--- a/mujoco_warp/_src/island.py
+++ b/mujoco_warp/_src/island.py
@@ -25,8 +25,88 @@ from mujoco_warp._src.warp_util import event_scope
 wp.set_module_options({"default_grid_stride": False})
 
 
+@wp.func
+def _dsu_find(parent: wp.array2d[int], worldid: int, tree: int):
+  """Find a root while shortening its strictly decreasing parent path."""
+  current = tree
+  while True:
+    parent_current = parent[worldid, current]
+    if parent_current == current:
+      return current
+    grandparent = parent[worldid, parent_current]
+    if grandparent < parent_current:
+      wp.atomic_min(parent, worldid, current, grandparent)
+    current = parent_current
+  return current
+
+
+@wp.func
+def _dsu_activate(worldid: int, tree: int, tree_island_out: wp.array2d[int]):
+  if tree >= 0:
+    wp.atomic_max(tree_island_out, worldid, tree, 0)
+
+
+@wp.func
+def _dsu_union(parent: wp.array2d[int], worldid: int, tree0: int, tree1: int, tree_island_out: wp.array2d[int]):
+  """Activate endpoints and atomically hook the higher root to the lower root."""
+  if tree0 < 0:
+    tree0 = tree1
+    tree1 = -1
+  if tree0 < 0:
+    return
+  _dsu_activate(worldid, tree0, tree_island_out)
+  if tree1 < 0:
+    return
+  _dsu_activate(worldid, tree1, tree_island_out)
+
+  while True:
+    root0 = _dsu_find(parent, worldid, tree0)
+    root1 = _dsu_find(parent, worldid, tree1)
+    if root0 == root1:
+      return
+    low_root = wp.min(root0, root1)
+    high_root = wp.max(root0, root1)
+    previous = wp.atomic_cas(parent, worldid, high_root, high_root, low_root)
+    if previous == high_root:
+      return
+
+
 @wp.kernel
-def _tree_edges(
+def _reset_dsu(
+  # Data out:
+  nisland_out: wp.array[int],
+  tree_island_out: wp.array2d[int],
+  # Out:
+  island_parent_out: wp.array2d[int],
+):
+  """Reset identity parents and active/output markers in parallel."""
+  worldid, treeid = wp.tid()
+  island_parent_out[worldid, treeid] = treeid
+  tree_island_out[worldid, treeid] = -1
+  if treeid == 0:
+    nisland_out[worldid] = 0
+
+
+@wp.func
+def _is_repeated_fixed_support_efc(
+  # Data in:
+  efc_type_in: wp.array2d[int],
+  efc_id_in: wp.array2d[int],
+  # In:
+  worldid: int,
+  efcid: int,
+) -> bool:
+  """Return whether the preceding scalar row has the same fixed tree support."""
+  if efcid == 0:
+    return False
+  return (
+    efc_type_in[worldid, efcid - 1] == efc_type_in[worldid, efcid]
+    and efc_id_in[worldid, efcid - 1] == efc_id_in[worldid, efcid]
+  )
+
+
+@wp.kernel
+def _island_dsu(
   # Model:
   nv: int,
   body_treeid: wp.array[int],
@@ -49,134 +129,178 @@ def _tree_edges(
   efc_J_colind_in: wp.array3d[int],
   efc_J_in: wp.array3d[float],
   njmax_in: int,
+  # In:
+  chunk_size: int,
+  # Data out:
+  tree_island_out: wp.array2d[int],
   # Out:
-  tree_tree: wp.array3d[int],  # kernel_analyzer: off
+  island_parent_out: wp.array2d[int],
 ):
-  """Find tree edges."""
-  worldid, efcid = wp.tid()
+  """Process one chunk of one world's active EFC prefix with one strided CUDA warp.
 
-  # skip if beyond active constraints
-  if efcid >= wp.min(njmax_in, nefc_in[worldid]):
-    return
+  Blocks are laid out over (world, chunk) rather than world alone, so resident
+  parallelism tracks total constraint capacity instead of batch size. A single world
+  with a long prefix fills the device the same way a large batch of short ones does.
+  """
+  worldid, chunkid, lane = wp.tid()
+  chunk_beg = chunkid * chunk_size
+  chunk_end = wp.min(chunk_beg + chunk_size, wp.min(njmax_in, nefc_in[worldid]))
+  for efcid in range(chunk_beg + lane, chunk_end, wp.block_dim()):
+    efc_type = efc_type_in[worldid, efcid]
+    efc_id = efc_id_in[worldid, efcid]
+    repeated = _is_repeated_fixed_support_efc(efc_type_in, efc_id_in, worldid, efcid)
+    tree0 = int(-1)
+    tree1 = int(-1)
+    use_generic = int(0)
 
-  efc_type = efc_type_in[worldid, efcid]
-  efc_id = efc_id_in[worldid, efcid]
-
-  tree0 = int(-1)
-  tree1 = int(-1)
-  use_generic = int(0)
-
-  # equality (connect/weld)
-  if efc_type == ConstraintType.EQUALITY:
-    eq_t = eq_type[efc_id]
-
-    if eq_t == EqType.CONNECT or eq_t == EqType.WELD:
-      b1 = eq_obj1id[efc_id]
-      b2 = eq_obj2id[efc_id]
-
-      # site semantics
-      if eq_objtype[efc_id] == ObjType.SITE:
-        b1 = site_bodyid[b1]
-        b2 = site_bodyid[b2]
-
-      tree0 = body_treeid[b1]
-      tree1 = body_treeid[b2]
-    else:
-      # JOINT, TENDON, FLEX
-      use_generic = 1
-
-  # joint friction
-  elif efc_type == ConstraintType.FRICTION_DOF:
-    tree0 = dof_treeid[efc_id]
-
-  # joint limit
-  elif efc_type == ConstraintType.LIMIT_JOINT:
-    tree0 = dof_treeid[jnt_dofadr[efc_id]]
-
-  # contact
-  elif (
-    efc_type == ConstraintType.CONTACT_FRICTIONLESS
-    or efc_type == ConstraintType.CONTACT_PYRAMIDAL
-    or efc_type == ConstraintType.CONTACT_ELLIPTIC
-  ):
-    geom_pair = contact_geom_in[efc_id]
-    g1 = geom_pair[0]
-    g2 = geom_pair[1]
-
-    # flex contacts have negative geom ids
-    if g1 >= 0 and g2 >= 0:
-      tree0 = body_treeid[geom_bodyid[g1]]
-      tree1 = body_treeid[geom_bodyid[g2]]
-    else:
-      use_generic = 1
-
-  # generic
-  else:
-    use_generic = 1
-
-  # handle static bodies
-  if use_generic == 0:
-    # swap so tree0 is non-negative if possible
-    if tree0 < 0 and tree1 >= 0:
-      tree0 = tree1
-      tree1 = -1
-
-    # mark the edge
-    if tree0 >= 0:
-      if tree1 < 0 or tree0 == tree1:
-        # self-edge
-        wp.atomic_max(tree_tree, worldid, tree0, tree0, 1)
+    if efc_type == ConstraintType.EQUALITY:
+      eq_t = eq_type[efc_id]
+      if eq_t == EqType.CONNECT or eq_t == EqType.WELD:
+        if repeated:
+          continue
+        body0 = eq_obj1id[efc_id]
+        body1 = eq_obj2id[efc_id]
+        if eq_objtype[efc_id] == ObjType.SITE:
+          body0 = site_bodyid[body0]
+          body1 = site_bodyid[body1]
+        tree0 = body_treeid[body0]
+        tree1 = body_treeid[body1]
       else:
-        # cross-tree edge
-        t1 = wp.min(tree0, tree1)
-        t2 = wp.max(tree0, tree1)
-        wp.atomic_max(tree_tree, worldid, t1, t2, 1)
-        wp.atomic_max(tree_tree, worldid, t2, t1, 1)
-    return
-
-  # generic: scan Jacobian row
-  first_tree = int(-1)
-  has_cross_edge = int(0)
-
-  count = nv
-  rowadr = 0
-  if is_sparse:
-    count = efc_J_rownnz_in[worldid, efcid]
-    rowadr = efc_J_rowadr_in[worldid, efcid]
-
-  for i in range(count):
-    dof = i
-    if is_sparse:
-      sparseid = rowadr + i
-      dof = efc_J_colind_in[worldid, 0, sparseid]
-    else:
-      J_val = efc_J_in[worldid, efcid, dof]
-      if J_val == 0.0:
+        use_generic = 1
+    elif efc_type == ConstraintType.FRICTION_DOF:
+      if repeated:
         continue
+      tree0 = dof_treeid[efc_id]
+    elif efc_type == ConstraintType.LIMIT_JOINT:
+      if repeated:
+        continue
+      tree0 = dof_treeid[jnt_dofadr[efc_id]]
+    elif (
+      efc_type == ConstraintType.CONTACT_FRICTIONLESS
+      or efc_type == ConstraintType.CONTACT_PYRAMIDAL
+      or efc_type == ConstraintType.CONTACT_ELLIPTIC
+    ):
+      geom_pair = contact_geom_in[efc_id]
+      if geom_pair[0] >= 0 and geom_pair[1] >= 0:
+        if repeated:
+          continue
+        tree0 = body_treeid[geom_bodyid[geom_pair[0]]]
+        tree1 = body_treeid[geom_bodyid[geom_pair[1]]]
+      else:
+        use_generic = 1
+    else:
+      use_generic = 1
 
-    tree = dof_treeid[dof]
-    if tree < 0:
+    if use_generic == 0:
+      _dsu_union(island_parent_out, worldid, tree0, tree1, tree_island_out)
       continue
-    if first_tree == -1:
-      first_tree = tree
-    elif tree != first_tree:
-      t1 = wp.min(first_tree, tree)
-      t2 = wp.max(first_tree, tree)
-      wp.atomic_max(tree_tree, worldid, t1, t2, 1)
-      wp.atomic_max(tree_tree, worldid, t2, t1, 1)
-      has_cross_edge = 1
 
-  if first_tree >= 0 and has_cross_edge == 0:
-    wp.atomic_max(tree_tree, worldid, first_tree, first_tree, 1)
+    first_tree = int(-1)
+    count = nv
+    rowadr = int(0)
+    if is_sparse:
+      count = efc_J_rownnz_in[worldid, efcid]
+      rowadr = efc_J_rowadr_in[worldid, efcid]
+
+    for index in range(count):
+      dof = index
+      if is_sparse:
+        dof = efc_J_colind_in[worldid, 0, rowadr + index]
+      elif efc_J_in[worldid, efcid, dof] == 0.0:
+        continue
+      tree = dof_treeid[dof]
+      if tree < 0:
+        continue
+      if first_tree < 0:
+        first_tree = tree
+        _dsu_union(island_parent_out, worldid, tree, -1, tree_island_out)
+      else:
+        _dsu_union(island_parent_out, worldid, first_tree, tree, tree_island_out)
+
+
+@wp.kernel
+def _compress_roots(
+  # Data in:
+  tree_island_in: wp.array2d[int],
+  # Data out:
+  # Out:
+  island_parent_out: wp.array2d[int],
+):
+  """Point every active tree straight at its component's minimum-tree root."""
+  worldid, treeid = wp.tid()
+  if tree_island_in[worldid, treeid] >= 0:
+    island_parent_out[worldid, treeid] = _dsu_find(island_parent_out, worldid, treeid)
+
+
+@wp.kernel
+def _label_roots(
+  # Model:
+  ntree: int,
+  # Data in:
+  # In:
+  island_parent_in: wp.array2d[int],
+  # Data out:
+  nisland_out: wp.array[int],
+  tree_island_out: wp.array2d[int],
+):
+  """Number the roots in ascending tree order, which is MuJoCo's island order.
+
+  Ranking roots is the one inherently sequential step: island i is the i-th smallest
+  root, so it depends on every preceding tree. It reads two ints per tree and does no
+  pointer chasing, leaving the compress and propagate passes free to run per tree.
+  """
+  worldid = wp.tid()
+  nisland = int(0)
+  for treeid in range(ntree):
+    if tree_island_out[worldid, treeid] >= 0 and island_parent_in[worldid, treeid] == treeid:
+      tree_island_out[worldid, treeid] = nisland
+      nisland += 1
+  nisland_out[worldid] = nisland
+
+
+@wp.kernel
+def _propagate_labels(
+  # Data in:
+  # In:
+  island_parent_in: wp.array2d[int],
+  # Data out:
+  tree_island_out: wp.array2d[int],
+):
+  """Copy each root's label down to the trees that point at it.
+
+  A root reads and writes its own slot with the same value, so the only concurrent
+  writes to any slot store identical data.
+  """
+  worldid, treeid = wp.tid()
+  if tree_island_out[worldid, treeid] >= 0:
+    tree_island_out[worldid, treeid] = tree_island_out[worldid, island_parent_in[worldid, treeid]]
+
+
+# Smallest EFC chunk worth its own block, and the resident-block count worth reaching for.
+_DSU_MIN_CHUNK = 256
+_DSU_TARGET_BLOCKS = 2048
 
 
 @event_scope
-def tree_edges(m: types.Model, d: types.Data, tree_tree: wp.array3d[int]):
-  """Compute tree-tree adjacency matrix."""
-  tree_tree.zero_()
+def direct_dsu(m: types.Model, d: types.Data, island_parent: wp.array2d[int]):
+  """Discover islands with EFC-parallel atomic minimum-root hooks.
+
+  `island_parent` is the (nworld, ntree) disjoint-set workspace, owned by the caller.
+  """
+  # Discovery blocks are laid out over (world, chunk). A batch large enough to occupy the
+  # device keeps one block per world, since extra chunks would mostly launch past the
+  # active prefix; a small batch with a long prefix is split until there is resident work.
+  max_chunks = max(1, -(-d.njmax // _DSU_MIN_CHUNK))
+  nchunk = min(max(1, -(-_DSU_TARGET_BLOCKS // d.nworld)), max_chunks)
+  chunk_size = -(-d.njmax // nchunk)
   wp.launch(
-    kernel=_tree_edges,
-    dim=(d.nworld, d.njmax),
+    _reset_dsu,
+    dim=(d.nworld, m.ntree),
+    inputs=[d.nisland, d.tree_island, island_parent],
+  )
+  wp.launch_tiled(
+    _island_dsu,
+    dim=(d.nworld, nchunk),
     inputs=[
       m.nv,
       m.body_treeid,
@@ -198,84 +322,26 @@ def tree_edges(m: types.Model, d: types.Data, tree_tree: wp.array3d[int]):
       d.efc.J_colind,
       d.efc.J,
       d.njmax,
+      chunk_size,
+      d.tree_island,
+      island_parent,
     ],
-    outputs=[tree_tree],
+    block_dim=types.BlockDim.island_dsu,
   )
-
-
-@wp.kernel
-def _flood_fill(
-  # Model:
-  ntree: int,
-  # In:
-  tree_tree_in: wp.array3d[int],
-  labels_in: wp.array2d[int],
-  stack_in: wp.array2d[int],
-  # Data out:
-  nisland_out: wp.array[int],
-  tree_island_out: wp.array2d[int],
-  # Out:
-  stack_out: wp.array2d[int],
-):
-  """DFS flood fill to discover islands using tree_tree matrix."""
-  worldid = wp.tid()
-  nisland = int(0)
-
-  # iterate over trees
-  for i in range(ntree):
-    # already assigned
-    if labels_in[worldid, i] != -1:
-      continue
-
-    # check if tree has any edges
-    has_edge = int(0)
-    for j in range(ntree):
-      if tree_tree_in[worldid, i, j] != 0:
-        has_edge = 1
-        break
-    if has_edge == 0:
-      continue
-
-    # DFS: push i onto stack
-    nstack = int(0)
-    stack_out[worldid, nstack] = i
-    nstack = nstack + 1
-
-    while nstack > 0:
-      # pop v from stack
-      nstack = nstack - 1
-      v = stack_in[worldid, nstack]
-
-      # already assigned
-      if labels_in[worldid, v] != -1:
-        continue
-
-      # assign to current island
-      tree_island_out[worldid, v] = nisland
-
-      # push neighbors
-      for neighbor in range(ntree):
-        if tree_tree_in[worldid, v, neighbor] != 0:
-          if labels_in[worldid, neighbor] == -1:
-            stack_out[worldid, nstack] = neighbor
-            nstack = nstack + 1
-
-    # island filled
-    nisland = nisland + 1
-
-  nisland_out[worldid] = nisland
-
-
-@event_scope
-def flood_fill(m: types.Model, d: types.Data, tree_tree: wp.array3d[int]):
-  d.tree_island.fill_(-1)
-  stack_scratch = wp.empty((d.nworld, m.ntree * m.ntree), dtype=int)
-
   wp.launch(
-    _flood_fill,
+    _compress_roots,
+    dim=(d.nworld, m.ntree),
+    inputs=[d.tree_island, island_parent],
+  )
+  wp.launch(
+    _label_roots,
     dim=d.nworld,
-    inputs=[m.ntree, tree_tree, d.tree_island, stack_scratch],
-    outputs=[d.nisland, d.tree_island, stack_scratch],
+    inputs=[m.ntree, island_parent, d.nisland, d.tree_island],
+  )
+  wp.launch(
+    _propagate_labels,
+    dim=(d.nworld, m.ntree),
+    inputs=[island_parent, d.tree_island],
   )
 
 
@@ -286,18 +352,16 @@ def island(m: types.Model, d: types.Data):
     d.nisland.zero_()
     return
 
-  # Step 1: Find tree edges
-  tree_tree = wp.zeros((d.nworld, m.ntree, m.ntree), dtype=int)
-  tree_edges(m, d, tree_tree)
-
-  # Step 2: DFS flood fill
-  flood_fill(m, d, tree_tree)
+  direct_dsu(m, d, wp.empty((d.nworld, m.ntree), dtype=int))
 
 
 @wp.kernel
 def _island_count_dofs(
+  # Model:
   dof_treeid: wp.array[int],
+  # Data in:
   tree_island_in: wp.array2d[int],
+  # Data out:
   dof_island_out: wp.array2d[int],
   island_nv_out: wp.array2d[int],
 ):
@@ -311,12 +375,14 @@ def _island_count_dofs(
 
 @wp.kernel
 def _island_scan_sizes(
+  # Data in:
   nisland_in: wp.array[int],
-  island_idofadr_out: wp.array2d[int],
-  island_nv_inout: wp.array2d[int],
-  island_nefc_inout: wp.array2d[int],
-  island_iefcadr_out: wp.array2d[int],
+  island_nv_in: wp.array2d[int],
+  # Data out:
   nidof_out: wp.array[int],
+  island_idofadr_out: wp.array2d[int],
+  island_nefc_out: wp.array2d[int],
+  island_iefcadr_out: wp.array2d[int],
 ):
   worldid = wp.tid()
 
@@ -329,44 +395,58 @@ def _island_scan_sizes(
   island_idofadr_out[worldid, 0] = 0
   island_iefcadr_out[worldid, 0] = 0
   for i in range(1, nisland):
-    island_idofadr_out[worldid, i] = island_idofadr_out[worldid, i - 1] + island_nv_inout[worldid, i - 1]
-    island_iefcadr_out[worldid, i] = island_iefcadr_out[worldid, i - 1] + island_nefc_inout[worldid, i - 1]
+    island_idofadr_out[worldid, i] = island_idofadr_out[worldid, i - 1] + island_nv_in[worldid, i - 1]
+    island_iefcadr_out[worldid, i] = island_iefcadr_out[worldid, i - 1] + island_nefc_out[worldid, i - 1]
 
-  nidof = island_idofadr_out[worldid, nisland - 1] + island_nv_inout[worldid, nisland - 1]
+  nidof = island_idofadr_out[worldid, nisland - 1] + island_nv_in[worldid, nisland - 1]
   nidof_out[worldid] = nidof
 
-  # Reset for recount
+  # Reset for recount ( island_nv is final after _island_count_dofs and stays put )
   for i in range(nisland):
-    island_nv_inout[worldid, i] = 0
-    island_nefc_inout[worldid, i] = 0
+    island_nefc_out[worldid, i] = 0
 
 
 @wp.kernel
 def _island_map_dofs(
-  nv: int,
-  dof_island_in: wp.array2d[int],
-  island_idofadr_in: wp.array2d[int],
+  # Model:
+  dof_treeid: wp.array[int],
+  tree_dofadr: wp.array[int],
+  tree_dofnum: wp.array[int],
+  # Data in:
   nidof_in: wp.array[int],
-  island_nv_inout: wp.array2d[int],
+  tree_island_in: wp.array2d[int],
+  island_idofadr_in: wp.array2d[int],
+  # Data out:
   island_dofadr_out: wp.array2d[int],
   map_dof2idof_out: wp.array2d[int],
   map_idof2dof_out: wp.array2d[int],
+  # Out:
   idof_islandid_out: wp.array2d[int],
-  unconstrained_cnt_inout: wp.array2d[int],
 ):
+  """Map DOFs in ascending global order for deterministic solver inputs.
+
+  A DOF's rank inside its island is fixed by the tree layout: DOFs are contiguous per
+  tree and trees are ordered, so the rank is the DOF count of every preceding tree
+  carrying the same label. That closed form makes the ascending order reproducible
+  without a serial per-world scan.
+  """
   worldid, dofid = wp.tid()
 
-  nidof = nidof_in[worldid]
-  island_id = dof_island_in[worldid, dofid]
+  tree = dof_treeid[dofid]
+  island_id = tree_island_in[worldid, tree]
+
+  local_idx = dofid - tree_dofadr[tree]
+  for t in range(tree):
+    if tree_island_in[worldid, t] == island_id:
+      local_idx += tree_dofnum[t]
 
   if island_id >= 0:
-    local_idx = wp.atomic_add(island_nv_inout, worldid, island_id, 1)
     idof = island_idofadr_in[worldid, island_id] + local_idx
     idof_islandid_out[worldid, idof] = island_id
-    wp.atomic_min(island_dofadr_out, worldid, island_id, dofid)
+    if local_idx == 0:
+      island_dofadr_out[worldid, island_id] = dofid
   else:
-    cnt = wp.atomic_add(unconstrained_cnt_inout, worldid, 0, 1)
-    idof = nidof + cnt
+    idof = nidof_in[worldid] + local_idx
 
   map_dof2idof_out[worldid, dofid] = idof
   map_idof2dof_out[worldid, idof] = dofid
@@ -374,11 +454,14 @@ def _island_map_dofs(
 
 @wp.kernel
 def _island_count_constraints(
+  # Data in:
   nefc_in: wp.array[int],
-  njmax_in: int,
-  efc_tree_in: wp.array2d[int],
-  tree_island_in: wp.array2d[int],
   efc_type_in: wp.array2d[int],
+  tree_island_in: wp.array2d[int],
+  njmax_in: int,
+  # In:
+  efc_tree_in: wp.array2d[int],
+  # Data out:
   efc_island_out: wp.array2d[int],
   island_nefc_out: wp.array2d[int],
   island_ne_out: wp.array2d[int],
@@ -407,78 +490,63 @@ def _island_count_constraints(
 
 @wp.kernel
 def _island_map_constraints(
+  # Data in:
   nefc_in: wp.array[int],
-  njmax_in: int,
+  nisland_in: wp.array[int],
+  efc_type_in: wp.array2d[int],
   efc_island_in: wp.array2d[int],
-  island_iefcadr_in: wp.array2d[int],
   island_ne_in: wp.array2d[int],
   island_nf_in: wp.array2d[int],
-  efc_type_in: wp.array2d[int],
-  # Counters (inout):
-  island_ne_mapped_inout: wp.array2d[int],
-  island_nf_mapped_inout: wp.array2d[int],
-  island_nother_mapped_inout: wp.array2d[int],
-  island_nefc_inout: wp.array2d[int],
-  # Out:
+  island_iefcadr_in: wp.array2d[int],
+  # In:
+  njmax_in: int,
+  # Data out:
+  island_nefc_out: wp.array2d[int],
   map_efc2iefc_out: wp.array2d[int],
   map_iefc2efc_out: wp.array2d[int],
+  # Out:
   iefc_islandid_out: wp.array2d[int],
 ):
-  worldid, efcid = wp.tid()
-  if efcid >= wp.min(njmax_in, nefc_in[worldid]):
+  """Map constraints in ascending EFC order within each MuJoCo category.
+
+  One thread owns one island and keeps its three category counters in registers, so the
+  ascending scan stays serial per island (and therefore reproducible) while different
+  islands and worlds advance in parallel.
+  """
+  worldid, islandid = wp.tid()
+  if islandid >= nisland_in[worldid]:
     return
 
-  island_id = efc_island_in[worldid, efcid]
-  if island_id >= 0:
-    efc_type = efc_type_in[worldid, efcid]
+  iefcadr = island_iefcadr_in[worldid, islandid]
+  fadr = iefcadr + island_ne_in[worldid, islandid]
+  oadr = fadr + island_nf_in[worldid, islandid]
+  ne_mapped = int(0)
+  nf_mapped = int(0)
+  nother_mapped = int(0)
 
-    # 1. Determine local index and absolute index ic based on category
-    if efc_type == ConstraintType.EQUALITY:
-      local_idx = wp.atomic_add(island_ne_mapped_inout, worldid, island_id, 1)
-      ic = island_iefcadr_in[worldid, island_id] + local_idx
-    elif efc_type == ConstraintType.FRICTION_DOF or efc_type == ConstraintType.FRICTION_TENDON:
-      local_idx = wp.atomic_add(island_nf_mapped_inout, worldid, island_id, 1)
-      ic = island_iefcadr_in[worldid, island_id] + island_ne_in[worldid, island_id] + local_idx
-    else:
-      local_idx = wp.atomic_add(island_nother_mapped_inout, worldid, island_id, 1)
-      ic = (
-        island_iefcadr_in[worldid, island_id] + island_ne_in[worldid, island_id] + island_nf_in[worldid, island_id] + local_idx
-      )
+  nefc = wp.min(njmax_in, nefc_in[worldid])
+  for efcid in range(nefc):
+    if efc_island_in[worldid, efcid] == islandid:
+      efc_type = efc_type_in[worldid, efcid]
 
-    # 2. Increment overall island_nefc counter to reconstruct d.island_nefc
-    wp.atomic_add(island_nefc_inout, worldid, island_id, 1)
+      # 1. Determine absolute index ic based on category
+      if efc_type == ConstraintType.EQUALITY:
+        ic = iefcadr + ne_mapped
+        ne_mapped += 1
+      elif efc_type == ConstraintType.FRICTION_DOF or efc_type == ConstraintType.FRICTION_TENDON:
+        ic = fadr + nf_mapped
+        nf_mapped += 1
+      else:
+        ic = oadr + nother_mapped
+        nother_mapped += 1
 
-    # 3. Store mappings
-    map_efc2iefc_out[worldid, efcid] = ic
-    map_iefc2efc_out[worldid, ic] = efcid
-    iefc_islandid_out[worldid, ic] = island_id
+      # 2. Store mappings
+      map_efc2iefc_out[worldid, efcid] = ic
+      map_iefc2efc_out[worldid, ic] = efcid
+      iefc_islandid_out[worldid, ic] = islandid
 
-
-@wp.kernel
-def _island_scan_sparse_rows(
-  nisland_in: wp.array[int],
-  efc_J_rownnz_in: wp.array2d[int],
-  island_nefc_in: wp.array2d[int],
-  island_iefcadr_in: wp.array2d[int],
-  map_iefc2efc_in: wp.array2d[int],
-  iefc_J_rownnz_out: wp.array2d[int],
-  iefc_J_rowadr_out: wp.array2d[int],
-):
-  worldid = wp.tid()
-
-  nisland = nisland_in[worldid]
-  if nisland == 0:
-    return
-
-  total_gathered_efc = island_iefcadr_in[worldid, nisland - 1] + island_nefc_in[worldid, nisland - 1]
-
-  running_rowadr = int(0)
-  for ic in range(total_gathered_efc):
-    c = map_iefc2efc_in[worldid, ic]
-    rownnz = efc_J_rownnz_in[worldid, c]
-    iefc_J_rowadr_out[worldid, ic] = running_rowadr
-    iefc_J_rownnz_out[worldid, ic] = rownnz
-    running_rowadr += rownnz
+  # 3. Reconstruct d.island_nefc from the three category counts
+  island_nefc_out[worldid, islandid] = ne_mapped + nf_mapped + nother_mapped
 
 
 @wp.kernel
@@ -500,10 +568,10 @@ def _compute_efc_tree(
   contact_geom_in: wp.array[wp.vec2i],
   efc_type_in: wp.array2d[int],
   efc_id_in: wp.array2d[int],
-  efc_J_in: wp.array3d[float],
   efc_J_rownnz_in: wp.array2d[int],
   efc_J_rowadr_in: wp.array2d[int],
   efc_J_colind_in: wp.array3d[int],
+  efc_J_in: wp.array3d[float],
   njmax_in: int,
   # Out:
   efc_tree_out: wp.array2d[int],
@@ -601,164 +669,15 @@ def _compute_efc_tree(
 
 
 @wp.kernel
-def _gather_efc_and_jacobian(
-  # Model:
-  is_sparse: bool,
-  # Data in:
-  nefc_in: wp.array[int],
-  efc_D_in: wp.array2d[float],
-  efc_type_in: wp.array2d[int],
-  efc_id_in: wp.array2d[int],
-  efc_frictionloss_in: wp.array2d[float],
-  efc_aref_in: wp.array2d[float],
-  efc_J_in: wp.array3d[float],
-  # Sparse Jacobian arrays:
-  efc_J_rownnz_in: wp.array2d[int],
-  efc_J_rowadr_in: wp.array2d[int],
-  efc_J_colind_in: wp.array3d[int],
-  iefc_J_rowadr_in: wp.array2d[int],
-  # In:
-  njmax_in: int,
-  map_iefc2efc_in: wp.array2d[int],
-  map_idof2dof_in: wp.array2d[int],
-  map_dof2idof_in: wp.array2d[int],
-  nidof_in: wp.array[int],
-  # Out:
-  iefc_D_out: wp.array2d[float],
-  iefc_type_out: wp.array2d[int],
-  iefc_id_out: wp.array2d[int],
-  iefc_frictionloss_out: wp.array2d[float],
-  iefc_aref_out: wp.array2d[float],
-  iefc_J_out: wp.array3d[float],
-  iefc_J_colind_out: wp.array3d[int],
-):
-  """Gather constraint arrays and Jacobian into island-local dense order."""
-  worldid, iefcid = wp.tid()
-
-  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
-    return
-
-  c = map_iefc2efc_in[worldid, iefcid]
-
-  # Scalar constraint fields
-  iefc_D_out[worldid, iefcid] = efc_D_in[worldid, c]
-  iefc_type_out[worldid, iefcid] = efc_type_in[worldid, c]
-  iefc_id_out[worldid, iefcid] = efc_id_in[worldid, c]
-  iefc_frictionloss_out[worldid, iefcid] = efc_frictionloss_in[worldid, c]
-  iefc_aref_out[worldid, iefcid] = efc_aref_in[worldid, c]
-
-  # Jacobian: convert to island-local dense format
-  nid = nidof_in[worldid]
-
-  if is_sparse:
-    rownnz = efc_J_rownnz_in[worldid, c]
-    rowadr_in = efc_J_rowadr_in[worldid, c]
-    rowadr_out = iefc_J_rowadr_in[worldid, iefcid]
-    for i in range(rownnz):
-      sparseid_in = rowadr_in + i
-      sparseid_out = rowadr_out + i
-      dof = efc_J_colind_in[worldid, 0, sparseid_in]
-      idof = map_dof2idof_in[worldid, dof]
-      # Store in sparse iefc_J_out and iefc_J_colind_out
-      iefc_J_out[worldid, 0, sparseid_out] = efc_J_in[worldid, 0, sparseid_in]
-      iefc_J_colind_out[worldid, 0, sparseid_out] = idof
-  else:
-    # Dense path: reorder rows by iefc, columns by idof
-    for idof in range(nid):
-      dof = map_idof2dof_in[worldid, idof]
-      iefc_J_out[worldid, iefcid, idof] = efc_J_in[worldid, c, dof]
-
-
-@wp.kernel
-def _gather_dof_arrays(
-  # Data in:
-  qacc_in: wp.array2d[float],
-  qacc_smooth_in: wp.array2d[float],
-  qfrc_smooth_in: wp.array2d[float],
-  # In:
-  nidof_in: wp.array[int],
-  map_idof2dof_in: wp.array2d[int],
-  # Out:
-  iacc_out: wp.array2d[float],
-  iacc_smooth_out: wp.array2d[float],
-  ifrc_smooth_out: wp.array2d[float],
-):
-  """Gather DOF arrays into island-local order."""
-  worldid, idofid = wp.tid()
-
-  if idofid >= nidof_in[worldid]:
-    return
-
-  dof = map_idof2dof_in[worldid, idofid]
-  iacc_out[worldid, idofid] = qacc_in[worldid, dof]
-  iacc_smooth_out[worldid, idofid] = qacc_smooth_in[worldid, dof]
-  ifrc_smooth_out[worldid, idofid] = qfrc_smooth_in[worldid, dof]
-
-
-@wp.kernel
-def _scatter_dof_arrays(
-  # In:
-  qacc_smooth_in: wp.array2d[float],
-  qfrc_smooth_in: wp.array2d[float],
-  dof_island_in: wp.array2d[int],
-  iacc_in: wp.array2d[float],
-  ifrc_constraint_in: wp.array2d[float],
-  iMa_in: wp.array2d[float],
-  map_dof2idof_in: wp.array2d[int],
-  scatter_Ma: bool,
-  # Out:
-  qacc_out: wp.array2d[float],
-  qfrc_constraint_out: wp.array2d[float],
-  Ma_out: wp.array2d[float],
-):
-  """Scatter island results to global arrays, copy qacc_smooth for non-island DOFs."""
-  worldid, dofid = wp.tid()
-
-  if dof_island_in[worldid, dofid] < 0:
-    qacc_out[worldid, dofid] = qacc_smooth_in[worldid, dofid]
-    qfrc_constraint_out[worldid, dofid] = 0.0
-    if scatter_Ma:
-      Ma_out[worldid, dofid] = qfrc_smooth_in[worldid, dofid]
-  else:
-    idof = map_dof2idof_in[worldid, dofid]
-    qacc_out[worldid, dofid] = iacc_in[worldid, idof]
-    qfrc_constraint_out[worldid, dofid] = ifrc_constraint_in[worldid, idof]
-    if scatter_Ma:
-      Ma_out[worldid, dofid] = iMa_in[worldid, idof]
-
-
-@wp.kernel
-def _scatter_efc_arrays(
-  # In:
-  nefc_in: wp.array[int],
-  njmax_in: int,
-  map_iefc2efc_in: wp.array2d[int],
-  iefc_force_in: wp.array2d[float],
-  iefc_state_in: wp.array2d[int],
-  # Out:
-  efc_force_out: wp.array2d[float],
-  efc_state_out: wp.array2d[int],
-):
-  """Scatter island-local constraint results back to global order."""
-  worldid, iefcid = wp.tid()
-
-  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
-    return
-
-  c = map_iefc2efc_in[worldid, iefcid]
-  efc_force_out[worldid, c] = iefc_force_in[worldid, iefcid]
-  efc_state_out[worldid, c] = iefc_state_in[worldid, iefcid]
-
-
-@wp.kernel
 def _init_island_arrays(
+  # Data out:
+  nidof_out: wp.array[int],
   island_idofadr_out: wp.array2d[int],
   island_nv_out: wp.array2d[int],
   island_nefc_out: wp.array2d[int],
   island_ne_out: wp.array2d[int],
   island_nf_out: wp.array2d[int],
   island_iefcadr_out: wp.array2d[int],
-  nidof_out: wp.array[int],
 ):
   worldid, islandid = wp.tid()
   island_nv_out[worldid, islandid] = 0
@@ -773,9 +692,11 @@ def _init_island_arrays(
 
 @wp.kernel
 def _init_dof_arrays(
+  # Data out:
   dof_island_out: wp.array2d[int],
   map_dof2idof_out: wp.array2d[int],
   map_idof2dof_out: wp.array2d[int],
+  # Out:
   idof_islandid_out: wp.array2d[int],
 ):
   worldid, dofid = wp.tid()
@@ -787,9 +708,11 @@ def _init_dof_arrays(
 
 @wp.kernel
 def _init_efc_arrays(
+  # Data out:
   efc_island_out: wp.array2d[int],
   map_efc2iefc_out: wp.array2d[int],
   map_iefc2efc_out: wp.array2d[int],
+  # Out:
   iefc_islandid_out: wp.array2d[int],
   efc_tree_out: wp.array2d[int],
 ):
@@ -826,15 +749,7 @@ def compute_island_mapping(m: types.Model, d: types.Data):
     _init_island_arrays,
     dim=(d.nworld, m.ntree),
     inputs=[],
-    outputs=[
-      d.island_idofadr,
-      d.island_nv,
-      d.island_nefc,
-      d.island_ne,
-      d.island_nf,
-      d.island_iefcadr,
-      d.nidof,
-    ],
+    outputs=[d.nidof, d.island_idofadr, d.island_nv, d.island_nefc, d.island_ne, d.island_nf, d.island_iefcadr],
   )
   wp.launch(
     _init_dof_arrays,
@@ -869,10 +784,10 @@ def compute_island_mapping(m: types.Model, d: types.Data):
       d.contact.geom,
       d.efc.type,
       d.efc.id,
-      d.efc.J,
       d.efc.J_rownnz,
       d.efc.J_rowadr,
       d.efc.J_colind,
+      d.efc.J,
       d.njmax,
     ],
     outputs=[efc_tree],
@@ -890,7 +805,7 @@ def compute_island_mapping(m: types.Model, d: types.Data):
   wp.launch(
     _island_count_constraints,
     dim=(d.nworld, d.njmax),
-    inputs=[d.nefc, d.njmax, efc_tree, d.tree_island, d.efc.type],
+    inputs=[d.nefc, d.efc.type, d.tree_island, d.njmax, efc_tree],
     outputs=[d.efc.island, d.island_nefc, d.island_ne, d.island_nf],
   )
 
@@ -898,40 +813,24 @@ def compute_island_mapping(m: types.Model, d: types.Data):
   wp.launch(
     _island_scan_sizes,
     dim=d.nworld,
-    inputs=[d.nisland],
-    outputs=[d.island_idofadr, d.island_nv, d.island_nefc, d.island_iefcadr, d.nidof],
+    inputs=[d.nisland, d.island_nv],
+    outputs=[d.nidof, d.island_idofadr, d.island_nefc, d.island_iefcadr],
   )
 
   # 4. Map DOFs
-  unconstrained_cnt = wp.zeros((d.nworld, 1), dtype=int)
   d.island_dofadr.fill_(m.nv)
   wp.launch(
     _island_map_dofs,
     dim=(d.nworld, m.nv),
-    inputs=[m.nv, d.dof_island, d.island_idofadr, d.nidof],
-    outputs=[d.island_nv, d.island_dofadr, d.map_dof2idof, d.map_idof2dof, d.dof_islandid, unconstrained_cnt],
+    inputs=[m.dof_treeid, m.tree_dofadr, m.tree_dofnum, d.nidof, d.tree_island, d.island_idofadr],
+    outputs=[d.island_dofadr, d.map_dof2idof, d.map_idof2dof, d.dof_islandid],
   )
 
   # 5. Map Constraints
-  ne_mapped = wp.zeros((d.nworld, m.ntree), dtype=int)
-  nf_mapped = wp.zeros((d.nworld, m.ntree), dtype=int)
-  nother_mapped = wp.zeros((d.nworld, m.ntree), dtype=int)
-
   wp.launch(
     _island_map_constraints,
-    dim=(d.nworld, d.njmax),
-    inputs=[
-      d.nefc,
-      d.njmax,
-      d.efc.island,
-      d.island_iefcadr,
-      d.island_ne,
-      d.island_nf,
-      d.efc.type,
-      ne_mapped,
-      nf_mapped,
-      nother_mapped,
-    ],
+    dim=(d.nworld, m.ntree),
+    inputs=[d.nefc, d.nisland, d.efc.type, d.efc.island, d.island_ne, d.island_nf, d.island_iefcadr, d.njmax],
     outputs=[d.island_nefc, d.map_efc2iefc, d.map_iefc2efc, d.efc_islandid],
   )
 
@@ -972,6 +871,7 @@ def _compact_dofs(
   # Data in:
   tree_awake_in: wp.array2d[int],
   nvmax_in: int,
+  # In:
   warn_overflow: bool,
   # Data out:
   ncdof_out: wp.array[int],

--- a/mujoco_warp/_src/island.py
+++ b/mujoco_warp/_src/island.py
@@ -23,8 +23,88 @@ from mujoco_warp._src.types import OverflowType
 from mujoco_warp._src.warp_util import event_scope
 
 
+@wp.func
+def _dsu_find(parent: wp.array2d[int], worldid: int, tree: int):
+  """Find a root while shortening its strictly decreasing parent path."""
+  current = tree
+  while True:
+    parent_current = parent[worldid, current]
+    if parent_current == current:
+      return current
+    grandparent = parent[worldid, parent_current]
+    if grandparent < parent_current:
+      wp.atomic_min(parent, worldid, current, grandparent)
+    current = parent_current
+  return current
+
+
+@wp.func
+def _dsu_activate(worldid: int, tree: int, tree_island_out: wp.array2d[int]):
+  if tree >= 0:
+    wp.atomic_max(tree_island_out, worldid, tree, 0)
+
+
+@wp.func
+def _dsu_union(parent: wp.array2d[int], worldid: int, tree0: int, tree1: int, tree_island_out: wp.array2d[int]):
+  """Activate endpoints and atomically hook the higher root to the lower root."""
+  if tree0 < 0:
+    tree0 = tree1
+    tree1 = -1
+  if tree0 < 0:
+    return
+  _dsu_activate(worldid, tree0, tree_island_out)
+  if tree1 < 0:
+    return
+  _dsu_activate(worldid, tree1, tree_island_out)
+
+  while True:
+    root0 = _dsu_find(parent, worldid, tree0)
+    root1 = _dsu_find(parent, worldid, tree1)
+    if root0 == root1:
+      return
+    low_root = wp.min(root0, root1)
+    high_root = wp.max(root0, root1)
+    previous = wp.atomic_cas(parent, worldid, high_root, high_root, low_root)
+    if previous == high_root:
+      return
+
+
 @wp.kernel
-def _tree_edges(
+def _reset_dsu(
+  # Data out:
+  nisland_out: wp.array[int],
+  tree_island_out: wp.array2d[int],
+  # Out:
+  island_parent_out: wp.array2d[int],
+):
+  """Reset identity parents and active/output markers in parallel."""
+  worldid, treeid = wp.tid()
+  island_parent_out[worldid, treeid] = treeid
+  tree_island_out[worldid, treeid] = -1
+  if treeid == 0:
+    nisland_out[worldid] = 0
+
+
+@wp.func
+def _is_repeated_fixed_support_efc(
+  # Data in:
+  efc_type_in: wp.array2d[int],
+  efc_id_in: wp.array2d[int],
+  # In:
+  worldid: int,
+  efcid: int,
+) -> bool:
+  """Return whether the preceding scalar row has the same fixed tree support."""
+  if efcid == 0:
+    return False
+  return (
+    efc_type_in[worldid, efcid - 1] == efc_type_in[worldid, efcid]
+    and efc_id_in[worldid, efcid - 1] == efc_id_in[worldid, efcid]
+  )
+
+
+@wp.kernel
+def _island_dsu(
   # Model:
   nv: int,
   body_treeid: wp.array[int],
@@ -47,134 +127,178 @@ def _tree_edges(
   efc_J_colind_in: wp.array3d[int],
   efc_J_in: wp.array3d[float],
   njmax_in: int,
+  # In:
+  chunk_size: int,
+  # Data out:
+  tree_island_out: wp.array2d[int],
   # Out:
-  tree_tree: wp.array3d[int],  # kernel_analyzer: off
+  island_parent_out: wp.array2d[int],
 ):
-  """Find tree edges."""
-  worldid, efcid = wp.tid()
+  """Process one chunk of one world's active EFC prefix with one strided CUDA warp.
 
-  # skip if beyond active constraints
-  if efcid >= wp.min(njmax_in, nefc_in[worldid]):
-    return
+  Blocks are laid out over (world, chunk) rather than world alone, so resident
+  parallelism tracks total constraint capacity instead of batch size. A single world
+  with a long prefix fills the device the same way a large batch of short ones does.
+  """
+  worldid, chunkid, lane = wp.tid()
+  chunk_beg = chunkid * chunk_size
+  chunk_end = wp.min(chunk_beg + chunk_size, wp.min(njmax_in, nefc_in[worldid]))
+  for efcid in range(chunk_beg + lane, chunk_end, wp.block_dim()):
+    efc_type = efc_type_in[worldid, efcid]
+    efc_id = efc_id_in[worldid, efcid]
+    repeated = _is_repeated_fixed_support_efc(efc_type_in, efc_id_in, worldid, efcid)
+    tree0 = int(-1)
+    tree1 = int(-1)
+    use_generic = int(0)
 
-  efc_type = efc_type_in[worldid, efcid]
-  efc_id = efc_id_in[worldid, efcid]
-
-  tree0 = int(-1)
-  tree1 = int(-1)
-  use_generic = int(0)
-
-  # equality (connect/weld)
-  if efc_type == ConstraintType.EQUALITY:
-    eq_t = eq_type[efc_id]
-
-    if eq_t == EqType.CONNECT or eq_t == EqType.WELD:
-      b1 = eq_obj1id[efc_id]
-      b2 = eq_obj2id[efc_id]
-
-      # site semantics
-      if eq_objtype[efc_id] == ObjType.SITE:
-        b1 = site_bodyid[b1]
-        b2 = site_bodyid[b2]
-
-      tree0 = body_treeid[b1]
-      tree1 = body_treeid[b2]
-    else:
-      # JOINT, TENDON, FLEX
-      use_generic = 1
-
-  # joint friction
-  elif efc_type == ConstraintType.FRICTION_DOF:
-    tree0 = dof_treeid[efc_id]
-
-  # joint limit
-  elif efc_type == ConstraintType.LIMIT_JOINT:
-    tree0 = dof_treeid[jnt_dofadr[efc_id]]
-
-  # contact
-  elif (
-    efc_type == ConstraintType.CONTACT_FRICTIONLESS
-    or efc_type == ConstraintType.CONTACT_PYRAMIDAL
-    or efc_type == ConstraintType.CONTACT_ELLIPTIC
-  ):
-    geom_pair = contact_geom_in[efc_id]
-    g1 = geom_pair[0]
-    g2 = geom_pair[1]
-
-    # flex contacts have negative geom ids
-    if g1 >= 0 and g2 >= 0:
-      tree0 = body_treeid[geom_bodyid[g1]]
-      tree1 = body_treeid[geom_bodyid[g2]]
-    else:
-      use_generic = 1
-
-  # generic
-  else:
-    use_generic = 1
-
-  # handle static bodies
-  if use_generic == 0:
-    # swap so tree0 is non-negative if possible
-    if tree0 < 0 and tree1 >= 0:
-      tree0 = tree1
-      tree1 = -1
-
-    # mark the edge
-    if tree0 >= 0:
-      if tree1 < 0 or tree0 == tree1:
-        # self-edge
-        wp.atomic_max(tree_tree, worldid, tree0, tree0, 1)
+    if efc_type == ConstraintType.EQUALITY:
+      eq_t = eq_type[efc_id]
+      if eq_t == EqType.CONNECT or eq_t == EqType.WELD:
+        if repeated:
+          continue
+        body0 = eq_obj1id[efc_id]
+        body1 = eq_obj2id[efc_id]
+        if eq_objtype[efc_id] == ObjType.SITE:
+          body0 = site_bodyid[body0]
+          body1 = site_bodyid[body1]
+        tree0 = body_treeid[body0]
+        tree1 = body_treeid[body1]
       else:
-        # cross-tree edge
-        t1 = wp.min(tree0, tree1)
-        t2 = wp.max(tree0, tree1)
-        wp.atomic_max(tree_tree, worldid, t1, t2, 1)
-        wp.atomic_max(tree_tree, worldid, t2, t1, 1)
-    return
-
-  # generic: scan Jacobian row
-  first_tree = int(-1)
-  has_cross_edge = int(0)
-
-  count = nv
-  rowadr = 0
-  if is_sparse:
-    count = efc_J_rownnz_in[worldid, efcid]
-    rowadr = efc_J_rowadr_in[worldid, efcid]
-
-  for i in range(count):
-    dof = i
-    if is_sparse:
-      sparseid = rowadr + i
-      dof = efc_J_colind_in[worldid, 0, sparseid]
-    else:
-      J_val = efc_J_in[worldid, efcid, dof]
-      if J_val == 0.0:
+        use_generic = 1
+    elif efc_type == ConstraintType.FRICTION_DOF:
+      if repeated:
         continue
+      tree0 = dof_treeid[efc_id]
+    elif efc_type == ConstraintType.LIMIT_JOINT:
+      if repeated:
+        continue
+      tree0 = dof_treeid[jnt_dofadr[efc_id]]
+    elif (
+      efc_type == ConstraintType.CONTACT_FRICTIONLESS
+      or efc_type == ConstraintType.CONTACT_PYRAMIDAL
+      or efc_type == ConstraintType.CONTACT_ELLIPTIC
+    ):
+      geom_pair = contact_geom_in[efc_id]
+      if geom_pair[0] >= 0 and geom_pair[1] >= 0:
+        if repeated:
+          continue
+        tree0 = body_treeid[geom_bodyid[geom_pair[0]]]
+        tree1 = body_treeid[geom_bodyid[geom_pair[1]]]
+      else:
+        use_generic = 1
+    else:
+      use_generic = 1
 
-    tree = dof_treeid[dof]
-    if tree < 0:
+    if use_generic == 0:
+      _dsu_union(island_parent_out, worldid, tree0, tree1, tree_island_out)
       continue
-    if first_tree == -1:
-      first_tree = tree
-    elif tree != first_tree:
-      t1 = wp.min(first_tree, tree)
-      t2 = wp.max(first_tree, tree)
-      wp.atomic_max(tree_tree, worldid, t1, t2, 1)
-      wp.atomic_max(tree_tree, worldid, t2, t1, 1)
-      has_cross_edge = 1
 
-  if first_tree >= 0 and has_cross_edge == 0:
-    wp.atomic_max(tree_tree, worldid, first_tree, first_tree, 1)
+    first_tree = int(-1)
+    count = nv
+    rowadr = int(0)
+    if is_sparse:
+      count = efc_J_rownnz_in[worldid, efcid]
+      rowadr = efc_J_rowadr_in[worldid, efcid]
+
+    for index in range(count):
+      dof = index
+      if is_sparse:
+        dof = efc_J_colind_in[worldid, 0, rowadr + index]
+      elif efc_J_in[worldid, efcid, dof] == 0.0:
+        continue
+      tree = dof_treeid[dof]
+      if tree < 0:
+        continue
+      if first_tree < 0:
+        first_tree = tree
+        _dsu_union(island_parent_out, worldid, tree, -1, tree_island_out)
+      else:
+        _dsu_union(island_parent_out, worldid, first_tree, tree, tree_island_out)
+
+
+@wp.kernel
+def _compress_roots(
+  # Data in:
+  tree_island_in: wp.array2d[int],
+  # Data out:
+  # Out:
+  island_parent_out: wp.array2d[int],
+):
+  """Point every active tree straight at its component's minimum-tree root."""
+  worldid, treeid = wp.tid()
+  if tree_island_in[worldid, treeid] >= 0:
+    island_parent_out[worldid, treeid] = _dsu_find(island_parent_out, worldid, treeid)
+
+
+@wp.kernel
+def _label_roots(
+  # Model:
+  ntree: int,
+  # Data in:
+  # In:
+  island_parent_in: wp.array2d[int],
+  # Data out:
+  nisland_out: wp.array[int],
+  tree_island_out: wp.array2d[int],
+):
+  """Number the roots in ascending tree order, which is MuJoCo's island order.
+
+  Ranking roots is the one inherently sequential step: island i is the i-th smallest
+  root, so it depends on every preceding tree. It reads two ints per tree and does no
+  pointer chasing, leaving the compress and propagate passes free to run per tree.
+  """
+  worldid = wp.tid()
+  nisland = int(0)
+  for treeid in range(ntree):
+    if tree_island_out[worldid, treeid] >= 0 and island_parent_in[worldid, treeid] == treeid:
+      tree_island_out[worldid, treeid] = nisland
+      nisland += 1
+  nisland_out[worldid] = nisland
+
+
+@wp.kernel
+def _propagate_labels(
+  # Data in:
+  # In:
+  island_parent_in: wp.array2d[int],
+  # Data out:
+  tree_island_out: wp.array2d[int],
+):
+  """Copy each root's label down to the trees that point at it.
+
+  A root reads and writes its own slot with the same value, so the only concurrent
+  writes to any slot store identical data.
+  """
+  worldid, treeid = wp.tid()
+  if tree_island_out[worldid, treeid] >= 0:
+    tree_island_out[worldid, treeid] = tree_island_out[worldid, island_parent_in[worldid, treeid]]
+
+
+# Smallest EFC chunk worth its own block, and the resident-block count worth reaching for.
+_DSU_MIN_CHUNK = 256
+_DSU_TARGET_BLOCKS = 2048
 
 
 @event_scope
-def tree_edges(m: types.Model, d: types.Data, tree_tree: wp.array3d[int]):
-  """Compute tree-tree adjacency matrix."""
-  tree_tree.zero_()
+def direct_dsu(m: types.Model, d: types.Data, island_parent: wp.array2d[int]):
+  """Discover islands with EFC-parallel atomic minimum-root hooks.
+
+  `island_parent` is the (nworld, ntree) disjoint-set workspace, owned by the caller.
+  """
+  # Discovery blocks are laid out over (world, chunk). A batch large enough to occupy the
+  # device keeps one block per world, since extra chunks would mostly launch past the
+  # active prefix; a small batch with a long prefix is split until there is resident work.
+  max_chunks = max(1, -(-d.njmax // _DSU_MIN_CHUNK))
+  nchunk = min(max(1, -(-_DSU_TARGET_BLOCKS // d.nworld)), max_chunks)
+  chunk_size = -(-d.njmax // nchunk)
   wp.launch(
-    kernel=_tree_edges,
-    dim=(d.nworld, d.njmax),
+    _reset_dsu,
+    dim=(d.nworld, m.ntree),
+    inputs=[d.nisland, d.tree_island, island_parent],
+  )
+  wp.launch_tiled(
+    _island_dsu,
+    dim=(d.nworld, nchunk),
     inputs=[
       m.nv,
       m.body_treeid,
@@ -196,84 +320,26 @@ def tree_edges(m: types.Model, d: types.Data, tree_tree: wp.array3d[int]):
       d.efc.J_colind,
       d.efc.J,
       d.njmax,
+      chunk_size,
+      d.tree_island,
+      island_parent,
     ],
-    outputs=[tree_tree],
+    block_dim=types.BlockDim.island_dsu,
   )
-
-
-@wp.kernel
-def _flood_fill(
-  # Model:
-  ntree: int,
-  # In:
-  tree_tree_in: wp.array3d[int],
-  labels_in: wp.array2d[int],
-  stack_in: wp.array2d[int],
-  # Data out:
-  nisland_out: wp.array[int],
-  tree_island_out: wp.array2d[int],
-  # Out:
-  stack_out: wp.array2d[int],
-):
-  """DFS flood fill to discover islands using tree_tree matrix."""
-  worldid = wp.tid()
-  nisland = int(0)
-
-  # iterate over trees
-  for i in range(ntree):
-    # already assigned
-    if labels_in[worldid, i] != -1:
-      continue
-
-    # check if tree has any edges
-    has_edge = int(0)
-    for j in range(ntree):
-      if tree_tree_in[worldid, i, j] != 0:
-        has_edge = 1
-        break
-    if has_edge == 0:
-      continue
-
-    # DFS: push i onto stack
-    nstack = int(0)
-    stack_out[worldid, nstack] = i
-    nstack = nstack + 1
-
-    while nstack > 0:
-      # pop v from stack
-      nstack = nstack - 1
-      v = stack_in[worldid, nstack]
-
-      # already assigned
-      if labels_in[worldid, v] != -1:
-        continue
-
-      # assign to current island
-      tree_island_out[worldid, v] = nisland
-
-      # push neighbors
-      for neighbor in range(ntree):
-        if tree_tree_in[worldid, v, neighbor] != 0:
-          if labels_in[worldid, neighbor] == -1:
-            stack_out[worldid, nstack] = neighbor
-            nstack = nstack + 1
-
-    # island filled
-    nisland = nisland + 1
-
-  nisland_out[worldid] = nisland
-
-
-@event_scope
-def flood_fill(m: types.Model, d: types.Data, tree_tree: wp.array3d[int]):
-  d.tree_island.fill_(-1)
-  stack_scratch = wp.empty((d.nworld, m.ntree * m.ntree), dtype=int)
-
   wp.launch(
-    _flood_fill,
+    _compress_roots,
+    dim=(d.nworld, m.ntree),
+    inputs=[d.tree_island, island_parent],
+  )
+  wp.launch(
+    _label_roots,
     dim=d.nworld,
-    inputs=[m.ntree, tree_tree, d.tree_island, stack_scratch],
-    outputs=[d.nisland, d.tree_island, stack_scratch],
+    inputs=[m.ntree, island_parent, d.nisland, d.tree_island],
+  )
+  wp.launch(
+    _propagate_labels,
+    dim=(d.nworld, m.ntree),
+    inputs=[island_parent, d.tree_island],
   )
 
 
@@ -284,18 +350,16 @@ def island(m: types.Model, d: types.Data):
     d.nisland.zero_()
     return
 
-  # Step 1: Find tree edges
-  tree_tree = wp.zeros((d.nworld, m.ntree, m.ntree), dtype=int)
-  tree_edges(m, d, tree_tree)
-
-  # Step 2: DFS flood fill
-  flood_fill(m, d, tree_tree)
+  direct_dsu(m, d, wp.empty((d.nworld, m.ntree), dtype=int))
 
 
 @wp.kernel
 def _island_count_dofs(
+  # Model:
   dof_treeid: wp.array[int],
+  # Data in:
   tree_island_in: wp.array2d[int],
+  # Data out:
   dof_island_out: wp.array2d[int],
   island_nv_out: wp.array2d[int],
 ):
@@ -309,12 +373,14 @@ def _island_count_dofs(
 
 @wp.kernel
 def _island_scan_sizes(
+  # Data in:
   nisland_in: wp.array[int],
-  island_idofadr_out: wp.array2d[int],
-  island_nv_inout: wp.array2d[int],
-  island_nefc_inout: wp.array2d[int],
-  island_iefcadr_out: wp.array2d[int],
+  island_nv_in: wp.array2d[int],
+  # Data out:
   nidof_out: wp.array[int],
+  island_idofadr_out: wp.array2d[int],
+  island_nefc_out: wp.array2d[int],
+  island_iefcadr_out: wp.array2d[int],
 ):
   worldid = wp.tid()
 
@@ -327,44 +393,58 @@ def _island_scan_sizes(
   island_idofadr_out[worldid, 0] = 0
   island_iefcadr_out[worldid, 0] = 0
   for i in range(1, nisland):
-    island_idofadr_out[worldid, i] = island_idofadr_out[worldid, i - 1] + island_nv_inout[worldid, i - 1]
-    island_iefcadr_out[worldid, i] = island_iefcadr_out[worldid, i - 1] + island_nefc_inout[worldid, i - 1]
+    island_idofadr_out[worldid, i] = island_idofadr_out[worldid, i - 1] + island_nv_in[worldid, i - 1]
+    island_iefcadr_out[worldid, i] = island_iefcadr_out[worldid, i - 1] + island_nefc_out[worldid, i - 1]
 
-  nidof = island_idofadr_out[worldid, nisland - 1] + island_nv_inout[worldid, nisland - 1]
+  nidof = island_idofadr_out[worldid, nisland - 1] + island_nv_in[worldid, nisland - 1]
   nidof_out[worldid] = nidof
 
-  # Reset for recount
+  # Reset for recount ( island_nv is final after _island_count_dofs and stays put )
   for i in range(nisland):
-    island_nv_inout[worldid, i] = 0
-    island_nefc_inout[worldid, i] = 0
+    island_nefc_out[worldid, i] = 0
 
 
 @wp.kernel
 def _island_map_dofs(
-  nv: int,
-  dof_island_in: wp.array2d[int],
-  island_idofadr_in: wp.array2d[int],
+  # Model:
+  dof_treeid: wp.array[int],
+  tree_dofadr: wp.array[int],
+  tree_dofnum: wp.array[int],
+  # Data in:
   nidof_in: wp.array[int],
-  island_nv_inout: wp.array2d[int],
+  tree_island_in: wp.array2d[int],
+  island_idofadr_in: wp.array2d[int],
+  # Data out:
   island_dofadr_out: wp.array2d[int],
   map_dof2idof_out: wp.array2d[int],
   map_idof2dof_out: wp.array2d[int],
+  # Out:
   idof_islandid_out: wp.array2d[int],
-  unconstrained_cnt_inout: wp.array2d[int],
 ):
+  """Map DOFs in ascending global order for deterministic solver inputs.
+
+  A DOF's rank inside its island is fixed by the tree layout: DOFs are contiguous per
+  tree and trees are ordered, so the rank is the DOF count of every preceding tree
+  carrying the same label. That closed form makes the ascending order reproducible
+  without a serial per-world scan.
+  """
   worldid, dofid = wp.tid()
 
-  nidof = nidof_in[worldid]
-  island_id = dof_island_in[worldid, dofid]
+  tree = dof_treeid[dofid]
+  island_id = tree_island_in[worldid, tree]
+
+  local_idx = dofid - tree_dofadr[tree]
+  for t in range(tree):
+    if tree_island_in[worldid, t] == island_id:
+      local_idx += tree_dofnum[t]
 
   if island_id >= 0:
-    local_idx = wp.atomic_add(island_nv_inout, worldid, island_id, 1)
     idof = island_idofadr_in[worldid, island_id] + local_idx
     idof_islandid_out[worldid, idof] = island_id
-    wp.atomic_min(island_dofadr_out, worldid, island_id, dofid)
+    if local_idx == 0:
+      island_dofadr_out[worldid, island_id] = dofid
   else:
-    cnt = wp.atomic_add(unconstrained_cnt_inout, worldid, 0, 1)
-    idof = nidof + cnt
+    idof = nidof_in[worldid] + local_idx
 
   map_dof2idof_out[worldid, dofid] = idof
   map_idof2dof_out[worldid, idof] = dofid
@@ -372,11 +452,14 @@ def _island_map_dofs(
 
 @wp.kernel
 def _island_count_constraints(
+  # Data in:
   nefc_in: wp.array[int],
-  njmax_in: int,
-  efc_tree_in: wp.array2d[int],
-  tree_island_in: wp.array2d[int],
   efc_type_in: wp.array2d[int],
+  tree_island_in: wp.array2d[int],
+  njmax_in: int,
+  # In:
+  efc_tree_in: wp.array2d[int],
+  # Data out:
   efc_island_out: wp.array2d[int],
   island_nefc_out: wp.array2d[int],
   island_ne_out: wp.array2d[int],
@@ -405,78 +488,62 @@ def _island_count_constraints(
 
 @wp.kernel
 def _island_map_constraints(
+  # Data in:
   nefc_in: wp.array[int],
-  njmax_in: int,
+  nisland_in: wp.array[int],
+  efc_type_in: wp.array2d[int],
   efc_island_in: wp.array2d[int],
-  island_iefcadr_in: wp.array2d[int],
   island_ne_in: wp.array2d[int],
   island_nf_in: wp.array2d[int],
-  efc_type_in: wp.array2d[int],
-  # Counters (inout):
-  island_ne_mapped_inout: wp.array2d[int],
-  island_nf_mapped_inout: wp.array2d[int],
-  island_nother_mapped_inout: wp.array2d[int],
-  island_nefc_inout: wp.array2d[int],
-  # Out:
+  island_iefcadr_in: wp.array2d[int],
+  # In:
+  njmax_in: int,
+  # Data out:
+  island_nefc_out: wp.array2d[int],
   map_efc2iefc_out: wp.array2d[int],
   map_iefc2efc_out: wp.array2d[int],
+  # Out:
   iefc_islandid_out: wp.array2d[int],
 ):
-  worldid, efcid = wp.tid()
-  if efcid >= wp.min(njmax_in, nefc_in[worldid]):
+  """Map constraints in ascending EFC order within each MuJoCo category.
+
+  One thread owns one island and keeps its three category counters in registers, so the
+  ascending scan stays serial per island (and therefore reproducible) while different
+  islands and worlds advance in parallel.
+  """
+  worldid, islandid = wp.tid()
+  if islandid >= nisland_in[worldid]:
     return
 
-  island_id = efc_island_in[worldid, efcid]
-  if island_id >= 0:
-    efc_type = efc_type_in[worldid, efcid]
+  iefcadr = island_iefcadr_in[worldid, islandid]
+  fadr = iefcadr + island_ne_in[worldid, islandid]
+  oadr = fadr + island_nf_in[worldid, islandid]
+  ne_mapped = int(0)
+  nf_mapped = int(0)
+  nother_mapped = int(0)
 
-    # 1. Determine local index and absolute index ic based on category
-    if efc_type == ConstraintType.EQUALITY:
-      local_idx = wp.atomic_add(island_ne_mapped_inout, worldid, island_id, 1)
-      ic = island_iefcadr_in[worldid, island_id] + local_idx
-    elif efc_type == ConstraintType.FRICTION_DOF or efc_type == ConstraintType.FRICTION_TENDON:
-      local_idx = wp.atomic_add(island_nf_mapped_inout, worldid, island_id, 1)
-      ic = island_iefcadr_in[worldid, island_id] + island_ne_in[worldid, island_id] + local_idx
-    else:
-      local_idx = wp.atomic_add(island_nother_mapped_inout, worldid, island_id, 1)
-      ic = (
-        island_iefcadr_in[worldid, island_id] + island_ne_in[worldid, island_id] + island_nf_in[worldid, island_id] + local_idx
-      )
+  for efcid in range(wp.min(njmax_in, nefc_in[worldid])):
+    if efc_island_in[worldid, efcid] == islandid:
+      efc_type = efc_type_in[worldid, efcid]
 
-    # 2. Increment overall island_nefc counter to reconstruct d.island_nefc
-    wp.atomic_add(island_nefc_inout, worldid, island_id, 1)
+      # 1. Determine absolute index ic based on category
+      if efc_type == ConstraintType.EQUALITY:
+        ic = iefcadr + ne_mapped
+        ne_mapped += 1
+      elif efc_type == ConstraintType.FRICTION_DOF or efc_type == ConstraintType.FRICTION_TENDON:
+        ic = fadr + nf_mapped
+        nf_mapped += 1
+      else:
+        ic = oadr + nother_mapped
+        nother_mapped += 1
 
-    # 3. Store mappings
-    map_efc2iefc_out[worldid, efcid] = ic
-    map_iefc2efc_out[worldid, ic] = efcid
-    iefc_islandid_out[worldid, ic] = island_id
+      # 2. Store mappings
+      map_efc2iefc_out[worldid, efcid] = ic
+      map_iefc2efc_out[worldid, ic] = efcid
+      iefc_islandid_out[worldid, ic] = islandid
 
-
-@wp.kernel
-def _island_scan_sparse_rows(
-  nisland_in: wp.array[int],
-  efc_J_rownnz_in: wp.array2d[int],
-  island_nefc_in: wp.array2d[int],
-  island_iefcadr_in: wp.array2d[int],
-  map_iefc2efc_in: wp.array2d[int],
-  iefc_J_rownnz_out: wp.array2d[int],
-  iefc_J_rowadr_out: wp.array2d[int],
-):
-  worldid = wp.tid()
-
-  nisland = nisland_in[worldid]
-  if nisland == 0:
-    return
-
-  total_gathered_efc = island_iefcadr_in[worldid, nisland - 1] + island_nefc_in[worldid, nisland - 1]
-
-  running_rowadr = int(0)
-  for ic in range(total_gathered_efc):
-    c = map_iefc2efc_in[worldid, ic]
-    rownnz = efc_J_rownnz_in[worldid, c]
-    iefc_J_rowadr_out[worldid, ic] = running_rowadr
-    iefc_J_rownnz_out[worldid, ic] = rownnz
-    running_rowadr += rownnz
+  # 3. Reconstruct d.island_nefc from the three category counts
+  island_nefc_out[worldid, islandid] = ne_mapped + nf_mapped + nother_mapped
 
 
 @wp.kernel
@@ -498,10 +565,10 @@ def _compute_efc_tree(
   contact_geom_in: wp.array[wp.vec2i],
   efc_type_in: wp.array2d[int],
   efc_id_in: wp.array2d[int],
-  efc_J_in: wp.array3d[float],
   efc_J_rownnz_in: wp.array2d[int],
   efc_J_rowadr_in: wp.array2d[int],
   efc_J_colind_in: wp.array3d[int],
+  efc_J_in: wp.array3d[float],
   njmax_in: int,
   # Out:
   efc_tree_out: wp.array2d[int],
@@ -599,164 +666,15 @@ def _compute_efc_tree(
 
 
 @wp.kernel
-def _gather_efc_and_jacobian(
-  # Model:
-  is_sparse: bool,
-  # Data in:
-  nefc_in: wp.array[int],
-  efc_D_in: wp.array2d[float],
-  efc_type_in: wp.array2d[int],
-  efc_id_in: wp.array2d[int],
-  efc_frictionloss_in: wp.array2d[float],
-  efc_aref_in: wp.array2d[float],
-  efc_J_in: wp.array3d[float],
-  # Sparse Jacobian arrays:
-  efc_J_rownnz_in: wp.array2d[int],
-  efc_J_rowadr_in: wp.array2d[int],
-  efc_J_colind_in: wp.array3d[int],
-  iefc_J_rowadr_in: wp.array2d[int],
-  # In:
-  njmax_in: int,
-  map_iefc2efc_in: wp.array2d[int],
-  map_idof2dof_in: wp.array2d[int],
-  map_dof2idof_in: wp.array2d[int],
-  nidof_in: wp.array[int],
-  # Out:
-  iefc_D_out: wp.array2d[float],
-  iefc_type_out: wp.array2d[int],
-  iefc_id_out: wp.array2d[int],
-  iefc_frictionloss_out: wp.array2d[float],
-  iefc_aref_out: wp.array2d[float],
-  iefc_J_out: wp.array3d[float],
-  iefc_J_colind_out: wp.array3d[int],
-):
-  """Gather constraint arrays and Jacobian into island-local dense order."""
-  worldid, iefcid = wp.tid()
-
-  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
-    return
-
-  c = map_iefc2efc_in[worldid, iefcid]
-
-  # Scalar constraint fields
-  iefc_D_out[worldid, iefcid] = efc_D_in[worldid, c]
-  iefc_type_out[worldid, iefcid] = efc_type_in[worldid, c]
-  iefc_id_out[worldid, iefcid] = efc_id_in[worldid, c]
-  iefc_frictionloss_out[worldid, iefcid] = efc_frictionloss_in[worldid, c]
-  iefc_aref_out[worldid, iefcid] = efc_aref_in[worldid, c]
-
-  # Jacobian: convert to island-local dense format
-  nid = nidof_in[worldid]
-
-  if is_sparse:
-    rownnz = efc_J_rownnz_in[worldid, c]
-    rowadr_in = efc_J_rowadr_in[worldid, c]
-    rowadr_out = iefc_J_rowadr_in[worldid, iefcid]
-    for i in range(rownnz):
-      sparseid_in = rowadr_in + i
-      sparseid_out = rowadr_out + i
-      dof = efc_J_colind_in[worldid, 0, sparseid_in]
-      idof = map_dof2idof_in[worldid, dof]
-      # Store in sparse iefc_J_out and iefc_J_colind_out
-      iefc_J_out[worldid, 0, sparseid_out] = efc_J_in[worldid, 0, sparseid_in]
-      iefc_J_colind_out[worldid, 0, sparseid_out] = idof
-  else:
-    # Dense path: reorder rows by iefc, columns by idof
-    for idof in range(nid):
-      dof = map_idof2dof_in[worldid, idof]
-      iefc_J_out[worldid, iefcid, idof] = efc_J_in[worldid, c, dof]
-
-
-@wp.kernel
-def _gather_dof_arrays(
-  # Data in:
-  qacc_in: wp.array2d[float],
-  qacc_smooth_in: wp.array2d[float],
-  qfrc_smooth_in: wp.array2d[float],
-  # In:
-  nidof_in: wp.array[int],
-  map_idof2dof_in: wp.array2d[int],
-  # Out:
-  iacc_out: wp.array2d[float],
-  iacc_smooth_out: wp.array2d[float],
-  ifrc_smooth_out: wp.array2d[float],
-):
-  """Gather DOF arrays into island-local order."""
-  worldid, idofid = wp.tid()
-
-  if idofid >= nidof_in[worldid]:
-    return
-
-  dof = map_idof2dof_in[worldid, idofid]
-  iacc_out[worldid, idofid] = qacc_in[worldid, dof]
-  iacc_smooth_out[worldid, idofid] = qacc_smooth_in[worldid, dof]
-  ifrc_smooth_out[worldid, idofid] = qfrc_smooth_in[worldid, dof]
-
-
-@wp.kernel
-def _scatter_dof_arrays(
-  # In:
-  qacc_smooth_in: wp.array2d[float],
-  qfrc_smooth_in: wp.array2d[float],
-  dof_island_in: wp.array2d[int],
-  iacc_in: wp.array2d[float],
-  ifrc_constraint_in: wp.array2d[float],
-  iMa_in: wp.array2d[float],
-  map_dof2idof_in: wp.array2d[int],
-  scatter_Ma: bool,
-  # Out:
-  qacc_out: wp.array2d[float],
-  qfrc_constraint_out: wp.array2d[float],
-  Ma_out: wp.array2d[float],
-):
-  """Scatter island results to global arrays, copy qacc_smooth for non-island DOFs."""
-  worldid, dofid = wp.tid()
-
-  if dof_island_in[worldid, dofid] < 0:
-    qacc_out[worldid, dofid] = qacc_smooth_in[worldid, dofid]
-    qfrc_constraint_out[worldid, dofid] = 0.0
-    if scatter_Ma:
-      Ma_out[worldid, dofid] = qfrc_smooth_in[worldid, dofid]
-  else:
-    idof = map_dof2idof_in[worldid, dofid]
-    qacc_out[worldid, dofid] = iacc_in[worldid, idof]
-    qfrc_constraint_out[worldid, dofid] = ifrc_constraint_in[worldid, idof]
-    if scatter_Ma:
-      Ma_out[worldid, dofid] = iMa_in[worldid, idof]
-
-
-@wp.kernel
-def _scatter_efc_arrays(
-  # In:
-  nefc_in: wp.array[int],
-  njmax_in: int,
-  map_iefc2efc_in: wp.array2d[int],
-  iefc_force_in: wp.array2d[float],
-  iefc_state_in: wp.array2d[int],
-  # Out:
-  efc_force_out: wp.array2d[float],
-  efc_state_out: wp.array2d[int],
-):
-  """Scatter island-local constraint results back to global order."""
-  worldid, iefcid = wp.tid()
-
-  if iefcid >= wp.min(njmax_in, nefc_in[worldid]):
-    return
-
-  c = map_iefc2efc_in[worldid, iefcid]
-  efc_force_out[worldid, c] = iefc_force_in[worldid, iefcid]
-  efc_state_out[worldid, c] = iefc_state_in[worldid, iefcid]
-
-
-@wp.kernel
 def _init_island_arrays(
+  # Data out:
+  nidof_out: wp.array[int],
   island_idofadr_out: wp.array2d[int],
   island_nv_out: wp.array2d[int],
   island_nefc_out: wp.array2d[int],
   island_ne_out: wp.array2d[int],
   island_nf_out: wp.array2d[int],
   island_iefcadr_out: wp.array2d[int],
-  nidof_out: wp.array[int],
 ):
   worldid, islandid = wp.tid()
   island_nv_out[worldid, islandid] = 0
@@ -771,9 +689,11 @@ def _init_island_arrays(
 
 @wp.kernel
 def _init_dof_arrays(
+  # Data out:
   dof_island_out: wp.array2d[int],
   map_dof2idof_out: wp.array2d[int],
   map_idof2dof_out: wp.array2d[int],
+  # Out:
   idof_islandid_out: wp.array2d[int],
 ):
   worldid, dofid = wp.tid()
@@ -785,9 +705,11 @@ def _init_dof_arrays(
 
 @wp.kernel
 def _init_efc_arrays(
+  # Data out:
   efc_island_out: wp.array2d[int],
   map_efc2iefc_out: wp.array2d[int],
   map_iefc2efc_out: wp.array2d[int],
+  # Out:
   iefc_islandid_out: wp.array2d[int],
   efc_tree_out: wp.array2d[int],
 ):
@@ -824,15 +746,7 @@ def compute_island_mapping(m: types.Model, d: types.Data):
     _init_island_arrays,
     dim=(d.nworld, m.ntree),
     inputs=[],
-    outputs=[
-      d.island_idofadr,
-      d.island_nv,
-      d.island_nefc,
-      d.island_ne,
-      d.island_nf,
-      d.island_iefcadr,
-      d.nidof,
-    ],
+    outputs=[d.nidof, d.island_idofadr, d.island_nv, d.island_nefc, d.island_ne, d.island_nf, d.island_iefcadr],
   )
   wp.launch(
     _init_dof_arrays,
@@ -867,10 +781,10 @@ def compute_island_mapping(m: types.Model, d: types.Data):
       d.contact.geom,
       d.efc.type,
       d.efc.id,
-      d.efc.J,
       d.efc.J_rownnz,
       d.efc.J_rowadr,
       d.efc.J_colind,
+      d.efc.J,
       d.njmax,
     ],
     outputs=[efc_tree],
@@ -888,7 +802,7 @@ def compute_island_mapping(m: types.Model, d: types.Data):
   wp.launch(
     _island_count_constraints,
     dim=(d.nworld, d.njmax),
-    inputs=[d.nefc, d.njmax, efc_tree, d.tree_island, d.efc.type],
+    inputs=[d.nefc, d.efc.type, d.tree_island, d.njmax, efc_tree],
     outputs=[d.efc.island, d.island_nefc, d.island_ne, d.island_nf],
   )
 
@@ -896,40 +810,24 @@ def compute_island_mapping(m: types.Model, d: types.Data):
   wp.launch(
     _island_scan_sizes,
     dim=d.nworld,
-    inputs=[d.nisland],
-    outputs=[d.island_idofadr, d.island_nv, d.island_nefc, d.island_iefcadr, d.nidof],
+    inputs=[d.nisland, d.island_nv],
+    outputs=[d.nidof, d.island_idofadr, d.island_nefc, d.island_iefcadr],
   )
 
   # 4. Map DOFs
-  unconstrained_cnt = wp.zeros((d.nworld, 1), dtype=int)
   d.island_dofadr.fill_(m.nv)
   wp.launch(
     _island_map_dofs,
     dim=(d.nworld, m.nv),
-    inputs=[m.nv, d.dof_island, d.island_idofadr, d.nidof],
-    outputs=[d.island_nv, d.island_dofadr, d.map_dof2idof, d.map_idof2dof, d.dof_islandid, unconstrained_cnt],
+    inputs=[m.dof_treeid, m.tree_dofadr, m.tree_dofnum, d.nidof, d.tree_island, d.island_idofadr],
+    outputs=[d.island_dofadr, d.map_dof2idof, d.map_idof2dof, d.dof_islandid],
   )
 
   # 5. Map Constraints
-  ne_mapped = wp.zeros((d.nworld, m.ntree), dtype=int)
-  nf_mapped = wp.zeros((d.nworld, m.ntree), dtype=int)
-  nother_mapped = wp.zeros((d.nworld, m.ntree), dtype=int)
-
   wp.launch(
     _island_map_constraints,
-    dim=(d.nworld, d.njmax),
-    inputs=[
-      d.nefc,
-      d.njmax,
-      d.efc.island,
-      d.island_iefcadr,
-      d.island_ne,
-      d.island_nf,
-      d.efc.type,
-      ne_mapped,
-      nf_mapped,
-      nother_mapped,
-    ],
+    dim=(d.nworld, m.ntree),
+    inputs=[d.nefc, d.nisland, d.efc.type, d.efc.island, d.island_ne, d.island_nf, d.island_iefcadr, d.njmax],
     outputs=[d.island_nefc, d.map_efc2iefc, d.map_iefc2efc, d.efc_islandid],
   )
 
@@ -970,6 +868,7 @@ def _compact_dofs(
   # Data in:
   tree_awake_in: wp.array2d[int],
   nvmax_in: int,
+  # In:
   warn_overflow: bool,
   # Data out:
   ncdof_out: wp.array[int],

--- a/mujoco_warp/_src/island_test.py
+++ b/mujoco_warp/_src/island_test.py
@@ -106,29 +106,6 @@ _ELLIPTIC_CONTACT_XML = """
 """
 
 
-# Mixed-constraint pile: static-plane contacts, body-body contacts that merge and split
-# as the pile settles, a weld pair, and a hinge tree carrying both a limit and friction.
-_MIXED_CONTACT_XML = """
-<mujoco>
-  <worldbody>
-    <geom type="plane" size="5 5 .1"/>
-    <body name="p0" pos="0 0 .12"><freejoint/><geom type="sphere" size=".1"/></body>
-    <body name="p1" pos=".13 0 .34"><freejoint/><geom type="sphere" size=".1"/></body>
-    <body name="p2" pos="-.05 .12 .56"><freejoint/><geom type="sphere" size=".1"/></body>
-    <body name="p3" pos="2 0 .12"><freejoint/><geom type="box" size=".1 .1 .1"/></body>
-    <body name="p4" pos="2 .05 .40"><freejoint/><geom type="box" size=".1 .1 .1"/></body>
-    <body name="w0" pos="-2 0 .5"><freejoint/><geom type="sphere" size=".1"/></body>
-    <body name="w1" pos="-2 .3 .5"><freejoint/><geom type="sphere" size=".1"/></body>
-    <body name="h0" pos="4 0 .5">
-      <joint type="hinge" axis="0 1 0" limited="true" range="-.3 .3" frictionloss="1"/>
-      <geom type="capsule" size=".05" fromto="0 0 0 .4 0 0"/>
-    </body>
-  </worldbody>
-  <equality><weld body1="w0" body2="w1"/></equality>
-</mujoco>
-"""
-
-
 def _limit_chain_xml(trees: int) -> str:
   """One limited slide joint per tree.
 
@@ -364,7 +341,7 @@ class IslandDiscoveryTest(absltest.TestCase):
     np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
 
   def test_generic_equality_matches_in_explicit_dense_and_sparse_modes(self):
-    """Generic Jacobian incidence is exact for both supported storage modes."""
+    """A joint equality takes the generic Jacobian path, and it is exact in both storage modes."""
     xml = """
     <mujoco>
       <worldbody>
@@ -380,6 +357,8 @@ class IslandDiscoveryTest(absltest.TestCase):
         del mjm, mjd
         mjwarp.fwd_position(m, d)
         self.assertEqual(m.is_sparse, jacobian == mujoco.mjtJacobian.mjJAC_SPARSE)
+        # a joint equality has no body incidence, so these rows can only reach the generic scan
+        self.assertIn(types.ConstraintType.EQUALITY, d.efc.type.numpy()[0, : d.nefc.numpy()[0]])
 
         island.island(m, d)
 
@@ -571,36 +550,34 @@ class IslandDiscoveryTest(absltest.TestCase):
     np.testing.assert_array_equal(d.nisland.numpy(), np.ones(d.nworld, dtype=np.int32))
     np.testing.assert_array_equal(d.tree_island.numpy(), expected)
 
-  def test_repeated_island_reset_is_bitwise_stable(self):
-    """Each call overwrites the persistent DSU workspace and output labels."""
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
-    del mjm, mjd
-    mjwarp.fwd_position(m, d)
+  def test_repeated_discovery_is_bitwise_stable(self):
+    """Every call overwrites the workspace and reproduces its labels exactly.
 
-    first_parent = _discover(m, d).numpy().copy()
-    first_labels = d.tree_island.numpy().copy()
-    first_nisland = d.nisland.numpy().copy()
+    Both fixtures poison `tree_island` and `nisland` before each repeat, so a phase that read
+    stale output instead of rewriting it would be caught. The 64-tree chain adds contention:
+    duplicate weld rows race to hook the same roots and must still converge on the minimum.
+    """
+    for label, xml, nworld in (("weld pair", _WELD_XML, 1), ("64-tree chain", _chain_xml(64), 2)):
+      with self.subTest(model=label):
+        mjm, mjd, m, d = test_data.fixture(xml=xml, nworld=nworld)
+        del mjm, mjd
+        mjwarp.fwd_position(m, d)
 
-    for _ in range(16):
-      d.tree_island.fill_(123)
-      d.nisland.fill_(123)
+        first_parent = _discover(m, d).numpy().copy()
+        first_labels = d.tree_island.numpy().copy()
+        first_nisland = d.nisland.numpy().copy()
+        # every tree ends in one island rooted at the minimum, whichever fixture this is
+        np.testing.assert_array_equal(first_parent, np.zeros((d.nworld, m.ntree), dtype=np.int32))
+        np.testing.assert_array_equal(first_labels, np.zeros((d.nworld, m.ntree), dtype=np.int32))
+        np.testing.assert_array_equal(first_nisland, np.ones(d.nworld, dtype=np.int32))
 
-      np.testing.assert_array_equal(_discover(m, d).numpy(), first_parent)
-      np.testing.assert_array_equal(d.tree_island.numpy(), first_labels)
-      np.testing.assert_array_equal(d.nisland.numpy(), first_nisland)
+        for _ in range(16):
+          d.tree_island.fill_(123)
+          d.nisland.fill_(123)
 
-  def test_high_contention_chain_is_bitwise_stable(self):
-    """Concurrent duplicate weld rows converge to one deterministic minimum root."""
-    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(64), nworld=2)
-    del mjm, mjd
-    mjwarp.fwd_position(m, d)
-    expected_parent = np.zeros((d.nworld, m.ntree), dtype=np.int32)
-    expected_labels = np.zeros((d.nworld, m.ntree), dtype=np.int32)
-
-    for _ in range(16):
-      np.testing.assert_array_equal(_discover(m, d).numpy(), expected_parent)
-      np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
-      np.testing.assert_array_equal(d.nisland.numpy(), np.ones(d.nworld, dtype=np.int32))
+          np.testing.assert_array_equal(_discover(m, d).numpy(), first_parent)
+          np.testing.assert_array_equal(d.tree_island.numpy(), first_labels)
+          np.testing.assert_array_equal(d.nisland.numpy(), first_nisland)
 
   def test_joint_friction_and_limit_rows_activate_their_dof_tree(self):
     """Special one-tree EFC rows use their prescribed DOF-tree incidence."""
@@ -625,27 +602,6 @@ class IslandDiscoveryTest(absltest.TestCase):
     island.island(m, d)
     np.testing.assert_array_equal(d.nisland.numpy(), np.array([1], dtype=np.int32))
     np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0]], dtype=np.int32))
-
-  def test_generic_equality_jacobian_unions_all_active_trees(self):
-    """Joint equality takes the generic Jacobian path rather than body incidence."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <option><flag island="disable"/></option>
-        <worldbody>
-          <body><joint name="j0" type="hinge"/><geom size=".1"/></body>
-          <body pos="1 0 0"><joint name="j1" type="hinge"/><geom size=".1"/></body>
-        </worldbody>
-        <equality><joint joint1="j0" joint2="j1"/></equality>
-      </mujoco>
-      """
-    )
-    del mjm, mjd
-    mjwarp.fwd_position(m, d)
-
-    self.assertIn(types.ConstraintType.EQUALITY, d.efc.type.numpy()[0, : d.nefc.numpy()[0]])
-    island.island(m, d)
-    np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0, 0]], dtype=np.int32))
 
   def test_warmed_island_does_not_sync_with_host(self):
     """The DSU path is safe to call inside a warmed graph region.
@@ -754,150 +710,6 @@ class IslandDiscoveryTest(absltest.TestCase):
     np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
     np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland)
 
-  def test_two_trees_one_constraint_one_island(self):
-    """Two trees connected by one constraint form one island.
-
-    topology:
-      [[0, 1],
-       [1, 0]]
-    """
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <option>
-          <flag island="disable"/>
-        </option>
-        <worldbody>
-          <body name="body1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-        </equality>
-      </mujoco>
-      """
-    )
-
-    d.nisland.fill_(-1)
-    d.tree_island.fill_(-1)
-    mjwarp.fwd_position(m, d)
-    island.island(m, d)
-
-    # should have exactly 1 island
-    self.assertEqual(d.nisland.numpy()[0], 1)
-    # both trees should be in island 0
-    tree_island = d.tree_island.numpy()[0]
-    self.assertEqual(tree_island[0], tree_island[1])
-    self.assertEqual(tree_island[0], 0)
-
-  def test_three_trees_chain_one_island(self):
-    """Three trees in a chain form one island.
-
-    topology:
-      [[0, 1, 0],
-       [1, 0, 1],
-       [0, 1, 0]]
-    """
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <option>
-          <flag island="disable"/>
-        </option>
-        <worldbody>
-          <body name="body1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body3" pos="2 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-          <weld body1="body2" body2="body3"/>
-        </equality>
-      </mujoco>
-      """
-    )
-
-    d.nisland.fill_(-1)
-    d.tree_island.fill_(-1)
-    mjwarp.fwd_position(m, d)
-    island.island(m, d)
-
-    # should have exactly 1 island
-    self.assertEqual(d.nisland.numpy()[0], 1)
-    # all trees should be in the same island
-    tree_island = d.tree_island.numpy()[0]
-    self.assertEqual(tree_island[0], tree_island[1])
-    self.assertEqual(tree_island[1], tree_island[2])
-
-  def test_two_disconnected_pairs_two_islands(self):
-    """Two pairs of disconnected trees form two islands.
-
-    topology:
-      [[0, 1, 0, 0],
-       [1, 0, 0, 0],
-       [0, 0, 0, 1],
-       [0, 0, 1, 0]]
-    """
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <option>
-          <flag island="disable"/>
-        </option>
-        <worldbody>
-          <body name="body1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body3" pos="10 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body4" pos="11 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-          <weld body1="body3" body2="body4"/>
-        </equality>
-      </mujoco>
-      """
-    )
-
-    d.nisland.fill_(-1)
-    d.tree_island.fill_(-1)
-    mjwarp.fwd_position(m, d)
-    island.island(m, d)
-
-    # should have exactly 2 islands
-    self.assertEqual(d.nisland.numpy()[0], 2)
-    # trees 0,1 should be in one island, trees 2,3 in another
-    tree_island = d.tree_island.numpy()[0]
-    self.assertEqual(tree_island[0], tree_island[1])
-    self.assertEqual(tree_island[2], tree_island[3])
-    self.assertNotEqual(tree_island[0], tree_island[2])
-
   def test_no_constraints_no_islands(self):
     """No constraints means no constrained islands.
 
@@ -927,101 +739,6 @@ class IslandDiscoveryTest(absltest.TestCase):
 
     # should have 0 islands (unconstrained tree is not an island)
     self.assertEqual(d.nisland.numpy()[0], 0)
-
-  def test_multiple_worlds(self):
-    """Test island discovery with nworld=2.
-
-    topology:
-      [[0, 1],
-       [1, 0]]
-    """
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <option>
-          <flag island="disable"/>
-        </option>
-        <worldbody>
-          <body name="body1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    d.nisland.fill_(-1)
-    d.tree_island.fill_(-1)
-    mjwarp.fwd_position(m, d)
-    island.island(m, d)
-
-    # both worlds should have exactly 1 island
-    nisland = d.nisland.numpy()
-    self.assertEqual(nisland[0], 1)
-    self.assertEqual(nisland[1], 1)
-
-    # both trees in both worlds should be in island 0
-    tree_island = d.tree_island.numpy()
-    for worldid in range(2):
-      self.assertEqual(tree_island[worldid, 0], 0)
-      self.assertEqual(tree_island[worldid, 1], 0)
-
-  def test_three_trees_star_hub_at_end(self):
-    """Three trees with tree 2 as hub connecting trees 0 and 1.
-
-    topology:
-      [[0, 0, 1],
-       [0, 0, 1],
-       [1, 1, 0]]
-    """
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <option>
-          <flag island="disable"/>
-        </option>
-        <worldbody>
-          <body name="body1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body3" pos="2 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body3"/>
-          <weld body1="body2" body2="body3"/>
-        </equality>
-      </mujoco>
-      """
-    )
-
-    d.nisland.fill_(-1)
-    d.tree_island.fill_(-1)
-    mjwarp.fwd_position(m, d)
-    island.island(m, d)
-
-    # should have exactly 1 island
-    self.assertEqual(d.nisland.numpy()[0], 1)
-    # all trees should be in the same island
-    tree_island = d.tree_island.numpy()[0]
-    self.assertEqual(tree_island[0], tree_island[1])
-    self.assertEqual(tree_island[1], tree_island[2])
 
 
 class IslandMappingTest(absltest.TestCase):
@@ -1249,18 +966,21 @@ class IslandMappingTest(absltest.TestCase):
       mjd.map_iefc2efc[:nefc],
     )
 
-  def test_dof_mapping_is_canonical_across_worlds(self):
-    """Island-local DOFs retain MuJoCo's ascending global-DOF order."""
+  def test_mapping_is_canonical_across_worlds(self):
+    """Island-local DOFs and constraints keep MuJoCo's order in every world."""
     mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(22), nworld=256)
     m.opt.disableflags &= ~types.DisableBit.ISLAND
 
     mjwarp.fwd_position(m, d)
     island.compute_island_mapping(m, d)
 
-    expected_dof2idof = np.tile(mjd.map_dof2idof[: mjm.nv], (d.nworld, 1))
-    expected_idof2dof = np.tile(mjd.map_idof2dof[: mjm.nv], (d.nworld, 1))
-    np.testing.assert_array_equal(d.map_dof2idof.numpy()[:, : mjm.nv], expected_dof2idof)
-    np.testing.assert_array_equal(d.map_idof2dof.numpy()[:, : mjm.nv], expected_idof2dof)
+    for name, got, want in (
+      ("map_dof2idof", d.map_dof2idof.numpy()[:, : mjm.nv], mjd.map_dof2idof[: mjm.nv]),
+      ("map_idof2dof", d.map_idof2dof.numpy()[:, : mjm.nv], mjd.map_idof2dof[: mjm.nv]),
+      ("map_efc2iefc", d.map_efc2iefc.numpy()[:, : mjd.nefc], mjd.map_efc2iefc[: mjd.nefc]),
+      ("map_iefc2efc", d.map_iefc2efc.numpy()[:, : mjd.nefc], mjd.map_iefc2efc[: mjd.nefc]),
+    ):
+      np.testing.assert_array_equal(got, np.tile(want, (d.nworld, 1)), err_msg=name)
 
   def test_dof_mapping_interleaves_islands_and_unconstrained_trees(self):
     """Disjoint islands separated by unconstrained trees keep MuJoCo's DOF order."""
@@ -1285,19 +1005,6 @@ class IslandMappingTest(absltest.TestCase):
     np.testing.assert_array_equal(
       d.island_dofadr.numpy()[:, : mjd.nisland], np.tile(mjd.island_dofadr[: mjd.nisland], (d.nworld, 1))
     )
-
-  def test_efc_mapping_is_canonical_across_worlds(self):
-    """Island-local constraints retain MuJoCo's category and EFC order."""
-    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(22), nworld=256)
-    m.opt.disableflags &= ~types.DisableBit.ISLAND
-
-    mjwarp.fwd_position(m, d)
-    island.compute_island_mapping(m, d)
-
-    expected_efc2iefc = np.tile(mjd.map_efc2iefc[: mjd.nefc], (d.nworld, 1))
-    expected_iefc2efc = np.tile(mjd.map_iefc2efc[: mjd.nefc], (d.nworld, 1))
-    np.testing.assert_array_equal(d.map_efc2iefc.numpy()[:, : mjd.nefc], expected_efc2iefc)
-    np.testing.assert_array_equal(d.map_iefc2efc.numpy()[:, : mjd.nefc], expected_iefc2efc)
 
   def test_island_ne_nf_parity(self):
     """island_ne and island_nf match MuJoCo C values."""

--- a/mujoco_warp/_src/island_test.py
+++ b/mujoco_warp/_src/island_test.py
@@ -15,8 +15,6 @@
 
 """Tests for island discovery."""
 
-from unittest import mock
-
 import mujoco
 import numpy as np
 import warp as wp
@@ -28,997 +26,419 @@ from mujoco_warp._src import island
 from mujoco_warp._src import types
 
 
-def _discover(m, d):
-  """Run discovery through a caller-owned workspace and return it for inspection."""
-  island_parent = wp.empty((d.nworld, m.ntree), dtype=int)
-  island.direct_dsu(m, d, island_parent)
-  return island_parent
+class IslandDiscoveryTopologyTest(absltest.TestCase):
+  """Tests island discovery across fundamental graph topologies."""
 
+  def test_connected_chain_collapses_to_single_island(self):
+    """A welded chain of trees compresses to a single island rooted at tree 0."""
+    count = 8
+    bodies = "".join(f'<body name="b{i}" pos="{i * 0.3} 0 0"><freejoint/><geom size=".1"/></body>' for i in range(count))
+    welds = "".join(f'<weld body1="b{i}" body2="b{i + 1}"/>' for i in range(count - 1))
 
-def _launch_chunking(nworld: int, njmax: int) -> tuple[int, int]:
-  """Report the (chunk count, chunk size) `direct_dsu` would launch for this shape.
-
-  The sizing arithmetic is inline in `direct_dsu`, so this drives the real code and reads
-  the grid back off the intercepted launch rather than restating the formula here.
-  """
-  m, d = mock.MagicMock(), mock.MagicMock()
-  d.nworld, d.njmax = nworld, njmax
-  with mock.patch.object(wp, "launch"), mock.patch.object(wp, "launch_tiled") as launch_tiled:
-    island.direct_dsu(m, d, mock.MagicMock())
-  call = launch_tiled.call_args
-  return call.kwargs["dim"][1], call.kwargs["inputs"][-3]
-
-
-# Shared XML models used across multiple island tests.
-# Basic weld constraint model.
-_WELD_XML = """
-<mujoco>
-  <worldbody>
-    <body name="b1">
-      <joint type="free"/>
-      <geom size=".1"/>
-    </body>
-    <body name="b2" pos="1 0 0">
-      <joint type="free"/>
-      <geom size=".1"/>
-    </body>
-  </worldbody>
-  <equality>
-    <weld body1="b1" body2="b2"/>
-  </equality>
-</mujoco>"""
-
-# One flex equality emitting several rows that share an id but not their tree support.
-_FLEX_EQUALITY_XML = """
-<mujoco>
-  <option jacobian="sparse"><flag contact="disable" gravity="disable"/></option>
-  <worldbody>
-    <flexcomp name="f" type="grid" dim="1" count="3 1 1"
-              spacing=".05 .05 .05" radius=".01" mass="1">
-      <edge equality="true"/>
-      <contact internal="false" selfcollide="none"/>
-    </flexcomp>
-  </worldbody>
-</mujoco>
-"""
-
-# A weld between two static bodies: both endpoints resolve to tree -1.
-_STATIC_WELD_XML = """
-<mujoco>
-  <option><flag contact="disable"/></option>
-  <worldbody>
-    <body name="s1"><geom size=".05"/></body>
-    <body name="s2" pos="1 0 0"><geom size=".05"/></body>
-    <body name="dyn" pos="2 0 0"><joint type="slide"/><geom size=".05"/></body>
-  </worldbody>
-  <equality><weld body1="s1" body2="s2"/></equality>
-</mujoco>
-"""
-
-_ELLIPTIC_CONTACT_XML = """
-<mujoco>
-  <option cone="elliptic"/>
-  <worldbody>
-    <body name="left" pos="-.05 0 0"><freejoint/><geom type="sphere" size=".1"/></body>
-    <body name="right" pos=".05 0 0"><freejoint/><geom type="sphere" size=".1"/></body>
-  </worldbody>
-</mujoco>
-"""
-
-
-def _limit_chain_xml(trees: int) -> str:
-  """One limited slide joint per tree.
-
-  A joint limit emits exactly one scalar EFC row, so each tree's activation rests on a
-  single row. Dropping any row anywhere in the prefix deactivates exactly one tree and
-  moves nisland, which multi-row constraints like weld would mask.
-  """
-  bodies = "".join(
-    f'<body name="b{i}" pos="{5 * i} 0 0">'
-    f'<joint type="slide" axis="1 0 0" limited="true" range="-1 1"/><geom size=".1"/></body>'
-    for i in range(trees)
-  )
-  return f'<mujoco><option><flag contact="disable"/></option><worldbody>{bodies}</worldbody></mujoco>'
-
-
-def _disjoint_contact_pairs_xml(pairs: int) -> str:
-  """Overlapping sphere pairs, far enough apart that each pair is its own island."""
-  bodies = "".join(
-    f'<body name="l{i}" pos="{10 * i} 0 1"><freejoint/><geom type="sphere" size=".1"/></body>'
-    f'<body name="r{i}" pos="{10 * i + 0.15} 0 1"><freejoint/><geom type="sphere" size=".1"/></body>'
-    for i in range(pairs)
-  )
-  return f'<mujoco><option gravity="0 0 0"/><worldbody>{bodies}</worldbody></mujoco>'
-
-
-def _site_equality_xml(kind: str) -> str:
-  return f"""
-  <mujoco>
-    <worldbody>
-      <body name="left" pos="-1 0 0"><freejoint/><geom size=".1"/><site name="left_site"/></body>
-      <body name="right" pos="1 0 0"><freejoint/><geom size=".1"/><site name="right_site"/></body>
-    </worldbody>
-    <equality><{kind} site1="left_site" site2="right_site"/></equality>
-  </mujoco>
-  """
-
-
-def _chain_xml(count: int, freejoint: bool = True) -> str:
-  """Welded chain of `count` trees. Slide joints keep `nv` linear for the large sizes."""
-  joint = "<freejoint/>" if freejoint else '<joint type="slide" axis="0 0 1"/>'
-  bodies = "".join(f'<body name="b{i}" pos="{i * 0.3} 0 0">{joint}<geom size=".1"/></body>' for i in range(count))
-  welds = "".join(f'<weld body1="b{i}" body2="b{i + 1}"/>' for i in range(count - 1))
-  option = "" if freejoint else '<option jacobian="sparse"><flag contact="disable"/></option>'
-  return f"<mujoco>{option}<worldbody>{bodies}</worldbody><equality>{welds}</equality></mujoco>"
-
-
-def _one_equality_xml(trees: int) -> str:
-  """Many single-DOF trees, exactly one of which is constrained, leaving the rest inactive."""
-  bodies = "".join(
-    f'<body name="b{i}" pos="{i} 0 0"><joint type="slide" axis="0 0 1"/><geom size=".05"/></body>' for i in range(trees)
-  )
-  return (
-    f'<mujoco><option jacobian="sparse"><flag contact="disable"/></option><worldbody>{bodies}</worldbody>'
-    f'<equality><weld body1="b0" body2="b1"/></equality></mujoco>'
-  )
-
-
-def _random_edge_pool_xml(trees: int, edges: int, seed: int = 7) -> str:
-  """Sparse fixed pool of weld equalities, plus static ones, for the randomized differential.
-
-  The pool is sparse relative to `trees` so random subsets of it produce fragmented partitions
-  rather than collapsing to a single island every trial.
-  """
-  rng = np.random.default_rng(seed)
-  bodies = "".join(
-    f'<body name="b{i}" pos="{i} 0 0"><joint type="slide" axis="0 0 1"/><geom size=".05"/></body>' for i in range(trees)
-  )
-  pairs = set()
-  while len(pairs) < edges:
-    lo, hi = sorted(rng.integers(0, trees, size=2))
-    if lo != hi:
-      pairs.add((int(lo), int(hi)))
-  equalities = "".join(f'<weld body1="b{lo}" body2="b{hi}"/>' for lo, hi in sorted(pairs))
-  equalities += "".join(f'<weld body1="world" body2="b{i}"/>' for i in range(0, trees, max(1, trees // 4)))
-  return (
-    f'<mujoco><option jacobian="sparse"><flag contact="disable"/></option>'
-    f"<worldbody>{bodies}</worldbody><equality>{equalities}</equality></mujoco>"
-  )
-
-
-def _reference_islands(edges, ntree: int):
-  """Label connected components by BFS from the lowest unvisited active tree.
-
-  Deliberately independent of the disjoint-set implementation under test: adjacency lists plus a
-  stack, matching the reference traversal in MuJoCo's randomized differential test.
-  """
-  active = np.zeros(ntree, dtype=bool)
-  adjacent = [[] for _ in range(ntree)]
-  for tree0, tree1 in edges:
-    if tree0 >= 0:
-      active[tree0] = True
-    if tree1 >= 0:
-      active[tree1] = True
-    if tree0 >= 0 and tree1 >= 0:
-      adjacent[tree0].append(tree1)
-      adjacent[tree1].append(tree0)
-
-  labels = np.full(ntree, -1, dtype=np.int32)
-  nisland = 0
-  for start in range(ntree):
-    if not active[start] or labels[start] != -1:
-      continue
-    labels[start] = nisland
-    pending = [start]
-    while pending:
-      tree = pending.pop()
-      for neighbor in adjacent[tree]:
-        if labels[neighbor] == -1:
-          labels[neighbor] = nisland
-          pending.append(neighbor)
-    nisland += 1
-  return labels, nisland
-
-
-class IslandDiscoveryTest(absltest.TestCase):
-  """Tests for full island discovery."""
-
-  def test_parent_workspace_uses_minimum_tree_identity_pointers(self):
-    """Active parents are compressed pointers to their component's minimum tree."""
     mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <option><flag island="disable"/></option>
-        <worldbody>
-          <body name="a"><freejoint/><geom size=".1"/></body>
-          <body name="b" pos="1 0 0"><freejoint/><geom size=".1"/></body>
-          <body name="c" pos="2 0 0"><freejoint/><geom size=".1"/></body>
-          <body name="free" pos="4 0 0"><freejoint/><geom size=".1"/></body>
-        </worldbody>
-        <equality>
-          <weld body1="c" body2="b"/>
-          <weld body1="b" body2="a"/>
-        </equality>
-      </mujoco>
-      """,
+      xml=f"<mujoco><worldbody>{bodies}</worldbody><equality>{welds}</equality></mujoco>",
       nworld=2,
     )
-    del mjm, mjd
     mjwarp.fwd_position(m, d)
 
-    parent = _discover(m, d).numpy()
-    tree_island = d.tree_island.numpy()
-
-    for world in range(d.nworld):
-      active = np.flatnonzero(tree_island[world] >= 0)
-      self.assertGreater(active.size, 0)
-      component_minimum = int(active.min())
-      np.testing.assert_array_equal(parent[world, active], component_minimum)
-      self.assertTrue(np.all(parent[world, active] >= 0))
-      self.assertTrue(np.all(parent[world, active] <= active))
-      self.assertEqual(parent[world, component_minimum], component_minimum)
-      inactive = np.flatnonzero(tree_island[world] < 0)
-      np.testing.assert_array_equal(parent[world, inactive], inactive)
-
-  def test_parent_workspace_and_canonical_labels(self):
-    """DSU storage is linear and labels are ordered by their first active tree."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <option><flag island="disable"/></option>
-        <worldbody>
-          <body name="a"><joint type="free"/><geom size=".1"/></body>
-          <body name="b" pos="1 0 0"><joint type="free"/><geom size=".1"/></body>
-          <body name="c" pos="5 0 0"><joint type="free"/><geom size=".1"/></body>
-          <body name="d" pos="6 0 0"><joint type="free"/><geom size=".1"/></body>
-          <body name="free" pos="10 0 0"><joint type="free"/><geom size=".1"/></body>
-        </worldbody>
-        <equality>
-          <weld body1="a" body2="b"/>
-          <weld body1="c" body2="d"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-    del mjm, mjd
-
-    mjwarp.fwd_position(m, d)
-    workspace = _discover(m, d)
-    # the disjoint-set workspace stays linear in ntree
-    self.assertEqual(workspace.shape, (d.nworld, m.ntree))
-    self.assertEqual(workspace.dtype, wp.int32)
-    self.assertEqual(workspace.capacity, d.nworld * m.ntree * 4)
-    np.testing.assert_array_equal(
-      d.tree_island.numpy(),
-      np.array([[0, 0, 1, 1, -1], [0, 0, 1, 1, -1]], dtype=np.int32),
-    )
-
-  def test_inactive_efc_suffix_is_ignored_per_world(self):
-    """Allocated EFC rows beyond each world's active prefix cannot activate trees."""
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML, nworld=2)
-    del mjm, mjd
-    mjwarp.fwd_position(m, d)
-    nefc = d.nefc.numpy().copy()
-    self.assertTrue(np.all(nefc > 0))
-    nefc[1] = 0
-    wp.copy(d.nefc, wp.array(nefc, dtype=wp.int32, device=d.nefc.device))
-
-    parent = _discover(m, d).numpy()
-
-    np.testing.assert_array_equal(d.nisland.numpy(), np.array([1, 0], dtype=np.int32))
-    np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0, 0], [-1, -1]], dtype=np.int32))
-    np.testing.assert_array_equal(parent, np.array([[0, 0], [0, 1]], dtype=np.int32))
-
-  def test_site_connect_and_weld_lower_to_body_trees(self):
-    """Site-based CONNECT and WELD constraints use their owning body trees."""
-    for kind in ("connect", "weld"):
-      with self.subTest(kind=kind):
-        mjm, mjd, m, d = test_data.fixture(xml=_site_equality_xml(kind), nworld=2)
-        del mjm, mjd
-        mjwarp.fwd_position(m, d)
-        self.assertEqual(m.eq_objtype.numpy()[0], types.ObjType.SITE)
-
-        island.island(m, d)
-
-        np.testing.assert_array_equal(d.nisland.numpy(), np.ones(2, dtype=np.int32))
-        np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
-
-  def test_elliptic_contact_uses_direct_geom_incidence(self):
-    """Elliptic contact rows connect the trees owning their two geoms."""
-    mjm, mjd, m, d = test_data.fixture(xml=_ELLIPTIC_CONTACT_XML, nworld=2)
-    del mjm, mjd
-    mjwarp.fwd_position(m, d)
-    efc_type = d.efc.type.numpy()
-    nefc = d.nefc.numpy()
-    self.assertTrue(
-      all(np.any(efc_type[world, : nefc[world]] == types.ConstraintType.CONTACT_ELLIPTIC) for world in range(d.nworld))
-    )
-
-    island.island(m, d)
-
-    np.testing.assert_array_equal(d.nisland.numpy(), np.ones(2, dtype=np.int32))
-    np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
-
-  def test_generic_equality_matches_in_explicit_dense_and_sparse_modes(self):
-    """A joint equality takes the generic Jacobian path, and it is exact in both storage modes."""
-    xml = """
-    <mujoco>
-      <worldbody>
-        <body><joint name="j0" type="hinge"/><geom size=".1"/></body>
-        <body pos="1 0 0"><joint name="j1" type="hinge"/><geom size=".1"/></body>
-      </worldbody>
-      <equality><joint joint1="j0" joint2="j1"/></equality>
-    </mujoco>
-    """
-    for jacobian in (mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE):
-      with self.subTest(jacobian=int(jacobian)):
-        mjm, mjd, m, d = test_data.fixture(xml=xml, nworld=2, overrides={"opt.jacobian": jacobian})
-        del mjm, mjd
-        mjwarp.fwd_position(m, d)
-        self.assertEqual(m.is_sparse, jacobian == mujoco.mjtJacobian.mjJAC_SPARSE)
-        # a joint equality has no body incidence, so these rows can only reach the generic scan
-        self.assertIn(types.ConstraintType.EQUALITY, d.efc.type.numpy()[0, : d.nefc.numpy()[0]])
-
-        island.island(m, d)
-
-        np.testing.assert_array_equal(d.nisland.numpy(), np.ones(2, dtype=np.int32))
-        np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
-
-  def test_atomic_discovery_drives_downstream_mapping(self):
-    """Atomic discovery outputs feed exact production DOF and EFC mappings."""
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML, nworld=2)
-    mjwarp.fwd_position(m, d)
-    island.island(m, d)
-    island.compute_island_mapping(m, d)
-
-    for world in range(d.nworld):
-      np.testing.assert_array_equal(d.dof_island.numpy()[world, : m.nv], mjd.dof_island[: mjm.nv])
-      np.testing.assert_array_equal(d.efc.island.numpy()[world, : mjd.nefc], mjd.efc_island[: mjd.nefc])
-      np.testing.assert_array_equal(d.island_nv.numpy()[world, : mjd.nisland], mjd.island_nv[: mjd.nisland])
-      np.testing.assert_array_equal(d.island_nefc.numpy()[world, : mjd.nisland], mjd.island_nefc[: mjd.nisland])
-
-  def test_dsu_chunking_splits_only_when_the_batch_leaves_the_device_idle(self):
-    """Chunk count trades against nworld, so a large batch keeps one block per world."""
-    # a batch that already fills the device is left alone: splitting it only launches
-    # blocks past the active prefix
-    self.assertEqual(_launch_chunking(nworld=2048, njmax=1024), (1, 1024))
-    self.assertEqual(_launch_chunking(nworld=4096, njmax=1024), (1, 1024))
-
-    # a single world with a long prefix is split until the device has work
-    nchunk, chunk_size = _launch_chunking(nworld=1, njmax=12352)
-    self.assertGreater(nchunk, 8)
-    self.assertGreaterEqual(chunk_size, 32)
-
-    # every input keeps full coverage of the prefix and at least one chunk
-    for nworld in (1, 7, 64, 512, 2048):
-      for njmax in (1, 31, 64, 255, 256, 1024, 3136, 12352, 65536):
-        nchunk, chunk_size = _launch_chunking(nworld=nworld, njmax=njmax)
-        self.assertGreaterEqual(nchunk, 1, f"{nworld=} {njmax=}")
-        self.assertGreaterEqual(chunk_size, 1, f"{nworld=} {njmax=}")
-        self.assertGreaterEqual(nchunk * chunk_size, njmax, f"{nworld=} {njmax=}")
-
-  def test_flex_equality_rows_are_rescanned_not_quotiented(self):
-    """Rows sharing one flex equality id carry different tree incidence, so none may be dropped.
-
-    Mirrors MuJoCo's `ProductionFlexEqualityRescansRows`. The repeated-row shortcut keys on
-    `(efc_type, efc_id)`, which is equal across these rows even though their support differs;
-    quotienting them would leave the last tree unactivated.
-    """
-    mjm, mjd, m, d = test_data.fixture(xml=_FLEX_EQUALITY_XML, nworld=2)
-    mjwarp.fwd_position(m, d)
-
-    nefc = int(d.nefc.numpy()[0])
-    efc_id = d.efc.id.numpy()[0, :nefc]
-    # the rows this test exists for: same id, different support
-    self.assertEqual(nefc, 2)
-    np.testing.assert_array_equal(efc_id, np.zeros(2, dtype=np.int32))
-    self.assertEqual(mjm.eq_type[0], types.EqType.FLEX)
-    row_trees = []
-    for row in range(nefc):
-      adr, nnz = d.efc.J_rowadr.numpy()[0, row], d.efc.J_rownnz.numpy()[0, row]
-      dofs = d.efc.J_colind.numpy()[0, 0, adr : adr + nnz]
-      row_trees.append(sorted(set(int(t) for t in m.dof_treeid.numpy()[dofs])))
-    self.assertEqual(row_trees, [[0, 1], [1, 2]])
-
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
     island.island(m, d)
 
     np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
     np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
 
-  def test_duplicate_fixed_support_rows_do_not_change_the_partition(self):
-    """Repeated scalar rows with equal `(efc_type, efc_id)` collapse to one representative."""
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML, nworld=2)
-    del mjm, mjd
+  def test_disconnected_pairs_form_independent_islands(self):
+    """Disconnected pairs form separate islands with canonical ascending IDs."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="a1"><freejoint/><geom size=".1"/></body>
+          <body name="a2" pos="1 0 0"><freejoint/><geom size=".1"/></body>
+          <body name="b1" pos="5 0 0"><freejoint/><geom size=".1"/></body>
+          <body name="b2" pos="6 0 0"><freejoint/><geom size=".1"/></body>
+        </worldbody>
+        <equality>
+          <weld body1="a1" body2="a2"/>
+          <weld body1="b1" body2="b2"/>
+        </equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
     mjwarp.fwd_position(m, d)
-    island.island(m, d)
-    expected_labels = d.tree_island.numpy().copy()
-    expected_nisland = d.nisland.numpy().copy()
 
-    # duplicate every active row in place; the H0 partition is unchanged by duplicate incidence
-    efc_type, efc_id, nefc = d.efc.type.numpy(), d.efc.id.numpy(), d.nefc.numpy()
-    for world in range(d.nworld):
-      n = nefc[world]
-      self.assertLessEqual(2 * n, d.njmax)
-      efc_type[world, n : 2 * n] = efc_type[world, :n]
-      efc_id[world, n : 2 * n] = efc_id[world, :n]
-      nefc[world] = 2 * n
-    wp.copy(d.efc.type, wp.array(efc_type, dtype=wp.int32, device=d.efc.type.device))
-    wp.copy(d.efc.id, wp.array(efc_id, dtype=wp.int32, device=d.efc.id.device))
-    wp.copy(d.nefc, wp.array(nefc, dtype=wp.int32, device=d.nefc.device))
-
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
     island.island(m, d)
 
-    np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
-    np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland)
+    np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
+
+  def test_unconstrained_trees_remain_unlabeled(self):
+    """Unconstrained trees remain labeled -1 and do not create islands."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="c1"><freejoint/><geom size=".1"/></body>
+          <body name="c2" pos="1 0 0"><freejoint/><geom size=".1"/></body>
+          <body name="free1" pos="3 0 0"><freejoint/><geom size=".1"/></body>
+          <body name="free2" pos="4 0 0"><freejoint/><geom size=".1"/></body>
+        </worldbody>
+        <equality><weld body1="c1" body2="c2"/></equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+    mjwarp.fwd_position(m, d)
+
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
+
+  def test_worldbody_constraint_activates_single_tree(self):
+    """A constraint between worldbody (tree < 0) and a body activates only that tree."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="floating"><freejoint/><geom size=".1"/></body>
+        </worldbody>
+        <equality><weld body1="world" body2="floating"/></equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+    mjwarp.fwd_position(m, d)
+
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
+
+  def test_no_constraints_no_islands(self):
+    """Free bodies with no constraints produce zero islands."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body><freejoint/><geom size=".1"/></body>
+        </worldbody>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+    mjwarp.fwd_position(m, d)
+
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.zeros(d.nworld, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.full((d.nworld, mjm.ntree), -1, dtype=np.int32))
+
+
+class IslandDiscoveryConstraintsTest(absltest.TestCase):
+  """Tests island discovery across all MuJoCo constraint types."""
+
+  def test_site_connect_and_weld(self):
+    """Site-based connect and weld equalities resolve to owning body trees."""
+    for kind in ("connect", "weld"):
+      with self.subTest(kind=kind):
+        mjm, mjd, m, d = test_data.fixture(
+          xml=f"""
+          <mujoco>
+            <worldbody>
+              <body name="l" pos="-1 0 0"><freejoint/><geom size=".1"/><site name="s1"/></body>
+              <body name="r" pos="1 0 0"><freejoint/><geom size=".1"/><site name="s2"/></body>
+            </worldbody>
+            <equality><{kind} site1="s1" site2="s2"/></equality>
+          </mujoco>
+          """,
+          nworld=2,
+        )
+        mjwarp.fwd_position(m, d)
+
+        d.nisland.fill_(-1)
+        d.tree_island.fill_(-1)
+        island.island(m, d)
+
+        np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
+        np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
+
+  def test_generic_equality_dense_and_sparse(self):
+    """Joint equalities take the generic Jacobian scan in both dense and sparse modes."""
+    for jac in (mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE):
+      with self.subTest(jacobian=int(jac)):
+        mjm, mjd, m, d = test_data.fixture(
+          xml="""
+          <mujoco>
+            <worldbody>
+              <body><joint name="j0" type="hinge"/><geom size=".1"/></body>
+              <body pos="1 0 0"><joint name="j1" type="hinge"/><geom size=".1"/></body>
+            </worldbody>
+            <equality><joint joint1="j0" joint2="j1"/></equality>
+          </mujoco>
+          """,
+          nworld=2,
+          overrides={"opt.jacobian": jac},
+        )
+        mjwarp.fwd_position(m, d)
+
+        d.nisland.fill_(-1)
+        d.tree_island.fill_(-1)
+        island.island(m, d)
+
+        np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
+        np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
+
+  def test_flex_equality_rescans_all_rows(self):
+    """Flex equality rows sharing an ID carry differing tree incidence and are not quotiented."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option jacobian="sparse"><flag contact="disable" gravity="disable"/></option>
+        <worldbody>
+          <flexcomp name="f" type="grid" dim="1" count="3 1 1" spacing=".05 .05 .05" radius=".01" mass="1">
+            <edge equality="true"/>
+            <contact internal="false" selfcollide="none"/>
+          </flexcomp>
+        </worldbody>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+    mjwarp.fwd_position(m, d)
+
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
+
+  def test_joint_friction_and_limits(self):
+    """Joint limits and frictionloss activate their owning DOF tree."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body><joint type="hinge" limited="true" range="-1 1" frictionloss="1"/><geom size=".1"/></body>
+        </worldbody>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+    d.qpos.fill_(2.0)
+    mjd.qpos[:] = 2.0
+    mujoco.mj_forward(mjm, mjd)
+    mjwarp.fwd_position(m, d)
+
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
+
+  def test_contacts_pyramidal_and_elliptic(self):
+    """Colliding geoms activate both trees under pyramidal and elliptic cones."""
+    for cone in ("pyramidal", "elliptic"):
+      with self.subTest(cone=cone):
+        mjm, mjd, m, d = test_data.fixture(
+          xml=f"""
+          <mujoco>
+            <option cone="{cone}"/>
+            <worldbody>
+              <body pos="-.05 0 0"><freejoint/><geom type="sphere" size=".1"/></body>
+              <body pos=".05 0 0"><freejoint/><geom type="sphere" size=".1"/></body>
+            </worldbody>
+          </mujoco>
+          """,
+          nworld=2,
+        )
+        mjwarp.fwd_position(m, d)
+
+        d.nisland.fill_(-1)
+        d.tree_island.fill_(-1)
+        island.island(m, d)
+
+        np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
+        np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
 
   def test_static_static_constraint_creates_no_island(self):
-    """A constraint between two static bodies activates nothing, as in MuJoCo.
-
-    Covers the incidence that MuJoCo's `DsuMergeRejectsStaticSelfIncidence` and
-    `ReportsConstraintBetweenTwoStaticBodies` guard. `_dsu_union` returns without touching the
-    workspace when both endpoints are static, so the partition is empty rather than diagnosed.
-    `tree_island` is only compared against its own expected value: with `nisland == 0` MuJoCo
-    leaves its copy unwritten, so cross-checking that array here would read undefined memory.
-    """
-    mjm, mjd, m, d = test_data.fixture(xml=_STATIC_WELD_XML, nworld=2)
+    """Constraints between two static bodies create no island, matching MuJoCo."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option><flag contact="disable"/></option>
+        <worldbody>
+          <body name="s1"><geom size=".05"/></body>
+          <body name="s2" pos="1 0 0"><geom size=".05"/></body>
+        </worldbody>
+        <equality><weld body1="s1" body2="s2"/></equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
     mjwarp.fwd_position(m, d)
-    self.assertGreater(int(d.nefc.numpy()[0]), 0)
-    np.testing.assert_array_equal(m.body_treeid.numpy()[[1, 2]], np.full(2, -1, dtype=np.int32))
 
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
     island.island(m, d)
 
     self.assertEqual(mjd.nisland, 0)
     np.testing.assert_array_equal(d.nisland.numpy(), np.zeros(d.nworld, dtype=np.int32))
     np.testing.assert_array_equal(d.tree_island.numpy(), np.full((d.nworld, mjm.ntree), -1, dtype=np.int32))
 
-  def test_randomized_incidence_matches_graph_traversal(self):
-    """Differential against an independent traversal over randomized incidence.
 
-    Mirrors MuJoCo's `DsuRandomizedDifferentialAgainstGraphTraversal`. Each world carries an
-    independent random multiset of equality rows drawn from a sparse fixed edge pool, including
-    static endpoints, duplicates and reversed pairs, so one launch covers `nworld` trials.
-    """
-    ntree, nedge, nworld, rounds = 24, 18, 16, 16
-    mjm, mjd, m, d = test_data.fixture(xml=_random_edge_pool_xml(ntree, nedge), nworld=nworld, njmax=1024)
-    del mjd
-    body_treeid = m.body_treeid.numpy()
-    eq_obj1, eq_obj2 = m.eq_obj1id.numpy(), m.eq_obj2id.numpy()
-    edge_trees = [(int(body_treeid[eq_obj1[e]]), int(body_treeid[eq_obj2[e]])) for e in range(mjm.neq)]
-    self.assertTrue(any(a < 0 or b < 0 for a, b in edge_trees), "pool must contain static endpoints")
+class IslandDiscoveryExecutionTest(absltest.TestCase):
+  """Tests multi-world execution, idempotency, and CUDA graph capturability."""
 
-    rng = np.random.default_rng(0)
-    efc_type, efc_id, nefc = d.efc.type.numpy(), d.efc.id.numpy(), d.nefc.numpy()
-    seen_nisland = set()
-    for round_ in range(rounds):
-      efc_type[:], efc_id[:] = 0, 0
-      trials = []
-      for world in range(nworld):
-        rows = rng.integers(0, mjm.neq, size=int(rng.integers(0, 16)))
-        efc_type[world, : rows.size] = int(types.ConstraintType.EQUALITY)
-        efc_id[world, : rows.size] = rows
-        nefc[world] = rows.size
-        trials.append([edge_trees[e] for e in rows])
-      wp.copy(d.efc.type, wp.array(efc_type, dtype=wp.int32, device=d.efc.type.device))
-      wp.copy(d.efc.id, wp.array(efc_id, dtype=wp.int32, device=d.efc.id.device))
-      wp.copy(d.nefc, wp.array(nefc, dtype=wp.int32, device=d.nefc.device))
-
-      island.island(m, d)
-
-      labels, nisland = d.tree_island.numpy(), d.nisland.numpy()
-      for world in range(nworld):
-        want_labels, want_nisland = _reference_islands(trials[world], ntree)
-        seen_nisland.add(want_nisland)
-        msg = f"round {round_} world {world}"
-        self.assertEqual(int(nisland[world]), want_nisland, msg)
-        np.testing.assert_array_equal(labels[world], want_labels, err_msg=msg)
-
-    # a pool that only ever produced one island would not discriminate
-    self.assertGreaterEqual(len(seen_nisland), 5)
-
-  def test_deep_connected_chain_compresses_to_one_island(self):
-    """A chain spanning every tree collapses to a single island.
-
-    Mirrors MuJoCo's `DsuAssignCompresses4096NodeAdversarialChain` and
-    `DsuHandlesLongConnectedBoundaryCase` at a size that keeps the fixture cheap.
-    """
-    trees = 1024
-    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(trees, freejoint=False), nworld=2, njmax=6 * trees + 64)
-    del mjm, mjd
-    mjwarp.fwd_position(m, d)
-
-    island.island(m, d)
-
-    np.testing.assert_array_equal(d.nisland.numpy(), np.ones(d.nworld, dtype=np.int32))
-    np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((d.nworld, trees), dtype=np.int32))
-
-  def test_one_equality_among_many_trees_leaves_the_rest_inactive(self):
-    """Only the two constrained trees join an island; every other tree stays unlabeled.
-
-    Mirrors MuJoCo's `BoundedArenaSupports1024Trees`.
-    """
-    trees = 1024
-    mjm, mjd, m, d = test_data.fixture(xml=_one_equality_xml(trees), nworld=2, njmax=256)
-    del mjm, mjd
-    mjwarp.fwd_position(m, d)
-
-    island.island(m, d)
-
-    expected = np.full((d.nworld, trees), -1, dtype=np.int32)
-    expected[:, 0] = 0
-    expected[:, 1] = 0
-    np.testing.assert_array_equal(d.nisland.numpy(), np.ones(d.nworld, dtype=np.int32))
-    np.testing.assert_array_equal(d.tree_island.numpy(), expected)
-
-  def test_repeated_discovery_is_bitwise_stable(self):
-    """Every call overwrites the workspace and reproduces its labels exactly.
-
-    Both fixtures poison `tree_island` and `nisland` before each repeat, so a phase that read
-    stale output instead of rewriting it would be caught. The 64-tree chain adds contention:
-    duplicate weld rows race to hook the same roots and must still converge on the minimum.
-    """
-    for label, xml, nworld in (("weld pair", _WELD_XML, 1), ("64-tree chain", _chain_xml(64), 2)):
-      with self.subTest(model=label):
-        mjm, mjd, m, d = test_data.fixture(xml=xml, nworld=nworld)
-        del mjm, mjd
-        mjwarp.fwd_position(m, d)
-
-        first_parent = _discover(m, d).numpy().copy()
-        first_labels = d.tree_island.numpy().copy()
-        first_nisland = d.nisland.numpy().copy()
-        # every tree ends in one island rooted at the minimum, whichever fixture this is
-        np.testing.assert_array_equal(first_parent, np.zeros((d.nworld, m.ntree), dtype=np.int32))
-        np.testing.assert_array_equal(first_labels, np.zeros((d.nworld, m.ntree), dtype=np.int32))
-        np.testing.assert_array_equal(first_nisland, np.ones(d.nworld, dtype=np.int32))
-
-        for _ in range(16):
-          d.tree_island.fill_(123)
-          d.nisland.fill_(123)
-
-          np.testing.assert_array_equal(_discover(m, d).numpy(), first_parent)
-          np.testing.assert_array_equal(d.tree_island.numpy(), first_labels)
-          np.testing.assert_array_equal(d.nisland.numpy(), first_nisland)
-
-  def test_joint_friction_and_limit_rows_activate_their_dof_tree(self):
-    """Special one-tree EFC rows use their prescribed DOF-tree incidence."""
+  def test_inactive_world_prefix_ignored(self):
+    """A world with nefc=0 leaves all trees inactive even if njmax > 0."""
     mjm, mjd, m, d = test_data.fixture(
       xml="""
       <mujoco>
-        <option><flag island="disable"/></option>
         <worldbody>
-          <body><joint type="hinge" limited="true" range="-1 1" frictionloss="1"/><geom size=".1"/></body>
+          <body name="b1"><freejoint/><geom size=".1"/></body>
+          <body name="b2" pos="1 0 0"><freejoint/><geom size=".1"/></body>
         </worldbody>
+        <equality><weld body1="b1" body2="b2"/></equality>
       </mujoco>
-      """
+      """,
+      nworld=2,
     )
-    del mjm, mjd
-    d.qpos.fill_(2.0)
-    mjwarp.fwd_position(m, d)
-
-    efc_types = d.efc.type.numpy()[0, : d.nefc.numpy()[0]]
-    self.assertIn(types.ConstraintType.FRICTION_DOF, efc_types)
-    self.assertIn(types.ConstraintType.LIMIT_JOINT, efc_types)
-
-    island.island(m, d)
-    np.testing.assert_array_equal(d.nisland.numpy(), np.array([1], dtype=np.int32))
-    np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0]], dtype=np.int32))
-
-  def test_warmed_island_does_not_sync_with_host(self):
-    """The DSU path is safe to call inside a warmed graph region.
-
-    `island` constructs its own workspace, so `wp.empty` is expected here. What must not
-    happen is a host round trip, which would break graph capture.
-    """
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
-    del mjm, mjd
-    mjwarp.fwd_position(m, d)
-    island.island(m, d)  # compile and warm the kernel before installing spies
-
-    with (
-      mock.patch.object(wp, "synchronize", side_effect=AssertionError("wp.synchronize")),
-      mock.patch.object(wp, "synchronize_device", side_effect=AssertionError("wp.synchronize_device")),
-      mock.patch.object(wp.array, "numpy", side_effect=AssertionError("array.numpy")),
-    ):
-      island.island(m, d)
-
-    # the workspace is the only allocation, and discovery itself makes none
-    workspace = wp.empty((d.nworld, m.ntree), dtype=int)
-    with (
-      mock.patch.object(wp, "empty", side_effect=AssertionError("wp.empty")),
-      mock.patch.object(wp, "zeros", side_effect=AssertionError("wp.zeros")),
-    ):
-      island.direct_dsu(m, d, workspace)
-
-  def test_discovery_covers_efc_rows_across_chunk_boundaries(self):
-    """Every row of an EFC prefix longer than one chunk still activates its tree."""
-    trees = 900
-    # the shared fixture defaults njmax to 64, which would truncate the prefix this test
-    # exists to cross, so Data is built here with capacity for every row
-    mjm = mujoco.MjModel.from_xml_string(_limit_chain_xml(trees))
-    mjd = mujoco.MjData(mjm)
-    mjd.qpos[:] = 2.0
-    mujoco.mj_forward(mjm, mjd)
-    m = mjwarp.put_model(mjm)
-    d = mjwarp.put_data(mjm, mjd, nworld=2, njmax=trees + 64, nconmax=1, nccdmax=1)
     mjwarp.fwd_position(m, d)
 
     nefc = d.nefc.numpy()
-    nchunk, chunk_size = _launch_chunking(d.nworld, d.njmax)
-    self.assertGreater(nchunk, 1, "fixture must be split across blocks")
-    self.assertGreater(int(nefc.min()), chunk_size, "active prefix must cross a chunk boundary")
-    self.assertLessEqual(int(nefc.max()), d.njmax, "prefix must fit njmax or rows are truncated")
+    nefc[1] = 0
+    wp.copy(d.nefc, wp.array(nefc, dtype=wp.int32, device=d.nefc.device))
 
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
     island.island(m, d)
-    dsu_labels = d.tree_island.numpy().copy()
-    dsu_nisland = d.nisland.numpy().copy()
 
-    # one row activates one tree, so a row dropped anywhere in the prefix moves the count
-    np.testing.assert_array_equal(dsu_nisland, np.full(d.nworld, trees, dtype=np.int32))
+    np.testing.assert_array_equal(d.nisland.numpy(), np.array([1, 0], dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy()[0], np.zeros(mjm.ntree, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy()[1], np.full(mjm.ntree, -1, dtype=np.int32))
 
-    # every tree is its own island, so labels must be the identity over active trees
-    np.testing.assert_array_equal(dsu_labels, np.tile(np.arange(trees, dtype=np.int32), (d.nworld, 1)))
-
-  def test_labels_are_invariant_to_efc_row_permutation(self):
-    """The H0 partition is a function of incidence, not of the order rows arrive in."""
-    # Consecutive rows share a constraint type but belong to different islands, so any
-    # order-sensitive shortcut merges or drops the wrong pair once the rows move.
-    mjm, mjd, m, d = test_data.fixture(xml=_disjoint_contact_pairs_xml(8), nworld=4)
-    del mjm, mjd
+  def test_repeated_discovery_is_idempotent(self):
+    """Poisoning output arrays before each run reproduces bitwise-identical results."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="b1"><freejoint/><geom size=".1"/></body>
+          <body name="b2" pos="1 0 0"><freejoint/><geom size=".1"/></body>
+        </worldbody>
+        <equality><weld body1="b1" body2="b2"/></equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
     mjwarp.fwd_position(m, d)
 
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
     island.island(m, d)
     expected_labels = d.tree_island.numpy().copy()
     expected_nisland = d.nisland.numpy().copy()
-    np.testing.assert_array_equal(expected_nisland, np.full(d.nworld, 8, dtype=np.int32))
 
-    efc_type = d.efc.type.numpy()
-    efc_id = d.efc.id.numpy()
-    nefc = d.nefc.numpy()
-    rng = np.random.default_rng(0)
-
-    for trial in range(8):
-      permuted_type, permuted_id = efc_type.copy(), efc_id.copy()
-      for world in range(d.nworld):
-        order = rng.permutation(nefc[world])
-        permuted_type[world, : nefc[world]] = efc_type[world, order]
-        permuted_id[world, : nefc[world]] = efc_id[world, order]
-      wp.copy(d.efc.type, wp.array(permuted_type, dtype=wp.int32, device=d.efc.type.device))
-      wp.copy(d.efc.id, wp.array(permuted_id, dtype=wp.int32, device=d.efc.id.device))
-
+    for _ in range(3):
+      d.tree_island.fill_(-1)
+      d.nisland.fill_(-1)
       island.island(m, d)
-
-      np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels, err_msg=f"trial {trial}")
-      np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland, err_msg=f"trial {trial}")
+      np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
+      np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland)
 
   @absltest.skipIf(not wp.get_device().is_cuda, "CUDA graph capture requires a CUDA device.")
-  def test_capture_replay_matches_direct_island_output(self):
-    """Graph replay produces the same labels and DSU workspace as a direct launch."""
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
-    del mjm, mjd
+  def test_cuda_graph_capture_and_replay(self):
+    """Direct DSU is capturable in CUDA graphs with zero host synchronizations."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="b1"><freejoint/><geom size=".1"/></body>
+          <body name="b2" pos="1 0 0"><freejoint/><geom size=".1"/></body>
+        </worldbody>
+        <equality><weld body1="b1" body2="b2"/></equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
     mjwarp.fwd_position(m, d)
-    workspace = wp.empty((d.nworld, m.ntree), dtype=int)
-    island.direct_dsu(m, d, workspace)
-    expected_parent = workspace.numpy().copy()
+
+    d.nisland.fill_(-1)
+    d.tree_island.fill_(-1)
+    island.island(m, d)
     expected_labels = d.tree_island.numpy().copy()
     expected_nisland = d.nisland.numpy().copy()
 
+    d.tree_island.fill_(-1)
+    d.nisland.fill_(-1)
+    workspace = wp.empty((d.nworld, m.ntree), dtype=int)
     with wp.ScopedCapture() as capture:
       island.direct_dsu(m, d, workspace)
     wp.capture_launch(capture.graph)
 
-    np.testing.assert_array_equal(workspace.numpy(), expected_parent)
     np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
     np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland)
 
-  def test_no_constraints_no_islands(self):
-    """No constraints means no constrained islands.
-
-    topology:
-      [[0]]  (no edges)
-    """
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <option>
-          <flag island="disable"/>
-        </option>
-        <worldbody>
-          <body>
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-      </mujoco>
-      """
-    )
-
-    d.nisland.fill_(-1)
-    d.tree_island.fill_(-1)
-    mjwarp.fwd_position(m, d)
-    island.island(m, d)
-
-    # should have 0 islands (unconstrained tree is not an island)
-    self.assertEqual(d.nisland.numpy()[0], 0)
-
 
 class IslandMappingTest(absltest.TestCase):
-  """Tests for island DOF/constraint mapping."""
+  """Tests downstream DOF and constraint mapping parity against MuJoCo C."""
 
-  def test_two_body_weld_mapping(self):
-    """Two free bodies with a weld: 1 island, all DOFs constrained."""
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
-    m.opt.disableflags &= ~types.DisableBit.ISLAND
-    island.compute_island_mapping(m, d)
-
-    nisland = d.nisland.numpy()[0]
-    self.assertEqual(nisland, 1)
-
-    # all DOFs should be in island 0
-    dof_island = d.dof_island.numpy()[0, : m.nv]
-    np.testing.assert_array_equal(dof_island, np.zeros(m.nv, dtype=int))
-
-    # nidof == nv (all DOFs are in islands)
-    nidof = d.nidof.numpy()[0]
-    self.assertEqual(nidof, m.nv)
-
-    # island_nv[0] == nv
-    island_nv = d.island_nv.numpy()[0]
-    self.assertEqual(island_nv[0], m.nv)
-
-  def test_two_disconnected_pairs_mapping(self):
-    """Two pairs of welded bodies: 2 islands, each with 12 DOFs."""
+  def test_mapping_parity_with_interleaved_unconstrained_trees(self):
+    """Disjoint islands separated by unconstrained trees match MuJoCo mapping parity."""
+    bodies = "".join(f'<body name="b{i}" pos="{i} 0 0"><freejoint/><geom size=".1"/></body>' for i in range(6))
     mjm, mjd, m, d = test_data.fixture(
-      xml="""
+      xml=f"""
       <mujoco>
-        <worldbody>
-          <body name="a1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="a2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="b1" pos="5 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="b2" pos="6 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
+        <worldbody>{bodies}</worldbody>
         <equality>
-          <weld body1="a1" body2="a2"/>
-          <weld body1="b1" body2="b2"/>
+          <weld body1="b0" body2="b2"/>
+          <weld body1="b3" body2="b5"/>
         </equality>
       </mujoco>
-      """
+      """,
+      nworld=4,
     )
     m.opt.disableflags &= ~types.DisableBit.ISLAND
-    island.compute_island_mapping(m, d)
-
-    nisland = d.nisland.numpy()[0]
-    self.assertEqual(nisland, 2)
-
-    # nidof == nv (all DOFs are in islands)
-    nidof = d.nidof.numpy()[0]
-    self.assertEqual(nidof, m.nv)
-
-    # each island has 12 DOFs (2 free joints = 12 DOFs)
-    island_nv = d.island_nv.numpy()[0]
-    self.assertEqual(island_nv[0], 12)
-    self.assertEqual(island_nv[1], 12)
-
-  def test_unconstrained_body_excluded(self):
-    """Body with no constraints gets dof_island=-1, is not in nidof."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="constrained1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="constrained2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="unconstrained" pos="5 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="constrained1" body2="constrained2"/>
-        </equality>
-      </mujoco>
-      """
-    )
-    m.opt.disableflags &= ~types.DisableBit.ISLAND
-    island.compute_island_mapping(m, d)
-
-    nisland = d.nisland.numpy()[0]
-    self.assertEqual(nisland, 1)
-
-    dof_island = d.dof_island.numpy()[0, : m.nv]
-    # first 12 DOFs (2 constrained bodies) in island 0
-    np.testing.assert_array_equal(dof_island[:12], np.zeros(12, dtype=int))
-    # last 6 DOFs (unconstrained body) should be -1
-    np.testing.assert_array_equal(dof_island[12:18], -np.ones(6, dtype=int))
-
-    # nidof == 12
-    nidof = d.nidof.numpy()[0]
-    self.assertEqual(nidof, 12)
-
-  def test_map_roundtrip(self):
-    """map_dof2idof and map_idof2dof are inverses for island DOFs."""
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
-    m.opt.disableflags &= ~types.DisableBit.ISLAND
-    island.compute_island_mapping(m, d)
-
-    nidof = d.nidof.numpy()[0]
-    map_d2i = d.map_dof2idof.numpy()[0, : m.nv]
-    map_i2d = d.map_idof2dof.numpy()[0, : m.nv]
-
-    # roundtrip: for island DOFs, map_idof2dof[map_dof2idof[d]] == d
-    for dof in range(m.nv):
-      island_id = d.dof_island.numpy()[0, dof]
-      if island_id >= 0:
-        idof = map_d2i[dof]
-        self.assertEqual(map_i2d[idof], dof)
-
-  def test_efc_map_roundtrip(self):
-    """map_efc2iefc and map_iefc2efc are inverses."""
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
-    m.opt.disableflags &= ~types.DisableBit.ISLAND
-    island.compute_island_mapping(m, d)
-
-    nefc = d.nefc.numpy()[0]
-    map_e2i = d.map_efc2iefc.numpy()[0, :nefc]
-    map_i2e = d.map_iefc2efc.numpy()[0, :nefc]
-
-    # roundtrip: map_iefc2efc[map_efc2iefc[c]] == c
-    for c in range(nefc):
-      ic = map_e2i[c]
-      self.assertEqual(map_i2e[ic], c)
-
-  def test_mujoco_parity_mapping(self):
-    """Compare DOF/constraint mapping arrays against MuJoCo C."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="a1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="a2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="b1" pos="5 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="b2" pos="6 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="a1" body2="a2"/>
-          <weld body1="b1" body2="b2"/>
-        </equality>
-      </mujoco>
-      """
-    )
-    m.opt.disableflags &= ~types.DisableBit.ISLAND
-    island.compute_island_mapping(m, d)
-
-    nv = mjm.nv
-    nisland = mjd.nisland
-    nefc = mjd.nefc
-
-    # Compare mapping arrays with MuJoCo C
-    np.testing.assert_array_equal(
-      d.island_nv.numpy()[0, :nisland],
-      mjd.island_nv[:nisland],
-    )
-    np.testing.assert_array_equal(
-      d.island_nefc.numpy()[0, :nisland],
-      mjd.island_nefc[:nisland],
-    )
-    np.testing.assert_array_equal(
-      d.island_idofadr.numpy()[0, :nisland],
-      mjd.island_idofadr[:nisland],
-    )
-    np.testing.assert_array_equal(
-      d.island_dofadr.numpy()[0, :nisland],
-      mjd.island_dofadr[:nisland],
-    )
-    np.testing.assert_array_equal(
-      d.island_iefcadr.numpy()[0, :nisland],
-      mjd.island_iefcadr[:nisland],
-    )
-    np.testing.assert_array_equal(
-      d.dof_island.numpy()[0, :nv],
-      mjd.dof_island[:nv],
-    )
-    np.testing.assert_array_equal(
-      d.map_dof2idof.numpy()[0, :nv],
-      mjd.map_dof2idof[:nv],
-    )
-    np.testing.assert_array_equal(
-      d.map_idof2dof.numpy()[0, :nv],
-      mjd.map_idof2dof[:nv],
-    )
-    np.testing.assert_array_equal(
-      d.efc.island.numpy()[0, :nefc],
-      mjd.efc_island[:nefc],
-    )
-    np.testing.assert_array_equal(
-      d.map_efc2iefc.numpy()[0, :nefc],
-      mjd.map_efc2iefc[:nefc],
-    )
-    np.testing.assert_array_equal(
-      d.map_iefc2efc.numpy()[0, :nefc],
-      mjd.map_iefc2efc[:nefc],
-    )
-
-  def test_mapping_is_canonical_across_worlds(self):
-    """Island-local DOFs and constraints keep MuJoCo's order in every world."""
-    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(22), nworld=256)
-    m.opt.disableflags &= ~types.DisableBit.ISLAND
-
     mjwarp.fwd_position(m, d)
+
+    # Poison all destination fields before computing mapping
+    d.dof_island.fill_(-1)
+    d.efc.island.fill_(-1)
+    d.island_nv.fill_(-1)
+    d.island_nefc.fill_(-1)
+    d.island_idofadr.fill_(-1)
+    d.island_dofadr.fill_(-1)
+    d.island_iefcadr.fill_(-1)
+    d.map_dof2idof.fill_(-1)
+    d.map_idof2dof.fill_(-1)
+    d.map_efc2iefc.fill_(-1)
+    d.map_iefc2efc.fill_(-1)
+
     island.compute_island_mapping(m, d)
 
     for name, got, want in (
+      ("dof_island", d.dof_island.numpy()[:, : mjm.nv], mjd.dof_island[: mjm.nv]),
       ("map_dof2idof", d.map_dof2idof.numpy()[:, : mjm.nv], mjd.map_dof2idof[: mjm.nv]),
       ("map_idof2dof", d.map_idof2dof.numpy()[:, : mjm.nv], mjd.map_idof2dof[: mjm.nv]),
+      ("island_dofadr", d.island_dofadr.numpy()[:, : mjd.nisland], mjd.island_dofadr[: mjd.nisland]),
+      ("efc_island", d.efc.island.numpy()[:, : mjd.nefc], mjd.efc_island[: mjd.nefc]),
       ("map_efc2iefc", d.map_efc2iefc.numpy()[:, : mjd.nefc], mjd.map_efc2iefc[: mjd.nefc]),
       ("map_iefc2efc", d.map_iefc2efc.numpy()[:, : mjd.nefc], mjd.map_iefc2efc[: mjd.nefc]),
     ):
       np.testing.assert_array_equal(got, np.tile(want, (d.nworld, 1)), err_msg=name)
-
-  def test_dof_mapping_interleaves_islands_and_unconstrained_trees(self):
-    """Disjoint islands separated by unconstrained trees keep MuJoCo's DOF order."""
-    bodies = "".join(f'<body name="b{i}" pos="{i} 0 0"><freejoint/><geom size=".1"/></body>' for i in range(6))
-    mjm, mjd, m, d = test_data.fixture(
-      xml=f"<mujoco><worldbody>{bodies}</worldbody>"
-      '<equality><weld body1="b0" body2="b2"/><weld body1="b3" body2="b5"/></equality></mujoco>',
-      nworld=64,
-    )
-    m.opt.disableflags &= ~types.DisableBit.ISLAND
-
-    mjwarp.fwd_position(m, d)
-    island.compute_island_mapping(m, d)
-
-    # b1 and b4 stay outside every island, so the constrained and unconstrained
-    # DOF ranges interleave rather than splitting at one boundary.
-    self.assertEqual(mjd.nisland, 2)
-    self.assertTrue(np.any(mjd.dof_island[: mjm.nv] < 0))
-
-    np.testing.assert_array_equal(d.map_dof2idof.numpy()[:, : mjm.nv], np.tile(mjd.map_dof2idof[: mjm.nv], (d.nworld, 1)))
-    np.testing.assert_array_equal(d.map_idof2dof.numpy()[:, : mjm.nv], np.tile(mjd.map_idof2dof[: mjm.nv], (d.nworld, 1)))
-    np.testing.assert_array_equal(
-      d.island_dofadr.numpy()[:, : mjd.nisland], np.tile(mjd.island_dofadr[: mjd.nisland], (d.nworld, 1))
-    )
-
-  def test_island_ne_nf_parity(self):
-    """island_ne and island_nf match MuJoCo C values."""
-    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
-    m.opt.disableflags &= ~types.DisableBit.ISLAND
-    island.compute_island_mapping(m, d)
-
-    nisland = mjd.nisland
-
-    if nisland > 0:
-      np.testing.assert_array_equal(
-        d.island_ne.numpy()[0, :nisland],
-        mjd.island_ne[:nisland],
-      )
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/island_test.py
+++ b/mujoco_warp/_src/island_test.py
@@ -15,6 +15,10 @@
 
 """Tests for island discovery."""
 
+import inspect
+from unittest import mock
+
+import mujoco
 import numpy as np
 import warp as wp
 from absl.testing import absltest
@@ -23,6 +27,28 @@ import mujoco_warp as mjwarp
 from mujoco_warp import test_data
 from mujoco_warp._src import island
 from mujoco_warp._src import types
+
+
+def _discover(m, d):
+  """Run discovery through a caller-owned workspace and return it for inspection."""
+  island_parent = wp.empty((d.nworld, m.ntree), dtype=int)
+  island.direct_dsu(m, d, island_parent)
+  return island_parent
+
+
+def _launch_chunking(nworld: int, njmax: int) -> tuple[int, int]:
+  """Report the (chunk count, chunk size) `direct_dsu` would launch for this shape.
+
+  The sizing arithmetic is inline in `direct_dsu`, so this drives the real code and reads
+  the grid back off the intercepted launch rather than restating the formula here.
+  """
+  m, d = mock.MagicMock(), mock.MagicMock()
+  d.nworld, d.njmax = nworld, njmax
+  with mock.patch.object(wp, "launch"), mock.patch.object(wp, "launch_tiled") as launch_tiled:
+    island.direct_dsu(m, d, mock.MagicMock())
+  call = launch_tiled.call_args
+  return call.kwargs["dim"][1], call.kwargs["inputs"][-3]
+
 
 # Shared XML models used across multiple island tests.
 # Basic weld constraint model.
@@ -43,365 +69,479 @@ _WELD_XML = """
   </equality>
 </mujoco>"""
 
+_ELLIPTIC_CONTACT_XML = """
+<mujoco>
+  <option cone="elliptic"/>
+  <worldbody>
+    <body name="left" pos="-.05 0 0"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="right" pos=".05 0 0"><freejoint/><geom type="sphere" size=".1"/></body>
+  </worldbody>
+</mujoco>
+"""
 
-class IslandEdgeDiscoveryTest(absltest.TestCase):
-  """Tests for edge discovery from constraint Jacobian."""
 
-  # TODO(team): add test for additional constraint types to test special cases
+# Mixed-constraint pile: static-plane contacts, body-body contacts that merge and split
+# as the pile settles, a weld pair, and a hinge tree carrying both a limit and friction.
+_MIXED_CONTACT_XML = """
+<mujoco>
+  <worldbody>
+    <geom type="plane" size="5 5 .1"/>
+    <body name="p0" pos="0 0 .12"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="p1" pos=".13 0 .34"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="p2" pos="-.05 .12 .56"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="p3" pos="2 0 .12"><freejoint/><geom type="box" size=".1 .1 .1"/></body>
+    <body name="p4" pos="2 .05 .40"><freejoint/><geom type="box" size=".1 .1 .1"/></body>
+    <body name="w0" pos="-2 0 .5"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="w1" pos="-2 .3 .5"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="h0" pos="4 0 .5">
+      <joint type="hinge" axis="0 1 0" limited="true" range="-.3 .3" frictionloss="1"/>
+      <geom type="capsule" size=".05" fromto="0 0 0 .4 0 0"/>
+    </body>
+  </worldbody>
+  <equality><weld body1="w0" body2="w1"/></equality>
+</mujoco>
+"""
 
-  def test_single_constraint_two_trees(self):
-    """A single weld constraint between two bodies creates one edge."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-        </equality>
-      </mujoco>
-      """
-    )
 
-    mjwarp.fwd_position(m, d)
+def _limit_chain_xml(trees: int) -> str:
+  """One limited slide joint per tree.
 
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
+  A joint limit emits exactly one scalar EFC row, so each tree's activation rests on a
+  single row. Dropping any row anywhere in the prefix deactivates exactly one tree and
+  moves nisland, which multi-row constraints like weld would mask.
+  """
+  bodies = "".join(
+    f'<body name="b{i}" pos="{5 * i} 0 0">'
+    f'<joint type="slide" axis="1 0 0" limited="true" range="-1 1"/><geom size=".1"/></body>'
+    for i in range(trees)
+  )
+  return f'<mujoco><option><flag contact="disable"/></option><worldbody>{bodies}</worldbody></mujoco>'
 
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
 
-  def test_constraint_within_single_tree_creates_self_edge(self):
-    """A constraint within a single tree creates a self-edge."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1">
-            <joint name="j1" type="slide"/>
-            <geom size=".1"/>
-            <body name="body2" pos="0 0 0.5">
-              <joint name="j2" type="slide"/>
-              <geom size=".1"/>
-            </body>
-          </body>
-        </worldbody>
-        <equality>
-          <joint joint1="j1" joint2="j2"/>
-        </equality>
-      </mujoco>
-      """
-    )
+def _disjoint_contact_pairs_xml(pairs: int) -> str:
+  """Overlapping sphere pairs, far enough apart that each pair is its own island."""
+  bodies = "".join(
+    f'<body name="l{i}" pos="{10 * i} 0 1"><freejoint/><geom type="sphere" size=".1"/></body>'
+    f'<body name="r{i}" pos="{10 * i + 0.15} 0 1"><freejoint/><geom type="sphere" size=".1"/></body>'
+    for i in range(pairs)
+  )
+  return f'<mujoco><option gravity="0 0 0"/><worldbody>{bodies}</worldbody></mujoco>'
 
-    mjwarp.fwd_position(m, d)
 
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
+def _site_equality_xml(kind: str) -> str:
+  return f"""
+  <mujoco>
+    <worldbody>
+      <body name="left" pos="-1 0 0"><freejoint/><geom size=".1"/><site name="left_site"/></body>
+      <body name="right" pos="1 0 0"><freejoint/><geom size=".1"/><site name="right_site"/></body>
+    </worldbody>
+    <equality><{kind} site1="left_site" site2="right_site"/></equality>
+  </mujoco>
+  """
 
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 0], 1)  # self-edge for tree 0
 
-  def test_three_bodies_chain(self):
-    """Three bodies with constraints A-B and B-C should have 2 edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="A">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="B" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="C" pos="2 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="A" body2="B"/>
-          <weld body1="B" body2="C"/>
-        </equality>
-      </mujoco>
-      """
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
-    self.assertEqual(tt[0, 1, 2], 1)
-    self.assertEqual(tt[0, 2, 1], 1)
-
-  def test_deduplication(self):
-    """Repeated constraints between same trees should be deduplicated."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1">
-            <joint name="j1" type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint name="j2" type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-          <connect body1="body1" body2="body2" anchor="0.5 0 0"/>
-        </equality>
-      </mujoco>
-      """
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
-    self.assertEqual(np.sum(tt[0]), 2)
-
-  def test_no_constraints(self):
-    """No constraints should produce no edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body>
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-      </mujoco>
-      """
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(np.sum(tt[0]), 0)
-
-  def test_multi_world_parallel(self):
-    """Each world's edges should be computed independently."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
-    self.assertEqual(tt[1, 0, 1], 1)
-    self.assertEqual(tt[1, 1, 0], 1)
-
-  def test_contact_constraint_edges(self):
-    """Contact constraints between geoms should create edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1" pos="0 0 0.5">
-            <joint type="free"/>
-            <geom size=".3"/>
-          </body>
-          <body name="body2" pos="0 0 1.1">
-            <joint type="free"/>
-            <geom size=".3"/>
-          </body>
-        </worldbody>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    nefc = d.nefc.numpy()
-    if nefc[0] > 0:
-      treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-      island.tree_edges(m, d, treetree)
-
-      tt = treetree.numpy()
-      self.assertEqual(tt[0, 0, 1], 1)
-      self.assertEqual(tt[0, 1, 0], 1)
-
-  def test_isolated_tree_no_edge(self):
-    """A floating body with no constraints should produce no edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body pos="0 0 10">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(np.sum(tt[0]), 0)
-    self.assertEqual(np.sum(tt[1]), 0)
-
-  def test_mixed_equality_and_contact(self):
-    """Both equality and contact constraints should contribute to edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="A" pos="0 0 0.5">
-            <joint type="free"/>
-            <geom size=".2"/>
-          </body>
-          <body name="B" pos="0 0 1.0">
-            <joint type="free"/>
-            <geom size=".2"/>
-          </body>
-          <body name="C" pos="2 0 0.5">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="B" body2="C"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 1, 2], 1)
-    self.assertEqual(tt[0, 2, 1], 1)
-
-  def test_worldbody_dofs_ignored(self):
-    """Constraints involving worldbody (tree < 0) should not cause spurious edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="fixed" pos="0 0 0">
-            <geom size=".1"/>
-          </body>
-          <body name="floating" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="world" body2="floating"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 0], 1)  # self-edge for floating tree
-
-  def test_constraint_touches_three_trees(self):
-    """Multiple constraints sharing a body create a star topology."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="A" pos="0 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="B" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="C" pos="2 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="A" body2="B"/>
-          <weld body1="A" body2="C"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
-    self.assertEqual(tt[0, 0, 2], 1)
-    self.assertEqual(tt[0, 2, 0], 1)
+def _chain_xml(count: int) -> str:
+  bodies = "".join(f'<body name="b{i}" pos="{i * 0.3} 0 0"><freejoint/><geom size=".1"/></body>' for i in range(count))
+  welds = "".join(f'<weld body1="b{i}" body2="b{i + 1}"/>' for i in range(count - 1))
+  return f"<mujoco><worldbody>{bodies}</worldbody><equality>{welds}</equality></mujoco>"
 
 
 class IslandDiscoveryTest(absltest.TestCase):
   """Tests for full island discovery."""
+
+  def test_parent_workspace_uses_minimum_tree_identity_pointers(self):
+    """Active parents are compressed pointers to their component's minimum tree."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option><flag island="disable"/></option>
+        <worldbody>
+          <body name="a"><freejoint/><geom size=".1"/></body>
+          <body name="b" pos="1 0 0"><freejoint/><geom size=".1"/></body>
+          <body name="c" pos="2 0 0"><freejoint/><geom size=".1"/></body>
+          <body name="free" pos="4 0 0"><freejoint/><geom size=".1"/></body>
+        </worldbody>
+        <equality>
+          <weld body1="c" body2="b"/>
+          <weld body1="b" body2="a"/>
+        </equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    parent = _discover(m, d).numpy()
+    tree_island = d.tree_island.numpy()
+
+    for world in range(d.nworld):
+      active = np.flatnonzero(tree_island[world] >= 0)
+      self.assertGreater(active.size, 0)
+      component_minimum = int(active.min())
+      np.testing.assert_array_equal(parent[world, active], component_minimum)
+      self.assertTrue(np.all(parent[world, active] >= 0))
+      self.assertTrue(np.all(parent[world, active] <= active))
+      self.assertEqual(parent[world, component_minimum], component_minimum)
+      inactive = np.flatnonzero(tree_island[world] < 0)
+      np.testing.assert_array_equal(parent[world, inactive], inactive)
+
+  def test_parent_workspace_and_canonical_labels(self):
+    """DSU storage is linear and labels are ordered by their first active tree."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option><flag island="disable"/></option>
+        <worldbody>
+          <body name="a"><joint type="free"/><geom size=".1"/></body>
+          <body name="b" pos="1 0 0"><joint type="free"/><geom size=".1"/></body>
+          <body name="c" pos="5 0 0"><joint type="free"/><geom size=".1"/></body>
+          <body name="d" pos="6 0 0"><joint type="free"/><geom size=".1"/></body>
+          <body name="free" pos="10 0 0"><joint type="free"/><geom size=".1"/></body>
+        </worldbody>
+        <equality>
+          <weld body1="a" body2="b"/>
+          <weld body1="c" body2="d"/>
+        </equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+    del mjm, mjd
+
+    mjwarp.fwd_position(m, d)
+    workspace = _discover(m, d)
+    # the disjoint-set workspace stays linear in ntree
+    self.assertEqual(workspace.shape, (d.nworld, m.ntree))
+    self.assertEqual(workspace.dtype, wp.int32)
+    self.assertEqual(workspace.capacity, d.nworld * m.ntree * 4)
+    np.testing.assert_array_equal(
+      d.tree_island.numpy(),
+      np.array([[0, 0, 1, 1, -1], [0, 0, 1, 1, -1]], dtype=np.int32),
+    )
+
+  def test_inactive_efc_suffix_is_ignored_per_world(self):
+    """Allocated EFC rows beyond each world's active prefix cannot activate trees."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML, nworld=2)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    nefc = d.nefc.numpy().copy()
+    self.assertTrue(np.all(nefc > 0))
+    nefc[1] = 0
+    wp.copy(d.nefc, wp.array(nefc, dtype=wp.int32, device=d.nefc.device))
+
+    parent = _discover(m, d).numpy()
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.array([1, 0], dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0, 0], [-1, -1]], dtype=np.int32))
+    np.testing.assert_array_equal(parent, np.array([[0, 0], [0, 1]], dtype=np.int32))
+
+  def test_site_connect_and_weld_lower_to_body_trees(self):
+    """Site-based CONNECT and WELD constraints use their owning body trees."""
+    for kind in ("connect", "weld"):
+      with self.subTest(kind=kind):
+        mjm, mjd, m, d = test_data.fixture(xml=_site_equality_xml(kind), nworld=2)
+        del mjm, mjd
+        mjwarp.fwd_position(m, d)
+        self.assertEqual(m.eq_objtype.numpy()[0], types.ObjType.SITE)
+
+        island.island(m, d)
+
+        np.testing.assert_array_equal(d.nisland.numpy(), np.ones(2, dtype=np.int32))
+        np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
+
+  def test_elliptic_contact_uses_direct_geom_incidence(self):
+    """Elliptic contact rows connect the trees owning their two geoms."""
+    mjm, mjd, m, d = test_data.fixture(xml=_ELLIPTIC_CONTACT_XML, nworld=2)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    efc_type = d.efc.type.numpy()
+    nefc = d.nefc.numpy()
+    self.assertTrue(
+      all(np.any(efc_type[world, : nefc[world]] == types.ConstraintType.CONTACT_ELLIPTIC) for world in range(d.nworld))
+    )
+
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.ones(2, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
+
+  def test_generic_equality_matches_in_explicit_dense_and_sparse_modes(self):
+    """Generic Jacobian incidence is exact for both supported storage modes."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <body><joint name="j0" type="hinge"/><geom size=".1"/></body>
+        <body pos="1 0 0"><joint name="j1" type="hinge"/><geom size=".1"/></body>
+      </worldbody>
+      <equality><joint joint1="j0" joint2="j1"/></equality>
+    </mujoco>
+    """
+    for jacobian in (mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE):
+      with self.subTest(jacobian=int(jacobian)):
+        mjm, mjd, m, d = test_data.fixture(xml=xml, nworld=2, overrides={"opt.jacobian": jacobian})
+        del mjm, mjd
+        mjwarp.fwd_position(m, d)
+        self.assertEqual(m.is_sparse, jacobian == mujoco.mjtJacobian.mjJAC_SPARSE)
+
+        island.island(m, d)
+
+        np.testing.assert_array_equal(d.nisland.numpy(), np.ones(2, dtype=np.int32))
+        np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
+
+  def test_atomic_discovery_drives_downstream_mapping(self):
+    """Atomic discovery outputs feed exact production DOF and EFC mappings."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML, nworld=2)
+    mjwarp.fwd_position(m, d)
+    island.island(m, d)
+    island.compute_island_mapping(m, d)
+
+    for world in range(d.nworld):
+      np.testing.assert_array_equal(d.dof_island.numpy()[world, : m.nv], mjd.dof_island[: mjm.nv])
+      np.testing.assert_array_equal(d.efc.island.numpy()[world, : mjd.nefc], mjd.efc_island[: mjd.nefc])
+      np.testing.assert_array_equal(d.island_nv.numpy()[world, : mjd.nisland], mjd.island_nv[: mjd.nisland])
+      np.testing.assert_array_equal(d.island_nefc.numpy()[world, : mjd.nisland], mjd.island_nefc[: mjd.nisland])
+
+  def test_direct_dsu_owns_no_hidden_allocation(self):
+    """Discovery allocates nothing of its own; the workspace comes from the caller."""
+    source = inspect.getsource(island.direct_dsu)
+    self.assertNotIn("wp.empty", source)
+    self.assertNotIn("wp.zeros", source)
+    self.assertIn("dim=(d.nworld, m.ntree)", source)
+    self.assertIn("wp.launch_tiled", source)
+    self.assertIn("dim=d.nworld", source)
+    self.assertIn("block_dim=types.BlockDim.island_dsu", source)
+    self.assertIn("island_parent", source)
+
+  def test_direct_dsu_blocks_cover_constraint_capacity_not_batch_size(self):
+    """Warp lanes stride one chunk of the active EFC prefix, never its capacity."""
+    source = inspect.getsource(island._island_dsu)
+    self.assertIn("worldid, chunkid, lane = wp.tid()", source)
+    self.assertIn("range(chunk_beg + lane, chunk_end, wp.block_dim())", source)
+
+  def test_dsu_chunking_splits_only_when_the_batch_leaves_the_device_idle(self):
+    """Chunk count trades against nworld, so a large batch keeps one block per world."""
+    # a batch that already fills the device is left alone: splitting it only launches
+    # blocks past the active prefix
+    self.assertEqual(_launch_chunking(nworld=2048, njmax=1024), (1, 1024))
+    self.assertEqual(_launch_chunking(nworld=4096, njmax=1024), (1, 1024))
+
+    # a single world with a long prefix is split until the device has work
+    nchunk, chunk_size = _launch_chunking(nworld=1, njmax=12352)
+    self.assertGreater(nchunk, 8)
+    self.assertGreaterEqual(chunk_size, 32)
+
+    # every input keeps full coverage of the prefix and at least one chunk
+    for nworld in (1, 7, 64, 512, 2048):
+      for njmax in (1, 31, 64, 255, 256, 1024, 3136, 12352, 65536):
+        nchunk, chunk_size = _launch_chunking(nworld=nworld, njmax=njmax)
+        self.assertGreaterEqual(nchunk, 1, f"{nworld=} {njmax=}")
+        self.assertGreaterEqual(chunk_size, 1, f"{nworld=} {njmax=}")
+        self.assertGreaterEqual(nchunk * chunk_size, njmax, f"{nworld=} {njmax=}")
+
+  def test_direct_dsu_collapses_only_repeated_fixed_support_rows(self):
+    """Known equal-support scalar rows keep one representative before union."""
+    helper = getattr(island, "_is_repeated_fixed_support_efc", None)
+    self.assertIsNotNone(helper)
+
+    helper_source = inspect.getsource(helper)
+    self.assertIn("efcid == 0", helper_source)
+    self.assertIn("efc_type_in[worldid, efcid - 1]", helper_source)
+    self.assertIn("efc_id_in[worldid, efcid - 1]", helper_source)
+
+    kernel_source = inspect.getsource(island._island_dsu)
+    quotient = kernel_source.index("repeated = _is_repeated_fixed_support_efc")
+    classification = kernel_source.index("if efc_type == ConstraintType.EQUALITY")
+    equality_body_lookup = kernel_source.index("body0 = eq_obj1id")
+    contact_tree_lookup = kernel_source.index("tree0 = body_treeid[geom_bodyid")
+    generic_scan = kernel_source.index("first_tree")
+    self.assertLess(quotient, classification)
+    self.assertGreaterEqual(kernel_source[:equality_body_lookup].count("if repeated:"), 1)
+    self.assertGreaterEqual(kernel_source[:contact_tree_lookup].count("if repeated:"), 2)
+    self.assertLess(contact_tree_lookup, generic_scan)
+
+  def test_repeated_island_reset_is_bitwise_stable(self):
+    """Each call overwrites the persistent DSU workspace and output labels."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    first_parent = _discover(m, d).numpy().copy()
+    first_labels = d.tree_island.numpy().copy()
+    first_nisland = d.nisland.numpy().copy()
+
+    for _ in range(16):
+      d.tree_island.fill_(123)
+      d.nisland.fill_(123)
+
+      np.testing.assert_array_equal(_discover(m, d).numpy(), first_parent)
+      np.testing.assert_array_equal(d.tree_island.numpy(), first_labels)
+      np.testing.assert_array_equal(d.nisland.numpy(), first_nisland)
+
+  def test_high_contention_chain_is_bitwise_stable(self):
+    """Concurrent duplicate weld rows converge to one deterministic minimum root."""
+    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(64), nworld=2)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    expected_parent = np.zeros((d.nworld, m.ntree), dtype=np.int32)
+    expected_labels = np.zeros((d.nworld, m.ntree), dtype=np.int32)
+
+    for _ in range(16):
+      np.testing.assert_array_equal(_discover(m, d).numpy(), expected_parent)
+      np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
+      np.testing.assert_array_equal(d.nisland.numpy(), np.ones(d.nworld, dtype=np.int32))
+
+  def test_joint_friction_and_limit_rows_activate_their_dof_tree(self):
+    """Special one-tree EFC rows use their prescribed DOF-tree incidence."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option><flag island="disable"/></option>
+        <worldbody>
+          <body><joint type="hinge" limited="true" range="-1 1" frictionloss="1"/><geom size=".1"/></body>
+        </worldbody>
+      </mujoco>
+      """
+    )
+    del mjm, mjd
+    d.qpos.fill_(2.0)
+    mjwarp.fwd_position(m, d)
+
+    efc_types = d.efc.type.numpy()[0, : d.nefc.numpy()[0]]
+    self.assertIn(types.ConstraintType.FRICTION_DOF, efc_types)
+    self.assertIn(types.ConstraintType.LIMIT_JOINT, efc_types)
+
+    island.island(m, d)
+    np.testing.assert_array_equal(d.nisland.numpy(), np.array([1], dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0]], dtype=np.int32))
+
+  def test_generic_equality_jacobian_unions_all_active_trees(self):
+    """Joint equality takes the generic Jacobian path rather than body incidence."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option><flag island="disable"/></option>
+        <worldbody>
+          <body><joint name="j0" type="hinge"/><geom size=".1"/></body>
+          <body pos="1 0 0"><joint name="j1" type="hinge"/><geom size=".1"/></body>
+        </worldbody>
+        <equality><joint joint1="j0" joint2="j1"/></equality>
+      </mujoco>
+      """
+    )
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    self.assertIn(types.ConstraintType.EQUALITY, d.efc.type.numpy()[0, : d.nefc.numpy()[0]])
+    island.island(m, d)
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0, 0]], dtype=np.int32))
+
+  def test_warmed_island_does_not_sync_with_host(self):
+    """The DSU path is safe to call inside a warmed graph region.
+
+    `island` constructs its own workspace, so `wp.empty` is expected here. What must not
+    happen is a host round trip, which would break graph capture.
+    """
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    island.island(m, d)  # compile and warm the kernel before installing spies
+
+    with (
+      mock.patch.object(wp, "synchronize", side_effect=AssertionError("wp.synchronize")),
+      mock.patch.object(wp, "synchronize_device", side_effect=AssertionError("wp.synchronize_device")),
+      mock.patch.object(wp.array, "numpy", side_effect=AssertionError("array.numpy")),
+    ):
+      island.island(m, d)
+
+    # the workspace is the only allocation, and discovery itself makes none
+    workspace = wp.empty((d.nworld, m.ntree), dtype=int)
+    with (
+      mock.patch.object(wp, "empty", side_effect=AssertionError("wp.empty")),
+      mock.patch.object(wp, "zeros", side_effect=AssertionError("wp.zeros")),
+    ):
+      island.direct_dsu(m, d, workspace)
+
+  def test_discovery_matches_dense_across_efc_chunk_boundaries(self):
+    """An EFC prefix far longer than one block's chunk still unions every pair."""
+    trees = 900
+    # the shared fixture defaults njmax to 64, which would truncate the prefix this test
+    # exists to cross, so Data is built here with capacity for every row
+    mjm = mujoco.MjModel.from_xml_string(_limit_chain_xml(trees))
+    mjd = mujoco.MjData(mjm)
+    mjd.qpos[:] = 2.0
+    mujoco.mj_forward(mjm, mjd)
+    m = mjwarp.put_model(mjm)
+    d = mjwarp.put_data(mjm, mjd, nworld=2, njmax=trees + 64, nconmax=1, nccdmax=1)
+    mjwarp.fwd_position(m, d)
+
+    nefc = d.nefc.numpy()
+    nchunk, chunk_size = _launch_chunking(d.nworld, d.njmax)
+    self.assertGreater(nchunk, 1, "fixture must be split across blocks")
+    self.assertGreater(int(nefc.min()), chunk_size, "active prefix must cross a chunk boundary")
+    self.assertLessEqual(int(nefc.max()), d.njmax, "prefix must fit njmax or rows are truncated")
+
+    island.island(m, d)
+    dsu_labels = d.tree_island.numpy().copy()
+    dsu_nisland = d.nisland.numpy().copy()
+
+    # one row activates one tree, so a row dropped anywhere in the prefix moves the count
+    np.testing.assert_array_equal(dsu_nisland, np.full(d.nworld, trees, dtype=np.int32))
+
+    # every tree is its own island, so labels must be the identity over active trees
+    np.testing.assert_array_equal(dsu_labels, np.tile(np.arange(trees, dtype=np.int32), (d.nworld, 1)))
+
+  def test_labels_are_invariant_to_efc_row_permutation(self):
+    """The H0 partition is a function of incidence, not of the order rows arrive in."""
+    # Consecutive rows share a constraint type but belong to different islands, so any
+    # order-sensitive shortcut merges or drops the wrong pair once the rows move.
+    mjm, mjd, m, d = test_data.fixture(xml=_disjoint_contact_pairs_xml(8), nworld=4)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    island.island(m, d)
+    expected_labels = d.tree_island.numpy().copy()
+    expected_nisland = d.nisland.numpy().copy()
+    np.testing.assert_array_equal(expected_nisland, np.full(d.nworld, 8, dtype=np.int32))
+
+    efc_type = d.efc.type.numpy()
+    efc_id = d.efc.id.numpy()
+    nefc = d.nefc.numpy()
+    rng = np.random.default_rng(0)
+
+    for trial in range(8):
+      permuted_type, permuted_id = efc_type.copy(), efc_id.copy()
+      for world in range(d.nworld):
+        order = rng.permutation(nefc[world])
+        permuted_type[world, : nefc[world]] = efc_type[world, order]
+        permuted_id[world, : nefc[world]] = efc_id[world, order]
+      wp.copy(d.efc.type, wp.array(permuted_type, dtype=wp.int32, device=d.efc.type.device))
+      wp.copy(d.efc.id, wp.array(permuted_id, dtype=wp.int32, device=d.efc.id.device))
+
+      island.island(m, d)
+
+      np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels, err_msg=f"trial {trial}")
+      np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland, err_msg=f"trial {trial}")
+
+  @absltest.skipIf(not wp.get_device().is_cuda, "CUDA graph capture requires a CUDA device.")
+  def test_capture_replay_matches_direct_island_output(self):
+    """Graph replay produces the same labels and DSU workspace as a direct launch."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    workspace = wp.empty((d.nworld, m.ntree), dtype=int)
+    island.direct_dsu(m, d, workspace)
+    expected_parent = workspace.numpy().copy()
+    expected_labels = d.tree_island.numpy().copy()
+    expected_nisland = d.nisland.numpy().copy()
+
+    with wp.ScopedCapture() as capture:
+      island.direct_dsu(m, d, workspace)
+    wp.capture_launch(capture.graph)
+
+    np.testing.assert_array_equal(workspace.numpy(), expected_parent)
+    np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
+    np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland)
 
   def test_two_trees_one_constraint_one_island(self):
     """Two trees connected by one constraint form one island.
@@ -897,6 +1037,56 @@ class IslandMappingTest(absltest.TestCase):
       d.map_iefc2efc.numpy()[0, :nefc],
       mjd.map_iefc2efc[:nefc],
     )
+
+  def test_dof_mapping_is_canonical_across_worlds(self):
+    """Island-local DOFs retain MuJoCo's ascending global-DOF order."""
+    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(22), nworld=256)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    mjwarp.fwd_position(m, d)
+    island.compute_island_mapping(m, d)
+
+    expected_dof2idof = np.tile(mjd.map_dof2idof[: mjm.nv], (d.nworld, 1))
+    expected_idof2dof = np.tile(mjd.map_idof2dof[: mjm.nv], (d.nworld, 1))
+    np.testing.assert_array_equal(d.map_dof2idof.numpy()[:, : mjm.nv], expected_dof2idof)
+    np.testing.assert_array_equal(d.map_idof2dof.numpy()[:, : mjm.nv], expected_idof2dof)
+
+  def test_dof_mapping_interleaves_islands_and_unconstrained_trees(self):
+    """Disjoint islands separated by unconstrained trees keep MuJoCo's DOF order."""
+    bodies = "".join(f'<body name="b{i}" pos="{i} 0 0"><freejoint/><geom size=".1"/></body>' for i in range(6))
+    mjm, mjd, m, d = test_data.fixture(
+      xml=f"<mujoco><worldbody>{bodies}</worldbody>"
+      '<equality><weld body1="b0" body2="b2"/><weld body1="b3" body2="b5"/></equality></mujoco>',
+      nworld=64,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    mjwarp.fwd_position(m, d)
+    island.compute_island_mapping(m, d)
+
+    # b1 and b4 stay outside every island, so the constrained and unconstrained
+    # DOF ranges interleave rather than splitting at one boundary.
+    self.assertEqual(mjd.nisland, 2)
+    self.assertTrue(np.any(mjd.dof_island[: mjm.nv] < 0))
+
+    np.testing.assert_array_equal(d.map_dof2idof.numpy()[:, : mjm.nv], np.tile(mjd.map_dof2idof[: mjm.nv], (d.nworld, 1)))
+    np.testing.assert_array_equal(d.map_idof2dof.numpy()[:, : mjm.nv], np.tile(mjd.map_idof2dof[: mjm.nv], (d.nworld, 1)))
+    np.testing.assert_array_equal(
+      d.island_dofadr.numpy()[:, : mjd.nisland], np.tile(mjd.island_dofadr[: mjd.nisland], (d.nworld, 1))
+    )
+
+  def test_efc_mapping_is_canonical_across_worlds(self):
+    """Island-local constraints retain MuJoCo's category and EFC order."""
+    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(22), nworld=256)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    mjwarp.fwd_position(m, d)
+    island.compute_island_mapping(m, d)
+
+    expected_efc2iefc = np.tile(mjd.map_efc2iefc[: mjd.nefc], (d.nworld, 1))
+    expected_iefc2efc = np.tile(mjd.map_iefc2efc[: mjd.nefc], (d.nworld, 1))
+    np.testing.assert_array_equal(d.map_efc2iefc.numpy()[:, : mjd.nefc], expected_efc2iefc)
+    np.testing.assert_array_equal(d.map_iefc2efc.numpy()[:, : mjd.nefc], expected_iefc2efc)
 
   def test_island_ne_nf_parity(self):
     """island_ne and island_nf match MuJoCo C values."""

--- a/mujoco_warp/_src/island_test.py
+++ b/mujoco_warp/_src/island_test.py
@@ -15,7 +15,6 @@
 
 """Tests for island discovery."""
 
-import inspect
 from unittest import mock
 
 import mujoco
@@ -68,6 +67,33 @@ _WELD_XML = """
     <weld body1="b1" body2="b2"/>
   </equality>
 </mujoco>"""
+
+# One flex equality emitting several rows that share an id but not their tree support.
+_FLEX_EQUALITY_XML = """
+<mujoco>
+  <option jacobian="sparse"><flag contact="disable" gravity="disable"/></option>
+  <worldbody>
+    <flexcomp name="f" type="grid" dim="1" count="3 1 1"
+              spacing=".05 .05 .05" radius=".01" mass="1">
+      <edge equality="true"/>
+      <contact internal="false" selfcollide="none"/>
+    </flexcomp>
+  </worldbody>
+</mujoco>
+"""
+
+# A weld between two static bodies: both endpoints resolve to tree -1.
+_STATIC_WELD_XML = """
+<mujoco>
+  <option><flag contact="disable"/></option>
+  <worldbody>
+    <body name="s1"><geom size=".05"/></body>
+    <body name="s2" pos="1 0 0"><geom size=".05"/></body>
+    <body name="dyn" pos="2 0 0"><joint type="slide"/><geom size=".05"/></body>
+  </worldbody>
+  <equality><weld body1="s1" body2="s2"/></equality>
+</mujoco>
+"""
 
 _ELLIPTIC_CONTACT_XML = """
 <mujoco>
@@ -140,10 +166,81 @@ def _site_equality_xml(kind: str) -> str:
   """
 
 
-def _chain_xml(count: int) -> str:
-  bodies = "".join(f'<body name="b{i}" pos="{i * 0.3} 0 0"><freejoint/><geom size=".1"/></body>' for i in range(count))
+def _chain_xml(count: int, freejoint: bool = True) -> str:
+  """Welded chain of `count` trees. Slide joints keep `nv` linear for the large sizes."""
+  joint = "<freejoint/>" if freejoint else '<joint type="slide" axis="0 0 1"/>'
+  bodies = "".join(f'<body name="b{i}" pos="{i * 0.3} 0 0">{joint}<geom size=".1"/></body>' for i in range(count))
   welds = "".join(f'<weld body1="b{i}" body2="b{i + 1}"/>' for i in range(count - 1))
-  return f"<mujoco><worldbody>{bodies}</worldbody><equality>{welds}</equality></mujoco>"
+  option = "" if freejoint else '<option jacobian="sparse"><flag contact="disable"/></option>'
+  return f"<mujoco>{option}<worldbody>{bodies}</worldbody><equality>{welds}</equality></mujoco>"
+
+
+def _one_equality_xml(trees: int) -> str:
+  """Many single-DOF trees, exactly one of which is constrained, leaving the rest inactive."""
+  bodies = "".join(
+    f'<body name="b{i}" pos="{i} 0 0"><joint type="slide" axis="0 0 1"/><geom size=".05"/></body>' for i in range(trees)
+  )
+  return (
+    f'<mujoco><option jacobian="sparse"><flag contact="disable"/></option><worldbody>{bodies}</worldbody>'
+    f'<equality><weld body1="b0" body2="b1"/></equality></mujoco>'
+  )
+
+
+def _random_edge_pool_xml(trees: int, edges: int, seed: int = 7) -> str:
+  """Sparse fixed pool of weld equalities, plus static ones, for the randomized differential.
+
+  The pool is sparse relative to `trees` so random subsets of it produce fragmented partitions
+  rather than collapsing to a single island every trial.
+  """
+  rng = np.random.default_rng(seed)
+  bodies = "".join(
+    f'<body name="b{i}" pos="{i} 0 0"><joint type="slide" axis="0 0 1"/><geom size=".05"/></body>' for i in range(trees)
+  )
+  pairs = set()
+  while len(pairs) < edges:
+    lo, hi = sorted(rng.integers(0, trees, size=2))
+    if lo != hi:
+      pairs.add((int(lo), int(hi)))
+  equalities = "".join(f'<weld body1="b{lo}" body2="b{hi}"/>' for lo, hi in sorted(pairs))
+  equalities += "".join(f'<weld body1="world" body2="b{i}"/>' for i in range(0, trees, max(1, trees // 4)))
+  return (
+    f'<mujoco><option jacobian="sparse"><flag contact="disable"/></option>'
+    f"<worldbody>{bodies}</worldbody><equality>{equalities}</equality></mujoco>"
+  )
+
+
+def _reference_islands(edges, ntree: int):
+  """Label connected components by BFS from the lowest unvisited active tree.
+
+  Deliberately independent of the disjoint-set implementation under test: adjacency lists plus a
+  stack, matching the reference traversal in MuJoCo's randomized differential test.
+  """
+  active = np.zeros(ntree, dtype=bool)
+  adjacent = [[] for _ in range(ntree)]
+  for tree0, tree1 in edges:
+    if tree0 >= 0:
+      active[tree0] = True
+    if tree1 >= 0:
+      active[tree1] = True
+    if tree0 >= 0 and tree1 >= 0:
+      adjacent[tree0].append(tree1)
+      adjacent[tree1].append(tree0)
+
+  labels = np.full(ntree, -1, dtype=np.int32)
+  nisland = 0
+  for start in range(ntree):
+    if not active[start] or labels[start] != -1:
+      continue
+    labels[start] = nisland
+    pending = [start]
+    while pending:
+      tree = pending.pop()
+      for neighbor in adjacent[tree]:
+        if labels[neighbor] == -1:
+          labels[neighbor] = nisland
+          pending.append(neighbor)
+    nisland += 1
+  return labels, nisland
 
 
 class IslandDiscoveryTest(absltest.TestCase):
@@ -302,23 +399,6 @@ class IslandDiscoveryTest(absltest.TestCase):
       np.testing.assert_array_equal(d.island_nv.numpy()[world, : mjd.nisland], mjd.island_nv[: mjd.nisland])
       np.testing.assert_array_equal(d.island_nefc.numpy()[world, : mjd.nisland], mjd.island_nefc[: mjd.nisland])
 
-  def test_direct_dsu_owns_no_hidden_allocation(self):
-    """Discovery allocates nothing of its own; the workspace comes from the caller."""
-    source = inspect.getsource(island.direct_dsu)
-    self.assertNotIn("wp.empty", source)
-    self.assertNotIn("wp.zeros", source)
-    self.assertIn("dim=(d.nworld, m.ntree)", source)
-    self.assertIn("wp.launch_tiled", source)
-    self.assertIn("dim=d.nworld", source)
-    self.assertIn("block_dim=types.BlockDim.island_dsu", source)
-    self.assertIn("island_parent", source)
-
-  def test_direct_dsu_blocks_cover_constraint_capacity_not_batch_size(self):
-    """Warp lanes stride one chunk of the active EFC prefix, never its capacity."""
-    source = inspect.getsource(island._island_dsu)
-    self.assertIn("worldid, chunkid, lane = wp.tid()", source)
-    self.assertIn("range(chunk_beg + lane, chunk_end, wp.block_dim())", source)
-
   def test_dsu_chunking_splits_only_when_the_batch_leaves_the_device_idle(self):
     """Chunk count trades against nworld, so a large batch keeps one block per world."""
     # a batch that already fills the device is left alone: splitting it only launches
@@ -339,26 +419,157 @@ class IslandDiscoveryTest(absltest.TestCase):
         self.assertGreaterEqual(chunk_size, 1, f"{nworld=} {njmax=}")
         self.assertGreaterEqual(nchunk * chunk_size, njmax, f"{nworld=} {njmax=}")
 
-  def test_direct_dsu_collapses_only_repeated_fixed_support_rows(self):
-    """Known equal-support scalar rows keep one representative before union."""
-    helper = getattr(island, "_is_repeated_fixed_support_efc", None)
-    self.assertIsNotNone(helper)
+  def test_flex_equality_rows_are_rescanned_not_quotiented(self):
+    """Rows sharing one flex equality id carry different tree incidence, so none may be dropped.
 
-    helper_source = inspect.getsource(helper)
-    self.assertIn("efcid == 0", helper_source)
-    self.assertIn("efc_type_in[worldid, efcid - 1]", helper_source)
-    self.assertIn("efc_id_in[worldid, efcid - 1]", helper_source)
+    Mirrors MuJoCo's `ProductionFlexEqualityRescansRows`. The repeated-row shortcut keys on
+    `(efc_type, efc_id)`, which is equal across these rows even though their support differs;
+    quotienting them would leave the last tree unactivated.
+    """
+    mjm, mjd, m, d = test_data.fixture(xml=_FLEX_EQUALITY_XML, nworld=2)
+    mjwarp.fwd_position(m, d)
 
-    kernel_source = inspect.getsource(island._island_dsu)
-    quotient = kernel_source.index("repeated = _is_repeated_fixed_support_efc")
-    classification = kernel_source.index("if efc_type == ConstraintType.EQUALITY")
-    equality_body_lookup = kernel_source.index("body0 = eq_obj1id")
-    contact_tree_lookup = kernel_source.index("tree0 = body_treeid[geom_bodyid")
-    generic_scan = kernel_source.index("first_tree")
-    self.assertLess(quotient, classification)
-    self.assertGreaterEqual(kernel_source[:equality_body_lookup].count("if repeated:"), 1)
-    self.assertGreaterEqual(kernel_source[:contact_tree_lookup].count("if repeated:"), 2)
-    self.assertLess(contact_tree_lookup, generic_scan)
+    nefc = int(d.nefc.numpy()[0])
+    efc_id = d.efc.id.numpy()[0, :nefc]
+    # the rows this test exists for: same id, different support
+    self.assertEqual(nefc, 2)
+    np.testing.assert_array_equal(efc_id, np.zeros(2, dtype=np.int32))
+    self.assertEqual(mjm.eq_type[0], types.EqType.FLEX)
+    row_trees = []
+    for row in range(nefc):
+      adr, nnz = d.efc.J_rowadr.numpy()[0, row], d.efc.J_rownnz.numpy()[0, row]
+      dofs = d.efc.J_colind.numpy()[0, 0, adr : adr + nnz]
+      row_trees.append(sorted(set(int(t) for t in m.dof_treeid.numpy()[dofs])))
+    self.assertEqual(row_trees, [[0, 1], [1, 2]])
+
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.full(d.nworld, mjd.nisland, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.tile(mjd.tree_island[: mjm.ntree], (d.nworld, 1)))
+
+  def test_duplicate_fixed_support_rows_do_not_change_the_partition(self):
+    """Repeated scalar rows with equal `(efc_type, efc_id)` collapse to one representative."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML, nworld=2)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    island.island(m, d)
+    expected_labels = d.tree_island.numpy().copy()
+    expected_nisland = d.nisland.numpy().copy()
+
+    # duplicate every active row in place; the H0 partition is unchanged by duplicate incidence
+    efc_type, efc_id, nefc = d.efc.type.numpy(), d.efc.id.numpy(), d.nefc.numpy()
+    for world in range(d.nworld):
+      n = nefc[world]
+      self.assertLessEqual(2 * n, d.njmax)
+      efc_type[world, n : 2 * n] = efc_type[world, :n]
+      efc_id[world, n : 2 * n] = efc_id[world, :n]
+      nefc[world] = 2 * n
+    wp.copy(d.efc.type, wp.array(efc_type, dtype=wp.int32, device=d.efc.type.device))
+    wp.copy(d.efc.id, wp.array(efc_id, dtype=wp.int32, device=d.efc.id.device))
+    wp.copy(d.nefc, wp.array(nefc, dtype=wp.int32, device=d.nefc.device))
+
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
+    np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland)
+
+  def test_static_static_constraint_creates_no_island(self):
+    """A constraint between two static bodies activates nothing, as in MuJoCo.
+
+    Covers the incidence that MuJoCo's `DsuMergeRejectsStaticSelfIncidence` and
+    `ReportsConstraintBetweenTwoStaticBodies` guard. `_dsu_union` returns without touching the
+    workspace when both endpoints are static, so the partition is empty rather than diagnosed.
+    `tree_island` is only compared against its own expected value: with `nisland == 0` MuJoCo
+    leaves its copy unwritten, so cross-checking that array here would read undefined memory.
+    """
+    mjm, mjd, m, d = test_data.fixture(xml=_STATIC_WELD_XML, nworld=2)
+    mjwarp.fwd_position(m, d)
+    self.assertGreater(int(d.nefc.numpy()[0]), 0)
+    np.testing.assert_array_equal(m.body_treeid.numpy()[[1, 2]], np.full(2, -1, dtype=np.int32))
+
+    island.island(m, d)
+
+    self.assertEqual(mjd.nisland, 0)
+    np.testing.assert_array_equal(d.nisland.numpy(), np.zeros(d.nworld, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.full((d.nworld, mjm.ntree), -1, dtype=np.int32))
+
+  def test_randomized_incidence_matches_graph_traversal(self):
+    """Differential against an independent traversal over randomized incidence.
+
+    Mirrors MuJoCo's `DsuRandomizedDifferentialAgainstGraphTraversal`. Each world carries an
+    independent random multiset of equality rows drawn from a sparse fixed edge pool, including
+    static endpoints, duplicates and reversed pairs, so one launch covers `nworld` trials.
+    """
+    ntree, nedge, nworld, rounds = 24, 18, 16, 16
+    mjm, mjd, m, d = test_data.fixture(xml=_random_edge_pool_xml(ntree, nedge), nworld=nworld, njmax=1024)
+    del mjd
+    body_treeid = m.body_treeid.numpy()
+    eq_obj1, eq_obj2 = m.eq_obj1id.numpy(), m.eq_obj2id.numpy()
+    edge_trees = [(int(body_treeid[eq_obj1[e]]), int(body_treeid[eq_obj2[e]])) for e in range(mjm.neq)]
+    self.assertTrue(any(a < 0 or b < 0 for a, b in edge_trees), "pool must contain static endpoints")
+
+    rng = np.random.default_rng(0)
+    efc_type, efc_id, nefc = d.efc.type.numpy(), d.efc.id.numpy(), d.nefc.numpy()
+    seen_nisland = set()
+    for round_ in range(rounds):
+      efc_type[:], efc_id[:] = 0, 0
+      trials = []
+      for world in range(nworld):
+        rows = rng.integers(0, mjm.neq, size=int(rng.integers(0, 16)))
+        efc_type[world, : rows.size] = int(types.ConstraintType.EQUALITY)
+        efc_id[world, : rows.size] = rows
+        nefc[world] = rows.size
+        trials.append([edge_trees[e] for e in rows])
+      wp.copy(d.efc.type, wp.array(efc_type, dtype=wp.int32, device=d.efc.type.device))
+      wp.copy(d.efc.id, wp.array(efc_id, dtype=wp.int32, device=d.efc.id.device))
+      wp.copy(d.nefc, wp.array(nefc, dtype=wp.int32, device=d.nefc.device))
+
+      island.island(m, d)
+
+      labels, nisland = d.tree_island.numpy(), d.nisland.numpy()
+      for world in range(nworld):
+        want_labels, want_nisland = _reference_islands(trials[world], ntree)
+        seen_nisland.add(want_nisland)
+        msg = f"round {round_} world {world}"
+        self.assertEqual(int(nisland[world]), want_nisland, msg)
+        np.testing.assert_array_equal(labels[world], want_labels, err_msg=msg)
+
+    # a pool that only ever produced one island would not discriminate
+    self.assertGreaterEqual(len(seen_nisland), 5)
+
+  def test_deep_connected_chain_compresses_to_one_island(self):
+    """A chain spanning every tree collapses to a single island.
+
+    Mirrors MuJoCo's `DsuAssignCompresses4096NodeAdversarialChain` and
+    `DsuHandlesLongConnectedBoundaryCase` at a size that keeps the fixture cheap.
+    """
+    trees = 1024
+    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(trees, freejoint=False), nworld=2, njmax=6 * trees + 64)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.ones(d.nworld, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((d.nworld, trees), dtype=np.int32))
+
+  def test_one_equality_among_many_trees_leaves_the_rest_inactive(self):
+    """Only the two constrained trees join an island; every other tree stays unlabeled.
+
+    Mirrors MuJoCo's `BoundedArenaSupports1024Trees`.
+    """
+    trees = 1024
+    mjm, mjd, m, d = test_data.fixture(xml=_one_equality_xml(trees), nworld=2, njmax=256)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    island.island(m, d)
+
+    expected = np.full((d.nworld, trees), -1, dtype=np.int32)
+    expected[:, 0] = 0
+    expected[:, 1] = 0
+    np.testing.assert_array_equal(d.nisland.numpy(), np.ones(d.nworld, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), expected)
 
   def test_repeated_island_reset_is_bitwise_stable(self):
     """Each call overwrites the persistent DSU workspace and output labels."""

--- a/mujoco_warp/_src/island_test.py
+++ b/mujoco_warp/_src/island_test.py
@@ -15,6 +15,10 @@
 
 """Tests for island discovery."""
 
+import inspect
+from unittest import mock
+
+import mujoco
 import numpy as np
 import warp as wp
 from absl.testing import absltest
@@ -23,6 +27,28 @@ import mujoco_warp as mjwarp
 from mujoco_warp import test_data
 from mujoco_warp._src import island
 from mujoco_warp._src import types
+
+
+def _discover(m, d):
+  """Run discovery through a caller-owned workspace and return it for inspection."""
+  island_parent = wp.empty((d.nworld, m.ntree), dtype=int)
+  island.direct_dsu(m, d, island_parent)
+  return island_parent
+
+
+def _launch_chunking(nworld: int, njmax: int) -> tuple[int, int]:
+  """Report the (chunk count, chunk size) `direct_dsu` would launch for this shape.
+
+  The sizing arithmetic is inline in `direct_dsu`, so this drives the real code and reads
+  the grid back off the intercepted launch rather than restating the formula here.
+  """
+  m, d = mock.MagicMock(), mock.MagicMock()
+  d.nworld, d.njmax = nworld, njmax
+  with mock.patch.object(wp, "launch"), mock.patch.object(wp, "launch_tiled") as launch_tiled:
+    island.direct_dsu(m, d, mock.MagicMock())
+  call = launch_tiled.call_args
+  return call.kwargs["dim"][1], call.kwargs["inputs"][-3]
+
 
 # Shared XML models used across multiple island tests.
 # Basic weld constraint model.
@@ -43,365 +69,479 @@ _WELD_XML = """
   </equality>
 </mujoco>"""
 
+_ELLIPTIC_CONTACT_XML = """
+<mujoco>
+  <option cone="elliptic"/>
+  <worldbody>
+    <body name="left" pos="-.05 0 0"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="right" pos=".05 0 0"><freejoint/><geom type="sphere" size=".1"/></body>
+  </worldbody>
+</mujoco>
+"""
 
-class IslandEdgeDiscoveryTest(absltest.TestCase):
-  """Tests for edge discovery from constraint Jacobian."""
 
-  # TODO(team): add test for additional constraint types to test special cases
+# Mixed-constraint pile: static-plane contacts, body-body contacts that merge and split
+# as the pile settles, a weld pair, and a hinge tree carrying both a limit and friction.
+_MIXED_CONTACT_XML = """
+<mujoco>
+  <worldbody>
+    <geom type="plane" size="5 5 .1"/>
+    <body name="p0" pos="0 0 .12"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="p1" pos=".13 0 .34"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="p2" pos="-.05 .12 .56"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="p3" pos="2 0 .12"><freejoint/><geom type="box" size=".1 .1 .1"/></body>
+    <body name="p4" pos="2 .05 .40"><freejoint/><geom type="box" size=".1 .1 .1"/></body>
+    <body name="w0" pos="-2 0 .5"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="w1" pos="-2 .3 .5"><freejoint/><geom type="sphere" size=".1"/></body>
+    <body name="h0" pos="4 0 .5">
+      <joint type="hinge" axis="0 1 0" limited="true" range="-.3 .3" frictionloss="1"/>
+      <geom type="capsule" size=".05" fromto="0 0 0 .4 0 0"/>
+    </body>
+  </worldbody>
+  <equality><weld body1="w0" body2="w1"/></equality>
+</mujoco>
+"""
 
-  def test_single_constraint_two_trees(self):
-    """A single weld constraint between two bodies creates one edge."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-        </equality>
-      </mujoco>
-      """
-    )
 
-    mjwarp.fwd_position(m, d)
+def _limit_chain_xml(trees: int) -> str:
+  """One limited slide joint per tree.
 
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
+  A joint limit emits exactly one scalar EFC row, so each tree's activation rests on a
+  single row. Dropping any row anywhere in the prefix deactivates exactly one tree and
+  moves nisland, which multi-row constraints like weld would mask.
+  """
+  bodies = "".join(
+    f'<body name="b{i}" pos="{5 * i} 0 0">'
+    f'<joint type="slide" axis="1 0 0" limited="true" range="-1 1"/><geom size=".1"/></body>'
+    for i in range(trees)
+  )
+  return f'<mujoco><option><flag contact="disable"/></option><worldbody>{bodies}</worldbody></mujoco>'
 
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
 
-  def test_constraint_within_single_tree_creates_self_edge(self):
-    """A constraint within a single tree creates a self-edge."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1">
-            <joint name="j1" type="slide"/>
-            <geom size=".1"/>
-            <body name="body2" pos="0 0 0.5">
-              <joint name="j2" type="slide"/>
-              <geom size=".1"/>
-            </body>
-          </body>
-        </worldbody>
-        <equality>
-          <joint joint1="j1" joint2="j2"/>
-        </equality>
-      </mujoco>
-      """
-    )
+def _disjoint_contact_pairs_xml(pairs: int) -> str:
+  """Overlapping sphere pairs, far enough apart that each pair is its own island."""
+  bodies = "".join(
+    f'<body name="l{i}" pos="{10 * i} 0 1"><freejoint/><geom type="sphere" size=".1"/></body>'
+    f'<body name="r{i}" pos="{10 * i + 0.15} 0 1"><freejoint/><geom type="sphere" size=".1"/></body>'
+    for i in range(pairs)
+  )
+  return f'<mujoco><option gravity="0 0 0"/><worldbody>{bodies}</worldbody></mujoco>'
 
-    mjwarp.fwd_position(m, d)
 
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
+def _site_equality_xml(kind: str) -> str:
+  return f"""
+  <mujoco>
+    <worldbody>
+      <body name="left" pos="-1 0 0"><freejoint/><geom size=".1"/><site name="left_site"/></body>
+      <body name="right" pos="1 0 0"><freejoint/><geom size=".1"/><site name="right_site"/></body>
+    </worldbody>
+    <equality><{kind} site1="left_site" site2="right_site"/></equality>
+  </mujoco>
+  """
 
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 0], 1)  # self-edge for tree 0
 
-  def test_three_bodies_chain(self):
-    """Three bodies with constraints A-B and B-C should have 2 edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="A">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="B" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="C" pos="2 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="A" body2="B"/>
-          <weld body1="B" body2="C"/>
-        </equality>
-      </mujoco>
-      """
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
-    self.assertEqual(tt[0, 1, 2], 1)
-    self.assertEqual(tt[0, 2, 1], 1)
-
-  def test_deduplication(self):
-    """Repeated constraints between same trees should be deduplicated."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1">
-            <joint name="j1" type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint name="j2" type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-          <connect body1="body1" body2="body2" anchor="0.5 0 0"/>
-        </equality>
-      </mujoco>
-      """
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
-    self.assertEqual(np.sum(tt[0]), 2)
-
-  def test_no_constraints(self):
-    """No constraints should produce no edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body>
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-      </mujoco>
-      """
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(np.sum(tt[0]), 0)
-
-  def test_multi_world_parallel(self):
-    """Each world's edges should be computed independently."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="body2" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="body1" body2="body2"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
-    self.assertEqual(tt[1, 0, 1], 1)
-    self.assertEqual(tt[1, 1, 0], 1)
-
-  def test_contact_constraint_edges(self):
-    """Contact constraints between geoms should create edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="body1" pos="0 0 0.5">
-            <joint type="free"/>
-            <geom size=".3"/>
-          </body>
-          <body name="body2" pos="0 0 1.1">
-            <joint type="free"/>
-            <geom size=".3"/>
-          </body>
-        </worldbody>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    nefc = d.nefc.numpy()
-    if nefc[0] > 0:
-      treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-      island.tree_edges(m, d, treetree)
-
-      tt = treetree.numpy()
-      self.assertEqual(tt[0, 0, 1], 1)
-      self.assertEqual(tt[0, 1, 0], 1)
-
-  def test_isolated_tree_no_edge(self):
-    """A floating body with no constraints should produce no edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body pos="0 0 10">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(np.sum(tt[0]), 0)
-    self.assertEqual(np.sum(tt[1]), 0)
-
-  def test_mixed_equality_and_contact(self):
-    """Both equality and contact constraints should contribute to edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="A" pos="0 0 0.5">
-            <joint type="free"/>
-            <geom size=".2"/>
-          </body>
-          <body name="B" pos="0 0 1.0">
-            <joint type="free"/>
-            <geom size=".2"/>
-          </body>
-          <body name="C" pos="2 0 0.5">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="B" body2="C"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 1, 2], 1)
-    self.assertEqual(tt[0, 2, 1], 1)
-
-  def test_worldbody_dofs_ignored(self):
-    """Constraints involving worldbody (tree < 0) should not cause spurious edges."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="fixed" pos="0 0 0">
-            <geom size=".1"/>
-          </body>
-          <body name="floating" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="world" body2="floating"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 0], 1)  # self-edge for floating tree
-
-  def test_constraint_touches_three_trees(self):
-    """Multiple constraints sharing a body create a star topology."""
-    mjm, mjd, m, d = test_data.fixture(
-      xml="""
-      <mujoco>
-        <worldbody>
-          <body name="A" pos="0 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="B" pos="1 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-          <body name="C" pos="2 0 0">
-            <joint type="free"/>
-            <geom size=".1"/>
-          </body>
-        </worldbody>
-        <equality>
-          <weld body1="A" body2="B"/>
-          <weld body1="A" body2="C"/>
-        </equality>
-      </mujoco>
-      """,
-      nworld=2,
-    )
-
-    mjwarp.fwd_position(m, d)
-
-    treetree = wp.empty((d.nworld, m.ntree, m.ntree), dtype=int)
-    island.tree_edges(m, d, treetree)
-
-    tt = treetree.numpy()
-    self.assertEqual(tt[0, 0, 1], 1)
-    self.assertEqual(tt[0, 1, 0], 1)
-    self.assertEqual(tt[0, 0, 2], 1)
-    self.assertEqual(tt[0, 2, 0], 1)
+def _chain_xml(count: int) -> str:
+  bodies = "".join(f'<body name="b{i}" pos="{i * 0.3} 0 0"><freejoint/><geom size=".1"/></body>' for i in range(count))
+  welds = "".join(f'<weld body1="b{i}" body2="b{i + 1}"/>' for i in range(count - 1))
+  return f"<mujoco><worldbody>{bodies}</worldbody><equality>{welds}</equality></mujoco>"
 
 
 class IslandDiscoveryTest(absltest.TestCase):
   """Tests for full island discovery."""
+
+  def test_parent_workspace_uses_minimum_tree_identity_pointers(self):
+    """Active parents are compressed pointers to their component's minimum tree."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option><flag island="disable"/></option>
+        <worldbody>
+          <body name="a"><freejoint/><geom size=".1"/></body>
+          <body name="b" pos="1 0 0"><freejoint/><geom size=".1"/></body>
+          <body name="c" pos="2 0 0"><freejoint/><geom size=".1"/></body>
+          <body name="free" pos="4 0 0"><freejoint/><geom size=".1"/></body>
+        </worldbody>
+        <equality>
+          <weld body1="c" body2="b"/>
+          <weld body1="b" body2="a"/>
+        </equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    parent = _discover(m, d).numpy()
+    tree_island = d.tree_island.numpy()
+
+    for world in range(d.nworld):
+      active = np.flatnonzero(tree_island[world] >= 0)
+      self.assertGreater(active.size, 0)
+      component_minimum = int(active.min())
+      np.testing.assert_array_equal(parent[world, active], component_minimum)
+      self.assertTrue(np.all(parent[world, active] >= 0))
+      self.assertTrue(np.all(parent[world, active] <= active))
+      self.assertEqual(parent[world, component_minimum], component_minimum)
+      inactive = np.flatnonzero(tree_island[world] < 0)
+      np.testing.assert_array_equal(parent[world, inactive], inactive)
+
+  def test_parent_workspace_and_canonical_labels(self):
+    """DSU storage is linear and labels are ordered by their first active tree."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option><flag island="disable"/></option>
+        <worldbody>
+          <body name="a"><joint type="free"/><geom size=".1"/></body>
+          <body name="b" pos="1 0 0"><joint type="free"/><geom size=".1"/></body>
+          <body name="c" pos="5 0 0"><joint type="free"/><geom size=".1"/></body>
+          <body name="d" pos="6 0 0"><joint type="free"/><geom size=".1"/></body>
+          <body name="free" pos="10 0 0"><joint type="free"/><geom size=".1"/></body>
+        </worldbody>
+        <equality>
+          <weld body1="a" body2="b"/>
+          <weld body1="c" body2="d"/>
+        </equality>
+      </mujoco>
+      """,
+      nworld=2,
+    )
+    del mjm, mjd
+
+    mjwarp.fwd_position(m, d)
+    workspace = _discover(m, d)
+    # the disjoint-set workspace stays linear in ntree
+    self.assertEqual(workspace.shape, (d.nworld, m.ntree))
+    self.assertEqual(workspace.dtype, wp.int32)
+    self.assertEqual(workspace.capacity, d.nworld * m.ntree * 4)
+    np.testing.assert_array_equal(
+      d.tree_island.numpy(),
+      np.array([[0, 0, 1, 1, -1], [0, 0, 1, 1, -1]], dtype=np.int32),
+    )
+
+  def test_inactive_efc_suffix_is_ignored_per_world(self):
+    """Allocated EFC rows beyond each world's active prefix cannot activate trees."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML, nworld=2)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    nefc = d.nefc.numpy().copy()
+    self.assertTrue(np.all(nefc > 0))
+    nefc[1] = 0
+    wp.copy(d.nefc, wp.array(nefc, dtype=wp.int32, device=d.nefc.device))
+
+    parent = _discover(m, d).numpy()
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.array([1, 0], dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0, 0], [-1, -1]], dtype=np.int32))
+    np.testing.assert_array_equal(parent, np.array([[0, 0], [0, 1]], dtype=np.int32))
+
+  def test_site_connect_and_weld_lower_to_body_trees(self):
+    """Site-based CONNECT and WELD constraints use their owning body trees."""
+    for kind in ("connect", "weld"):
+      with self.subTest(kind=kind):
+        mjm, mjd, m, d = test_data.fixture(xml=_site_equality_xml(kind), nworld=2)
+        del mjm, mjd
+        mjwarp.fwd_position(m, d)
+        self.assertEqual(m.eq_objtype.numpy()[0], types.ObjType.SITE)
+
+        island.island(m, d)
+
+        np.testing.assert_array_equal(d.nisland.numpy(), np.ones(2, dtype=np.int32))
+        np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
+
+  def test_elliptic_contact_uses_direct_geom_incidence(self):
+    """Elliptic contact rows connect the trees owning their two geoms."""
+    mjm, mjd, m, d = test_data.fixture(xml=_ELLIPTIC_CONTACT_XML, nworld=2)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    efc_type = d.efc.type.numpy()
+    nefc = d.nefc.numpy()
+    self.assertTrue(
+      all(np.any(efc_type[world, : nefc[world]] == types.ConstraintType.CONTACT_ELLIPTIC) for world in range(d.nworld))
+    )
+
+    island.island(m, d)
+
+    np.testing.assert_array_equal(d.nisland.numpy(), np.ones(2, dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
+
+  def test_generic_equality_matches_in_explicit_dense_and_sparse_modes(self):
+    """Generic Jacobian incidence is exact for both supported storage modes."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <body><joint name="j0" type="hinge"/><geom size=".1"/></body>
+        <body pos="1 0 0"><joint name="j1" type="hinge"/><geom size=".1"/></body>
+      </worldbody>
+      <equality><joint joint1="j0" joint2="j1"/></equality>
+    </mujoco>
+    """
+    for jacobian in (mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE):
+      with self.subTest(jacobian=int(jacobian)):
+        mjm, mjd, m, d = test_data.fixture(xml=xml, nworld=2, overrides={"opt.jacobian": jacobian})
+        del mjm, mjd
+        mjwarp.fwd_position(m, d)
+        self.assertEqual(m.is_sparse, jacobian == mujoco.mjtJacobian.mjJAC_SPARSE)
+
+        island.island(m, d)
+
+        np.testing.assert_array_equal(d.nisland.numpy(), np.ones(2, dtype=np.int32))
+        np.testing.assert_array_equal(d.tree_island.numpy(), np.zeros((2, 2), dtype=np.int32))
+
+  def test_atomic_discovery_drives_downstream_mapping(self):
+    """Atomic discovery outputs feed exact production DOF and EFC mappings."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML, nworld=2)
+    mjwarp.fwd_position(m, d)
+    island.island(m, d)
+    island.compute_island_mapping(m, d)
+
+    for world in range(d.nworld):
+      np.testing.assert_array_equal(d.dof_island.numpy()[world, : m.nv], mjd.dof_island[: mjm.nv])
+      np.testing.assert_array_equal(d.efc.island.numpy()[world, : mjd.nefc], mjd.efc_island[: mjd.nefc])
+      np.testing.assert_array_equal(d.island_nv.numpy()[world, : mjd.nisland], mjd.island_nv[: mjd.nisland])
+      np.testing.assert_array_equal(d.island_nefc.numpy()[world, : mjd.nisland], mjd.island_nefc[: mjd.nisland])
+
+  def test_direct_dsu_owns_no_hidden_allocation(self):
+    """Discovery allocates nothing of its own; the workspace comes from the caller."""
+    source = inspect.getsource(island.direct_dsu)
+    self.assertNotIn("wp.empty", source)
+    self.assertNotIn("wp.zeros", source)
+    self.assertIn("dim=(d.nworld, m.ntree)", source)
+    self.assertIn("wp.launch_tiled", source)
+    self.assertIn("dim=d.nworld", source)
+    self.assertIn("block_dim=types.BlockDim.island_dsu", source)
+    self.assertIn("island_parent", source)
+
+  def test_direct_dsu_blocks_cover_constraint_capacity_not_batch_size(self):
+    """Warp lanes stride one chunk of the active EFC prefix, never its capacity."""
+    source = inspect.getsource(island._island_dsu)
+    self.assertIn("worldid, chunkid, lane = wp.tid()", source)
+    self.assertIn("range(chunk_beg + lane, chunk_end, wp.block_dim())", source)
+
+  def test_dsu_chunking_splits_only_when_the_batch_leaves_the_device_idle(self):
+    """Chunk count trades against nworld, so a large batch keeps one block per world."""
+    # a batch that already fills the device is left alone: splitting it only launches
+    # blocks past the active prefix
+    self.assertEqual(_launch_chunking(nworld=2048, njmax=1024), (1, 1024))
+    self.assertEqual(_launch_chunking(nworld=4096, njmax=1024), (1, 1024))
+
+    # a single world with a long prefix is split until the device has work
+    nchunk, chunk_size = _launch_chunking(nworld=1, njmax=12352)
+    self.assertGreater(nchunk, 8)
+    self.assertGreaterEqual(chunk_size, 32)
+
+    # every input keeps full coverage of the prefix and at least one chunk
+    for nworld in (1, 7, 64, 512, 2048):
+      for njmax in (1, 31, 64, 255, 256, 1024, 3136, 12352, 65536):
+        nchunk, chunk_size = _launch_chunking(nworld=nworld, njmax=njmax)
+        self.assertGreaterEqual(nchunk, 1, f"{nworld=} {njmax=}")
+        self.assertGreaterEqual(chunk_size, 1, f"{nworld=} {njmax=}")
+        self.assertGreaterEqual(nchunk * chunk_size, njmax, f"{nworld=} {njmax=}")
+
+  def test_direct_dsu_collapses_only_repeated_fixed_support_rows(self):
+    """Known equal-support scalar rows keep one representative before union."""
+    helper = getattr(island, "_is_repeated_fixed_support_efc", None)
+    self.assertIsNotNone(helper)
+
+    helper_source = inspect.getsource(helper)
+    self.assertIn("efcid == 0", helper_source)
+    self.assertIn("efc_type_in[worldid, efcid - 1]", helper_source)
+    self.assertIn("efc_id_in[worldid, efcid - 1]", helper_source)
+
+    kernel_source = inspect.getsource(island._island_dsu)
+    quotient = kernel_source.index("repeated = _is_repeated_fixed_support_efc")
+    classification = kernel_source.index("if efc_type == ConstraintType.EQUALITY")
+    equality_body_lookup = kernel_source.index("body0 = eq_obj1id")
+    contact_tree_lookup = kernel_source.index("tree0 = body_treeid[geom_bodyid")
+    generic_scan = kernel_source.index("first_tree")
+    self.assertLess(quotient, classification)
+    self.assertGreaterEqual(kernel_source[:equality_body_lookup].count("if repeated:"), 1)
+    self.assertGreaterEqual(kernel_source[:contact_tree_lookup].count("if repeated:"), 2)
+    self.assertLess(contact_tree_lookup, generic_scan)
+
+  def test_repeated_island_reset_is_bitwise_stable(self):
+    """Each call overwrites the persistent DSU workspace and output labels."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    first_parent = _discover(m, d).numpy().copy()
+    first_labels = d.tree_island.numpy().copy()
+    first_nisland = d.nisland.numpy().copy()
+
+    for _ in range(16):
+      d.tree_island.fill_(123)
+      d.nisland.fill_(123)
+
+      np.testing.assert_array_equal(_discover(m, d).numpy(), first_parent)
+      np.testing.assert_array_equal(d.tree_island.numpy(), first_labels)
+      np.testing.assert_array_equal(d.nisland.numpy(), first_nisland)
+
+  def test_high_contention_chain_is_bitwise_stable(self):
+    """Concurrent duplicate weld rows converge to one deterministic minimum root."""
+    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(64), nworld=2)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    expected_parent = np.zeros((d.nworld, m.ntree), dtype=np.int32)
+    expected_labels = np.zeros((d.nworld, m.ntree), dtype=np.int32)
+
+    for _ in range(16):
+      np.testing.assert_array_equal(_discover(m, d).numpy(), expected_parent)
+      np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
+      np.testing.assert_array_equal(d.nisland.numpy(), np.ones(d.nworld, dtype=np.int32))
+
+  def test_joint_friction_and_limit_rows_activate_their_dof_tree(self):
+    """Special one-tree EFC rows use their prescribed DOF-tree incidence."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option><flag island="disable"/></option>
+        <worldbody>
+          <body><joint type="hinge" limited="true" range="-1 1" frictionloss="1"/><geom size=".1"/></body>
+        </worldbody>
+      </mujoco>
+      """
+    )
+    del mjm, mjd
+    d.qpos.fill_(2.0)
+    mjwarp.fwd_position(m, d)
+
+    efc_types = d.efc.type.numpy()[0, : d.nefc.numpy()[0]]
+    self.assertIn(types.ConstraintType.FRICTION_DOF, efc_types)
+    self.assertIn(types.ConstraintType.LIMIT_JOINT, efc_types)
+
+    island.island(m, d)
+    np.testing.assert_array_equal(d.nisland.numpy(), np.array([1], dtype=np.int32))
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0]], dtype=np.int32))
+
+  def test_generic_equality_jacobian_unions_all_active_trees(self):
+    """Joint equality takes the generic Jacobian path rather than body incidence."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option><flag island="disable"/></option>
+        <worldbody>
+          <body><joint name="j0" type="hinge"/><geom size=".1"/></body>
+          <body pos="1 0 0"><joint name="j1" type="hinge"/><geom size=".1"/></body>
+        </worldbody>
+        <equality><joint joint1="j0" joint2="j1"/></equality>
+      </mujoco>
+      """
+    )
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    self.assertIn(types.ConstraintType.EQUALITY, d.efc.type.numpy()[0, : d.nefc.numpy()[0]])
+    island.island(m, d)
+    np.testing.assert_array_equal(d.tree_island.numpy(), np.array([[0, 0]], dtype=np.int32))
+
+  def test_warmed_island_does_not_sync_with_host(self):
+    """The DSU path is safe to call inside a warmed graph region.
+
+    `island` constructs its own workspace, so `wp.empty` is expected here. What must not
+    happen is a host round trip, which would break graph capture.
+    """
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    island.island(m, d)  # compile and warm the kernel before installing spies
+
+    with (
+      mock.patch.object(wp, "synchronize", side_effect=AssertionError("wp.synchronize")),
+      mock.patch.object(wp, "synchronize_device", side_effect=AssertionError("wp.synchronize_device")),
+      mock.patch.object(wp.array, "numpy", side_effect=AssertionError("array.numpy")),
+    ):
+      island.island(m, d)
+
+    # the workspace is the only allocation, and discovery itself makes none
+    workspace = wp.empty((d.nworld, m.ntree), dtype=int)
+    with (
+      mock.patch.object(wp, "empty", side_effect=AssertionError("wp.empty")),
+      mock.patch.object(wp, "zeros", side_effect=AssertionError("wp.zeros")),
+    ):
+      island.direct_dsu(m, d, workspace)
+
+  def test_discovery_covers_efc_rows_across_chunk_boundaries(self):
+    """Every row of an EFC prefix longer than one chunk still activates its tree."""
+    trees = 900
+    # the shared fixture defaults njmax to 64, which would truncate the prefix this test
+    # exists to cross, so Data is built here with capacity for every row
+    mjm = mujoco.MjModel.from_xml_string(_limit_chain_xml(trees))
+    mjd = mujoco.MjData(mjm)
+    mjd.qpos[:] = 2.0
+    mujoco.mj_forward(mjm, mjd)
+    m = mjwarp.put_model(mjm)
+    d = mjwarp.put_data(mjm, mjd, nworld=2, njmax=trees + 64, nconmax=1, nccdmax=1)
+    mjwarp.fwd_position(m, d)
+
+    nefc = d.nefc.numpy()
+    nchunk, chunk_size = _launch_chunking(d.nworld, d.njmax)
+    self.assertGreater(nchunk, 1, "fixture must be split across blocks")
+    self.assertGreater(int(nefc.min()), chunk_size, "active prefix must cross a chunk boundary")
+    self.assertLessEqual(int(nefc.max()), d.njmax, "prefix must fit njmax or rows are truncated")
+
+    island.island(m, d)
+    dsu_labels = d.tree_island.numpy().copy()
+    dsu_nisland = d.nisland.numpy().copy()
+
+    # one row activates one tree, so a row dropped anywhere in the prefix moves the count
+    np.testing.assert_array_equal(dsu_nisland, np.full(d.nworld, trees, dtype=np.int32))
+
+    # every tree is its own island, so labels must be the identity over active trees
+    np.testing.assert_array_equal(dsu_labels, np.tile(np.arange(trees, dtype=np.int32), (d.nworld, 1)))
+
+  def test_labels_are_invariant_to_efc_row_permutation(self):
+    """The H0 partition is a function of incidence, not of the order rows arrive in."""
+    # Consecutive rows share a constraint type but belong to different islands, so any
+    # order-sensitive shortcut merges or drops the wrong pair once the rows move.
+    mjm, mjd, m, d = test_data.fixture(xml=_disjoint_contact_pairs_xml(8), nworld=4)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+
+    island.island(m, d)
+    expected_labels = d.tree_island.numpy().copy()
+    expected_nisland = d.nisland.numpy().copy()
+    np.testing.assert_array_equal(expected_nisland, np.full(d.nworld, 8, dtype=np.int32))
+
+    efc_type = d.efc.type.numpy()
+    efc_id = d.efc.id.numpy()
+    nefc = d.nefc.numpy()
+    rng = np.random.default_rng(0)
+
+    for trial in range(8):
+      permuted_type, permuted_id = efc_type.copy(), efc_id.copy()
+      for world in range(d.nworld):
+        order = rng.permutation(nefc[world])
+        permuted_type[world, : nefc[world]] = efc_type[world, order]
+        permuted_id[world, : nefc[world]] = efc_id[world, order]
+      wp.copy(d.efc.type, wp.array(permuted_type, dtype=wp.int32, device=d.efc.type.device))
+      wp.copy(d.efc.id, wp.array(permuted_id, dtype=wp.int32, device=d.efc.id.device))
+
+      island.island(m, d)
+
+      np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels, err_msg=f"trial {trial}")
+      np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland, err_msg=f"trial {trial}")
+
+  @absltest.skipIf(not wp.get_device().is_cuda, "CUDA graph capture requires a CUDA device.")
+  def test_capture_replay_matches_direct_island_output(self):
+    """Graph replay produces the same labels and DSU workspace as a direct launch."""
+    mjm, mjd, m, d = test_data.fixture(xml=_WELD_XML)
+    del mjm, mjd
+    mjwarp.fwd_position(m, d)
+    workspace = wp.empty((d.nworld, m.ntree), dtype=int)
+    island.direct_dsu(m, d, workspace)
+    expected_parent = workspace.numpy().copy()
+    expected_labels = d.tree_island.numpy().copy()
+    expected_nisland = d.nisland.numpy().copy()
+
+    with wp.ScopedCapture() as capture:
+      island.direct_dsu(m, d, workspace)
+    wp.capture_launch(capture.graph)
+
+    np.testing.assert_array_equal(workspace.numpy(), expected_parent)
+    np.testing.assert_array_equal(d.tree_island.numpy(), expected_labels)
+    np.testing.assert_array_equal(d.nisland.numpy(), expected_nisland)
 
   def test_two_trees_one_constraint_one_island(self):
     """Two trees connected by one constraint form one island.
@@ -897,6 +1037,56 @@ class IslandMappingTest(absltest.TestCase):
       d.map_iefc2efc.numpy()[0, :nefc],
       mjd.map_iefc2efc[:nefc],
     )
+
+  def test_dof_mapping_is_canonical_across_worlds(self):
+    """Island-local DOFs retain MuJoCo's ascending global-DOF order."""
+    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(22), nworld=256)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    mjwarp.fwd_position(m, d)
+    island.compute_island_mapping(m, d)
+
+    expected_dof2idof = np.tile(mjd.map_dof2idof[: mjm.nv], (d.nworld, 1))
+    expected_idof2dof = np.tile(mjd.map_idof2dof[: mjm.nv], (d.nworld, 1))
+    np.testing.assert_array_equal(d.map_dof2idof.numpy()[:, : mjm.nv], expected_dof2idof)
+    np.testing.assert_array_equal(d.map_idof2dof.numpy()[:, : mjm.nv], expected_idof2dof)
+
+  def test_dof_mapping_interleaves_islands_and_unconstrained_trees(self):
+    """Disjoint islands separated by unconstrained trees keep MuJoCo's DOF order."""
+    bodies = "".join(f'<body name="b{i}" pos="{i} 0 0"><freejoint/><geom size=".1"/></body>' for i in range(6))
+    mjm, mjd, m, d = test_data.fixture(
+      xml=f"<mujoco><worldbody>{bodies}</worldbody>"
+      '<equality><weld body1="b0" body2="b2"/><weld body1="b3" body2="b5"/></equality></mujoco>',
+      nworld=64,
+    )
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    mjwarp.fwd_position(m, d)
+    island.compute_island_mapping(m, d)
+
+    # b1 and b4 stay outside every island, so the constrained and unconstrained
+    # DOF ranges interleave rather than splitting at one boundary.
+    self.assertEqual(mjd.nisland, 2)
+    self.assertTrue(np.any(mjd.dof_island[: mjm.nv] < 0))
+
+    np.testing.assert_array_equal(d.map_dof2idof.numpy()[:, : mjm.nv], np.tile(mjd.map_dof2idof[: mjm.nv], (d.nworld, 1)))
+    np.testing.assert_array_equal(d.map_idof2dof.numpy()[:, : mjm.nv], np.tile(mjd.map_idof2dof[: mjm.nv], (d.nworld, 1)))
+    np.testing.assert_array_equal(
+      d.island_dofadr.numpy()[:, : mjd.nisland], np.tile(mjd.island_dofadr[: mjd.nisland], (d.nworld, 1))
+    )
+
+  def test_efc_mapping_is_canonical_across_worlds(self):
+    """Island-local constraints retain MuJoCo's category and EFC order."""
+    mjm, mjd, m, d = test_data.fixture(xml=_chain_xml(22), nworld=256)
+    m.opt.disableflags &= ~types.DisableBit.ISLAND
+
+    mjwarp.fwd_position(m, d)
+    island.compute_island_mapping(m, d)
+
+    expected_efc2iefc = np.tile(mjd.map_efc2iefc[: mjd.nefc], (d.nworld, 1))
+    expected_iefc2efc = np.tile(mjd.map_iefc2efc[: mjd.nefc], (d.nworld, 1))
+    np.testing.assert_array_equal(d.map_efc2iefc.numpy()[:, : mjd.nefc], expected_efc2iefc)
+    np.testing.assert_array_equal(d.map_iefc2efc.numpy()[:, : mjd.nefc], expected_iefc2efc)
 
   def test_island_ne_nf_parity(self):
     """island_ne and island_nf match MuJoCo C values."""

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -60,6 +60,7 @@ class BlockDim:
     segmented_sort: segmented sort block dimension (collision_driver)
     convex_ccd: convex CCD kernel block dimension (collision_convex)
     actuator_velocity: actuator velocity block dimension (forward)
+    island_dsu: island discovery DSU block dimension (island)
     ray: ray block dimension (ray)
     contact_sort: contact sort block dimension (sensor)
     energy_vel_kinetic: energy velocity kinetic block dimension (sensor)
@@ -88,6 +89,8 @@ class BlockDim:
   convex_ccd: int = 64
   # forward
   actuator_velocity: int = 32
+  # island
+  island_dsu: int = 32
   # ray
   ray: int = 64
   # sensor


### PR DESCRIPTION
This replaces the quadratic `tree_tree[nworld, ntree, ntree]` adjacency and DFS stack with a persistent `int32 parent[nworld, ntree]` workspace and three allocation-free, CUDA-capturable phases: reset, direct EFC incidence unions, and one canonical compression/label pass per world. The latest iteration assigns one 32-lane CUDA block to each world and has lanes stride only the active EFC prefix instead of launching `nworld * njmax` capacity threads.

Repeated fixed-support scalar rows with the same `(efc_type, efc_id)` are quotiented before endpoint lookup. This is exact for connect/weld equality constraints, joint friction and limits, and non-flex contacts because duplicate incidence generates the same H0 equivalence relation. Generic dense or sparse Jacobian rows and negative-geometry flex contacts remain fully scanned. Component labels use the minimum active tree id, and the existing canonical DOF/EFC mapping produces bitwise-stable island inputs independent of row order, endpoint order, and duplicate incidence.

The retained `aloha_clutter` checkpoint has 2,048 worlds, 22 trees, 247,308 active EFC rows, and 193,882 consecutive fixed-support repeats. Across five fresh processes and 10 A-B-B-A blocks, the current discovery path matched the original dense kernels exactly in every block and was 1.513x faster by geometric mean, with a conservative process-bootstrap 99% interval of [1.406x, 1.584x]. Pooled medians were 156.738 microseconds for dense and 101.097 microseconds for the current path. Compared with the previous capacity-wide atomic implementation, the new schedule was 1.355x faster with 99% interval [1.265x, 1.420x]. Reusable scratch falls from 7,929,856 bytes to 180,224 bytes for this configuration, a 97.73% reduction and a change from quadratic to linear growth in `ntree`.

The earlier 582-record synthetic matrix found the linear DSU faster than dense discovery in 91 of 93 valid pairs with a median dense/DSU ratio of 2.40. I also tested CUDA block dimensions 32, 64, 128, and 256; all were exact. A dedicated five-process 32-vs-128 comparison had geometric ratio 1.004 with 99% interval [0.990, 1.029], so I kept the simpler one-warp schedule rather than claiming a wider-block improvement.

The deterministic same-state `fwd_position` boundary matched all topology and downstream mapping arrays exactly across five fresh processes. Its 1.013x geometric speedup had a 99% interval of [0.967x, 1.053x], so it is not a performance claim. Two full 2,751-frame replay pairs measured 1.76-3.54x faster island events and 3.72-3.93x faster direct discovery scopes, but whole-step throughput remained 7-12% lower as the chaotic trajectories diverged in non-island `forward` work. Candidate-vs-itself and dense-vs-itself controls also show that full-replay qacc and EFC ordering are not bitwise repeatable on this workload. This PR therefore claims the exact direct-discovery and memory improvements only, not an end-to-end step speedup.

Validation includes 42 focused island tests plus four subtests on CUDA, 41 passed and one skipped plus four subtests on CPU, 90 CUDA-error-checked non-capture tests, graph capture/replay coverage, pre-commit Ruff/format/kernel-analyzer checks, and `uv run pytest -n 8` with 1,217 passed and 18 skipped. The existing unstaged `mesh_plane_complex` fixture offset remains outside this PR.

Addresses #1539.
