### PR TITLE
Improve renderer.

### DIFF
--- a/mujoco_warp/_src/bvh.py
+++ b/mujoco_warp/_src/bvh.py
@@ -441,7 +441,7 @@ def build_mesh_bvh(
   indices = indices.flatten()
   pmin = np.min(points, axis=0)
   pmax = np.max(points, axis=0)
-  half = 0.5 * (pmax - pmin)
+  half = np.maximum(np.abs(pmin), np.abs(pmax))
 
   points = wp.array(points, dtype=wp.vec3)
   indices = wp.array(indices, dtype=wp.int32)

--- a/mujoco_warp/_src/ray.py
+++ b/mujoco_warp/_src/ray.py
@@ -28,6 +28,10 @@ from mujoco_warp._src.types import vec6
 
 wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 
+# Widen ray prune bounds so a coincident hit survives to the closest-hit tie-break.
+RAY_TOL_REL = 1.0e-6
+RAY_TOL_ABS = 1.0e-9
+
 
 @wp.func
 def _ray_map(pos: wp.vec3, mat: wp.mat33, pnt: wp.vec3, vec: wp.vec3) -> Tuple[wp.vec3, wp.vec3]:
@@ -714,19 +718,20 @@ def ray_mesh_with_bvh(
   f = int(-1)
 
   lpnt, lvec = _ray_map(pos, mat, pnt, vec)
+  mesh_bvh = mesh_bvh_id[mesh_geom_id]
 
   # Culling drops back-facing triangles, not the mesh: like a rasterizer, march
   # past culled hits to the next surface (bounded to keep the kernel in check).
   offset = float(0.0)
   for _ in range(8):
-    hit = wp.mesh_query_ray(mesh_bvh_id[mesh_geom_id], lpnt + lvec * offset, lvec, max_t - offset, t, u, v, sign, n, f)
+    hit = wp.mesh_query_ray(mesh_bvh, lpnt + lvec * offset, lvec, max_t - offset, t, u, v, sign, n, f)
     if not hit:
       return -1.0, wp.vec3(0.0, 0.0, 0.0), 0.0, 0.0, -1, -1
     if (not cull_backfaces) or wp.dot(lvec, n) < 0.0:
       normal = mat @ n
       normal = wp.normalize(normal)
       return offset + t, normal, u, v, f, mesh_geom_id
-    offset += t * (1.0 + 1.0e-6) + 1.0e-9
+    offset += t * (1.0 + RAY_TOL_REL) + RAY_TOL_ABS
 
   return -1.0, wp.vec3(0.0, 0.0, 0.0), 0.0, 0.0, -1, -1
 

--- a/mujoco_warp/_src/ray.py
+++ b/mujoco_warp/_src/ray.py
@@ -714,17 +714,19 @@ def ray_mesh_with_bvh(
   f = int(-1)
 
   lpnt, lvec = _ray_map(pos, mat, pnt, vec)
-  hit = wp.mesh_query_ray(mesh_bvh_id[mesh_geom_id], lpnt, lvec, max_t, t, u, v, sign, n, f)
 
-  if not hit:
-    return -1.0, wp.vec3(0.0, 0.0, 0.0), 0.0, 0.0, -1, -1
-
-  # Front-face hit, or back-face hit when cull is disabled: rotate the
-  # local-space normal into world space and return the hit.
-  if (not cull_backfaces) or wp.dot(lvec, n) < 0.0:
-    normal = mat @ n
-    normal = wp.normalize(normal)
-    return t, normal, u, v, f, mesh_geom_id
+  # Culling drops back-facing triangles, not the mesh: like a rasterizer, march
+  # past culled hits to the next surface (bounded to keep the kernel in check).
+  offset = float(0.0)
+  for _ in range(8):
+    hit = wp.mesh_query_ray(mesh_bvh_id[mesh_geom_id], lpnt + lvec * offset, lvec, max_t - offset, t, u, v, sign, n, f)
+    if not hit:
+      return -1.0, wp.vec3(0.0, 0.0, 0.0), 0.0, 0.0, -1, -1
+    if (not cull_backfaces) or wp.dot(lvec, n) < 0.0:
+      normal = mat @ n
+      normal = wp.normalize(normal)
+      return offset + t, normal, u, v, f, mesh_geom_id
+    offset += t * (1.0 + 1.0e-6) + 1.0e-9
 
   return -1.0, wp.vec3(0.0, 0.0, 0.0), 0.0, 0.0, -1, -1
 

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -356,11 +356,12 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
     bounds_nr = int(0)
     ngeom = bvh_ngeom + flex_bvh_ngeom
 
-    # A coincident geom sits exactly at dist; widen the prune so it survives to
-    # reach the tie-break below.
+    # max_t is exclusive: widen so coincident hits reach the tie-break below.
     while wp.bvh_query_next(query, bounds_nr, dist * (1.0 + 1.0e-6) + 1.0e-9):
       gi_global = bounds_nr
       local_id = gi_global - (worldid * ngeom)
+
+      query_dist = dist * (1.0 + 1.0e-6) + 1.0e-9
 
       d = float(-1.0)
       hit_mesh_id = int(-1)
@@ -397,7 +398,7 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
             geom_xmat_in[worldid, gi],
             ray_origin_world,
             ray_dir_world,
-            dist,
+            query_dist,
             cull_backfaces,
           )
       if wp.static(int(GeomType.SPHERE) in geom_ray_types):
@@ -465,7 +466,7 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
               geom_xmat_in[worldid, gi],
               ray_origin_world,
               ray_dir_world,
-              dist * (1.0 + 1.0e-6) + 1.0e-9,  # max_t is exclusive
+              query_dist,
               cull_backfaces,
             )
       if wp.static(int(GeomType.FLEX) in geom_ray_types):
@@ -502,7 +503,7 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
               d = 0.0 if hit else -1.0
             else:
               flex_gr = flex_group_root[worldid, flexid]
-              d, n, u, v, f = ray_flex_with_bvh(flex_bvh_id, flexid, flex_gr, ray_origin_world, ray_dir_world, dist)
+              d, n, u, v, f = ray_flex_with_bvh(flex_bvh_id, flexid, flex_gr, ray_origin_world, ray_dir_world, query_dist)
               if d >= 0.0:
                 hit_mesh_id = flexid
 
@@ -517,11 +518,9 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
         if d >= 0.0 and d < dist:
           return hit_geom_id, d, n, u, v, f, hit_mesh_id
       else:
-        # MuJoCo's GL depth test (GL_LEQUAL) leaves the last-drawn geom on top, so
-        # coincident surfaces resolve to the higher geom index.
-        closer = d < dist
-        if wp.abs(d - dist) <= 1.0e-6 * wp.max(dist, 1.0) and geom_id >= 0 and hit_geom_id > geom_id:
-          closer = True
+        # Ties go to the higher geom index, like MuJoCo's GL depth test.
+        tol = 1.0e-6 * wp.max(dist, 1.0)
+        closer = (d < dist - tol) or (wp.abs(d - dist) <= tol and (geom_id < 0 or hit_geom_id > geom_id))
         if d >= 0.0 and closer:
           dist = d
           normal = n

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -848,6 +848,11 @@ def render(m: Model, d: Data, rc: RenderContext):
       wp.static(rc_static["enable_backface_culling"]),
     )
 
+    if wp.static(not rc_static["enable_backface_culling"]):
+      # Two-sided shading: light a back-facing hit as if it faced the viewer.
+      if geom_id >= 0 and wp.dot(normal, ray_dir_world) > 0.0:
+        normal = -normal
+
     splat_color = wp.vec3(0.0)
     splat_transmittance = float(1.0)
     splat_depth = float(-1.0)

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -348,7 +348,9 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
     bounds_nr = int(0)
     ngeom = bvh_ngeom + flex_bvh_ngeom
 
