### PR TITLE
Stabilize Windows collision and mixed-block tests

### DIFF
--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -433,7 +433,8 @@ class CollisionTest(parameterized.TestCase):
           </asset>
           <worldbody>
             <geom size="40 40 40" type="plane"/>
-            <body pos="0.0 2.0 0.0" euler="90 90 0">
+            <!-- Keep the tip off the plane so contact generation is not decided by exact tangency. -->
+            <body pos="0.0 2.0 0.001" euler="90 90 0">
               <freejoint/>
               <geom size="0.2 0.2 0.2" type="mesh" mesh="poly"/>
             </body>

--- a/mujoco_warp/_src/smooth_test.py
+++ b/mujoco_warp/_src/smooth_test.py
@@ -613,7 +613,7 @@ class SmoothTest(parameterized.TestCase):
   def test_factor_solve_mixed_blocks(self):
     """Per-block factor/solve: sparse LDL, scalar, and tile blocks all share one qLD."""
 
-    # A 70-dof hinge chain (one block > M_BLOCK_DENSE_MAX -> sparse LDL), a 6-dof hinge chain
+    # A hinge chain one DOF above M_BLOCK_DENSE_MAX (sparse LDL), a 6-dof hinge chain
     # (scalar Cholesky), and a 7-dof hinge chain (tile Cholesky): factor_m/solve_m must run all
     # three passes into one qLD. (Coupled blocks, not free joints: a free joint on a sphere has
     # diagonal M and would take the compact path, which stores no factor.)
@@ -625,7 +625,7 @@ class SmoothTest(parameterized.TestCase):
         + "</body>" * k
       )
 
-    n = 70
+    n = types.M_BLOCK_DENSE_MAX + 1
     chain = (
       "".join('<body pos="0 0 .05"><joint type="hinge" axis="1 0 0"/><geom type="capsule" size=".02 .025"/>' for _ in range(n))
       + "</body>" * n


### PR DESCRIPTION
On Windows with Python 3.14, two otherwise valid tests fail for platform-specific fixture reasons.

The complex mesh-plane fixture places one tip exactly tangent to the plane. MuJoCo reports an approximately zero-depth numerical contact while Warp omits it; lifting the body by 1 mm preserves the intended penetrating contact and makes contact generation unambiguous.

The mixed-block solve fixture builds 70 nested bodies, which can overflow the Windows XML parser stack before the solver runs. Using `M_BLOCK_DENSE_MAX + 1` (65 DOFs currently) remains the minimal coverage of the sparse LDL branch without exercising that parser limit.

This changes only test fixtures; collision and solver behavior are unchanged. Validated on Windows with Python 3.14.6: the two targeted tests passed, the full suite reported 1262 passed and 19 skipped, and `pre-commit run -a` passed all hooks.
