### PR TITLE
Drop the tendon-armature all-sparse forcing

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -191,12 +191,6 @@ def _m_blocks(mjm: mujoco.MjModel):
   return [(int(adr), int(num)) for adr, num in zip(mjm.tree_dofadr, mjm.tree_dofnum) if num > 0]
 
 
-def _m_allow_dense(mjm: mujoco.MjModel) -> bool:
-  """Whether any block may use the packed dense layout (tendon armature forces all-sparse)."""
-  # tendon armature accumulates into M in CSR layout, which the packed block layout cannot represent
-  return not (mjm.ntendon and np.any(mjm.tendon_armature))
-
-
 def m_block_layout(mjm: mujoco.MjModel) -> dict:
   """Per-block dense/sparse layout for M's diagonal blocks.
 
@@ -205,7 +199,6 @@ def m_block_layout(mjm: mujoco.MjModel) -> dict:
   """
   nv = mjm.nv
   blocks = _m_blocks(mjm)
-  allow_dense = _m_allow_dense(mjm)
   dof_adr = np.full(nv, types.Q_LD_BLOCK_SPARSE, dtype=np.int32)
   scalar_tiles = {}
   gather_tiles = {}
@@ -217,14 +210,14 @@ def m_block_layout(mjm: mujoco.MjModel) -> dict:
     compact = nnz == size
     triangular = nnz == size * (size + 1) // 2
 
-    if size <= types.M_BLOCK_SCALAR_MAX and (compact or (allow_dense and triangular)):
+    if size <= types.M_BLOCK_SCALAR_MAX and (compact or triangular):
       scalar_tiles.setdefault(size, []).append(start)
       if compact:
         dof_adr[start : start + size] = types.Q_LD_BLOCK_COMPACT
       else:
         dof_adr[start : start + size] = off
         off += size * size
-    elif allow_dense and size <= types.M_BLOCK_DENSE_MAX:
+    elif size <= types.M_BLOCK_DENSE_MAX:
       gather_tiles.setdefault(size, []).append(start)
       dof_adr[start : start + size] = off
       off += size * size


### PR DESCRIPTION
Since M became CSR-only with per-block factorization (#1424), every factor path gathers its input from the CSR M at factor time, after the per-step tendon-armature accumulation has written into it — so the `_m_allow_dense` gate that forced armature models onto the all-sparse LDL path has never guarded a real hazard: it landed in the same commit as the factor-time gather that makes it moot. Tendon armature also only ever produces ancestor-pair terms (the accumulation walks dof_parentid), so its contributions land in existing CSR slots inside the diagonal blocks, matching MuJoCo's own projection on the CPU — no per-block representation can miss them. Removing the gate lets models with tendon armature classify their blocks by the normal size rules instead of paying the sparse LDL path at every size. The existing tendon-armature tests cover parity through the newly-permitted dense path.