-    while wp.bvh_query_next(query, bounds_nr, dist):
+    # A coincident geom sits exactly at dist; widen the prune so it survives to
+    # reach the tie-break below.
+    while wp.bvh_query_next(query, bounds_nr, dist * (1.0 + 1.0e-6) + 1.0e-9):
       gi_global = bounds_nr
       local_id = gi_global - (worldid * ngeom)
 
@@ -455,7 +457,7 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
               geom_xmat_in[worldid, gi],
               ray_origin_world,
               ray_dir_world,
-              dist,
+              dist * (1.0 + 1.0e-6) + 1.0e-9,  # max_t is exclusive
               cull_backfaces,
             )
       if wp.static(int(GeomType.FLEX) in geom_ray_types):
@@ -507,7 +509,12 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
         if d >= 0.0 and d < dist:
           return hit_geom_id, d, n, u, v, f, hit_mesh_id
       else:
-        if d >= 0.0 and d < dist:
+        # MuJoCo's GL depth test (GL_LEQUAL) leaves the last-drawn geom on top, so
+        # coincident surfaces resolve to the higher geom index.
+        closer = d < dist
+        if wp.abs(d - dist) <= 1.0e-6 * wp.max(dist, 1.0) and geom_id >= 0 and hit_geom_id > geom_id:
+          closer = True
+        if d >= 0.0 and closer:
           dist = d
           normal = n
           geom_id = hit_geom_id

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -20,6 +20,8 @@ import warp as wp
 
 from mujoco_warp._src import math
 from mujoco_warp._src.bvh import SPLAT_MIN_RESPONSE
+from mujoco_warp._src.ray import RAY_TOL_ABS
+from mujoco_warp._src.ray import RAY_TOL_REL
 from mujoco_warp._src.ray import ray_box
 from mujoco_warp._src.ray import ray_capsule
 from mujoco_warp._src.ray import ray_cylinder
@@ -357,11 +359,11 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
     ngeom = bvh_ngeom + flex_bvh_ngeom
 
     # max_t is exclusive: widen so coincident hits reach the tie-break below.
-    while wp.bvh_query_next(query, bounds_nr, dist * (1.0 + 1.0e-6) + 1.0e-9):
+    while wp.bvh_query_next(query, bounds_nr, dist * (1.0 + RAY_TOL_REL) + RAY_TOL_ABS):
       gi_global = bounds_nr
       local_id = gi_global - (worldid * ngeom)
 
-      query_dist = dist * (1.0 + 1.0e-6) + 1.0e-9
+      query_dist = dist * (1.0 + RAY_TOL_REL) + RAY_TOL_ABS
 
       d = float(-1.0)
       hit_mesh_id = int(-1)
@@ -519,7 +521,7 @@ def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Fu
           return hit_geom_id, d, n, u, v, f, hit_mesh_id
       else:
         # Ties go to the higher geom index, like MuJoCo's GL depth test.
-        tol = 1.0e-6 * wp.max(dist, 1.0)
+        tol = RAY_TOL_REL * wp.max(dist, 1.0)
         closer = (d < dist - tol) or (wp.abs(d - dist) <= tol and (geom_id < 0 or hit_geom_id > geom_id))
         if d >= 0.0 and closer:
           dist = d
@@ -860,14 +862,12 @@ def _build_megakernel(m: Model, rc: RenderContext):
       face = wp.transpose(mat) @ normal
       tri = mesh_facenormal[mesh_faceadr[mesh_id] + f]
       adr = mesh_normaladr[mesh_id]
-      normal = wp.normalize(
-        mat
-        @ (
-          vertex_normal(mesh_normal[adr + tri[0]], face) * u
-          + vertex_normal(mesh_normal[adr + tri[1]], face) * v
-          + vertex_normal(mesh_normal[adr + tri[2]], face) * (1.0 - u - v)
-        )
+      vec = (
+        vertex_normal(mesh_normal[adr + tri[0]], face) * u
+        + vertex_normal(mesh_normal[adr + tri[1]], face) * v
+        + vertex_normal(mesh_normal[adr + tri[2]], face) * (1.0 - u - v)
       )
+      normal = wp.normalize(mat @ vec)
 
     if wp.static(not rc_static["enable_backface_culling"]):
       # Two-sided shading: light a back-facing hit as if it faced the viewer.

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -674,18 +674,8 @@ def _make_compute_lighting(cast_ray_first_hit: wp.Function) -> wp.Function:
   return compute_lighting
 
 
-@event_scope
-def render(m: Model, d: Data, rc: RenderContext):
-  """Render the current frame.
-
-  Outputs are stored in buffers within the render context.
-
-  Args:
-    m: The model on device.
-    d: The data on device.
-    rc: The render context on device.
-  """
-  rc.seg_data.fill_(wp.vec2i(-1, -1))
+def _build_megakernel(m: Model, rc: RenderContext):
+  """Construct the specialised megakernel for this context."""
   has_splats = rc.splat_count > 0
 
   # Specialize the ray-cast helpers to the geom types present in the scene so the
@@ -1146,6 +1136,28 @@ def render(m: Model, d: Data, rc: RenderContext):
       hit_color[2] * 255.0,
       255.0,
     )
+
+  return _render_megakernel
+
+
+@event_scope
+def render(m: Model, d: Data, rc: RenderContext):
+  """Render the current frame.
+
+  Outputs are stored in buffers within the render context.
+
+  Args:
+    m: The model on device.
+    d: The data on device.
+    rc: The render context on device.
+  """
+  rc.seg_data.fill_(wp.vec2i(-1, -1))
+  # Specialising the megakernel costs more than launching it, so keep it on the
+  # context: the static configuration it closes over is fixed at creation.
+  _render_megakernel = getattr(rc, "_megakernel", None)
+  if _render_megakernel is None:
+    _render_megakernel = _build_megakernel(m, rc)
+    object.__setattr__(rc, "_megakernel", _render_megakernel)
 
   wp.launch(
     kernel=_render_megakernel,

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -860,7 +860,13 @@ def render(m: Model, d: Data, rc: RenderContext):
       wp.static(rc_static["enable_backface_culling"]),
     )
 
