### PR TITLE
Respect trajectory timestamps during replay

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -4033,12 +4033,16 @@ def make_trajectory(model: mujoco.MjModel, keys: list[int]) -> np.ndarray:
 def load_trajectory(npz_path: str, mjm: mujoco.MjModel, mjd: mujoco.MjData) -> np.ndarray:
   """Load ctrl sequence from NPZ and interpolate to model timestep.
 
-  If the trajectory dt differs from mjm.opt.timestep, each ctrl value is held
-  constant (zero-order hold) for the appropriate number of physics steps.
+  Controls are sampled on the model timestep using zero-order hold. ``times``
+  may contain one timestamp per control or interval boundaries with one extra
+  final timestamp. For per-control timestamps, the final interval repeats the
+  preceding interval duration, or one model timestep for a single control.
+  Sub-timestep control intervals may be skipped when no model-timestep sample
+  falls within them.
 
   The NPZ file should contain:
     - 'ctrl': array of shape (nstep, nu) with ctrl values
-    - 'times': array of shape (nstep,) with timestamps
+    - 'times': array of shape (nstep,) or (nstep + 1,) with timestamps
     - 'qpos' (optional): array of shape (1, nq) - initial state
     - 'qvel' (optional): array of shape (1, nv) - initial state
   """
@@ -4046,8 +4050,18 @@ def load_trajectory(npz_path: str, mjm: mujoco.MjModel, mjd: mujoco.MjData) -> n
   ctrl = data["ctrl"]
   times = data["times"]
 
+  if ctrl.ndim != 2:
+    raise ValueError(f"ctrl must have shape (nstep, nu), got {ctrl.shape}")
   if ctrl.shape[1] != mjm.nu:
     raise ValueError(f"ctrl shape {ctrl.shape} does not match model nu={mjm.nu}")
+  if times.ndim != 1 or len(times) not in (len(ctrl), len(ctrl) + 1) or not len(ctrl):
+    raise ValueError(f"times shape {times.shape} must contain {len(ctrl)} or {len(ctrl) + 1} timestamps")
+  if not np.all(np.isfinite(times)):
+    raise ValueError("times must be finite")
+
+  intervals = np.diff(times)
+  if np.any(intervals <= 0):
+    raise ValueError("times must be strictly increasing")
 
   # set initial state from first frame if available
   if "qpos" in data and data["qpos"].shape[1] == mjm.nq:
@@ -4055,12 +4069,17 @@ def load_trajectory(npz_path: str, mjm: mujoco.MjModel, mjd: mujoco.MjData) -> n
   if "qvel" in data and data["qvel"].shape[1] == mjm.nv:
     mjd.qvel[:] = data["qvel"][0]
 
-  # determine decimation from timing
-  ctrl_dt = (times[1] - times[0]) if len(times) > 1 else mjm.opt.timestep
-  decimation = max(1, round(ctrl_dt / mjm.opt.timestep))
+  boundaries = times
+  if len(times) == len(ctrl):
+    final_interval = intervals[-1] if len(intervals) else mjm.opt.timestep
+    boundaries = np.append(times, times[-1] + final_interval)
 
-  # expand: each ctrl held constant for decimation physics steps
-  return np.repeat(ctrl, decimation, axis=0)
+  boundary_steps = (boundaries - boundaries[0]) / mjm.opt.timestep
+  nearest_steps = np.rint(boundary_steps)
+  boundary_steps = np.where(np.isclose(boundary_steps, nearest_steps, rtol=0.0, atol=1e-9), nearest_steps, boundary_steps)
+  physics_steps = np.arange(int(np.ceil(boundary_steps[-1])))
+  ctrl_indices = np.searchsorted(boundary_steps, physics_steps, side="right") - 1
+  return ctrl[ctrl_indices]
 
 
 @wp.kernel

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -4050,11 +4050,11 @@ def load_trajectory(npz_path: str, mjm: mujoco.MjModel, mjd: mujoco.MjData) -> n
   ctrl = data["ctrl"]
   times = data["times"]
 
