### PR TITLE
Move create_render_context to render_util module

### DIFF
--- a/mujoco_warp/__init__.py
+++ b/mujoco_warp/__init__.py
@@ -54,7 +54,6 @@ from mujoco_warp._src.history import init_sensor_history as init_sensor_history
 from mujoco_warp._src.history import read_ctrl as read_ctrl
 from mujoco_warp._src.history import read_sensor as read_sensor
 from mujoco_warp._src.inverse import inverse as inverse
-from mujoco_warp._src.io import create_render_context as create_render_context
 from mujoco_warp._src.io import get_data_into as get_data_into
 from mujoco_warp._src.io import make_data as make_data
 from mujoco_warp._src.io import put_data as put_data
@@ -71,6 +70,7 @@ from mujoco_warp._src.passive import passive as passive
 from mujoco_warp._src.ray import ray as ray
 from mujoco_warp._src.ray import rays as rays
 from mujoco_warp._src.render import render as render
+from mujoco_warp._src.render_util import create_render_context as create_render_context
 from mujoco_warp._src.render_util import get_depth as get_depth
 from mujoco_warp._src.render_util import get_rgb as get_rgb
 from mujoco_warp._src.render_util import get_segmentation as get_segmentation

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -21,9 +21,7 @@ import mujoco
 import numpy as np
 import warp as wp
 
-from mujoco_warp._src import bvh
 from mujoco_warp._src import math as mjmath
-from mujoco_warp._src import render_util
 from mujoco_warp._src import sleep
 from mujoco_warp._src import smooth
 from mujoco_warp._src import support
@@ -36,31 +34,6 @@ from mujoco_warp._src.types import TrnType
 from mujoco_warp._src.types import vec10
 
 wp.set_module_options({"default_grid_stride": False})
-
-
-def _is_array_spec(typ) -> bool:
-  """Check if a type annotation is an array spec (wp.array instance or bracket annotation)."""
-  return isinstance(typ, wp.array) or type(typ).__name__ == "_ArrayAnnotation"
-
-
-def _mark_batched(obj):
-  """Recursively set _is_batched = True on all batched warp arrays within obj."""
-  if not dataclasses.is_dataclass(obj):
-    return
-  for f in dataclasses.fields(obj):
-    val = getattr(obj, f.name, None)
-    if val is None:
-      continue
-    if dataclasses.is_dataclass(val):
-      _mark_batched(val)
-      continue
-    if not isinstance(val, wp.array):
-      continue
-    if not _is_array_spec(f.type):
-      continue
-    spec_shape = getattr(f.type, "shape", ())
-    if spec_shape and spec_shape[0] in ("*", "nworld"):
-      val._is_batched = True
 
 
 def _create_array(data: Any, spec, sizes: dict[str, int], batch_size: int = 1) -> wp.array | None:
@@ -300,7 +273,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   warp_util.check_toolkit_driver()
 
   batch_sizes = batch_sizes or {}
-  model_fields = {f.name: f.type for f in dataclasses.fields(types.Model) if _is_array_spec(f.type)}
+  model_fields = {f.name: f.type for f in dataclasses.fields(types.Model) if warp_util.is_array_spec(f.type)}
   for name, size in batch_sizes.items():
     field_type = model_fields.get(name)
     spec_shape = getattr(field_type, "shape", ())
@@ -442,7 +415,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
 
   # place opt on device
   for f in dataclasses.fields(types.Option):
-    if _is_array_spec(f.type):
+    if warp_util.is_array_spec(f.type):
       setattr(opt, f.name, _create_array(getattr(opt, f.name), f.type, {"*": 1}))
     else:
       setattr(opt, f.name, f.type(getattr(opt, f.name)))
@@ -1285,11 +1258,11 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
     }
   )
   for f in dataclasses.fields(types.Model):
-    if _is_array_spec(f.type):
+    if warp_util.is_array_spec(f.type):
       batch_size = batch_sizes.get(f.name, 1)
       setattr(m, f.name, _create_array(getattr(m, f.name), f.type, sizes, batch_size))
 
-  _mark_batched(m)
+  warp_util.mark_batched(m)
   return m
 
 