-    if geom_id >= 0 and mesh_id >= 0 and f >= 0 and geom_type[geom_id] == int(GeomType.MESH.value):
+    if (
+      wp.static(rc_static["enable_vertex_normals"])
+      and geom_id >= 0
+      and mesh_id >= 0
+      and f >= 0
+      and geom_type[geom_id] == int(GeomType.MESH.value)
+    ):
       mat = geom_xmat_in[worldid, geom_id]
       face = wp.transpose(mat) @ normal
       tri = mesh_facenormal[mesh_faceadr[mesh_id] + f]

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -291,6 +291,14 @@ def sample_skybox(
   return wp.vec3(color[0], color[1], color[2])
 
 
+@wp.func
+def vertex_normal(n: wp.vec3, face: wp.vec3) -> wp.vec3:
+  # Matches mjr_uploadMesh: a vertex normal more than ~37 degrees off the face is unusable.
+  if wp.dot(n, face) < 0.8:
+    return face
+  return n
+
+
 def _make_cast_ray(geom_ray_types: Tuple[int], first_hit: bool = False) -> wp.Function:
   """Build a ray-cast func specialized to the geom types present in the scene.
 
@@ -716,6 +724,8 @@ def render(m: Model, d: Data, rc: RenderContext):
     flex_edge: wp.array[wp.vec2i],
     flex_radius: wp.array[float],
     mesh_faceadr: wp.array[int],
+    mesh_normaladr: wp.array[int],
+    mesh_normal: wp.array[wp.vec3],
     mat_texid: wp.array3d[int],
     mat_texrepeat: wp.array2d[wp.vec2],
     mat_emission: wp.array2d[float],
@@ -752,6 +762,7 @@ def render(m: Model, d: Data, rc: RenderContext):
     enabled_geom_ids: wp.array[int],
     mesh_bvh_id: wp.array[wp.uint64],
     mesh_facetexcoord: wp.array[wp.vec3i],
+    mesh_facenormal: wp.array[wp.vec3i],
     mesh_texcoord: wp.array[wp.vec2],
     mesh_texcoord_offsets: wp.array[int],
     hfield_bvh_id: wp.array[wp.uint64],
@@ -847,6 +858,20 @@ def render(m: Model, d: Data, rc: RenderContext):
       float(MJ_MAXVAL),
       wp.static(rc_static["enable_backface_culling"]),
     )
+
+    if geom_id >= 0 and mesh_id >= 0 and f >= 0 and geom_type[geom_id] == int(GeomType.MESH.value):
+      mat = geom_xmat_in[worldid, geom_id]
+      face = wp.transpose(mat) @ normal
+      tri = mesh_facenormal[mesh_faceadr[mesh_id] + f]
+      adr = mesh_normaladr[mesh_id]
+      normal = wp.normalize(
+        mat
+        @ (
+          vertex_normal(mesh_normal[adr + tri[0]], face) * u
+          + vertex_normal(mesh_normal[adr + tri[1]], face) * v
+          + vertex_normal(mesh_normal[adr + tri[2]], face) * (1.0 - u - v)
+        )
+      )
 
     if wp.static(not rc_static["enable_backface_culling"]):
       # Two-sided shading: light a back-facing hit as if it faced the viewer.
@@ -1139,6 +1164,8 @@ def render(m: Model, d: Data, rc: RenderContext):
       m.flex_edge,
       m.flex_radius,
       m.mesh_faceadr,
+      m.mesh_normaladr,
+      m.mesh_normal,
       m.mat_texid,
       m.mat_texrepeat,
       m.mat_emission,
@@ -1173,6 +1200,7 @@ def render(m: Model, d: Data, rc: RenderContext):
       rc.enabled_geom_ids,
       rc.mesh_bvh_id,
       rc.mesh_facetexcoord,
+      rc.mesh_facenormal,
       rc.mesh_texcoord,
       rc.mesh_texcoord_offsets,
       rc.hfield_bvh_id,

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -1153,10 +1153,9 @@ def render(m: Model, d: Data, rc: RenderContext):
   rc.seg_data.fill_(wp.vec2i(-1, -1))
   # Specialising the megakernel costs more than launching it, so keep it on the
   # context: the static configuration it closes over is fixed at creation.
-  _render_megakernel = getattr(rc, "_megakernel", None)
-  if _render_megakernel is None:
-    _render_megakernel = _build_megakernel(m, rc)
-    object.__setattr__(rc, "_megakernel", _render_megakernel)
+  if rc._megakernel is None:
+    rc._megakernel = _build_megakernel(m, rc)
+  _render_megakernel = rc._megakernel
 
   wp.launch(
     kernel=_render_megakernel,

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -582,6 +582,7 @@ def _make_compute_lighting(cast_ray_first_hit: wp.Function) -> wp.Function:
     mat_spec: float,
     mat_shin_exp: float,
     cull_backfaces: bool,
+    shadow_light_fraction: float,
     enable_specular: bool,
     default_attenuation: bool,
     has_spot: bool,
@@ -658,7 +659,7 @@ def _make_compute_lighting(cast_ray_first_hit: wp.Function) -> wp.Function:
       )
 
       if shadow_geom_id != -1:
-        visible = NO_LIGHT_AMBIENT_FALLBACK
+        visible = shadow_light_fraction
 
     weight = attenuation * visible
     diff_rgb = lightdiff * (ndotl * weight)
@@ -1071,6 +1072,7 @@ def render(m: Model, d: Data, rc: RenderContext):
         mat_spec,
         mat_shin_exp,
         wp.static(rc_static["enable_backface_culling"]),
+        wp.static(rc_static["shadow_light_fraction"]),
         wp.static(rc_static["enable_specular"]),
         wp.static(rc_static["light_attenuation_is_default"]),
         wp.static(rc_static["has_spot_lights"]),
@@ -1120,6 +1122,7 @@ def render(m: Model, d: Data, rc: RenderContext):
         mat_spec,
         mat_shin_exp,
         wp.static(rc_static["enable_backface_culling"]),
+        wp.static(rc_static["shadow_light_fraction"]),
         wp.static(rc_static["enable_specular"]),
         True,
         False,

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -712,6 +712,34 @@ class RenderTest(parameterized.TestCase):
 
     self.assertGreater(np.count_nonzero(seg[:32] >= 0), 100)
 
+  @parameterized.parameters("box", "mesh")
+  def test_coincident_geoms_resolve_to_higher_index(self, geom_type: str):
+    # Two geoms in the same place: MuJoCo's GL depth test (GL_LEQUAL) leaves the
+    # last-drawn geom on top, so the higher index must win every pixel, not
+    # whichever the BVH reaches first.
+    s = 0.2
+    vert = " ".join(f"{x} {y} {z}" for x in (-s, s) for y in (-s, s) for z in (-s, s))
+    asset = f'<asset><mesh name="m" vertex="{vert}"/></asset>' if geom_type == "mesh" else ""
+    geom = 'type="mesh" mesh="m"' if geom_type == "mesh" else f'type="box" size="{s} {s} {s}"'
+    xml = f"""
+    <mujoco>
+      {asset}
+      <worldbody>
+        <light pos="0 -1 1"/>
+        <camera pos="0 -1.5 0" xyaxes="1 0 0 0 0 1"/>
+        <geom {geom} rgba="1 0 0 1"/>
+        <geom {geom} rgba="0 1 0 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, _, m, d = test_data.fixture(xml=xml)
+    rc = mjw.create_render_context(mjm, cam_res=(32, 32), render_seg=True)
+    mjw.render(m, d, rc)
+    seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
+
+    self.assertGreater(np.count_nonzero(seg == 1), 0)
+    self.assertEqual(np.count_nonzero(seg == 0), 0)
+
 if __name__ == "__main__":
   wp.init()
   absltest.main()

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -761,6 +761,59 @@ class RenderTest(parameterized.TestCase):
 
     self.assertGreater(int(rgb.min()), 0)
 
+  def test_unusable_vertex_normals_fall_back_to_the_face(self):
+    # A bare-vertex hull has no authored normals: at a cube corner MuJoCo's face
+    # contributions cancel and it stores the [0, 0, 1] sentinel. Rejecting those
+    # against the face normal must render the hull exactly like the primitive.
+    s = 0.3
+    vert = " ".join(f"{x} {y} {z}" for x in (-s, s) for y in (-s, s) for z in (-s, s))
+
+    def render(geom):
+      xml = f"""
+      <mujoco>
+        <asset><mesh name="cube" vertex="{vert}"/></asset>
+        <worldbody>
+          <light pos="0 -2 1" dir="0 0.9 -0.45" directional="true" diffuse="0.55 0.55 0.55"/>
+          <camera pos="0 -3 0" xyaxes="1 0 0 0 0 1" fovy="25"/>
+          <geom {geom} euler="20 0 30" rgba="0.8 0.8 0.8 1"/>
+        </worldbody>
+      </mujoco>
+      """
+      mjm, _, m, d = test_data.fixture(xml=xml)
+      rc = mjw.create_render_context(mjm, cam_res=(64, 64), render_rgb=True, use_ambient_lighting=False)
+      mjw.render(m, d, rc)
+      return _unpack_rgb(rc.rgb_data.numpy()[0])
+
+    np.testing.assert_array_equal(render('type="mesh" mesh="cube"'), render(f'type="box" size="{s} {s} {s}"'))
+
+  def test_authored_normals_shade_smoothly(self):
+    # On a sphere hull neighbouring faces stay inside the tolerance, so MuJoCo
+    # keeps real vertex normals: interpolating them must leave no flat facet.
+    n, r = 64, 0.3
+    i = np.arange(n) + 0.5
+    phi = np.arccos(1.0 - 2.0 * i / n)
+    theta = np.pi * (1.0 + 5.0**0.5) * i
+    pts = r * np.stack([np.cos(theta) * np.sin(phi), np.sin(theta) * np.sin(phi), np.cos(phi)], axis=-1)
+    xml = f"""
+    <mujoco>
+      <asset><mesh name="sphere" vertex="{" ".join(f"{x:.5f}" for x in pts.ravel())}"/></asset>
+      <worldbody>
+        <light pos="0 -2 1" dir="0 0.9 -0.45" directional="true" diffuse="0.55 0.55 0.55"/>
+        <camera pos="0 -1.6 0" xyaxes="1 0 0 0 0 1" fovy="30"/>
+        <geom type="mesh" mesh="sphere" rgba="0.8 0.8 0.8 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, _, m, d = test_data.fixture(xml=xml)
+    rc = mjw.create_render_context(mjm, cam_res=(64, 64), render_rgb=True, render_seg=True, use_ambient_lighting=False)
+    mjw.render(m, d, rc)
+    red = _unpack_rgb(rc.rgb_data.numpy()[0])[..., 0]
+    seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
+    value, count = np.unique(red[seg == 0], return_counts=True)
+
+    self.assertGreater(len(value), 120)
+    self.assertLess(int(count.max()), 40)
+
 if __name__ == "__main__":
   wp.init()
   absltest.main()

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -687,6 +687,30 @@ class RenderTest(parameterized.TestCase):
     # Verify that the two worlds rendered different skybox backgrounds
     self.assertFalse(np.array_equal(rgb_w0, rgb_w1))
 
+  def test_mesh_bounds_contain_offcentre_mesh(self):
+    # Recentred on its centroid the pyramid spans -h/4 to 3h/4, but a half-extent
+    # of 0.5 * (pmax - pmin) reaches only h/2, cutting the apex off. The camera
+    # sits on that cut looking along the horizon, so rays above the centre row
+    # only travel upwards: they reach the apex only if it is inside the bounds.
+    b, h = 0.1, 0.4
+    xml = f"""
+    <mujoco>
+      <asset>
+        <mesh name="pyramid" vertex="{-b} {-b} 0  {b} {-b} 0  {b} {b} 0  {-b} {b} 0  0 0 {h}"/>
+      </asset>
+      <worldbody>
+        <light pos="0 -1 2"/>
+        <camera pos="0 -0.5 {0.25 * h + 0.5 * h}" xyaxes="1 0 0 0 0 1" fovy="30"/>
+        <geom type="mesh" mesh="pyramid" rgba="1 0 0 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, _, m, d = test_data.fixture(xml=xml)
+    rc = mjw.create_render_context(mjm, cam_res=(64, 64), render_seg=True)
+    mjw.render(m, d, rc)
+    seg = rc.seg_data.numpy()[0].reshape(64, 64, 2)[..., 0]
+
+    self.assertGreater(np.count_nonzero(seg[:32] >= 0), 100)
 
 if __name__ == "__main__":
   wp.init()

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -740,6 +740,27 @@ class RenderTest(parameterized.TestCase):
     self.assertGreater(np.count_nonzero(seg == 1), 0)
     self.assertEqual(np.count_nonzero(seg == 0), 0)
 
+  def test_backfaces_are_shaded_two_sided(self):
+    # Camera inside the box: every visible face points away from it. Shading
+    # those hits with an unflipped normal leaves the interior at zero diffuse.
+    xml = """
+    <mujoco>
+      <worldbody>
+        <light pos="0 0 0.5" diffuse="1 1 1"/>
+        <camera pos="0 0 0" xyaxes="1 0 0 0 0 1"/>
+        <geom type="box" size="1 1 1" rgba="0.8 0.8 0.8 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, _, m, d = test_data.fixture(xml=xml)
+    rc = mjw.create_render_context(
+      mjm, cam_res=(32, 32), render_rgb=True, enable_backface_culling=False, use_ambient_lighting=False
+    )
+    mjw.render(m, d, rc)
+    rgb = _unpack_rgb(rc.rgb_data.numpy()[0])
+
+    self.assertGreater(int(rgb.min()), 0)
+
 if __name__ == "__main__":
   wp.init()
   absltest.main()

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -864,6 +864,61 @@ class RenderTest(parameterized.TestCase):
     self.assertGreater(len(value), 120)
     self.assertLess(int(count.max()), 40)
 
+  def test_vertex_normals_can_be_disabled(self):
+    # Same sphere hull as above: disabling vertex normals falls back to face
+    # normals, collapsing the smooth gradient into a few flat facet levels.
+    n, r = 64, 0.3
+    i = np.arange(n) + 0.5
+    phi = np.arccos(1.0 - 2.0 * i / n)
+    theta = np.pi * (1.0 + 5.0**0.5) * i
+    pts = r * np.stack([np.cos(theta) * np.sin(phi), np.sin(theta) * np.sin(phi), np.cos(phi)], axis=-1)
+    xml = f"""
+    <mujoco>
+      <asset><mesh name="sphere" vertex="{" ".join(f"{x:.5f}" for x in pts.ravel())}"/></asset>
+      <worldbody>
+        <light pos="0 -2 1" dir="0 0.9 -0.45" directional="true" diffuse="0.55 0.55 0.55"/>
+        <camera pos="0 -1.6 0" xyaxes="1 0 0 0 0 1" fovy="30"/>
+        <geom type="mesh" mesh="sphere" rgba="0.8 0.8 0.8 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, _, m, d = test_data.fixture(xml=xml)
+
+    def render(enable):
+      rc = mjw.create_render_context(
+        mjm, cam_res=(64, 64), render_rgb=True, render_seg=True, use_ambient_lighting=False, enable_vertex_normals=enable
+      )
+      mjw.render(m, d, rc)
+      red = _unpack_rgb(rc.rgb_data.numpy()[0])[..., 0]
+      seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
+      return np.unique(red[seg == 0], return_counts=True)
+
+    value_smooth, count_smooth = render(True)
+    value_flat, count_flat = render(False)
+
+    self.assertGreater(len(value_smooth), len(value_flat))
+    self.assertGreater(int(count_flat.max()), int(count_smooth.max()))
+
+  def test_megakernel_cached_across_renders(self):
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+    <mujoco>
+      <worldbody>
+        <light pos="0 0 2"/>
+        <camera pos="0 -2 0" xyaxes="1 0 0 0 0 1"/>
+        <geom type="sphere" size="0.2" rgba="1 0 0 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    )
+    rc = mjw.create_render_context(mjm, cam_res=(32, 32), render_rgb=True)
+    self.assertIsNone(rc._megakernel)
+    mjw.render(m, d, rc)
+    kernel = rc._megakernel
+    self.assertIsNotNone(kernel)
+    mjw.render(m, d, rc)
+    self.assertIs(rc._megakernel, kernel)
+
   def test_shadow_light_fraction_scales_shadowed_light(self):
     # How much of a light survives its own shadow: 0 is black, 1 is no shadow.
     xml = """

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -814,6 +814,42 @@ class RenderTest(parameterized.TestCase):
     self.assertGreater(len(value), 120)
     self.assertLess(int(count.max()), 40)
 
+  def test_shadow_light_fraction_scales_shadowed_light(self):
+    # How much of a light survives its own shadow: 0 is black, 1 is no shadow.
+    xml = """
+    <mujoco>
+      <worldbody>
+        <light pos="0 0 3" dir="0 0 -1" directional="true" diffuse="1 1 1" castshadow="true"/>
+        <camera pos="0 -1.2 1.2" xyaxes="1 0 0 0 0.7 0.7" fovy="60"/>
+        <geom type="plane" size="2 2 0.1" rgba="0.8 0.8 0.8 1"/>
+        <geom type="box" pos="0 0 0.5" size="0.25 0.25 0.02" rgba="0.2 0.2 0.9 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    shadowed = []
+    for fraction in (0.0, 0.3, 0.6, 1.0):
+      mjm, _, m, d = test_data.fixture(xml=xml)
+      rc = mjw.create_render_context(
+        mjm,
+        cam_res=(64, 64),
+        render_rgb=True,
+        render_seg=True,
+        use_shadows=True,
+        use_ambient_lighting=False,
+        shadow_light_fraction=fraction,
+      )
+      mjw.render(m, d, rc)
+      red = _unpack_rgb(rc.rgb_data.numpy()[0])[..., 0]
+      seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
+      floor = red[seg == 0]
+      shadowed.append((int(floor.min()), int(floor.max())))
+
+    darkest = [lo for lo, _ in shadowed]
+    self.assertEqual(darkest, sorted(darkest))
+    self.assertLess(darkest[0], darkest[-1])
+    self.assertEqual(shadowed[-1][0], shadowed[-1][1])
+
+
 if __name__ == "__main__":
   wp.init()
   absltest.main()

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -688,42 +688,45 @@ class RenderTest(parameterized.TestCase):
     self.assertFalse(np.array_equal(rgb_w0, rgb_w1))
 
   def test_mesh_bounds_contain_offcentre_mesh(self):
-    # Recentred on its centroid the pyramid spans -h/4 to 3h/4, but a half-extent
-    # of 0.5 * (pmax - pmin) reaches only h/2, cutting the apex off. The camera
-    # sits on that cut looking along the horizon, so rays above the centre row
-    # only travel upwards: they reach the apex only if it is inside the bounds.
-    b, h = 0.1, 0.4
-    xml = f"""
+    # Recentred on its centroid the pyramid (height 0.4) spans -0.1 to 0.3, but a
+    # half-extent of 0.5 * (pmax - pmin) reaches only 0.2, cutting the apex off.
+    # The camera sits on that cut (z = 0.3) looking along the horizon, so rays
+    # above the centre row reach the apex only if it is inside the bounds.
+    mjm, _, m, d = test_data.fixture(
+      xml="""
     <mujoco>
       <asset>
-        <mesh name="pyramid" vertex="{-b} {-b} 0  {b} {-b} 0  {b} {b} 0  {-b} {b} 0  0 0 {h}"/>
+        <mesh name="pyramid" vertex="-0.1 -0.1 0  0.1 -0.1 0  0.1 0.1 0  -0.1 0.1 0  0 0 0.4"/>
       </asset>
       <worldbody>
         <light pos="0 -1 2"/>
-        <camera pos="0 -0.5 {0.25 * h + 0.5 * h}" xyaxes="1 0 0 0 0 1" fovy="30"/>
+        <camera pos="0 -0.5 0.3" xyaxes="1 0 0 0 0 1" fovy="30"/>
         <geom type="mesh" mesh="pyramid" rgba="1 0 0 1"/>
       </worldbody>
     </mujoco>
     """
-    mjm, _, m, d = test_data.fixture(xml=xml)
+    )
     rc = mjw.create_render_context(mjm, cam_res=(64, 64), render_seg=True)
     mjw.render(m, d, rc)
     seg = rc.seg_data.numpy()[0].reshape(64, 64, 2)[..., 0]
 
     self.assertGreater(np.count_nonzero(seg[:32] >= 0), 100)
 
-  @parameterized.parameters("box", "mesh")
-  def test_coincident_geoms_resolve_to_higher_index(self, geom_type: str):
+  @parameterized.named_parameters(
+    ("box", 'type="box" size="0.2 0.2 0.2"'),
+    ("mesh", 'type="mesh" mesh="cube"'),
+  )
+  def test_coincident_geoms_resolve_to_higher_index(self, geom: str):
     # Two geoms in the same place: MuJoCo's GL depth test (GL_LEQUAL) leaves the
     # last-drawn geom on top, so the higher index must win every pixel, not
     # whichever the BVH reaches first.
-    s = 0.2
-    vert = " ".join(f"{x} {y} {z}" for x in (-s, s) for y in (-s, s) for z in (-s, s))
-    asset = f'<asset><mesh name="m" vertex="{vert}"/></asset>' if geom_type == "mesh" else ""
-    geom = 'type="mesh" mesh="m"' if geom_type == "mesh" else f'type="box" size="{s} {s} {s}"'
-    xml = f"""
+    mjm, _, m, d = test_data.fixture(
+      xml=f"""
     <mujoco>
-      {asset}
+      <asset>
+        <mesh name="cube" vertex="-0.2 -0.2 -0.2  -0.2 -0.2 0.2  -0.2 0.2 -0.2  -0.2 0.2 0.2
+                                  0.2 -0.2 -0.2  0.2 -0.2 0.2  0.2 0.2 -0.2  0.2 0.2 0.2"/>
+      </asset>
       <worldbody>
         <light pos="0 -1 1"/>
         <camera pos="0 -1.5 0" xyaxes="1 0 0 0 0 1"/>
@@ -732,7 +735,7 @@ class RenderTest(parameterized.TestCase):
       </worldbody>
     </mujoco>
     """
-    mjm, _, m, d = test_data.fixture(xml=xml)
+    )
     rc = mjw.create_render_context(mjm, cam_res=(32, 32), render_seg=True)
     mjw.render(m, d, rc)
     seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
@@ -740,27 +743,34 @@ class RenderTest(parameterized.TestCase):
     self.assertGreater(np.count_nonzero(seg == 1), 0)
     self.assertEqual(np.count_nonzero(seg == 0), 0)
 
+  _RING = """
+        <geom type="sphere" size="0.05" pos="0.700 0.000 0" rgba="0.5 0.5 0.9 1"/>
+        <geom type="sphere" size="0.05" pos="0.536 0.321 0" rgba="0.5 0.5 0.9 1"/>
+        <geom type="sphere" size="0.05" pos="0.122 0.492 0" rgba="0.5 0.5 0.9 1"/>
+        <geom type="sphere" size="0.05" pos="-0.350 0.433 0" rgba="0.5 0.5 0.9 1"/>
+        <geom type="sphere" size="0.05" pos="-0.658 0.171 0" rgba="0.5 0.5 0.9 1"/>
+        <geom type="sphere" size="0.05" pos="-0.658 -0.171 0" rgba="0.5 0.5 0.9 1"/>
+        <geom type="sphere" size="0.05" pos="-0.350 -0.433 0" rgba="0.5 0.5 0.9 1"/>
+        <geom type="sphere" size="0.05" pos="0.122 -0.492 0" rgba="0.5 0.5 0.9 1"/>
+        <geom type="sphere" size="0.05" pos="0.536 -0.321 0" rgba="0.5 0.5 0.9 1"/>"""
+
   @parameterized.parameters(False, True)
   def test_coincident_geoms_with_roundoff_resolve_to_higher_index(self, extra_geoms: bool):
     # The lower-index box sits nearer by less than the tie tolerance: roundoff
     # must not let it win. The extra geoms reshuffle the BVH traversal order so
     # both visit orders of the pair are exercised.
-    ring = "".join(
-      f'<geom type="sphere" size="0.05" pos="{0.7 * np.cos(t):.3f} {0.5 * np.sin(t):.3f} 0" rgba="0.5 0.5 0.9 1"/>'
-      for t in np.linspace(0.0, 2.0 * np.pi, 9, endpoint=False)
-    )
-    xml = f"""
+    mjm, _, m, d = test_data.fixture(
+      xml=f"""
     <mujoco>
       <worldbody>
         <light pos="0 -1 1"/>
-        <camera pos="0 -2 0" xyaxes="1 0 0 0 0 1"/>
-        {ring if extra_geoms else ""}
+        <camera pos="0 -2 0" xyaxes="1 0 0 0 0 1"/>{self._RING if extra_geoms else ""}
         <geom type="box" size="0.2 0.2 0.2" rgba="1 0 0 1"/>
         <geom type="box" pos="0 1e-7 0" size="0.2 0.2 0.2" rgba="0 1 0 1"/>
       </worldbody>
     </mujoco>
     """
-    mjm, _, m, d = test_data.fixture(xml=xml)
+    )
     rc = mjw.create_render_context(mjm, cam_res=(32, 32), render_seg=True)
     mjw.render(m, d, rc)
     seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
@@ -772,7 +782,8 @@ class RenderTest(parameterized.TestCase):
   def test_backface_cull_skips_culled_triangles(self):
     # An inside-out tetra: like GL, culling must drop its near faces yet still
     # draw the far face behind them, not drop the whole mesh.
-    xml = """
+    mjm, _, m, d = test_data.fixture(
+      xml="""
     <mujoco>
       <asset><mesh name="tetra" vertex="1 1 1  1 -1 -1  -1 1 -1  -1 -1 1" face="0 2 1  0 1 3  0 3 2  1 2 3"/></asset>
       <worldbody>
@@ -783,7 +794,7 @@ class RenderTest(parameterized.TestCase):
       </worldbody>
     </mujoco>
     """
-    mjm, _, m, d = test_data.fixture(xml=xml)
+    )
     rc = mjw.create_render_context(mjm, cam_res=(32, 32), render_seg=True, enable_backface_culling=True)
     mjw.render(m, d, rc)
     seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
@@ -793,7 +804,8 @@ class RenderTest(parameterized.TestCase):
   def test_backfaces_are_shaded_two_sided(self):
     # Camera inside the box: every visible face points away from it. Shading
     # those hits with an unflipped normal leaves the interior at zero diffuse.
-    xml = """
+    mjm, _, m, d = test_data.fixture(
+      xml="""
     <mujoco>
       <worldbody>
         <light pos="0 0 0.5" diffuse="1 1 1"/>
@@ -802,7 +814,7 @@ class RenderTest(parameterized.TestCase):
       </worldbody>
     </mujoco>
     """
-    mjm, _, m, d = test_data.fixture(xml=xml)
+    )
     rc = mjw.create_render_context(
       mjm, cam_res=(32, 32), render_rgb=True, enable_backface_culling=False, use_ambient_lighting=False
     )
@@ -815,13 +827,15 @@ class RenderTest(parameterized.TestCase):
     # A bare-vertex hull has no authored normals: at a cube corner MuJoCo's face
     # contributions cancel and it stores the [0, 0, 1] sentinel. Rejecting those
     # against the face normal must render the hull exactly like the primitive.
-    s = 0.3
-    vert = " ".join(f"{x} {y} {z}" for x in (-s, s) for y in (-s, s) for z in (-s, s))
-
-    def render(geom):
-      xml = f"""
+    rgb = []
+    for geom in ('type="mesh" mesh="cube"', 'type="box" size="0.3 0.3 0.3"'):
+      mjm, _, m, d = test_data.fixture(
+        xml=f"""
       <mujoco>
-        <asset><mesh name="cube" vertex="{vert}"/></asset>
+        <asset>
+          <mesh name="cube" vertex="-0.3 -0.3 -0.3  -0.3 -0.3 0.3  -0.3 0.3 -0.3  -0.3 0.3 0.3
+                                    0.3 -0.3 -0.3  0.3 -0.3 0.3  0.3 0.3 -0.3  0.3 0.3 0.3"/>
+        </asset>
         <worldbody>
           <light pos="0 -2 1" dir="0 0.9 -0.45" directional="true" diffuse="0.55 0.55 0.55"/>
           <camera pos="0 -3 0" xyaxes="1 0 0 0 0 1" fovy="25"/>
@@ -829,22 +843,24 @@ class RenderTest(parameterized.TestCase):
         </worldbody>
       </mujoco>
       """
-      mjm, _, m, d = test_data.fixture(xml=xml)
+      )
       rc = mjw.create_render_context(mjm, cam_res=(64, 64), render_rgb=True, use_ambient_lighting=False)
       mjw.render(m, d, rc)
-      return _unpack_rgb(rc.rgb_data.numpy()[0])
+      rgb.append(_unpack_rgb(rc.rgb_data.numpy()[0]))
 
-    np.testing.assert_array_equal(render('type="mesh" mesh="cube"'), render(f'type="box" size="{s} {s} {s}"'))
+    np.testing.assert_array_equal(rgb[0], rgb[1])
 
-  def test_authored_normals_shade_smoothly(self):
+  def test_authored_normals_shade_smoothly_unless_disabled(self):
     # On a sphere hull neighbouring faces stay inside the tolerance, so MuJoCo
-    # keeps real vertex normals: interpolating them must leave no flat facet.
+    # keeps real vertex normals: interpolating them must leave no flat facet,
+    # while enable_vertex_normals=False must collapse back to facet levels.
     n, r = 64, 0.3
     i = np.arange(n) + 0.5
     phi = np.arccos(1.0 - 2.0 * i / n)
     theta = np.pi * (1.0 + 5.0**0.5) * i
     pts = r * np.stack([np.cos(theta) * np.sin(phi), np.sin(theta) * np.sin(phi), np.cos(phi)], axis=-1)
-    xml = f"""
+    mjm, _, m, d = test_data.fixture(
+      xml=f"""
     <mujoco>
       <asset><mesh name="sphere" vertex="{" ".join(f"{x:.5f}" for x in pts.ravel())}"/></asset>
       <worldbody>
@@ -854,50 +870,29 @@ class RenderTest(parameterized.TestCase):
       </worldbody>
     </mujoco>
     """
-    mjm, _, m, d = test_data.fixture(xml=xml)
-    rc = mjw.create_render_context(mjm, cam_res=(64, 64), render_rgb=True, render_seg=True, use_ambient_lighting=False)
-    mjw.render(m, d, rc)
-    red = _unpack_rgb(rc.rgb_data.numpy()[0])[..., 0]
-    seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
-    value, count = np.unique(red[seg == 0], return_counts=True)
+    )
 
-    self.assertGreater(len(value), 120)
-    self.assertLess(int(count.max()), 40)
-
-  def test_vertex_normals_can_be_disabled(self):
-    # Same sphere hull as above: disabling vertex normals falls back to face
-    # normals, collapsing the smooth gradient into a few flat facet levels.
-    n, r = 64, 0.3
-    i = np.arange(n) + 0.5
-    phi = np.arccos(1.0 - 2.0 * i / n)
-    theta = np.pi * (1.0 + 5.0**0.5) * i
-    pts = r * np.stack([np.cos(theta) * np.sin(phi), np.sin(theta) * np.sin(phi), np.cos(phi)], axis=-1)
-    xml = f"""
-    <mujoco>
-      <asset><mesh name="sphere" vertex="{" ".join(f"{x:.5f}" for x in pts.ravel())}"/></asset>
-      <worldbody>
-        <light pos="0 -2 1" dir="0 0.9 -0.45" directional="true" diffuse="0.55 0.55 0.55"/>
-        <camera pos="0 -1.6 0" xyaxes="1 0 0 0 0 1" fovy="30"/>
-        <geom type="mesh" mesh="sphere" rgba="0.8 0.8 0.8 1"/>
-      </worldbody>
-    </mujoco>
-    """
-    mjm, _, m, d = test_data.fixture(xml=xml)
-
-    def render(enable):
+    values, counts = [], []
+    for enable_vertex_normals in (True, False):
       rc = mjw.create_render_context(
-        mjm, cam_res=(64, 64), render_rgb=True, render_seg=True, use_ambient_lighting=False, enable_vertex_normals=enable
+        mjm,
+        cam_res=(64, 64),
+        render_rgb=True,
+        render_seg=True,
+        use_ambient_lighting=False,
+        enable_vertex_normals=enable_vertex_normals,
       )
       mjw.render(m, d, rc)
       red = _unpack_rgb(rc.rgb_data.numpy()[0])[..., 0]
       seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
-      return np.unique(red[seg == 0], return_counts=True)
+      value, count = np.unique(red[seg == 0], return_counts=True)
+      values.append(value)
+      counts.append(count)
 
-    value_smooth, count_smooth = render(True)
-    value_flat, count_flat = render(False)
-
-    self.assertGreater(len(value_smooth), len(value_flat))
-    self.assertGreater(int(count_flat.max()), int(count_smooth.max()))
+    self.assertGreater(len(values[0]), 120)
+    self.assertLess(int(counts[0].max()), 40)
+    self.assertGreater(len(values[0]), len(values[1]))
+    self.assertGreater(int(counts[1].max()), int(counts[0].max()))
 
   def test_megakernel_cached_across_renders(self):
     mjm, _, m, d = test_data.fixture(
@@ -919,10 +914,14 @@ class RenderTest(parameterized.TestCase):
     mjw.render(m, d, rc)
     self.assertIs(rc._megakernel, kernel)
 
-  def test_shadow_light_fraction_scales_shadowed_light(self):
-    # How much of a light survives its own shadow: 0 is black, 1 is no shadow.
-    xml = """
+  @parameterized.parameters(0.0, 0.3, 1.0)
+  def test_shadow_light_fraction_scales_shadowed_light(self, fraction: float):
+    # How much of a light survives its own shadow: 0 renders the shadowed floor
+    # black, 1 erases the shadow, and mid-fractions sit strictly between.
+    mjm, _, m, d = test_data.fixture(
+      xml="""
     <mujoco>
+      <visual><headlight active="0"/></visual>
       <worldbody>
         <light pos="0 0 3" dir="0 0 -1" directional="true" diffuse="1 1 1" castshadow="true"/>
         <camera pos="0 -1.2 1.2" xyaxes="1 0 0 0 0.7 0.7" fovy="60"/>
@@ -931,28 +930,30 @@ class RenderTest(parameterized.TestCase):
       </worldbody>
     </mujoco>
     """
-    shadowed = []
-    for fraction in (0.0, 0.3, 0.6, 1.0):
-      mjm, _, m, d = test_data.fixture(xml=xml)
-      rc = mjw.create_render_context(
-        mjm,
-        cam_res=(64, 64),
-        render_rgb=True,
-        render_seg=True,
-        use_shadows=True,
-        use_ambient_lighting=False,
-        shadow_light_fraction=fraction,
-      )
-      mjw.render(m, d, rc)
-      red = _unpack_rgb(rc.rgb_data.numpy()[0])[..., 0]
-      seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
-      floor = red[seg == 0]
-      shadowed.append((int(floor.min()), int(floor.max())))
+    )
+    rc = mjw.create_render_context(
+      mjm,
+      cam_res=(64, 64),
+      render_rgb=True,
+      render_seg=True,
+      use_shadows=True,
+      use_ambient_lighting=False,
+      enable_specular=False,
+      shadow_light_fraction=fraction,
+    )
+    mjw.render(m, d, rc)
+    red = _unpack_rgb(rc.rgb_data.numpy()[0])[..., 0]
+    seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
+    floor = red[seg == 0]
 
-    darkest = [lo for lo, _ in shadowed]
-    self.assertEqual(darkest, sorted(darkest))
-    self.assertLess(darkest[0], darkest[-1])
-    self.assertEqual(shadowed[-1][0], shadowed[-1][1])
+    if fraction == 0.0:
+      self.assertEqual(int(floor.min()), 0)
+      self.assertGreater(int(floor.max()), 0)
+    elif fraction == 1.0:
+      self.assertEqual(int(floor.min()), int(floor.max()))
+    else:
+      self.assertGreater(int(floor.min()), 0)
+      self.assertLess(int(floor.min()), int(floor.max()))
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -740,6 +740,35 @@ class RenderTest(parameterized.TestCase):
     self.assertGreater(np.count_nonzero(seg == 1), 0)
     self.assertEqual(np.count_nonzero(seg == 0), 0)
 
+  @parameterized.parameters(False, True)
+  def test_coincident_geoms_with_roundoff_resolve_to_higher_index(self, extra_geoms: bool):
+    # The lower-index box sits nearer by less than the tie tolerance: roundoff
+    # must not let it win. The extra geoms reshuffle the BVH traversal order so
+    # both visit orders of the pair are exercised.
+    ring = "".join(
+      f'<geom type="sphere" size="0.05" pos="{0.7 * np.cos(t):.3f} {0.5 * np.sin(t):.3f} 0" rgba="0.5 0.5 0.9 1"/>'
+      for t in np.linspace(0.0, 2.0 * np.pi, 9, endpoint=False)
+    )
+    xml = f"""
+    <mujoco>
+      <worldbody>
+        <light pos="0 -1 1"/>
+        <camera pos="0 -2 0" xyaxes="1 0 0 0 0 1"/>
+        {ring if extra_geoms else ""}
+        <geom type="box" size="0.2 0.2 0.2" rgba="1 0 0 1"/>
+        <geom type="box" pos="0 1e-7 0" size="0.2 0.2 0.2" rgba="0 1 0 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, _, m, d = test_data.fixture(xml=xml)
+    rc = mjw.create_render_context(mjm, cam_res=(32, 32), render_seg=True)
+    mjw.render(m, d, rc)
+    seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
+    nbox = mjm.ngeom - 2, mjm.ngeom - 1
+
+    self.assertGreater(np.count_nonzero(seg == nbox[1]), 0)
+    self.assertEqual(np.count_nonzero(seg == nbox[0]), 0)
+
   def test_backfaces_are_shaded_two_sided(self):
     # Camera inside the box: every visible face points away from it. Shading
     # those hits with an unflipped normal leaves the interior at zero diffuse.

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -769,6 +769,27 @@ class RenderTest(parameterized.TestCase):
     self.assertGreater(np.count_nonzero(seg == nbox[1]), 0)
     self.assertEqual(np.count_nonzero(seg == nbox[0]), 0)
 
+  def test_backface_cull_skips_culled_triangles(self):
+    # An inside-out tetra: like GL, culling must drop its near faces yet still
+    # draw the far face behind them, not drop the whole mesh.
+    xml = """
+    <mujoco>
+      <asset><mesh name="tetra" vertex="1 1 1  1 -1 -1  -1 1 -1  -1 -1 1" face="0 2 1  0 1 3  0 3 2  1 2 3"/></asset>
+      <worldbody>
+        <light pos="0 -3 1"/>
+        <camera pos="0 -3 0" xyaxes="1 0 0 0 0 1"/>
+        <geom name="tetra" type="mesh" mesh="tetra"/>
+        <geom name="marker" type="box" size="0.5 0.5 0.5" pos="0 5 0"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, _, m, d = test_data.fixture(xml=xml)
+    rc = mjw.create_render_context(mjm, cam_res=(32, 32), render_seg=True, enable_backface_culling=True)
+    mjw.render(m, d, rc)
+    seg = rc.seg_data.numpy()[0].reshape(-1, 2)[..., 0]
+
+    self.assertGreater(np.count_nonzero(seg == 0), 0)
+
   def test_backfaces_are_shaded_two_sided(self):
     # Camera inside the box: every visible face points away from it. Shading
     # those hits with an unflipped normal leaves the interior at zero diffuse.

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -321,6 +321,7 @@ def create_render_context(
   render_skybox: bool = False,
   enable_backface_culling: bool = True,
   shadow_light_fraction: float = 0.3,
+  enable_vertex_normals: bool = True,
   enable_specular: bool = True,
   enable_emission: bool = True,
   enable_per_light_ambient: bool = True,
@@ -358,6 +359,8 @@ def create_render_context(
                    Requires the model to contain a texture with type `mjTEXTURE_SKYBOX`.
     shadow_light_fraction: Fraction of a light's direct contribution reaching an
       occluded point. 0 is a true shadow.
+    enable_vertex_normals: Shade meshes from their authored vertex normals,
+      matching mjr_uploadMesh. When False, use the face normal.
     enable_backface_culling: Drop primitive-ray hits whose normal faces away from
                              the ray (ray origin inside the geom). Matches MuJoCo's
                              mesh-ray rule. Default True. Disable for a small
@@ -730,6 +733,7 @@ def create_render_context(
     enable_backface_culling=enable_backface_culling,
     shadow_light_fraction=shadow_light_fraction,
     geom_ray_types=geom_ray_types,
+    enable_vertex_normals=enable_vertex_normals,
     enable_specular=enable_specular,
     enable_emission=enable_emission,
     enable_per_light_ambient=enable_per_light_ambient,

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -320,6 +320,7 @@ def create_render_context(
   use_precomputed_rays: bool = True,
   render_skybox: bool = False,
   enable_backface_culling: bool = True,
+  shadow_light_fraction: float = 0.3,
   enable_specular: bool = True,
   enable_emission: bool = True,
   enable_per_light_ambient: bool = True,
@@ -355,6 +356,8 @@ def create_render_context(
                           When using domain randomization for camera intrinsics, set to False.
     render_skybox: Whether to shade missed rays with the MuJoCo skybox texture.
                    Requires the model to contain a texture with type `mjTEXTURE_SKYBOX`.
+    shadow_light_fraction: Fraction of a light's direct contribution reaching an
+      occluded point. 0 is a true shadow.
     enable_backface_culling: Drop primitive-ray hits whose normal faces away from
                              the ray (ray origin inside the geom). Matches MuJoCo's
                              mesh-ray rule. Default True. Disable for a small
@@ -725,6 +728,7 @@ def create_render_context(
     znear=znear,
     total_rays=int(total),
     enable_backface_culling=enable_backface_culling,
+    shadow_light_fraction=shadow_light_fraction,
     geom_ray_types=geom_ray_types,
     enable_specular=enable_specular,
     enable_emission=enable_emission,

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -690,6 +690,7 @@ def create_render_context(
     mesh_texcoord=wp.array(mjm.mesh_texcoord, dtype=wp.vec2),
     mesh_texcoord_offsets=wp.array(mjm.mesh_texcoordadr, dtype=int),
     mesh_facetexcoord=wp.array(mjm.mesh_facetexcoord, dtype=wp.vec3i),
+    mesh_facenormal=wp.array(mjm.mesh_facenormal, dtype=wp.vec3i),
     textures=textures,
     textures_registry=textures_registry,
     hfield_registry=hfield_registry,

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2668,3 +2668,4 @@ class RenderContext:
   splat_group_root: array("nworld", int)
   splat_count: int
   geom_ray_types: tuple = ()
+  _megakernel: Optional[wp.Kernel] = None

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2499,6 +2499,7 @@ class RenderContext:
     mesh_texcoord: mesh texture coordinates
     mesh_texcoord_offsets: mesh texture coordinate offsets
     mesh_facetexcoord: mesh face texture coordinates
+    mesh_facenormal: per-face indices into Model.mesh_normal
     textures: textures
     textures_registry: texture registry
     hfield_registry: hfield BVH id to warp mesh mapping
@@ -2609,6 +2610,7 @@ class RenderContext:
   mesh_texcoord: array("*", wp.vec2)
   mesh_texcoord_offsets: array("nmesh", int)
   mesh_facetexcoord: array("nmeshface", wp.vec3i)
+  mesh_facenormal: array("nmeshface", wp.vec3i)
   textures: array("*", wp.Texture2D)
   textures_registry: list[wp.Texture2D]
   hfield_registry: dict

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2544,6 +2544,8 @@ class RenderContext:
     headlight_ambient: RGB ambient color of the headlight (from vis.headlight).
     headlight_diffuse: RGB diffuse color of the headlight.
     headlight_specular: RGB specular color of the headlight.
+    shadow_light_fraction: fraction of a light's direct contribution reaching an
+      occluded point; 0 is a true shadow
     enable_backface_culling: drop primitive ray hits whose normal faces away
       from the ray (i.e. the ray origin is inside the geom). Matches MuJoCo's
       mesh-ray rule. When False, the renderer reports inner-surface hits, which
@@ -2645,6 +2647,7 @@ class RenderContext:
   znear: float
   total_rays: int
   enable_backface_culling: bool
+  shadow_light_fraction: float
   enable_specular: bool
   enable_emission: bool
   enable_per_light_ambient: bool

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2562,6 +2562,8 @@ class RenderContext:
     has_orthographic_camera: True iff any actively rendering camera uses
       orthographic projection. When False, the kernel skips the ray origin
       offset since it is always zero for perspective-only scenes.
+    enable_vertex_normals: when True, shade meshes from their authored vertex
+      normals, matching mjr_uploadMesh; when False, use the face normal.
     enable_specular: when True, evaluate the Phong specular highlight per
       light per pixel (uses `mat_specular` / `mat_shininess`). When False,
       the entire specular branch is removed at compile time. Useful for
@@ -2648,6 +2650,7 @@ class RenderContext:
   total_rays: int
   enable_backface_culling: bool
   shadow_light_fraction: float
+  enable_vertex_normals: bool
   enable_specular: bool
   enable_emission: bool
   enable_per_light_ambient: bool


### PR DESCRIPTION
This PR fixes several rendering correctness issues in the raytracer. In every image below: native MuJoCo (OpenGL) on the left, mjwarp @ main in the middle, and mjwarp @ this PR on the right.

**Meshes were clipped.** The BVH stored half-extents of `0.5 * (pmax - pmin)` about the mesh origin. For meshes whose vertices aren't centered on the origin, this bounding box does not contain the full mesh, causing chunks of geometry to disappear at some view angles.

![mesh clipping](https://raw.githubusercontent.com/kevinzakka/mujoco_warp/156fd9807096a54284aeab385ce7bb444fe26869/images/nanoeval_clipped_bottle.png)

*Look at the white bottle's cap: main clips its top rim away, leaving a gray gap between cap and collar.*

**Coincident surfaces flickered.** Which geom won depended on BVH traversal order. Ties now resolve to the higher geom index: the later-declared geom wins, matching native MuJoCo, whose depth test leaves the last draw on top.

![coincident geoms](https://raw.githubusercontent.com/kevinzakka/mujoco_warp/baa4279d8f7766fd871cde7d478634f3accbbe6f/images/coincident_geoms.png)

*Two exactly coincident boxes, red declared before green. Main shows whichever the BVH happens to visit first; this PR shows the later-declared green, like native MuJoCo.*

**Backfaces rendered black** when backface culling was disabled. Shading is now two-sided.

![two sided shading](https://raw.githubusercontent.com/kevinzakka/mujoco_warp/baa4279d8f7766fd871cde7d478634f3accbbe6f/images/two_sided_bin.png)

*The bin's rim and interior wall face away from the camera: main leaves them black and flat, this PR shades them.*

**Smooth meshes rendered faceted.** Authored vertex normals were ignored. The renderer now interpolates vertex normals and rejects MuJoCo's [0, 0, 1] sentinel normals against the face normal, matching MuJoCo's mesh-normal handling. This is gated by `enable_vertex_normals`.

![vertex normals](https://raw.githubusercontent.com/kevinzakka/mujoco_warp/baa4279d8f7766fd871cde7d478634f3accbbe6f/images/nanoeval_bottle_closeup.png)

*Main shades each face flat, banding the ribbed bottle; this PR matches the reference.*

![vertex normals and shadows](https://raw.githubusercontent.com/kevinzakka/mujoco_warp/baa4279d8f7766fd871cde7d478634f3accbbe6f/images/nanoeval_wrist_f0120.png)

*The same fix from a wrist camera; both bottles lose their faceting.*

Two smaller changes are included:
* `shadow_light_fraction` exposes the previously hardcoded 0.3 in-shadow light fraction.
* The megakernel is built once per context instead of on every `render()` call.

There is no measurable performance regression on `aloha_clutter_vision` (2048 worlds, 4 cameras @ 64x64, RGB + depth + segmentation, shadows; RTX 5090):

| | main | this PR |
|---|---|---|
| steps/s | 7,921 | 7,936 |
| render, ms/step | 126.18 | 125.97 |