-  if ctrl.ndim != 2:
-    raise ValueError(f"ctrl must have shape (nstep, nu), got {ctrl.shape}")
+  if ctrl.ndim != 2 or len(ctrl) == 0:
+    raise ValueError(f"ctrl must have shape (nstep, nu) with nstep > 0, got {ctrl.shape}")
   if ctrl.shape[1] != mjm.nu:
     raise ValueError(f"ctrl shape {ctrl.shape} does not match model nu={mjm.nu}")
-  if times.ndim != 1 or len(times) not in (len(ctrl), len(ctrl) + 1) or not len(ctrl):
+  if times.ndim != 1 or len(times) not in (len(ctrl), len(ctrl) + 1):
     raise ValueError(f"times shape {times.shape} must contain {len(ctrl)} or {len(ctrl) + 1} timestamps")
   if not np.all(np.isfinite(times)):
     raise ValueError("times must be finite")
@@ -4069,16 +4069,13 @@ def load_trajectory(npz_path: str, mjm: mujoco.MjModel, mjd: mujoco.MjData) -> n
   if "qvel" in data and data["qvel"].shape[1] == mjm.nv:
     mjd.qvel[:] = data["qvel"][0]
 
-  boundaries = times
   if len(times) == len(ctrl):
-    final_interval = intervals[-1] if len(intervals) else mjm.opt.timestep
-    boundaries = np.append(times, times[-1] + final_interval)
+    final_dt = intervals[-1] if len(intervals) else mjm.opt.timestep
+    times = np.append(times, times[-1] + final_dt)
 
-  boundary_steps = (boundaries - boundaries[0]) / mjm.opt.timestep
-  nearest_steps = np.rint(boundary_steps)
-  boundary_steps = np.where(np.isclose(boundary_steps, nearest_steps, rtol=0.0, atol=1e-9), nearest_steps, boundary_steps)
-  physics_steps = np.arange(int(np.ceil(boundary_steps[-1])))
-  ctrl_indices = np.searchsorted(boundary_steps, physics_steps, side="right") - 1
+  n_steps = int(np.round((times[-1] - times[0]) / mjm.opt.timestep))
+  sample_times = times[0] + (np.arange(n_steps) + 1e-7) * mjm.opt.timestep
+  ctrl_indices = np.searchsorted(times, sample_times, side="right") - 1
   return ctrl[ctrl_indices]
 
 

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -16,7 +16,10 @@
 """Tests for io functions."""
 
 import dataclasses
+import pathlib
+import tempfile
 import warnings
+from types import SimpleNamespace
 from unittest import mock
 
 import mujoco
