### PR TITLE
type `xfrc_applied` as `wp.spatial_vector`

### DIFF
--- a/mujoco_warp/viewer.py
+++ b/mujoco_warp/viewer.py
@@ -88,7 +88,7 @@ def _make_warp_step_fn(mjm, m, d, graph, ctrls=None):
       graph = _compile_step(m, d) if wp.get_device().is_cuda else None
     wp.copy(d.ctrl, wp.array([mjd.ctrl.astype(np.float32)]))
     wp.copy(d.act, wp.array([mjd.act.astype(np.float32)]))
-    wp.copy(d.xfrc_applied, wp.array([mjd.xfrc_applied.astype(np.float32)]))
+    wp.copy(d.xfrc_applied, wp.array([mjd.xfrc_applied], dtype=wp.spatial_vector))
     wp.copy(d.qpos, wp.array([mjd.qpos.astype(np.float32)]))
     wp.copy(d.qvel, wp.array([mjd.qvel.astype(np.float32)]))
     wp.copy(d.time, wp.array([mjd.time], dtype=wp.float32))


### PR DESCRIPTION
the following errors

```
mjwarp-viewer benchmarks/humanoid/humanoid.xml --nconmax=128 --njmax=512
```

```
wp.copy(d.xfrc_applied, wp.array([mjd.xfrc_applied.astype(np.float32)]))
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
RuntimeError: Incompatible array data types
```

this pr fixes the error by typing with `wp.spatial_vector`