### PR TITLE
Size the box-box edge-axis tie-break to float32 rounding

### DIFF
--- a/mujoco_warp/_src/collision_primitive_core.py
+++ b/mujoco_warp/_src/collision_primitive_core.py
@@ -638,6 +638,15 @@ def box_box(
   separation = wp.float32(margin + s_sum_3[0] + s_sum_3[1] + s_sum_3[2])
   axis_code = wp.int32(-1)
 
+  # An edge axis has to beat the best face axis by more than the rounding error of the
+  # separations themselves. Those are sums of box extents times rotation entries, so their
+  # float32 error is absolute and proportional to the extents, while the separation of a
+  # resting contact is near zero -- a relative margin cannot express that. It matters
+  # because when both boxes are level four of the nine edge-cross axes ARE the face normal,
+  # so they tie with it to the last bit and rounding alone would otherwise hand a face-face
+  # contact to the edge-edge branch, which then reports a point outside the boxes.
+  edge_slack = wp.float32(1.0e-6) * (box1_size[0] + box1_size[1] + box1_size[2] + box2_size[0] + box2_size[1] + box2_size[2])
+
   # First test: consider boxes' face normals
   for i in range(3):
     c1 = -wp.abs(pos21[i]) + box1_size[i] + plen2[i]
@@ -693,7 +702,7 @@ def box_box(
         return contact_dist, contact_pos, contact_normals
 
       # Track minimum separation and which edge-edge pair it occurs on
-      if c3 < separation * (1.0 - 1e-12):
+      if c3 < separation - edge_slack:
         separation = c3
         # Determine which corners/edges are closest
         cle1 = 0

--- a/mujoco_warp/_src/collision_primitive_core_test.py
+++ b/mujoco_warp/_src/collision_primitive_core_test.py
@@ -19,6 +19,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 from mujoco_warp._src import collision_primitive_core
+from mujoco_warp._src.collision_primitive_core import box_box
 from mujoco_warp._src.collision_primitive_core import sphere_triangle
 
 
@@ -529,6 +530,70 @@ class CylinderTriangleTest(parameterized.TestCase):
     )
 
     self.assertLess(dist[0], collision_primitive_core.MJ_MAXVAL)
+
+
+@wp.kernel
+def box_box_kernel(
+  # In:
+  box1_pos: wp.vec3,
+  box1_rot: wp.mat33,
+  box1_size: wp.vec3,
+  box2_pos: wp.vec3,
+  box2_rot: wp.mat33,
+  box2_size: wp.vec3,
+  margin: float,
+  # Out:
+  dist_out: wp.array[float],
+):
+  dist, pos, normal = box_box(box1_pos, box1_rot, box1_size, box2_pos, box2_rot, box2_size, margin)
+  for i in range(8):
+    dist_out[i] = dist[i]
+
+
+class BoxBoxTest(parameterized.TestCase):
+  """Tests for box_box collision."""
+
+  def test_level_boxes_pick_a_face_axis(self):
+    """A level bar resting on a level table must not take the edge-edge branch.
+
+    When both boxes are level, four of the nine edge-cross separating axes are exactly the
+    face normal, so their separations tie with the best face axis to the last float32 bit.
+    If an edge axis wins the tie, edge-edge geometry runs on what is a face-face contact and
+    reports a contact orders of magnitude deeper than the boxes overlap. The poses below are
+    what kinematics produces for a bar overlapping a table by 1e-4 m at one such yaw.
+    """
+    overlap = 1.0e-4
+    dist = wp.zeros(8, dtype=float)
+
+    wp.launch(
+      box_box_kernel,
+      dim=1,
+      inputs=[
+        wp.vec3(0.1917702853679657, 0.1877419650554657, 0.414900004863739),
+        wp.mat33(
+          0.6132574081420898,
+          -0.7898833751678467,
+          0.0,
+          0.7898833751678467,
+          0.6132574081420898,
+          0.0,
+          0.0,
+          0.0,
+          1.000000238418579,
+        ),
+        wp.vec3(0.06, 0.003, 0.015),
+        wp.vec3(0.3499999940395355, 0.0, 0.20000000298023224),
+        wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        wp.vec3(0.6, 0.4, 0.2),
+        0.0,
+      ],
+      outputs=[dist],
+    )
+
+    dist = dist.numpy()
+    populated = dist[dist < collision_primitive_core.MJ_MAXVAL]
+    self.assertGreater(populated.size, 0)
+    np.testing.assert_allclose(populated, -overlap, atol=1e-6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix box_box ghost contacts on level resting surfaces under FP32

When two boxes rest flat against each other, four of the nine edge-cross  separating axes are parallel to the face normal, creating an exact tie in separation depth. In FP32, the legacy relative margin `1.0 - 1e-12` rounds to 1.0, allowing FP32 cancellation noise in cross-product evaluation to  erroneously pick an edge axis over the face axis. The subsequent edge-edge routine degenerates on face contacts and generates phantom contact points hundreds of millimeters deep.

This patch introduces an absolute `edge_slack` proportional to the sum of the box half-extents (`1e-6 * sum(sizes)`), ensuring face axes are stably preferred on near-ties regardless of near-zero resting separation. Adds a regression test covering the degenerate resting pose.

Simply increasing the relative margin does not work: the separations are sums of box extents times rotation entries, so their FP32 error is absolute (~5e-8 m for supports of order 0.4 m) against a resting separation of ~1e-4 m — a relative error near 5e-4. Both 1e-6 and 1e-4 leave every failing pose failing.


(Note: Mujoco's C has since rewritten this collider on main using Sutherland-Hodgman face clipping and precision-aware constants split on mjUSESINGLE. Porting that is likely the better long-term direction)