@@ -1911,7 +1884,7 @@ def make_data(
   d.dof_cdof.fill_(-1)
   d.cdof_dof.fill_(-1)
 
-  _mark_batched(d)
+  warp_util.mark_batched(d)
   return d
 
 
@@ -2205,7 +2178,7 @@ def put_data(
 
   d.nacon = wp.array([mjd.ncon * nworld], dtype=int)
 
-  _mark_batched(d)
+  warp_util.mark_batched(d)
   return d
 
 
@@ -4081,463 +4054,3 @@ def load_trajectory(npz_path: str, mjm: mujoco.MjModel, mjd: mujoco.MjData) -> n
   sample_times = times[0] + (np.arange(n_steps) + 1e-7) * mjm.opt.timestep
   ctrl_indices = np.searchsorted(times, sample_times, side="right") - 1
   return ctrl[ctrl_indices]
-
-
-@wp.kernel
-def _build_rays(
-  # In:
-  offset: int,
-  img_w: int,
-  img_h: int,
-  projection: int,
-  fovy: float,
-  sensorsize: wp.vec2,
-  intrinsic: wp.vec4,
-  znear: float,
-  # Out:
-  ray_out: wp.array[wp.vec3],
-):
-  xid, yid = wp.tid()
-  ray_out[offset + xid + yid * img_w] = render_util.compute_ray(
-    projection, fovy, sensorsize, intrinsic, img_w, img_h, xid, yid, znear
-  )
-
-
-def create_render_context(
-  mjm: mujoco.MjModel,
-  nworld: int = 1,
-  cam_res: list[tuple[int, int]] | tuple[int, int] | None = None,
-  render_rgb: list[bool] | bool | None = None,
-  render_depth: list[bool] | bool | None = None,
-  render_seg: list[bool] | bool | None = None,
-  use_textures: bool = True,
-  use_fast_math: bool = True,
-  use_shadows: bool = False,
-  use_ambient_lighting: bool = True,
-  enabled_geom_groups: list[int] = [0, 1, 2],
-  cam_active: list[bool] | list[str] | list[int] | None = None,
-  background_color: tuple[float, float, float, float] = (0.1, 0.1, 0.2, 1.0),
-  flex_render_smooth: bool = True,
-  use_precomputed_rays: bool = True,
-  render_skybox: bool = False,
-  enable_backface_culling: bool = True,
-  enable_specular: bool = True,
-  enable_emission: bool = True,
-  enable_per_light_ambient: bool = True,
-  splat_position: np.ndarray | None = None,
-  splat_rotation: np.ndarray | None = None,
-  splat_scale: np.ndarray | None = None,
-  splat_rgba: np.ndarray | None = None,
-  splat_adr: np.ndarray | None = None,
-  splat_group_id: np.ndarray | None = None,
-) -> types.RenderContext:
-  """Creates a render context on device.
-
-  Args:
-    mjm: The model containing kinematic and dynamic information on host.
-    nworld: The number of worlds.
-    cam_res: The width and height to render each camera image. If None, uses the
-             MuJoCo model values.
-    render_rgb: Whether to render RGB images. If None, uses the MuJoCo model values.
-    render_depth: Whether to render depth images. If None, uses the MuJoCo model values.
-    render_seg: Whether to render segmentation (per-pixel object ID/type pairs).
-      If None, uses the MuJoCo model values.
-    use_textures: Whether to use textures.
-    use_fast_math: Whether to enable fast math for the render kernel.
-    use_shadows: Whether to use shadows.
-    use_ambient_lighting: Top-level ambient switch. When False, skips all
-                          ambient contributions, including headlight ambient,
-                          the no-light fallback, and per-light ambient.
-    enabled_geom_groups: The geom groups to render.
-    cam_active: List of booleans, camera names (str), or camera indices (int) indicating
-                which cameras to include in rendering. If None, all cameras are included.
-    flex_render_smooth: Whether to render flex meshes smoothly.
-    use_precomputed_rays: Use precomputed rays instead of computing during rendering.
-                          When using domain randomization for camera intrinsics, set to False.
-    render_skybox: Whether to shade missed rays with the MuJoCo skybox texture.
-                   Requires the model to contain a texture with type `mjTEXTURE_SKYBOX`.
-    enable_backface_culling: Drop primitive-ray hits whose normal faces away from
-                             the ray (ray origin inside the geom). Matches MuJoCo's
-                             mesh-ray rule. Default True. Disable for a small
-                             performance gain when no camera is ever inside a geom.
-    background_color: The color to use for background pixels when no skybox is rendered.
-    enable_specular: Evaluate specular highlights per light. When False the
-                     half-vector normalize and shininess `pow` are dropped at
-                     compile time. Disable for performance when no specular is present.
-    enable_emission: Add `mat_emission * base_color` per shaded pixel. When
-                     False the term is dropped at compile time. Disable for performance
-                     when no emission is present.
-    enable_per_light_ambient: When ambient lighting is enabled, sum each
-                              light's `ambient` color into shaded pixels
-                              even outside its cone or in shadow. When False
-                              the per-light ambient pass is removed at compile
-                              time. Disable for performance when model lights
-                              do not use ambient colors.
-    splat_position: Splat centers in world coordinates (nsplat, 3).
-    splat_rotation: Splat rotations as (w, x, y, z) (nsplat, 4).
-    splat_scale: Splat scales as standard deviation in each dimension (nsplat, 3).
-    splat_rgba: Splat color and opacity (nsplat, 4).
-    splat_adr: Offset of each splat in the splat attribute arrays,
-               if None then all splats are in one group.
-    splat_group_id: Splat id for each world (nworld,). If None then all worlds
-                    use the first splat group.
-
-  Returns:
-    The render context containing rendering fields and output arrays on device.
-  """
-  mjd = mujoco.MjData(mjm)
-  mujoco.mj_forward(mjm, mjd)
-
-  constructor = "cubql"
-
-  # Build grouped splat BVH.
-  splat_attribute = (splat_position, splat_rotation, splat_scale, splat_rgba)
-  if splat_position is None:
-    if any(value is not None for value in (*splat_attribute[1:], splat_adr, splat_group_id)):
-      raise ValueError("splat attributes, offsets, and group IDs must be supplied together")
-
-    splat_position = wp.empty(0, dtype=wp.vec3)
-    splat_rotation = wp.empty(0, dtype=wp.quat)
-    splat_scale = wp.empty(0, dtype=wp.vec3)
-    splat_rgba = wp.empty(0, dtype=wp.vec4)
-    splat_bvh = None
-    splat_bvh_id = wp.uint64(0)
-    splat_lower = wp.empty(0, dtype=wp.vec3)
-    splat_upper = wp.empty(0, dtype=wp.vec3)
-    splat_group_root = wp.empty(nworld, dtype=int)
-    splat_count = 0
-  else:
-    nsplat = splat_position.shape[0]
-    if (
-      splat_position.shape != (nsplat, 3)
-      or splat_rotation.shape != (nsplat, 4)
-      or splat_scale.shape != (nsplat, 3)
-      or splat_rgba.shape != (nsplat, 4)
-    ):
-      raise ValueError("splat attributes must have shapes (nsplat, 3), (nsplat, 4), (nsplat, 3), and (nsplat, 4)")
-    if splat_adr is not None and splat_adr.ndim != 1:
-      raise ValueError("splat_adr must be one-dimensional")
-    if splat_group_id is not None and splat_group_id.shape != (nworld,):
-      raise ValueError("splat_group_id must be of shape (nworld,)")
-
-    if splat_adr is None:
-      splat_adr = np.array([0, splat_position.shape[0]], dtype=np.int32)
-    if splat_group_id is None:
-      splat_group_id = np.zeros(nworld, dtype=np.int32)
-    (
-      splat_position,
-      splat_rotation,
-      splat_scale,
-      splat_rgba,
-      splat_bvh,
-      splat_bvh_id,
-      splat_lower,
-      splat_upper,
-      splat_group_root,
-      splat_count,
-    ) = bvh.build_splat_bvh(*splat_attribute, splat_adr, splat_group_id, constructor="sah")
-
-  # Mesh BVHs – build for all meshes so per-world variants are available
-  nmesh = mjm.nmesh
-  geom_enabled_mask = np.isin(mjm.geom_group, list(enabled_geom_groups))
-  geom_enabled_idx = np.nonzero(geom_enabled_mask)[0]
-
-  mesh_registry = {}
-  mesh_bvh_id = [wp.uint64(0) for _ in range(nmesh)]
-  mesh_bounds_size = [wp.vec3(0.0, 0.0, 0.0) for _ in range(nmesh)]
-
-  for mid in range(nmesh):
-    mesh, half = bvh.build_mesh_bvh(mjm, mid, constructor=constructor)
-    mesh_registry[mesh.id] = mesh
-    mesh_bvh_id[mid] = mesh.id
-    mesh_bounds_size[mid] = half
-
-  mesh_bvh_id_arr = wp.array(mesh_bvh_id, dtype=wp.uint64)
-  mesh_bounds_size_arr = wp.array(mesh_bounds_size, dtype=wp.vec3)
-
-  # HField BVHs
-  nhfield = mjm.nhfield
-  hfield_geom_mask = geom_enabled_mask & (mjm.geom_type == types.GeomType.HFIELD) & (mjm.geom_dataid >= 0)
-  used_hfield_id = set(mjm.geom_dataid[hfield_geom_mask].astype(int))
-  hfield_registry = {}
-  hfield_bvh_id = [wp.uint64(0) for _ in range(nhfield)]
-  hfield_bounds_size = [wp.vec3(0.0, 0.0, 0.0) for _ in range(nhfield)]
-
-  for hid in used_hfield_id:
-    hmesh, hhalf = bvh.build_hfield_bvh(mjm, hid, constructor=constructor)
-    hfield_registry[hmesh.id] = hmesh
-    hfield_bvh_id[hid] = hmesh.id
-    hfield_bounds_size[hid] = hhalf
-
-  hfield_bvh_id_arr = wp.array(hfield_bvh_id, dtype=wp.uint64)
-  hfield_bounds_size_arr = wp.array(hfield_bounds_size, dtype=wp.vec3)
-
-  # Flex BVHs
-  nflex = mjm.nflex
-  flex_registry = {}
-
-  # Scene BVH flex primitives: 1D → one capsule per edge, 2D/3D → one box per flex
-  flex_geom_flexid = []
-  flex_geom_edgeid = []
-  flex_bvh_id = np.full(nflex, 0, dtype=np.uint64)
-  # Indexed later as [worldid, flexid].
-  flex_group_root = np.full((nworld, nflex), -1, dtype=int)
-
-  for f in range(nflex):
-    if mjm.flex_dim[f] == 1:
-      edge_adr = mjm.flex_edgeadr[f]
-      flex_geom_flexid.extend([f] * mjm.flex_edgenum[f])
-      flex_geom_edgeid.extend([edge_adr + e for e in range(mjm.flex_edgenum[f])])
-    else:
-      flex_geom_flexid.append(f)
-      flex_geom_edgeid.append(-1)
-      fmesh, group_root = bvh.build_flex_bvh(mjm, mjd, nworld, f)
-      flex_registry[f] = fmesh
-      flex_bvh_id[f] = fmesh.id
-      flex_group_root[:, f] = group_root.numpy()
-
-  textures_registry = []
-  for i in range(mjm.ntex):
-    textures_registry.append(render_util.create_warp_texture(mjm, i))
-  textures = wp.array(textures_registry, dtype=wp.Texture2D)
-
-  # Locate skybox texture
-  skybox_tex_ids = np.nonzero(mjm.tex_type == mujoco.mjtTexture.mjTEXTURE_SKYBOX)[0] if mjm.ntex else np.array([], dtype=int)
-  if render_skybox and skybox_tex_ids.size > 0:
-    skybox_tex_id_np = np.array([skybox_tex_ids[0]], dtype=int)
-    skybox_face_width_np = np.array([mjm.tex_width[skybox_tex_ids[0]]], dtype=int)
-  else:
-    render_skybox = False
-    skybox_tex_id_np = np.array([-1], dtype=int)
-    skybox_face_width_np = np.array([1], dtype=int)
-
-  # Filter active cameras
-  if cam_active is not None:
-    if len(cam_active) > 0 and isinstance(cam_active[0], (bool, np.bool_)):
-      assert len(cam_active) == mjm.ncam, f"cam_active must have length {mjm.ncam} (got {len(cam_active)})"
-      active_cam_indices = [int(i) for i in np.nonzero(cam_active)[0]]
-    elif len(cam_active) > 0 and isinstance(cam_active[0], str):
-      active_cam_indices = []
-      for name in cam_active:
-        cid = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_CAMERA, name)
-        if cid == -1:
-          raise ValueError(f"Camera '{name}' not found in model.")
-        active_cam_indices.append(cid)
-    elif len(cam_active) > 0 and isinstance(cam_active[0], (int, np.integer)):
-      active_cam_indices = [int(x) for x in cam_active]
-    else:
-      raise ValueError(f"Invalid cam_active format: {cam_active}")
-  else:
-    active_cam_indices = list(range(mjm.ncam))
-
-  ncam = len(active_cam_indices)
-
-  if cam_res is not None:
-    if isinstance(cam_res, tuple):
-      cam_res = [cam_res] * ncam
-    elif isinstance(cam_res, list) and len(cam_res) == 1 and ncam > 1:
-      cam_res = cam_res * ncam
-    if len(cam_res) != ncam:
-      raise ValueError(f"Camera resolutions count ({len(cam_res)}) does not match active camera count ({ncam}).")
-    active_cam_res = cam_res
-  else:
-    active_cam_res = mjm.cam_resolution[active_cam_indices]
-
-  cam_res_arr = wp.array(active_cam_res, dtype=wp.vec2i)
-
-  if render_rgb is None:
-    render_rgb = [bool(np.any(mjm.cam_output[i] & mujoco.mjtCamOutBit.mjCAMOUT_RGB)) for i in active_cam_indices]
-  elif isinstance(render_rgb, bool):
-    render_rgb = [render_rgb] * ncam
-  elif isinstance(render_rgb, (list, np.ndarray)):
-    if len(render_rgb) == mjm.ncam and ncam != mjm.ncam:
-      render_rgb = [bool(render_rgb[i]) for i in active_cam_indices]
-    elif len(render_rgb) == 1 and ncam > 1:
-      render_rgb = [bool(render_rgb[0])] * ncam
-    else:
-      render_rgb = [bool(x) for x in render_rgb]
-
-  if render_depth is None:
-    render_depth = [bool(np.any(mjm.cam_output[i] & mujoco.mjtCamOutBit.mjCAMOUT_DEPTH)) for i in active_cam_indices]
-  elif isinstance(render_depth, bool):
-    render_depth = [render_depth] * ncam
-  elif isinstance(render_depth, (list, np.ndarray)):
-    if len(render_depth) == mjm.ncam and ncam != mjm.ncam:
-      render_depth = [bool(render_depth[i]) for i in active_cam_indices]
-    elif len(render_depth) == 1 and ncam > 1:
-      render_depth = [bool(render_depth[0])] * ncam
-    else:
-      render_depth = [bool(x) for x in render_depth]
-
-  if render_seg is None:
-    render_seg = [bool(np.any(mjm.cam_output[i] & mujoco.mjtCamOutBit.mjCAMOUT_SEG)) for i in active_cam_indices]
-  elif isinstance(render_seg, bool):
-    render_seg = [render_seg] * ncam
-  elif isinstance(render_seg, (list, np.ndarray)):
-    if len(render_seg) == mjm.ncam and ncam != mjm.ncam:
-      render_seg = [bool(render_seg[i]) for i in active_cam_indices]
-    elif len(render_seg) == 1 and ncam > 1:
-      render_seg = [bool(render_seg[0])] * ncam
-    else:
-      render_seg = [bool(x) for x in render_seg]
-
-  if len(render_rgb) != ncam:
-    raise ValueError(f"render_rgb length ({len(render_rgb)}) does not match active camera count ({ncam}).")
-  if len(render_depth) != ncam:
-    raise ValueError(f"render_depth length ({len(render_depth)}) does not match active camera count ({ncam}).")
-  if len(render_seg) != ncam:
-    raise ValueError(f"render_seg length ({len(render_seg)}) does not match active camera count ({ncam}).")
-
-  rgb_adr = -1 * np.ones(ncam, dtype=int)
-  depth_adr = -1 * np.ones(ncam, dtype=int)
-  seg_adr = -1 * np.ones(ncam, dtype=int)
-  cam_res_np = cam_res_arr.numpy()
-  ri = 0
-  di = 0
-  si = 0
-  total = 0
-
-  for idx in range(ncam):
-    if render_rgb[idx]:
-      rgb_adr[idx] = ri
-      ri += cam_res_np[idx][0] * cam_res_np[idx][1]
-    if render_depth[idx]:
-      depth_adr[idx] = di
-      di += cam_res_np[idx][0] * cam_res_np[idx][1]
-    if render_seg[idx]:
-      seg_adr[idx] = si
-      si += cam_res_np[idx][0] * cam_res_np[idx][1]
-
-    total += cam_res_np[idx][0] * cam_res_np[idx][1]
-
-  znear = float(mjm.vis.map.znear * mjm.stat.extent)
-
-  ray = wp.zeros(int(total), dtype=wp.vec3)
-
-  cam_projection = mjm.cam_projection
-
-  offset = 0
-  for idx, cam_id_val in enumerate(active_cam_indices):
-    cam_id = int(cam_id_val)
-    img_w = int(cam_res_np[idx][0])
-    img_h = int(cam_res_np[idx][1])
-    wp.launch(
-      kernel=_build_rays,
-      dim=(img_w, img_h),
-      inputs=[
-        offset,
-        img_w,
-        img_h,
-        int(mjm.cam_projection[cam_id]),
-        float(mjm.cam_fovy[cam_id]),
-        wp.vec2(float(mjm.cam_sensorsize[cam_id, 0]), float(mjm.cam_sensorsize[cam_id, 1])),
-        wp.vec4(
-          float(mjm.cam_intrinsic[cam_id, 0]),
-          float(mjm.cam_intrinsic[cam_id, 1]),
-          float(mjm.cam_intrinsic[cam_id, 2]),
-          float(mjm.cam_intrinsic[cam_id, 3]),
-        ),
-        znear,
-      ],
-      outputs=[ray],
-    )
-    offset += img_w * img_h
-
-  bvh_ngeom = len(geom_enabled_idx)
-
-  # Geom types present among enabled geoms, plus FLEX when flex primitives exist.
-  # Used to statically eliminate unused intersection branches in the ray-cast kernels.
-  geom_ray_types = set(int(t) for t in mjm.geom_type[geom_enabled_idx])
-  if len(flex_geom_flexid) > 0:
-    geom_ray_types.add(int(types.GeomType.FLEX))
-  geom_ray_types = tuple(sorted(geom_ray_types))
-  if mjm.nlight == 0:
-    light_attenuation_is_default = True
-    has_spot_lights = False
-  else:
-    atten = np.asarray(mjm.light_attenuation, dtype=np.float32).reshape(-1, 3)
-    light_attenuation_is_default = bool(np.allclose(atten, np.array([1.0, 0.0, 0.0], dtype=np.float32)))
-    has_spot_lights = bool((np.asarray(mjm.light_type) == int(mujoco.mjtLightType.mjLIGHT_SPOT)).any())
-
-  rc = types.RenderContext(
-    nrender=ncam,
-    cam_res=cam_res_arr,
-    cam_id_map=wp.array(active_cam_indices, dtype=int),
-    use_textures=use_textures,
-    use_fast_math=use_fast_math,
-    use_shadows=use_shadows,
-    use_ambient_lighting=use_ambient_lighting,
-    background_color=render_util.pack_rgba_to_uint32(
-      background_color[0] * 255.0, background_color[1] * 255.0, background_color[2] * 255.0, background_color[3] * 255.0
-    ),
-    use_precomputed_rays=use_precomputed_rays,
-    render_skybox=render_skybox,
-    skybox_tex_id=wp.array(skybox_tex_id_np, dtype=int),
-    skybox_face_width=wp.array(skybox_face_width_np, dtype=int),
-    headlight_active=bool(mjm.vis.headlight.active),
-    headlight_ambient=wp.vec3(mjm.vis.headlight.ambient),
-    headlight_diffuse=wp.vec3(mjm.vis.headlight.diffuse),
-    headlight_specular=wp.vec3(mjm.vis.headlight.specular),
-    bvh_ngeom=bvh_ngeom,
-    enabled_geom_ids=wp.array(geom_enabled_idx, dtype=int),
-    mesh_registry=mesh_registry,
-    mesh_bvh_id=mesh_bvh_id_arr,
-    mesh_bounds_size=mesh_bounds_size_arr,
-    mesh_texcoord=wp.array(mjm.mesh_texcoord, dtype=wp.vec2),
-    mesh_texcoord_offsets=wp.array(mjm.mesh_texcoordadr, dtype=int),
-    mesh_facetexcoord=wp.array(mjm.mesh_facetexcoord, dtype=wp.vec3i),
-    textures=textures,
-    textures_registry=textures_registry,
-    hfield_registry=hfield_registry,
-    hfield_bvh_id=hfield_bvh_id_arr,
-    hfield_bounds_size=hfield_bounds_size_arr,
-    flex_mesh_registry=flex_registry,
-    flex_rgba=wp.array(mjm.flex_rgba, dtype=wp.vec4),
-    flex_bvh_id=wp.array(flex_bvh_id, dtype=wp.uint64),
-    flex_group_root=wp.array(flex_group_root, dtype=int),
-    flex_render_smooth=flex_render_smooth,
-    bvh_nflexgeom=len(flex_geom_flexid),
-    flex_dim_np=mjm.flex_dim,
-    flex_geom_flexid=wp.array(flex_geom_flexid, dtype=int),
-    flex_geom_edgeid=wp.array(flex_geom_edgeid, dtype=int),
-    bvh=None,
-    bvh_id=None,
-    lower=wp.zeros(nworld * (bvh_ngeom + len(flex_geom_flexid)), dtype=wp.vec3),
-    upper=wp.zeros(nworld * (bvh_ngeom + len(flex_geom_flexid)), dtype=wp.vec3),
-    group=wp.zeros(nworld * (bvh_ngeom + len(flex_geom_flexid)), dtype=int),
-    group_root=wp.zeros(nworld, dtype=int),
-    ray=ray,
-    rgb_data=wp.zeros((nworld, ri), dtype=wp.uint32),
-    rgb_adr=wp.array(rgb_adr, dtype=int),
-    depth_data=wp.zeros((nworld, di), dtype=wp.float32),
-    depth_adr=wp.array(depth_adr, dtype=int),
-    render_rgb=wp.array(render_rgb, dtype=bool),
-    render_depth=wp.array(render_depth, dtype=bool),
-    seg_data=wp.zeros((nworld, max(si, 1)), dtype=wp.vec2i),
-    seg_adr=wp.array(seg_adr, dtype=int),
-    render_seg=wp.array(render_seg, dtype=bool),
-    znear=znear,
-    total_rays=int(total),
-    enable_backface_culling=enable_backface_culling,
-    geom_ray_types=geom_ray_types,
-    enable_specular=enable_specular,
-    enable_emission=enable_emission,
-    enable_per_light_ambient=enable_per_light_ambient,
-    light_attenuation_is_default=light_attenuation_is_default,
-    has_spot_lights=has_spot_lights,
-    splat_position=splat_position,
-    splat_rotation=splat_rotation,
-    splat_scale=splat_scale,
-    splat_rgba=splat_rgba,
-    splat_bvh=splat_bvh,
-    splat_bvh_id=splat_bvh_id,
-    splat_lower=splat_lower,
-    splat_upper=splat_upper,
-    splat_group_root=splat_group_root,
-    splat_count=splat_count,
-  )
-
-  bvh.build_scene_bvh(mjm, mjd, rc, nworld)
-
-  _mark_batched(rc)
-  return rc

--- a/mujoco_warp/_src/io_jax_test.py
+++ b/mujoco_warp/_src/io_jax_test.py
@@ -30,8 +30,8 @@ from absl.testing import parameterized
 
 import mujoco_warp as mjw
 from mujoco_warp import test_data
-from mujoco_warp._src.io import _is_array_spec
 from mujoco_warp._src.types import Callback
+from mujoco_warp._src.warp_util import is_array_spec
 
 _IO_TEST_MODELS = (
   "pendula.xml",
@@ -52,7 +52,7 @@ def _dims_match(test_obj, d1: Any, d2: Any, prefix: str = ""):
       _dims_match(test_obj, a1, a2, prefix + f1.name + ".")
       continue
 
-    if _is_array_spec(f1.type) or _is_array_spec(f2.type):
+    if is_array_spec(f1.type) or is_array_spec(f2.type):
       s1, s2 = a1.shape, a2.shape
       test_obj.assertEqual(len(s1), len(s2), f"{full_name} dims mismatch. Got {s1} and {s2}.")
       test_obj.assertEqual(s1, s2, f"{full_name} dims mismatch. Got {s1} and {s2}.")
@@ -91,7 +91,7 @@ def _check_type_matches_annotation(test_obj, obj: Any, prefix: str = ""):
       test_obj.assertIsInstance(np_scalar_type(val), type_, msg.format(**locals()))
       continue
 
-    if _is_array_spec(type_):
+    if is_array_spec(type_):
       test_obj.assertIsInstance(val, wp.array, msg.format(**locals()))
       continue
 
@@ -113,7 +113,7 @@ def _check_type_matches_annotation(test_obj, obj: Any, prefix: str = ""):
           test_obj.assertIsInstance(np_scalar_type(val), type_, msg.format(**locals()))
           continue
 
-        if _is_array_spec(type_):
+        if is_array_spec(type_):
           test_obj.assertIsInstance(val, wp.array, msg.format(**locals()))
           continue
 
@@ -138,7 +138,7 @@ def _check_annotation_compat(
     if v in (int, bool, float):
       continue
 
-    if _is_array_spec(v):
+    if is_array_spec(v):
       continue
 
     if wp.types.type_is_composite(v):
@@ -187,7 +187,7 @@ def _leading_dims_scale_w_nworld(test_obj, d1: Any, d2: Any, nworld1: int, nworl
       _leading_dims_scale_w_nworld(test_obj, a1, a2, nworld1, nworld2, prefix + f1.name + ".")
       continue
 
-    if _is_array_spec(f1.type) or _is_array_spec(f2.type):
+    if is_array_spec(f1.type) or is_array_spec(f2.type):
       s1, s2 = a1.shape[0], a2.shape[0]
       if s1 == s2:
         continue

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -399,7 +399,7 @@ _IO_TEST_MODELS = (
   "hfield/hfield.xml",
 )
 
-# TODO: Add more cameras for testing projection and intrinsics
+
 _MESH_RANDOMIZE_XML = """
 <mujoco>
   <asset>

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -400,19 +400,6 @@ _IO_TEST_MODELS = (
 )
 
 # TODO: Add more cameras for testing projection and intrinsics
-_CAMERA_TEST_XML = """
-<mujoco>
-  <worldbody>
-    <light pos="0 0 3" dir="0 0 -1"/>
-    <camera name="cam1" pos="0 -3 2" xyaxes="1 0 0 0 0.6 0.8" resolution="64 64" output="rgb"/>
-    <camera name="cam2" pos="0 3 2" xyaxes="-1 0 0 0 0.6 0.8" resolution="32 32" output="depth"/>
-    <camera name="cam3" pos="3 0 2" xyaxes="0 1 0 -0.6 0 0.8" resolution="16 16" output="rgb depth"/>
-    <geom type="plane" size="5 5 0.1"/>
-    <geom type="sphere" size="0.5" pos="0 0 1"/>
-  </worldbody>
-</mujoco>
-"""
-
 _MESH_RANDOMIZE_XML = """
 <mujoco>
   <asset>
@@ -572,12 +559,12 @@ class IOTest(parameterized.TestCase):
     """Verify that all fields specified with 'nworld' or '*' are marked with _is_batched=True."""
     fixture_outputs = test_data.fixture("pendula.xml")
     if dataclass_type is types.RenderContext:
-      obj = io.create_render_context(fixture_outputs[0], nworld=1)
+      obj = mjwarp.create_render_context(fixture_outputs[0], nworld=1)
     else:
       obj = next(o for o in fixture_outputs if isinstance(o, dataclass_type))
 
     for f in dataclasses.fields(dataclass_type):
-      if not io._is_array_spec(f.type):
+      if not warp_util.is_array_spec(f.type):
         continue
       spec_shape = getattr(f.type, "shape", ())
       if not (spec_shape and spec_shape[0] in ("*", "nworld")):
@@ -2049,7 +2036,7 @@ class IOTest(parameterized.TestCase):
 
     # field has batched dimension and defaults to batch size 1
     for f in dataclasses.fields(types.Model):
-      if not io._is_array_spec(f.type):
+      if not warp_util.is_array_spec(f.type):
         continue
       spec_shape = getattr(f.type, "shape", ())
       if not spec_shape or spec_shape[0] != "*":
@@ -2682,178 +2669,6 @@ class IOTest(parameterized.TestCase):
     )
     cl_read = m.actuator_cranklength.numpy()
     np.testing.assert_allclose(cl_read[0, 0], 0.42, atol=1e-6)
-
-  @parameterized.parameters(1, 4)
-  def test_bvh_creation(self, nworld):
-    """Test that the BVH is created correctly for single world and multiple worlds."""
-    mjm, mjd, m, d = test_data.fixture("primitives.xml", nworld=nworld)
-    rc = mjwarp.create_render_context(mjm, nworld=nworld, cam_res=(64, 64), use_textures=False)
-
-    self.assertIsNotNone(rc)
-    self.assertEqual(rc.nrender, mjm.ncam)
-
-    self.assertEqual(rc.lower.shape, (nworld * rc.bvh_ngeom,), "lower")
-    self.assertEqual(rc.upper.shape, (nworld * rc.bvh_ngeom,), "upper")
-    self.assertEqual(rc.group.shape, (nworld * rc.bvh_ngeom,), "group")
-    self.assertEqual(rc.group_root.shape, (nworld,), "group_root")
-
-    self.assertIsNotNone(rc.bvh_id)
-    self.assertNotEqual(rc.bvh_id, 0, "bvh_id")
-
-    group_np = rc.group.numpy()
-    _assert_eq(group_np, np.repeat(np.arange(nworld), rc.bvh_ngeom), "render context group values")
-
-  def test_output_buffers(self):
-    """Test that the output rgb and depth buffers have correct shapes and addresses."""
-    mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
-    width, height = 32, 24
-    rc = mjwarp.create_render_context(mjm, cam_res=(width, height), render_rgb=True, render_depth=True)
-
-    expected_total = 3 * width * height
-
-    self.assertEqual(rc.nrender, 3, "nrender")
-    self.assertEqual(rc.rgb_data.shape, (1, expected_total), "rgb_data")
-    self.assertEqual(rc.depth_data.shape, (1, expected_total), "depth_data")
-
-    rgb_adr = rc.rgb_adr.numpy()
-    depth_adr = rc.depth_adr.numpy()
-    _assert_eq(rgb_adr, [0, width * height, 2 * width * height], "rgb_adr")
-    _assert_eq(depth_adr, [0, width * height, 2 * width * height], "depth_adr")
-
-  def test_heterogeneous_camera(self):
-    """Tests render context with different resolutions and output."""
-    mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
-    cam_res = [(64, 64), (32, 32), (16, 16)]
-    rc = mjwarp.create_render_context(mjm, cam_res=cam_res, render_rgb=True, render_depth=True)
-
-    self.assertEqual(rc.nrender, 3, "nrender")
-    _assert_eq(rc.cam_res.numpy(), cam_res, "cam_res")
-
-    expected_total = 64 * 64 + 32 * 32 + 16 * 16
-    self.assertEqual(rc.rgb_data.shape, (1, expected_total), "rgb_data")
-    self.assertEqual(rc.depth_data.shape, (1, expected_total), "depth_data")
-
-    rgb_adr = rc.rgb_adr.numpy()
-    depth_adr = rc.depth_adr.numpy()
-    _assert_eq(rgb_adr, [0, 64 * 64, 64 * 64 + 32 * 32], "rgb_adr")
-    _assert_eq(depth_adr, [0, 64 * 64, 64 * 64 + 32 * 32], "depth_adr")
-
-    # Test that results are same when reading from mjmodel fields loaded through xml
-    rc_xml = mjwarp.create_render_context(mjm, render_rgb=True, render_depth=True)
-    self.assertEqual(rc.rgb_data.shape, rc_xml.rgb_data.shape, "rgb_data")
-    self.assertEqual(rc.depth_data.shape, rc_xml.depth_data.shape, "depth_data")
-    _assert_eq(rc.rgb_adr.numpy(), rc_xml.rgb_adr.numpy(), "rgb_adr")
-    _assert_eq(rc.depth_adr.numpy(), rc_xml.depth_adr.numpy(), "depth_adr")
-
-  def test_cam_active_filtering(self):
-    mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
-    width, height = 32, 32
-
-    rc = mjwarp.create_render_context(mjm, cam_res=(width, height), cam_active=[True, False, True])
-
-    self.assertEqual(rc.nrender, 2, "nrender")
-
-    expected_total = 2 * width * height
-    self.assertEqual(rc.rgb_data.shape, (1, expected_total), "rgb_data")
-
-  def test_rgb_only_and_depth_only(self):
-    """Test that disabling rgb or depth correctly reduces the shape and invalidates the address."""
-    mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
-    width, height = 32, 32
-    pixels = width * height
-
-    rc = mjwarp.create_render_context(
-      mjm,
-      cam_res=(width, height),
-      render_rgb=[True, False, True],
-      render_depth=[False, True, True],
-    )
-
-    self.assertEqual(rc.rgb_data.shape, (1, 2 * pixels), "rgb_data")
-    self.assertEqual(rc.depth_data.shape, (1, 2 * pixels), "depth_data")
-    _assert_eq(rc.rgb_adr.numpy(), [0, -1, pixels], "rgb_adr")
-    _assert_eq(rc.depth_adr.numpy(), [-1, 0, pixels], "depth_adr")
-    _assert_eq(rc.render_rgb.numpy(), [True, False, True], "render_rgb")
-    _assert_eq(rc.render_depth.numpy(), [False, True, True], "render_depth")
-
-    # Test that results are same when reading from mjmodel fields loaded through xml
-    rc_xml = mjwarp.create_render_context(mjm, cam_res=(width, height))
-    self.assertEqual(rc.rgb_data.shape, rc_xml.rgb_data.shape, "rgb_data")
-    self.assertEqual(rc.depth_data.shape, rc_xml.depth_data.shape, "depth_data")
-    _assert_eq(rc.rgb_adr.numpy(), rc_xml.rgb_adr.numpy(), "rgb_adr")
-    _assert_eq(rc.depth_adr.numpy(), rc_xml.depth_adr.numpy(), "depth_adr")
-    _assert_eq(rc.render_rgb.numpy(), rc_xml.render_rgb.numpy(), "render_rgb")
-    _assert_eq(rc.render_depth.numpy(), rc_xml.render_depth.numpy(), "render_depth")
-
-  def test_segmentation_from_camera_output(self):
-    """Segmentation auto-detected from camera output attribute in XML."""
-    xml = """
-    <mujoco>
-      <worldbody>
-        <light pos="0 0 3" dir="0 0 -1"/>
-        <geom type="plane" size="10 10 0.1"/>
-        <geom type="sphere" size="0.2" pos="0 0 0.5" rgba="1 0 0 1"/>
-        <flexcomp type="grid" count="2 2 1" spacing="0.1 0.1 0.1" pos="-0.1 -0.1 0.7"
-                  radius="0.02" name="cloth" dim="2" mass="0.1">
-          <contact condim="3" solref="0.01 1" solimp=".95 .99 .0001"
-                   selfcollide="none" conaffinity="1" contype="1"/>
-          <edge damping="0.01"/>
-        </flexcomp>
-        <camera name="cam" pos="0 -1 0.5" xyaxes="1 0 0 0 0 1"
-                resolution="32 32" output="segmentation"/>
-      </worldbody>
-    </mujoco>
-    """
-    mjm = mujoco.MjModel.from_xml_string(xml)
-    self.assertEqual(mjm.nflex, 1, "nflex")
-    rc = mjwarp.create_render_context(mjm, nworld=1, cam_res=(32, 32))
-    pixels = 32 * 32
-
-    self.assertEqual(rc.seg_data.shape, (1, pixels), "seg_data")
-    _assert_eq(rc.seg_adr.numpy(), [0], "seg_adr")
-    _assert_eq(rc.render_seg.numpy(), [True], "render_seg")
-
-  def test_render_context_with_textures(self):
-    mjm, mjd, m, d = test_data.fixture("mug/mug.xml")
-    rc = mjwarp.create_render_context(mjm, render_rgb=True, render_depth=True, use_textures=True)
-    self.assertTrue(rc.use_textures, "use_textures")
-    self.assertEqual(rc.textures.shape, (mjm.ntex,), "textures")
-
-  def test_render_context_lighting_flags(self):
-    mjm, _, _, _ = test_data.fixture(
-      xml="""
-      <mujoco>
-        <visual>
-          <headlight active="0" ambient="0.2 0.3 0.4" diffuse="0.5 0.6 0.7" specular="0.8 0.9 1.0"/>
-        </visual>
-        <worldbody>
-          <light pos="0 0 3" dir="0 0 -1" attenuation="1 0.1 0.05" cutoff="25"/>
-          <geom type="sphere" size="0.3"/>
-        </worldbody>
-      </mujoco>
-      """
-    )
-    rc = mjwarp.create_render_context(
-      mjm,
-      cam_res=(32, 32),
-      render_rgb=True,
-      use_shadows=False,
-      use_ambient_lighting=False,
-      enable_specular=False,
-      enable_emission=False,
-      enable_per_light_ambient=False,
-    )
-    self.assertFalse(rc.use_shadows)
-    self.assertFalse(rc.use_ambient_lighting)
-    self.assertFalse(rc.enable_specular)
-    self.assertFalse(rc.enable_emission)
-    self.assertFalse(rc.enable_per_light_ambient)
-    self.assertFalse(rc.headlight_active)
-    self.assertFalse(rc.light_attenuation_is_default)
-    self.assertTrue(rc.has_spot_lights)
-    _assert_eq(np.asarray(rc.headlight_ambient), mjm.vis.headlight.ambient, "headlight_ambient")
-    _assert_eq(np.asarray(rc.headlight_diffuse), mjm.vis.headlight.diffuse, "headlight_diffuse")
-    _assert_eq(np.asarray(rc.headlight_specular), mjm.vis.headlight.specular, "headlight_specular")
 
   def test_check_toolkit_driver_warns(self):
     """Tests that check_toolkit_driver warns."""

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -14,8 +14,12 @@
 # ==============================================================================
 
 import mujoco
+import numpy as np
 import warp as wp
 
+from mujoco_warp._src import bvh
+from mujoco_warp._src import types
+from mujoco_warp._src import warp_util
 from mujoco_warp._src.types import ProjectionType
 from mujoco_warp._src.types import RenderContext
 
@@ -245,3 +249,461 @@ def get_segmentation(rc: RenderContext, camera_index: int, seg_out: wp.array3d[w
     inputs=[rc.seg_data, rc.seg_adr, camera_index],
     outputs=[seg_out],
   )
+
+
+@wp.kernel
+def _build_rays(
+  # In:
+  offset: int,
+  img_w: int,
+  img_h: int,
+  projection: int,
+  fovy: float,
+  sensorsize: wp.vec2,
+  intrinsic: wp.vec4,
+  znear: float,
+  # Out:
+  ray_out: wp.array[wp.vec3],
+):
+  xid, yid = wp.tid()
+  ray_out[offset + xid + yid * img_w] = compute_ray(projection, fovy, sensorsize, intrinsic, img_w, img_h, xid, yid, znear)
+
+
+def create_render_context(
+  mjm: mujoco.MjModel,
+  nworld: int = 1,
+  cam_res: list[tuple[int, int]] | tuple[int, int] | None = None,
+  render_rgb: list[bool] | bool | None = None,
+  render_depth: list[bool] | bool | None = None,
+  render_seg: list[bool] | bool | None = None,
+  use_textures: bool = True,
+  use_fast_math: bool = True,
+  use_shadows: bool = False,
+  use_ambient_lighting: bool = True,
+  enabled_geom_groups: list[int] = [0, 1, 2],
+  cam_active: list[bool] | list[str] | list[int] | None = None,
+  background_color: tuple[float, float, float, float] = (0.1, 0.1, 0.2, 1.0),
+  flex_render_smooth: bool = True,
+  use_precomputed_rays: bool = True,
+  render_skybox: bool = False,
+  enable_backface_culling: bool = True,
+  enable_specular: bool = True,
+  enable_emission: bool = True,
+  enable_per_light_ambient: bool = True,
+  splat_position: np.ndarray | None = None,
+  splat_rotation: np.ndarray | None = None,
+  splat_scale: np.ndarray | None = None,
+  splat_rgba: np.ndarray | None = None,
+  splat_adr: np.ndarray | None = None,
+  splat_group_id: np.ndarray | None = None,
+) -> types.RenderContext:
+  """Creates a render context on device.
+
+  Args:
+    mjm: The model containing kinematic and dynamic information on host.
+    nworld: The number of worlds.
+    cam_res: The width and height to render each camera image. If None, uses the
+             MuJoCo model values.
+    render_rgb: Whether to render RGB images. If None, uses the MuJoCo model values.
+    render_depth: Whether to render depth images. If None, uses the MuJoCo model values.
+    render_seg: Whether to render segmentation (per-pixel object ID/type pairs).
+      If None, uses the MuJoCo model values.
+    use_textures: Whether to use textures.
+    use_fast_math: Whether to enable fast math for the render kernel.
+    use_shadows: Whether to use shadows.
+    use_ambient_lighting: Top-level ambient switch. When False, skips all
+                          ambient contributions, including headlight ambient,
+                          the no-light fallback, and per-light ambient.
+    enabled_geom_groups: The geom groups to render.
+    cam_active: List of booleans, camera names (str), or camera indices (int) indicating
+                which cameras to include in rendering. If None, all cameras are included.
+    flex_render_smooth: Whether to render flex meshes smoothly.
+    use_precomputed_rays: Use precomputed rays instead of computing during rendering.
+                          When using domain randomization for camera intrinsics, set to False.
+    render_skybox: Whether to shade missed rays with the MuJoCo skybox texture.
+                   Requires the model to contain a texture with type `mjTEXTURE_SKYBOX`.
+    enable_backface_culling: Drop primitive-ray hits whose normal faces away from
+                             the ray (ray origin inside the geom). Matches MuJoCo's
+                             mesh-ray rule. Default True. Disable for a small
+                             performance gain when no camera is ever inside a geom.
+    background_color: The color to use for background pixels when no skybox is rendered.
+    enable_specular: Evaluate specular highlights per light. When False the
+                     half-vector normalize and shininess `pow` are dropped at
+                     compile time. Disable for performance when no specular is present.
+    enable_emission: Add `mat_emission * base_color` per shaded pixel. When
+                     False the term is dropped at compile time. Disable for performance
+                     when no emission is present.
+    enable_per_light_ambient: When ambient lighting is enabled, sum each
+                              light's `ambient` color into shaded pixels
+                              even outside its cone or in shadow. When False
+                              the per-light ambient pass is removed at compile
+                              time. Disable for performance when model lights
+                              do not use ambient colors.
+    splat_position: Splat centers in world coordinates (nsplat, 3).
+    splat_rotation: Splat rotations as (w, x, y, z) (nsplat, 4).
+    splat_scale: Splat scales as standard deviation in each dimension (nsplat, 3).
+    splat_rgba: Splat color and opacity (nsplat, 4).
+    splat_adr: Offset of each splat in the splat attribute arrays,
+               if None then all splats are in one group.
+    splat_group_id: Splat id for each world (nworld,). If None then all worlds
+                    use the first splat group.
+
+  Returns:
+    The render context containing rendering fields and output arrays on device.
+  """
+  mjd = mujoco.MjData(mjm)
+  mujoco.mj_forward(mjm, mjd)
+
+  constructor = "cubql"
+
+  # Build grouped splat BVH.
+  splat_attribute = (splat_position, splat_rotation, splat_scale, splat_rgba)
+  if splat_position is None:
+    if any(value is not None for value in (*splat_attribute[1:], splat_adr, splat_group_id)):
+      raise ValueError("splat attributes, offsets, and group IDs must be supplied together")
+
+    splat_position = wp.empty(0, dtype=wp.vec3)
+    splat_rotation = wp.empty(0, dtype=wp.quat)
+    splat_scale = wp.empty(0, dtype=wp.vec3)
+    splat_rgba = wp.empty(0, dtype=wp.vec4)
+    splat_bvh = None
+    splat_bvh_id = wp.uint64(0)
+    splat_lower = wp.empty(0, dtype=wp.vec3)
+    splat_upper = wp.empty(0, dtype=wp.vec3)
+    splat_group_root = wp.empty(nworld, dtype=int)
+    splat_count = 0
+  else:
+    nsplat = splat_position.shape[0]
+    if (
+      splat_position.shape != (nsplat, 3)
+      or splat_rotation.shape != (nsplat, 4)
+      or splat_scale.shape != (nsplat, 3)
+      or splat_rgba.shape != (nsplat, 4)
+    ):
+      raise ValueError("splat attributes must have shapes (nsplat, 3), (nsplat, 4), (nsplat, 3), and (nsplat, 4)")
+    if splat_adr is not None and splat_adr.ndim != 1:
+      raise ValueError("splat_adr must be one-dimensional")
+    if splat_group_id is not None and splat_group_id.shape != (nworld,):
+      raise ValueError("splat_group_id must be of shape (nworld,)")
+
+    if splat_adr is None:
+      splat_adr = np.array([0, splat_position.shape[0]], dtype=np.int32)
+    if splat_group_id is None:
+      splat_group_id = np.zeros(nworld, dtype=np.int32)
+    (
+      splat_position,
+      splat_rotation,
+      splat_scale,
+      splat_rgba,
+      splat_bvh,
+      splat_bvh_id,
+      splat_lower,
+      splat_upper,
+      splat_group_root,
+      splat_count,
+    ) = bvh.build_splat_bvh(*splat_attribute, splat_adr, splat_group_id, constructor="sah")
+
+  # Mesh BVHs – build for all meshes so per-world variants are available
+  nmesh = mjm.nmesh
+  geom_enabled_mask = np.isin(mjm.geom_group, list(enabled_geom_groups))
+  geom_enabled_idx = np.nonzero(geom_enabled_mask)[0]
+
+  mesh_registry = {}
+  mesh_bvh_id = [wp.uint64(0) for _ in range(nmesh)]
+  mesh_bounds_size = [wp.vec3(0.0, 0.0, 0.0) for _ in range(nmesh)]
+
+  for mid in range(nmesh):
+    mesh, half = bvh.build_mesh_bvh(mjm, mid, constructor=constructor)
+    mesh_registry[mesh.id] = mesh
+    mesh_bvh_id[mid] = mesh.id
+    mesh_bounds_size[mid] = half
+
+  mesh_bvh_id_arr = wp.array(mesh_bvh_id, dtype=wp.uint64)
+  mesh_bounds_size_arr = wp.array(mesh_bounds_size, dtype=wp.vec3)
+
+  # HField BVHs
+  nhfield = mjm.nhfield
+  hfield_geom_mask = geom_enabled_mask & (mjm.geom_type == types.GeomType.HFIELD) & (mjm.geom_dataid >= 0)
+  used_hfield_id = set(mjm.geom_dataid[hfield_geom_mask].astype(int))
+  hfield_registry = {}
+  hfield_bvh_id = [wp.uint64(0) for _ in range(nhfield)]
+  hfield_bounds_size = [wp.vec3(0.0, 0.0, 0.0) for _ in range(nhfield)]
+
+  for hid in used_hfield_id:
+    hmesh, hhalf = bvh.build_hfield_bvh(mjm, hid, constructor=constructor)
+    hfield_registry[hmesh.id] = hmesh
+    hfield_bvh_id[hid] = hmesh.id
+    hfield_bounds_size[hid] = hhalf
+
+  hfield_bvh_id_arr = wp.array(hfield_bvh_id, dtype=wp.uint64)
+  hfield_bounds_size_arr = wp.array(hfield_bounds_size, dtype=wp.vec3)
+
+  # Flex BVHs
+  nflex = mjm.nflex
+  flex_registry = {}
+
+  # Scene BVH flex primitives: 1D → one capsule per edge, 2D/3D → one box per flex
+  flex_geom_flexid = []
+  flex_geom_edgeid = []
+  flex_bvh_id = np.full(nflex, 0, dtype=np.uint64)
+  # Indexed later as [worldid, flexid].
+  flex_group_root = np.full((nworld, nflex), -1, dtype=int)
+
+  for f in range(nflex):
+    if mjm.flex_dim[f] == 1:
+      edge_adr = mjm.flex_edgeadr[f]
+      flex_geom_flexid.extend([f] * mjm.flex_edgenum[f])
+      flex_geom_edgeid.extend([edge_adr + e for e in range(mjm.flex_edgenum[f])])
+    else:
+      flex_geom_flexid.append(f)
+      flex_geom_edgeid.append(-1)
+      fmesh, group_root = bvh.build_flex_bvh(mjm, mjd, nworld, f)
+      flex_registry[f] = fmesh
+      flex_bvh_id[f] = fmesh.id
+      flex_group_root[:, f] = group_root.numpy()
+
+  textures_registry = []
+  for i in range(mjm.ntex):
+    textures_registry.append(create_warp_texture(mjm, i))
+  textures = wp.array(textures_registry, dtype=wp.Texture2D)
+
+  # Locate skybox texture
+  skybox_tex_ids = np.nonzero(mjm.tex_type == mujoco.mjtTexture.mjTEXTURE_SKYBOX)[0] if mjm.ntex else np.array([], dtype=int)
+  if render_skybox and skybox_tex_ids.size > 0:
+    skybox_tex_id_np = np.array([skybox_tex_ids[0]], dtype=int)
+    skybox_face_width_np = np.array([mjm.tex_width[skybox_tex_ids[0]]], dtype=int)
+  else:
+    render_skybox = False
+    skybox_tex_id_np = np.array([-1], dtype=int)
+    skybox_face_width_np = np.array([1], dtype=int)
+
+  # Filter active cameras
+  if cam_active is not None:
+    if len(cam_active) > 0 and isinstance(cam_active[0], (bool, np.bool_)):
+      assert len(cam_active) == mjm.ncam, f"cam_active must have length {mjm.ncam} (got {len(cam_active)})"
+      active_cam_indices = [int(i) for i in np.nonzero(cam_active)[0]]
+    elif len(cam_active) > 0 and isinstance(cam_active[0], str):
+      active_cam_indices = []
+      for name in cam_active:
+        cid = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_CAMERA, name)
+        if cid == -1:
+          raise ValueError(f"Camera '{name}' not found in model.")
+        active_cam_indices.append(cid)
+    elif len(cam_active) > 0 and isinstance(cam_active[0], (int, np.integer)):
+      active_cam_indices = [int(x) for x in cam_active]
+    else:
+      raise ValueError(f"Invalid cam_active format: {cam_active}")
+  else:
+    active_cam_indices = list(range(mjm.ncam))
+
+  ncam = len(active_cam_indices)
+
+  if cam_res is not None:
+    if isinstance(cam_res, tuple):
+      cam_res = [cam_res] * ncam
+    elif isinstance(cam_res, list) and len(cam_res) == 1 and ncam > 1:
+      cam_res = cam_res * ncam
+    if len(cam_res) != ncam:
+      raise ValueError(f"Camera resolutions count ({len(cam_res)}) does not match active camera count ({ncam}).")
+    active_cam_res = cam_res
+  else:
+    active_cam_res = mjm.cam_resolution[active_cam_indices]
+
+  cam_res_arr = wp.array(active_cam_res, dtype=wp.vec2i)
+
+  if render_rgb is None:
+    render_rgb = [bool(np.any(mjm.cam_output[i] & mujoco.mjtCamOutBit.mjCAMOUT_RGB)) for i in active_cam_indices]
+  elif isinstance(render_rgb, bool):
+    render_rgb = [render_rgb] * ncam
+  elif isinstance(render_rgb, (list, np.ndarray)):
+    if len(render_rgb) == mjm.ncam and ncam != mjm.ncam:
+      render_rgb = [bool(render_rgb[i]) for i in active_cam_indices]
+    elif len(render_rgb) == 1 and ncam > 1:
+      render_rgb = [bool(render_rgb[0])] * ncam
+    else:
+      render_rgb = [bool(x) for x in render_rgb]
+
+  if render_depth is None:
+    render_depth = [bool(np.any(mjm.cam_output[i] & mujoco.mjtCamOutBit.mjCAMOUT_DEPTH)) for i in active_cam_indices]
+  elif isinstance(render_depth, bool):
+    render_depth = [render_depth] * ncam
+  elif isinstance(render_depth, (list, np.ndarray)):
+    if len(render_depth) == mjm.ncam and ncam != mjm.ncam:
+      render_depth = [bool(render_depth[i]) for i in active_cam_indices]
+    elif len(render_depth) == 1 and ncam > 1:
+      render_depth = [bool(render_depth[0])] * ncam
+    else:
+      render_depth = [bool(x) for x in render_depth]
+
+  if render_seg is None:
+    render_seg = [bool(np.any(mjm.cam_output[i] & mujoco.mjtCamOutBit.mjCAMOUT_SEG)) for i in active_cam_indices]
+  elif isinstance(render_seg, bool):
+    render_seg = [render_seg] * ncam
+  elif isinstance(render_seg, (list, np.ndarray)):
+    if len(render_seg) == mjm.ncam and ncam != mjm.ncam:
+      render_seg = [bool(render_seg[i]) for i in active_cam_indices]
+    elif len(render_seg) == 1 and ncam > 1:
+      render_seg = [bool(render_seg[0])] * ncam
+    else:
+      render_seg = [bool(x) for x in render_seg]
+
+  if len(render_rgb) != ncam:
+    raise ValueError(f"render_rgb length ({len(render_rgb)}) does not match active camera count ({ncam}).")
+  if len(render_depth) != ncam:
+    raise ValueError(f"render_depth length ({len(render_depth)}) does not match active camera count ({ncam}).")
+  if len(render_seg) != ncam:
+    raise ValueError(f"render_seg length ({len(render_seg)}) does not match active camera count ({ncam}).")
+
+  rgb_adr = -1 * np.ones(ncam, dtype=int)
+  depth_adr = -1 * np.ones(ncam, dtype=int)
+  seg_adr = -1 * np.ones(ncam, dtype=int)
+  cam_res_np = cam_res_arr.numpy()
+  ri = 0
+  di = 0
+  si = 0
+  total = 0
+
+  for idx in range(ncam):
+    if render_rgb[idx]:
+      rgb_adr[idx] = ri
+      ri += cam_res_np[idx][0] * cam_res_np[idx][1]
+    if render_depth[idx]:
+      depth_adr[idx] = di
+      di += cam_res_np[idx][0] * cam_res_np[idx][1]
+    if render_seg[idx]:
+      seg_adr[idx] = si
+      si += cam_res_np[idx][0] * cam_res_np[idx][1]
+
+    total += cam_res_np[idx][0] * cam_res_np[idx][1]
+
+  znear = float(mjm.vis.map.znear * mjm.stat.extent)
+
+  ray = wp.zeros(int(total), dtype=wp.vec3)
+
+  cam_projection = mjm.cam_projection
+
+  offset = 0
+  for idx, cam_id_val in enumerate(active_cam_indices):
+    cam_id = int(cam_id_val)
+    img_w = int(cam_res_np[idx][0])
+    img_h = int(cam_res_np[idx][1])
+    wp.launch(
+      kernel=_build_rays,
+      dim=(img_w, img_h),
+      inputs=[
+        offset,
+        img_w,
+        img_h,
+        int(mjm.cam_projection[cam_id]),
+        float(mjm.cam_fovy[cam_id]),
+        wp.vec2(float(mjm.cam_sensorsize[cam_id, 0]), float(mjm.cam_sensorsize[cam_id, 1])),
+        wp.vec4(
+          float(mjm.cam_intrinsic[cam_id, 0]),
+          float(mjm.cam_intrinsic[cam_id, 1]),
+          float(mjm.cam_intrinsic[cam_id, 2]),
+          float(mjm.cam_intrinsic[cam_id, 3]),
+        ),
+        znear,
+      ],
+      outputs=[ray],
+    )
+    offset += img_w * img_h
+
+  bvh_ngeom = len(geom_enabled_idx)
+
+  # Geom types present among enabled geoms, plus FLEX when flex primitives exist.
+  # Used to statically eliminate unused intersection branches in the ray-cast kernels.
+  geom_ray_types = set(int(t) for t in mjm.geom_type[geom_enabled_idx])
+  if len(flex_geom_flexid) > 0:
+    geom_ray_types.add(int(types.GeomType.FLEX))
+  geom_ray_types = tuple(sorted(geom_ray_types))
+  if mjm.nlight == 0:
+    light_attenuation_is_default = True
+    has_spot_lights = False
+  else:
+    atten = np.asarray(mjm.light_attenuation, dtype=np.float32).reshape(-1, 3)
+    light_attenuation_is_default = bool(np.allclose(atten, np.array([1.0, 0.0, 0.0], dtype=np.float32)))
+    has_spot_lights = bool((np.asarray(mjm.light_type) == int(mujoco.mjtLightType.mjLIGHT_SPOT)).any())
+
+  rc = types.RenderContext(
+    nrender=ncam,
+    cam_res=cam_res_arr,
+    cam_id_map=wp.array(active_cam_indices, dtype=int),
+    use_textures=use_textures,
+    use_fast_math=use_fast_math,
+    use_shadows=use_shadows,
+    use_ambient_lighting=use_ambient_lighting,
+    background_color=pack_rgba_to_uint32(
+      background_color[0] * 255.0, background_color[1] * 255.0, background_color[2] * 255.0, background_color[3] * 255.0
+    ),
+    use_precomputed_rays=use_precomputed_rays,
+    render_skybox=render_skybox,
+    skybox_tex_id=wp.array(skybox_tex_id_np, dtype=int),
+    skybox_face_width=wp.array(skybox_face_width_np, dtype=int),
+    headlight_active=bool(mjm.vis.headlight.active),
+    headlight_ambient=wp.vec3(mjm.vis.headlight.ambient),
+    headlight_diffuse=wp.vec3(mjm.vis.headlight.diffuse),
+    headlight_specular=wp.vec3(mjm.vis.headlight.specular),
+    bvh_ngeom=bvh_ngeom,
+    enabled_geom_ids=wp.array(geom_enabled_idx, dtype=int),
+    mesh_registry=mesh_registry,
+    mesh_bvh_id=mesh_bvh_id_arr,
+    mesh_bounds_size=mesh_bounds_size_arr,
+    mesh_texcoord=wp.array(mjm.mesh_texcoord, dtype=wp.vec2),
+    mesh_texcoord_offsets=wp.array(mjm.mesh_texcoordadr, dtype=int),
+    mesh_facetexcoord=wp.array(mjm.mesh_facetexcoord, dtype=wp.vec3i),
+    textures=textures,
+    textures_registry=textures_registry,
+    hfield_registry=hfield_registry,
+    hfield_bvh_id=hfield_bvh_id_arr,
+    hfield_bounds_size=hfield_bounds_size_arr,
+    flex_mesh_registry=flex_registry,
+    flex_rgba=wp.array(mjm.flex_rgba, dtype=wp.vec4),
+    flex_bvh_id=wp.array(flex_bvh_id, dtype=wp.uint64),
+    flex_group_root=wp.array(flex_group_root, dtype=int),
+    flex_render_smooth=flex_render_smooth,
+    bvh_nflexgeom=len(flex_geom_flexid),
+    flex_dim_np=mjm.flex_dim,
+    flex_geom_flexid=wp.array(flex_geom_flexid, dtype=int),
+    flex_geom_edgeid=wp.array(flex_geom_edgeid, dtype=int),
+    bvh=None,
+    bvh_id=None,
+    lower=wp.zeros(nworld * (bvh_ngeom + len(flex_geom_flexid)), dtype=wp.vec3),
+    upper=wp.zeros(nworld * (bvh_ngeom + len(flex_geom_flexid)), dtype=wp.vec3),
+    group=wp.zeros(nworld * (bvh_ngeom + len(flex_geom_flexid)), dtype=int),
+    group_root=wp.zeros(nworld, dtype=int),
+    ray=ray,
+    rgb_data=wp.zeros((nworld, ri), dtype=wp.uint32),
+    rgb_adr=wp.array(rgb_adr, dtype=int),
+    depth_data=wp.zeros((nworld, di), dtype=wp.float32),
+    depth_adr=wp.array(depth_adr, dtype=int),
+    render_rgb=wp.array(render_rgb, dtype=bool),
+    render_depth=wp.array(render_depth, dtype=bool),
+    seg_data=wp.zeros((nworld, max(si, 1)), dtype=wp.vec2i),
+    seg_adr=wp.array(seg_adr, dtype=int),
+    render_seg=wp.array(render_seg, dtype=bool),
+    znear=znear,
+    total_rays=int(total),
+    enable_backface_culling=enable_backface_culling,
+    geom_ray_types=geom_ray_types,
+    enable_specular=enable_specular,
+    enable_emission=enable_emission,
+    enable_per_light_ambient=enable_per_light_ambient,
+    light_attenuation_is_default=light_attenuation_is_default,
+    has_spot_lights=has_spot_lights,
+    splat_position=splat_position,
+    splat_rotation=splat_rotation,
+    splat_scale=splat_scale,
+    splat_rgba=splat_rgba,
+    splat_bvh=splat_bvh,
+    splat_bvh_id=splat_bvh_id,
+    splat_lower=splat_lower,
+    splat_upper=splat_upper,
+    splat_group_root=splat_group_root,
+    splat_count=splat_count,
+  )
+
+  bvh.build_scene_bvh(mjm, mjd, rc, nworld)
+
+  warp_util.mark_batched(rc)
+  return rc

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -296,7 +296,7 @@ def create_render_context(
   splat_rgba: np.ndarray | None = None,
   splat_adr: np.ndarray | None = None,
   splat_group_id: np.ndarray | None = None,
-) -> types.RenderContext:
+) -> RenderContext:
   """Creates a render context on device.
 
   Args:
@@ -625,7 +625,7 @@ def create_render_context(
     light_attenuation_is_default = bool(np.allclose(atten, np.array([1.0, 0.0, 0.0], dtype=np.float32)))
     has_spot_lights = bool((np.asarray(mjm.light_type) == int(mujoco.mjtLightType.mjLIGHT_SPOT)).any())
 
-  rc = types.RenderContext(
+  rc = RenderContext(
     nrender=ncam,
     cam_res=cam_res_arr,
     cam_id_map=wp.array(active_cam_indices, dtype=int),

--- a/mujoco_warp/_src/render_util_test.py
+++ b/mujoco_warp/_src/render_util_test.py
@@ -14,17 +14,40 @@
 # ==============================================================================
 """Tests for render utility functions."""
 
+import mujoco
 import numpy as np
 import warp as wp
 from absl.testing import absltest
+from absl.testing import parameterized
 
 import mujoco_warp as mjw
+import mujoco_warp as mjwarp
 from mujoco_warp import test_data
 from mujoco_warp._src import render_util
 from mujoco_warp._src import types
 
 
-class RenderUtilTest(absltest.TestCase):
+def _assert_eq(a, b, name):
+  tol = 5e-4
+  err_msg = f"mismatch: {name}"
+  np.testing.assert_allclose(a, b, err_msg=err_msg, atol=tol, rtol=tol)
+
+
+_CAMERA_TEST_XML = """
+<mujoco>
+  <worldbody>
+    <light pos="0 0 3" dir="0 0 -1"/>
+    <camera name="cam1" pos="0 -3 2" xyaxes="1 0 0 0 0.6 0.8" resolution="64 64" output="rgb"/>
+    <camera name="cam2" pos="0 3 2" xyaxes="-1 0 0 0 0.6 0.8" resolution="32 32" output="depth"/>
+    <camera name="cam3" pos="3 0 2" xyaxes="0 1 0 -0.6 0 0.8" resolution="16 16" output="rgb depth"/>
+    <geom type="plane" size="5 5 0.1"/>
+    <geom type="sphere" size="0.5" pos="0 0 1"/>
+  </worldbody>
+</mujoco>
+"""
+
+
+class RenderUtilTest(parameterized.TestCase):
   def test_create_warp_texture(self):
     """Tests that create_warp_texture creates a valid texture."""
     mjm, mjd, m, d = test_data.fixture("ray.xml")
@@ -125,6 +148,178 @@ class RenderUtilTest(absltest.TestCase):
     self.assertTrue(np.any(flex_mask), "Expected at least one flex hit")
     self.assertTrue(np.all(seg_np[..., 0][flex_mask] >= 0))
     self.assertGreater(np.unique(seg_np[..., 0][flex_mask]).shape[0], 1)
+
+  @parameterized.parameters(1, 4)
+  def test_bvh_creation(self, nworld):
+    """Test that the BVH is created correctly for single world and multiple worlds."""
+    mjm, mjd, m, d = test_data.fixture("primitives.xml", nworld=nworld)
+    rc = mjwarp.create_render_context(mjm, nworld=nworld, cam_res=(64, 64), use_textures=False)
+
+    self.assertIsNotNone(rc)
+    self.assertEqual(rc.nrender, mjm.ncam)
+
+    self.assertEqual(rc.lower.shape, (nworld * rc.bvh_ngeom,), "lower")
+    self.assertEqual(rc.upper.shape, (nworld * rc.bvh_ngeom,), "upper")
+    self.assertEqual(rc.group.shape, (nworld * rc.bvh_ngeom,), "group")
+    self.assertEqual(rc.group_root.shape, (nworld,), "group_root")
+
+    self.assertIsNotNone(rc.bvh_id)
+    self.assertNotEqual(rc.bvh_id, 0, "bvh_id")
+
+    group_np = rc.group.numpy()
+    _assert_eq(group_np, np.repeat(np.arange(nworld), rc.bvh_ngeom), "render context group values")
+
+  def test_output_buffers(self):
+    """Test that the output rgb and depth buffers have correct shapes and addresses."""
+    mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
+    width, height = 32, 24
+    rc = mjwarp.create_render_context(mjm, cam_res=(width, height), render_rgb=True, render_depth=True)
+
+    expected_total = 3 * width * height
+
+    self.assertEqual(rc.nrender, 3, "nrender")
+    self.assertEqual(rc.rgb_data.shape, (1, expected_total), "rgb_data")
+    self.assertEqual(rc.depth_data.shape, (1, expected_total), "depth_data")
+
+    rgb_adr = rc.rgb_adr.numpy()
+    depth_adr = rc.depth_adr.numpy()
+    _assert_eq(rgb_adr, [0, width * height, 2 * width * height], "rgb_adr")
+    _assert_eq(depth_adr, [0, width * height, 2 * width * height], "depth_adr")
+
+  def test_heterogeneous_camera(self):
+    """Tests render context with different resolutions and output."""
+    mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
+    cam_res = [(64, 64), (32, 32), (16, 16)]
+    rc = mjwarp.create_render_context(mjm, cam_res=cam_res, render_rgb=True, render_depth=True)
+
+    self.assertEqual(rc.nrender, 3, "nrender")
+    _assert_eq(rc.cam_res.numpy(), cam_res, "cam_res")
+
+    expected_total = 64 * 64 + 32 * 32 + 16 * 16
+    self.assertEqual(rc.rgb_data.shape, (1, expected_total), "rgb_data")
+    self.assertEqual(rc.depth_data.shape, (1, expected_total), "depth_data")
+
+    rgb_adr = rc.rgb_adr.numpy()
+    depth_adr = rc.depth_adr.numpy()
+    _assert_eq(rgb_adr, [0, 64 * 64, 64 * 64 + 32 * 32], "rgb_adr")
+    _assert_eq(depth_adr, [0, 64 * 64, 64 * 64 + 32 * 32], "depth_adr")
+
+    # Test that results are same when reading from mjmodel fields loaded through xml
+    rc_xml = mjwarp.create_render_context(mjm, render_rgb=True, render_depth=True)
+    self.assertEqual(rc.rgb_data.shape, rc_xml.rgb_data.shape, "rgb_data")
+    self.assertEqual(rc.depth_data.shape, rc_xml.depth_data.shape, "depth_data")
+    _assert_eq(rc.rgb_adr.numpy(), rc_xml.rgb_adr.numpy(), "rgb_adr")
+    _assert_eq(rc.depth_adr.numpy(), rc_xml.depth_adr.numpy(), "depth_adr")
+
+  def test_cam_active_filtering(self):
+    mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
+    width, height = 32, 32
+
+    rc = mjwarp.create_render_context(mjm, cam_res=(width, height), cam_active=[True, False, True])
+
+    self.assertEqual(rc.nrender, 2, "nrender")
+
+    expected_total = 2 * width * height
+    self.assertEqual(rc.rgb_data.shape, (1, expected_total), "rgb_data")
+
+  def test_rgb_only_and_depth_only(self):
+    """Test that disabling rgb or depth correctly reduces the shape and invalidates the address."""
+    mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
+    width, height = 32, 32
+    pixels = width * height
+
+    rc = mjwarp.create_render_context(
+      mjm,
+      cam_res=(width, height),
+      render_rgb=[True, False, True],
+      render_depth=[False, True, True],
+    )
+
+    self.assertEqual(rc.rgb_data.shape, (1, 2 * pixels), "rgb_data")
+    self.assertEqual(rc.depth_data.shape, (1, 2 * pixels), "depth_data")
+    _assert_eq(rc.rgb_adr.numpy(), [0, -1, pixels], "rgb_adr")
+    _assert_eq(rc.depth_adr.numpy(), [-1, 0, pixels], "depth_adr")
+    _assert_eq(rc.render_rgb.numpy(), [True, False, True], "render_rgb")
+    _assert_eq(rc.render_depth.numpy(), [False, True, True], "render_depth")
+
+    # Test that results are same when reading from mjmodel fields loaded through xml
+    rc_xml = mjwarp.create_render_context(mjm, cam_res=(width, height))
+    self.assertEqual(rc.rgb_data.shape, rc_xml.rgb_data.shape, "rgb_data")
+    self.assertEqual(rc.depth_data.shape, rc_xml.depth_data.shape, "depth_data")
+    _assert_eq(rc.rgb_adr.numpy(), rc_xml.rgb_adr.numpy(), "rgb_adr")
+    _assert_eq(rc.depth_adr.numpy(), rc_xml.depth_adr.numpy(), "depth_adr")
+    _assert_eq(rc.render_rgb.numpy(), rc_xml.render_rgb.numpy(), "render_rgb")
+    _assert_eq(rc.render_depth.numpy(), rc_xml.render_depth.numpy(), "render_depth")
+
+  def test_segmentation_from_camera_output(self):
+    """Segmentation auto-detected from camera output attribute in XML."""
+    xml = """
+    <mujoco>
+      <worldbody>
+        <light pos="0 0 3" dir="0 0 -1"/>
+        <geom type="plane" size="10 10 0.1"/>
+        <geom type="sphere" size="0.2" pos="0 0 0.5" rgba="1 0 0 1"/>
+        <flexcomp type="grid" count="2 2 1" spacing="0.1 0.1 0.1" pos="-0.1 -0.1 0.7"
+                  radius="0.02" name="cloth" dim="2" mass="0.1">
+          <contact condim="3" solref="0.01 1" solimp=".95 .99 .0001"
+                   selfcollide="none" conaffinity="1" contype="1"/>
+          <edge damping="0.01"/>
+        </flexcomp>
+        <camera name="cam" pos="0 -1 0.5" xyaxes="1 0 0 0 0 1"
+                resolution="32 32" output="segmentation"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm = mujoco.MjModel.from_xml_string(xml)
+    self.assertEqual(mjm.nflex, 1, "nflex")
+    rc = mjwarp.create_render_context(mjm, nworld=1, cam_res=(32, 32))
+    pixels = 32 * 32
+
+    self.assertEqual(rc.seg_data.shape, (1, pixels), "seg_data")
+    _assert_eq(rc.seg_adr.numpy(), [0], "seg_adr")
+    _assert_eq(rc.render_seg.numpy(), [True], "render_seg")
+
+  def test_render_context_with_textures(self):
+    mjm, mjd, m, d = test_data.fixture("mug/mug.xml")
+    rc = mjwarp.create_render_context(mjm, render_rgb=True, render_depth=True, use_textures=True)
+    self.assertTrue(rc.use_textures, "use_textures")
+    self.assertEqual(rc.textures.shape, (mjm.ntex,), "textures")
+
+  def test_render_context_lighting_flags(self):
+    mjm, _, _, _ = test_data.fixture(
+      xml="""
+      <mujoco>
+        <visual>
+          <headlight active="0" ambient="0.2 0.3 0.4" diffuse="0.5 0.6 0.7" specular="0.8 0.9 1.0"/>
+        </visual>
+        <worldbody>
+          <light pos="0 0 3" dir="0 0 -1" attenuation="1 0.1 0.05" cutoff="25"/>
+          <geom type="sphere" size="0.3"/>
+        </worldbody>
+      </mujoco>
+      """
+    )
+    rc = mjwarp.create_render_context(
+      mjm,
+      cam_res=(32, 32),
+      render_rgb=True,
+      use_shadows=False,
+      use_ambient_lighting=False,
+      enable_specular=False,
+      enable_emission=False,
+      enable_per_light_ambient=False,
+    )
+    self.assertFalse(rc.use_shadows)
+    self.assertFalse(rc.use_ambient_lighting)
+    self.assertFalse(rc.enable_specular)
+    self.assertFalse(rc.enable_emission)
+    self.assertFalse(rc.enable_per_light_ambient)
+    self.assertFalse(rc.headlight_active)
+    self.assertFalse(rc.light_attenuation_is_default)
+    self.assertTrue(rc.has_spot_lights)
+    _assert_eq(np.asarray(rc.headlight_ambient), mjm.vis.headlight.ambient, "headlight_ambient")
+    _assert_eq(np.asarray(rc.headlight_diffuse), mjm.vis.headlight.diffuse, "headlight_diffuse")
+    _assert_eq(np.asarray(rc.headlight_specular), mjm.vis.headlight.specular, "headlight_specular")
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/render_util_test.py
+++ b/mujoco_warp/_src/render_util_test.py
@@ -21,7 +21,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import mujoco_warp as mjw
-import mujoco_warp as mjwarp
 from mujoco_warp import test_data
 from mujoco_warp._src import render_util
 from mujoco_warp._src import types
@@ -153,7 +152,7 @@ class RenderUtilTest(parameterized.TestCase):
   def test_bvh_creation(self, nworld):
     """Test that the BVH is created correctly for single world and multiple worlds."""
     mjm, mjd, m, d = test_data.fixture("primitives.xml", nworld=nworld)
-    rc = mjwarp.create_render_context(mjm, nworld=nworld, cam_res=(64, 64), use_textures=False)
+    rc = mjw.create_render_context(mjm, nworld=nworld, cam_res=(64, 64), use_textures=False)
 
     self.assertIsNotNone(rc)
     self.assertEqual(rc.nrender, mjm.ncam)
@@ -173,7 +172,7 @@ class RenderUtilTest(parameterized.TestCase):
     """Test that the output rgb and depth buffers have correct shapes and addresses."""
     mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
     width, height = 32, 24
-    rc = mjwarp.create_render_context(mjm, cam_res=(width, height), render_rgb=True, render_depth=True)
+    rc = mjw.create_render_context(mjm, cam_res=(width, height), render_rgb=True, render_depth=True)
 
     expected_total = 3 * width * height
 
@@ -190,7 +189,7 @@ class RenderUtilTest(parameterized.TestCase):
     """Tests render context with different resolutions and output."""
     mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
     cam_res = [(64, 64), (32, 32), (16, 16)]
-    rc = mjwarp.create_render_context(mjm, cam_res=cam_res, render_rgb=True, render_depth=True)
+    rc = mjw.create_render_context(mjm, cam_res=cam_res, render_rgb=True, render_depth=True)
 
     self.assertEqual(rc.nrender, 3, "nrender")
     _assert_eq(rc.cam_res.numpy(), cam_res, "cam_res")
@@ -205,7 +204,7 @@ class RenderUtilTest(parameterized.TestCase):
     _assert_eq(depth_adr, [0, 64 * 64, 64 * 64 + 32 * 32], "depth_adr")
 
     # Test that results are same when reading from mjmodel fields loaded through xml
-    rc_xml = mjwarp.create_render_context(mjm, render_rgb=True, render_depth=True)
+    rc_xml = mjw.create_render_context(mjm, render_rgb=True, render_depth=True)
     self.assertEqual(rc.rgb_data.shape, rc_xml.rgb_data.shape, "rgb_data")
     self.assertEqual(rc.depth_data.shape, rc_xml.depth_data.shape, "depth_data")
     _assert_eq(rc.rgb_adr.numpy(), rc_xml.rgb_adr.numpy(), "rgb_adr")
@@ -215,7 +214,7 @@ class RenderUtilTest(parameterized.TestCase):
     mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)
     width, height = 32, 32
 
-    rc = mjwarp.create_render_context(mjm, cam_res=(width, height), cam_active=[True, False, True])
+    rc = mjw.create_render_context(mjm, cam_res=(width, height), cam_active=[True, False, True])
 
     self.assertEqual(rc.nrender, 2, "nrender")
 
@@ -228,7 +227,7 @@ class RenderUtilTest(parameterized.TestCase):
     width, height = 32, 32
     pixels = width * height
 
-    rc = mjwarp.create_render_context(
+    rc = mjw.create_render_context(
       mjm,
       cam_res=(width, height),
       render_rgb=[True, False, True],
@@ -243,7 +242,7 @@ class RenderUtilTest(parameterized.TestCase):
     _assert_eq(rc.render_depth.numpy(), [False, True, True], "render_depth")
 
     # Test that results are same when reading from mjmodel fields loaded through xml
-    rc_xml = mjwarp.create_render_context(mjm, cam_res=(width, height))
+    rc_xml = mjw.create_render_context(mjm, cam_res=(width, height))
     self.assertEqual(rc.rgb_data.shape, rc_xml.rgb_data.shape, "rgb_data")
     self.assertEqual(rc.depth_data.shape, rc_xml.depth_data.shape, "depth_data")
     _assert_eq(rc.rgb_adr.numpy(), rc_xml.rgb_adr.numpy(), "rgb_adr")
@@ -272,7 +271,7 @@ class RenderUtilTest(parameterized.TestCase):
     """
     mjm = mujoco.MjModel.from_xml_string(xml)
     self.assertEqual(mjm.nflex, 1, "nflex")
-    rc = mjwarp.create_render_context(mjm, nworld=1, cam_res=(32, 32))
+    rc = mjw.create_render_context(mjm, nworld=1, cam_res=(32, 32))
     pixels = 32 * 32
 
     self.assertEqual(rc.seg_data.shape, (1, pixels), "seg_data")
@@ -281,7 +280,7 @@ class RenderUtilTest(parameterized.TestCase):
 
   def test_render_context_with_textures(self):
     mjm, mjd, m, d = test_data.fixture("mug/mug.xml")
-    rc = mjwarp.create_render_context(mjm, render_rgb=True, render_depth=True, use_textures=True)
+    rc = mjw.create_render_context(mjm, render_rgb=True, render_depth=True, use_textures=True)
     self.assertTrue(rc.use_textures, "use_textures")
     self.assertEqual(rc.textures.shape, (mjm.ntex,), "textures")
 
@@ -299,7 +298,7 @@ class RenderUtilTest(parameterized.TestCase):
       </mujoco>
       """
     )
-    rc = mjwarp.create_render_context(
+    rc = mjw.create_render_context(
       mjm,
       cam_res=(32, 32),
       render_rgb=True,

--- a/mujoco_warp/_src/render_util_test.py
+++ b/mujoco_warp/_src/render_util_test.py
@@ -32,6 +32,7 @@ def _assert_eq(a, b, name):
   np.testing.assert_allclose(a, b, err_msg=err_msg, atol=tol, rtol=tol)
 
 
+# TODO: Add more cameras for testing projection and intrinsics
 _CAMERA_TEST_XML = """
 <mujoco>
   <worldbody>

--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import dataclasses
 import functools
 import inspect
 import warnings
@@ -20,6 +21,31 @@ import warnings
 import warp as wp
 
 _STACK = None
+
+
+def is_array_spec(typ) -> bool:
+  """Check if a type annotation is an array spec (wp.array instance or bracket annotation)."""
+  return isinstance(typ, wp.array) or type(typ).__name__ == "_ArrayAnnotation"
+
+
+def mark_batched(obj):
+  """Recursively set _is_batched = True on all batched warp arrays within obj."""
+  if not dataclasses.is_dataclass(obj):
+    return
+  for f in dataclasses.fields(obj):
+    val = getattr(obj, f.name, None)
+    if val is None:
+      continue
+    if dataclasses.is_dataclass(val):
+      mark_batched(val)
+      continue
+    if not isinstance(val, wp.array):
+      continue
+    if not is_array_spec(f.type):
+      continue
+    spec_shape = getattr(f.type, "shape", ())
+    if spec_shape and spec_shape[0] in ("*", "nworld"):
+      val._is_batched = True
 
 
 class EventTracer:


### PR DESCRIPTION
io.py contains multiple distinct responsibilities that make it difficult to navigate. This change moves create_render_context and _build_rays from io.py into render_util.py, consolidating all rendering setup alongside existing rendering extraction utilities (get_rgb, get_depth, get_segmentation). The corresponding unit tests are moved from io_test.py into render_util_test.py. create_render_context continues to be exported from the top-level mujoco_warp package for backward compatibility.