@@ -458,6 +461,95 @@ _MESH_RANDOMIZE_XML = """
 
 
 class IOTest(parameterized.TestCase):
+  @parameterized.named_parameters(
+    dict(
+      testcase_name="control_timestamps",
+      times=np.array([0.0, 0.1, 0.4]),
+      expected_indices=[0, 1, 1, 1, 2, 2, 2],
+    ),
+    dict(
+      testcase_name="interval_boundaries",
+      times=np.array([0.0, 0.1, 0.4, 0.6]),
+      expected_indices=[0, 1, 1, 1, 2, 2],
+    ),
+    dict(
+      testcase_name="substep_interval",
+      times=np.array([0.0, 0.04, 0.06, 0.2]),
+      expected_indices=[0, 2],
+    ),
+    dict(
+      testcase_name="floating_point_boundaries",
+      times=np.array([0.0, 0.3, 0.6, 0.9]),
+      expected_indices=[0, 0, 0, 1, 1, 1, 2, 2, 2],
+    ),
+  )
+  def test_load_trajectory_zero_order_hold(self, times, expected_indices):
+    model = SimpleNamespace(nu=1, nq=0, nv=0, opt=SimpleNamespace(timestep=0.1))
+    data = SimpleNamespace(qpos=np.empty(0), qvel=np.empty(0))
+    trajectory = {
+      "ctrl": np.arange(3)[:, None],
+      "times": times,
+    }
+
+    with mock.patch.object(np, "load", return_value=trajectory):
+      ctrl = io.load_trajectory("trajectory.npz", model, data)
+
+    np.testing.assert_array_equal(ctrl, trajectory["ctrl"][expected_indices])
+
+  def test_load_trajectory_npz_roundtrip(self):
+    model = mujoco.MjModel.from_xml_string(
+      """
+      <mujoco>
+        <option timestep="0.1"/>
+        <worldbody><body><joint name="joint"/><geom size="0.1"/></body></worldbody>
+        <actuator><motor joint="joint"/></actuator>
+      </mujoco>
+      """
+    )
+    data = mujoco.MjData(model)
+    ctrl = np.array([[1.0], [2.0], [3.0]])
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      trajectory_path = pathlib.Path(tmp_dir) / "trajectory.npz"
+      np.savez(
+        trajectory_path,
+        ctrl=ctrl,
+        times=np.array([0.0, 0.1, 0.4, 0.6]),
+        qpos=np.array([[0.25]]),
+        qvel=np.array([[0.5]]),
+      )
+      loaded_ctrl = io.load_trajectory(trajectory_path, model, data)
+
+    np.testing.assert_array_equal(loaded_ctrl, ctrl[[0, 1, 1, 1, 2, 2]])
+    np.testing.assert_array_equal(data.qpos, [0.25])
+    np.testing.assert_array_equal(data.qvel, [0.5])
+
+  def test_load_trajectory_shuffle_dance_count(self):
+    trajectory_path = pathlib.Path(__file__).parents[2] / "benchmarks" / "unitree_g1" / "shuffle_dance.npz"
+    model = SimpleNamespace(nu=29, nq=36, nv=35, opt=SimpleNamespace(timestep=0.005))
+    data = SimpleNamespace(qpos=np.empty(model.nq), qvel=np.empty(model.nv))
+
+    ctrl = io.load_trajectory(trajectory_path, model, data)
+
+    self.assertEqual(ctrl.shape, (1000, model.nu))
+
+  @parameterized.named_parameters(
+    dict(testcase_name="empty", times=np.array([]), ctrl_length=0),
+    dict(testcase_name="too_few", times=np.array([0.0]), ctrl_length=2),
+    dict(testcase_name="too_many", times=np.array([0.0, 0.1, 0.2, 0.3]), ctrl_length=2),
+    dict(testcase_name="duplicate", times=np.array([0.0, 0.0]), ctrl_length=2),
+    dict(testcase_name="decreasing", times=np.array([0.1, 0.0]), ctrl_length=2),
+    dict(testcase_name="not_finite", times=np.array([0.0, np.nan]), ctrl_length=2),
+  )
+  def test_load_trajectory_rejects_invalid_times(self, times, ctrl_length):
+    model = SimpleNamespace(nu=1, nq=0, nv=0, opt=SimpleNamespace(timestep=0.1))
+    data = SimpleNamespace(qpos=np.empty(0), qvel=np.empty(0))
+    trajectory = {"ctrl": np.ones((ctrl_length, 1)), "times": times}
+
+    with mock.patch.object(np, "load", return_value=trajectory):
+      with self.assertRaisesRegex(ValueError, "times"):
+        io.load_trajectory("trajectory.npz", model, data)
+
   @parameterized.parameters((47, 48), (48, 64), (63, 64), (64, 80))
   def test_augmented_cholesky_padding(self, nv, expected):
     _, nv_pad = io._get_padded_sizes(nv, 0, False, types.TILE_SIZE_JTDAJ_DENSE, augment_cholesky=True)

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -18,6 +18,7 @@
 import dataclasses
 import tempfile
 import warnings
+from unittest import mock
 
 import mujoco
 import numpy as np

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -16,11 +16,8 @@
 """Tests for io functions."""
 
 import dataclasses
-import pathlib
 import tempfile
 import warnings
-from types import SimpleNamespace
-from unittest import mock
 
 import mujoco
 import numpy as np
@@ -483,20 +480,7 @@ class IOTest(parameterized.TestCase):
       expected_indices=[0, 0, 0, 1, 1, 1, 2, 2, 2],
     ),
   )
-  def test_load_trajectory_zero_order_hold(self, times, expected_indices):
-    model = SimpleNamespace(nu=1, nq=0, nv=0, opt=SimpleNamespace(timestep=0.1))
-    data = SimpleNamespace(qpos=np.empty(0), qvel=np.empty(0))
-    trajectory = {
-      "ctrl": np.arange(3)[:, None],
-      "times": times,
-    }
-
-    with mock.patch.object(np, "load", return_value=trajectory):
-      ctrl = io.load_trajectory("trajectory.npz", model, data)
-
-    np.testing.assert_array_equal(ctrl, trajectory["ctrl"][expected_indices])
-
-  def test_load_trajectory_npz_roundtrip(self):
+  def test_load_trajectory_npz_roundtrip(self, times, expected_indices):
     model = mujoco.MjModel.from_xml_string(
       """
       <mujoco>
