### PR TITLE
fix(sensor): allow _sensor_tactile under deterministic execution

### DIFF
--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -2216,6 +2216,11 @@ def _sensor_tactile(
   weld_geom_list_in: wp.array3d[int],
   # Data out:
   sensordata_out: wp.array2d[float],
+  # Aliases sensordata_out. Bound separately so the atomic_max on the normal
+  # channel and the atomic_add on the shear channels are distinct reduction
+  # targets: deterministic mode allows only one reduction family per target, and
+  # the channels are disjoint (channel 0 vs channels 1 and 2).
+  sensordata_max_out: wp.array2d[float],
 ):
   worldid, taxelid = wp.tid()
 
@@ -2303,7 +2308,7 @@ def _sensor_tactile(
       forceT[2] = wp.abs(wp.dot(vel_rel, tang2))
 
     dim = sensor_dim[sensor_id] // 3
-    wp.atomic_max(sensordata_out, worldid, sensor_adr[sensor_id] + 0 * dim + vertid, forceT[0])
+    wp.atomic_max(sensordata_max_out, worldid, sensor_adr[sensor_id] + 0 * dim + vertid, forceT[0])
     wp.atomic_add(sensordata_out, worldid, sensor_adr[sensor_id] + 1 * dim + vertid, forceT[1])
     wp.atomic_add(sensordata_out, worldid, sensor_adr[sensor_id] + 2 * dim + vertid, forceT[2])
 
@@ -2593,6 +2598,7 @@ def sensor_acc(m: Model, d: Data):
       weld_geom_list,
     ],
     outputs=[
+      d.sensordata,
       d.sensordata,
     ],
   )


### PR DESCRIPTION
Fixes the codegen rejection reported in #1590.

Warp's deterministic mode allows one reduction family per target array, so
`_sensor_tactile` is rejected: it writes the normal channel with `atomic_max` and
the two shear channels with `atomic_add`, all into `sensordata_out`. Since the
kernel is built with the rest of the module, this blocks
`wp.config.deterministic` for every model, including ones with no tactile sensor
(reproduced with `nsensortaxel == 0`).

The three writes land on disjoint indices — channel `k` at `adr + k*dim + vertid`
with `vertid < dim` — so binding the max channel as its own parameter and passing
the same buffer at the launch gives Warp one reduction family per target. Memory
layout, downstream consumers and physics are unchanged: no extra allocation, no
kernel split, no second pass over the contacts.

The documented alternatives (a separate array merged by a follow-up kernel, or a
split into a max kernel and an add kernel over a shared `wp.func`) also work, at
the cost of an allocation or a second contact pass. Happy to switch if aliasing
one buffer under two parameters is not the shape you want.

## Verification

warp-lang 1.16.0, mujoco-warp 3.11.0, mujoco 3.11.0, CUDA 12.9, RTX 4090.
RL training loop (mjlab, rl_games PPO, 32 envs, seed 42, cold kernel cache),
comparing episodic reward point by point across two runs of the same seed:

| | first differing epoch | points identical |
|---|---|---|
| deterministic mode off | 1 | 0/12 |
| deterministic mode on, sensor module dropped to `NOT_GUARANTEED` | 5 | 4/8 |
| deterministic mode on, this patch | none | 10/10 |

Without the patch the same configuration does not compile at all.

Note when testing: this only reproduces on a cold kernel cache. With a warm cache,
modules compiled before the option was set are reused, so a run can appear to
succeed while silently not being deterministic.
