### PR TITLE
Export OverflowType in the public API.

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -113,6 +113,7 @@ from mujoco_warp._src.types import IntegratorType as IntegratorType
 from mujoco_warp._src.types import JointType as JointType
 from mujoco_warp._src.types import ObjType as ObjType
 from mujoco_warp._src.types import Option as Option
+from mujoco_warp._src.types import OverflowType as OverflowType
 from mujoco_warp._src.types import RenderContext as RenderContext
 from mujoco_warp._src.types import SolverType as SolverType
 from mujoco_warp._src.types import State as State


### PR DESCRIPTION
Export the existing `OverflowType` enum from the public `mujoco_warp` package. `Data.overflow` is a programmatic bitmask, but consumers currently have to import `_src.types` or hardcode its bits. This does not change the enum, its values, or overflow behavior.

The public import/identity probe, `mujoco_warp._src.types_test`, and pre-commit pass. The full suite reports 1,236 passed and 23 skipped, with the same unrelated `IOTest.test_put_data_nefc_zero_dense` failure reproduced on unmodified current main.