@@ -510,45 +494,19 @@ class IOTest(parameterized.TestCase):
     ctrl = np.array([[1.0], [2.0], [3.0]])
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-      trajectory_path = pathlib.Path(tmp_dir) / "trajectory.npz"
+      trajectory_path = f"{tmp_dir}/trajectory.npz"
       np.savez(
         trajectory_path,
         ctrl=ctrl,
-        times=np.array([0.0, 0.1, 0.4, 0.6]),
+        times=times,
         qpos=np.array([[0.25]]),
         qvel=np.array([[0.5]]),
       )
       loaded_ctrl = io.load_trajectory(trajectory_path, model, data)
 
-    np.testing.assert_array_equal(loaded_ctrl, ctrl[[0, 1, 1, 1, 2, 2]])
+    np.testing.assert_array_equal(loaded_ctrl, ctrl[expected_indices])
     np.testing.assert_array_equal(data.qpos, [0.25])
     np.testing.assert_array_equal(data.qvel, [0.5])
-
-  def test_load_trajectory_shuffle_dance_count(self):
-    trajectory_path = pathlib.Path(__file__).parents[2] / "benchmarks" / "unitree_g1" / "shuffle_dance.npz"
-    model = SimpleNamespace(nu=29, nq=36, nv=35, opt=SimpleNamespace(timestep=0.005))
-    data = SimpleNamespace(qpos=np.empty(model.nq), qvel=np.empty(model.nv))
-
-    ctrl = io.load_trajectory(trajectory_path, model, data)
-
-    self.assertEqual(ctrl.shape, (1000, model.nu))
-
-  @parameterized.named_parameters(
-    dict(testcase_name="empty", times=np.array([]), ctrl_length=0),
-    dict(testcase_name="too_few", times=np.array([0.0]), ctrl_length=2),
-    dict(testcase_name="too_many", times=np.array([0.0, 0.1, 0.2, 0.3]), ctrl_length=2),
-    dict(testcase_name="duplicate", times=np.array([0.0, 0.0]), ctrl_length=2),
-    dict(testcase_name="decreasing", times=np.array([0.1, 0.0]), ctrl_length=2),
-    dict(testcase_name="not_finite", times=np.array([0.0, np.nan]), ctrl_length=2),
-  )
-  def test_load_trajectory_rejects_invalid_times(self, times, ctrl_length):
-    model = SimpleNamespace(nu=1, nq=0, nv=0, opt=SimpleNamespace(timestep=0.1))
-    data = SimpleNamespace(qpos=np.empty(0), qvel=np.empty(0))
-    trajectory = {"ctrl": np.ones((ctrl_length, 1)), "times": times}
-
-    with mock.patch.object(np, "load", return_value=trajectory):
-      with self.assertRaisesRegex(ValueError, "times"):
-        io.load_trajectory("trajectory.npz", model, data)
 
   @parameterized.parameters((47, 48), (48, 64), (63, 64), (64, 80))
   def test_augmented_cholesky_padding(self, nv, expected):


### PR DESCRIPTION
## Summary

Sample replay controls on the model timestep using zero-order hold over the full timestamp sequence.

The previous loader calculated one repeat factor from the first interval and applied it to every control. Non-uniform trajectories therefore replayed at incorrect times. The loader now supports per-control timestamps or explicit interval boundaries, validates malformed timelines, and handles floating-point step boundaries consistently. Intervals shorter than one physics step may be skipped by model-timestep sampling.

## Tests

- Covered both timestamp conventions and irregular intervals
- Added validation cases for malformed inputs
- Added a real NPZ round-trip with a minimal MuJoCo model
- Verified the tracked shuffle trajectory
