### PR TITLE
multicontact warn

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -29,6 +29,7 @@ from mujoco_warp._src import smooth
 from mujoco_warp._src import support
 from mujoco_warp._src import types
 from mujoco_warp._src import warp_util
+from mujoco_warp._src.collision_driver import MJ_COLLISION_TABLE
 from mujoco_warp._src.types import MJ_MINVAL
 from mujoco_warp._src.types import BiasType
 from mujoco_warp._src.types import TrnType
@@ -688,6 +689,31 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   nativeccd_disabled = mjm.opt.disableflags & types.DisableBit.NATIVECCD
   BOX = int(mujoco.mjtGeom.mjGEOM_BOX)
   MESH = int(mujoco.mjtGeom.mjGEOM_MESH)
+
+  # TODO(team): remove after implementing multicontact support for CCD pairs.
+  if use_multiccd:
+    unsupported_multiccd_pairs = []
+    for (g1, g2), col_type in MJ_COLLISION_TABLE.items():
+      if g1 == types.GeomType.BOX and g2 == types.GeomType.BOX and nativeccd_disabled:
+        continue
+      if col_type == types.CollisionType.CONVEX:
+        if g1 in (types.GeomType.SPHERE, types.GeomType.ELLIPSOID) or g2 in (
+          types.GeomType.SPHERE,
+          types.GeomType.ELLIPSOID,
+        ):
+          continue
+        if (g1, g2) not in (
+          (types.GeomType.BOX, types.GeomType.BOX),
+          (types.GeomType.BOX, types.GeomType.MESH),
+          (types.GeomType.MESH, types.GeomType.MESH),
+        ):
+          if m.geom_pair_type_count[geom_trid_index(int(g1), int(g2))] > 0:
+            unsupported_multiccd_pairs.append((g1.name, g2.name))
+    if unsupported_multiccd_pairs:
+      warnings.warn(
+        "MULTICCD is enabled, but the scene contains CCD pairs without multicontact support:"
+        f" {unsupported_multiccd_pairs}. At most 1 contact will be generated for these pairs."
+      )
 
   has_boxbox = m.geom_pair_type_count[geom_trid_index(BOX, BOX)] > 0
   has_multiccd_pairs = has_boxbox or (

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -16,6 +16,7 @@
 """Tests for io functions."""
 
 import dataclasses
+import warnings
 from unittest import mock
 
 import mujoco
@@ -3171,6 +3172,55 @@ class IOTest(parameterized.TestCase):
     # Should succeed without NotImplementedError
     m = mjwarp.put_model(mjm)
     self.assertEqual(m.has_3d_flex, True)
+
+  # TODO(team): remove after implementing multicontact support for CCD pairs.
+  @parameterized.parameters(
+    ("cylinder", "box"),
+    ("cylinder", "cylinder"),
+    ("cylinder", "mesh"),
+    ("capsule", "cylinder"),
+    ("capsule", "mesh"),
+  )
+  def test_unsupported_multiccd_warning(self, geom1_type, geom2_type):
+    """Tests warning for unsupported multicontact CCD pairs when MULTICCD is enabled."""
+
+    def _make_geom_xml(gtype: str) -> str:
+      if gtype == "mesh":
+        return '<geom type="mesh" mesh="m"/>'
+      elif gtype in ("cylinder", "capsule"):
+        return f'<geom type="{gtype}" size=".1 .1"/>'
+      elif gtype == "sphere":
+        return '<geom type="sphere" size=".1"/>'
+      else:
+        return f'<geom type="{gtype}" size=".1 .1 .1"/>'
+
+    mesh_asset = '<mesh name="m" vertex="0 0 0 1 0 0 0 1 0 0 0 1"/>' if "mesh" in (geom1_type, geom2_type) else ""
+    xml = f"""
+      <mujoco>
+        <asset>
+          {mesh_asset}
+        </asset>
+        <worldbody>
+          <body>
+            <freejoint/>
+            {_make_geom_xml(geom1_type)}
+          </body>
+          <body pos="0 0 .5">
+            <freejoint/>
+            {_make_geom_xml(geom2_type)}
+          </body>
+        </worldbody>
+      </mujoco>
+    """
+    mjm = mujoco.MjModel.from_xml_string(xml)
+
+    with self.assertWarns(UserWarning):
+      mjwarp.put_model(mjm)
+
+    mjm.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_MULTICCD
+    with warnings.catch_warnings():
+      warnings.simplefilter("error")
+      mjwarp.put_model(mjm)
 
 
 # TODO(team): test set_const_0 sparse


### PR DESCRIPTION
add warning to `io.put_model` for ccd pairs that do not have multicontact support