### PR TITLE
Add ray offset for orthographic cameras

### DIFF
--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -725,6 +725,7 @@ def render(m: Model, d: Data, rc: RenderContext):
     cam_res: wp.array[wp.vec2i],
     cam_id_map: wp.array[int],
     ray: wp.array[wp.vec3],
+    ray_offset: wp.array[wp.vec3],
     rgb_adr: wp.array[int],
     depth_adr: wp.array[int],
     seg_adr: wp.array[int],
@@ -782,12 +783,13 @@ def render(m: Model, d: Data, rc: RenderContext):
 
     if wp.static(rc_static["use_precomputed_rays"]):
       ray_dir_local_cam = ray[rayid]
+      ray_offset_local_cam = ray_offset[rayid]
     else:
       img_w = cam_res[camid][0]
       img_h = cam_res[camid][1]
       px = rayid_local % img_w
       py = rayid_local // img_w
-      ray_dir_local_cam = compute_ray(
+      ray_dir_local_cam, ray_offset_local_cam = compute_ray(
         cam_projection[mujoco_cam_id],
         cam_fovy[worldid % cam_fovy.shape[0], mujoco_cam_id],
         cam_sensorsize[mujoco_cam_id],
@@ -799,8 +801,8 @@ def render(m: Model, d: Data, rc: RenderContext):
         wp.static(rc_static["znear"]),
       )
 
-    ray_origin_world = cam_xpos_in[worldid, mujoco_cam_id]
     cam_mat_world = cam_xmat_in[worldid, mujoco_cam_id]
+    ray_origin_world = cam_xpos_in[worldid, mujoco_cam_id] + cam_mat_world @ ray_offset_local_cam
     ray_dir_world = cam_mat_world @ ray_dir_local_cam
 
     geom_id, dist, normal, u, v, f, mesh_id = cast_ray(
@@ -1137,6 +1139,7 @@ def render(m: Model, d: Data, rc: RenderContext):
       rc.cam_res,
       rc.cam_id_map,
       rc.ray,
+      rc.ray_offset,
       rc.rgb_adr,
       rc.depth_adr,
       rc.seg_adr,

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -802,7 +802,9 @@ def render(m: Model, d: Data, rc: RenderContext):
       )
 
     cam_mat_world = cam_xmat_in[worldid, mujoco_cam_id]
-    ray_origin_world = cam_xpos_in[worldid, mujoco_cam_id] + cam_mat_world @ ray_offset_local_cam
+    ray_origin_world = cam_xpos_in[worldid, mujoco_cam_id]
+    if wp.static(rc_static["has_orthographic_camera"]):
+      ray_origin_world += cam_mat_world @ ray_offset_local_cam
     ray_dir_world = cam_mat_world @ ray_dir_local_cam
 
     geom_id, dist, normal, u, v, f, mesh_id = cast_ray(

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -409,8 +409,7 @@ class RenderTest(parameterized.TestCase):
   @parameterized.named_parameters(("precomputed_rays", True), ("dynamic_rays", False))
   def test_segmentation_orthographic_matches_mujoco(self, use_precomputed_rays: bool):
     """Orthographic segmentation should match native MuJoCo, including vertical orientation."""
-    mjm, mjd, _m, d = test_data.fixture(xml=self._ORTHOGRAPHIC_SCENE)
-    m = mjw.put_model(mjm)
+    mjm, mjd, m, d = test_data.fixture(xml=self._ORTHOGRAPHIC_SCENE)
     cam_w, cam_h = 64, 64
 
     rc = mjw.create_render_context(

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -377,6 +377,56 @@ class RenderTest(parameterized.TestCase):
 
     np.testing.assert_array_equal(warp_seg_np, mj_seg)
 
+  def test_render_segmentation_orthographic(self):
+    """Orthographic camera's rays must shift across pixels, depending on its offset."""
+    xml = """
+      <mujoco>
+        <worldbody>
+          <camera name="cam" pos="0 -10 0" xyaxes="1 0 0 0 0 1" projection="orthographic" fovy="10"/>
+          <geom name="left_box" type="box" size="1 2 1" pos="-2 0 0" rgba="1 0 0 1"/>
+          <geom name="right_box" type="box" size="1 2 1" pos="2 0 0" rgba="0 0 1 1"/>
+        </worldbody>
+      </mujoco>
+    """
+    mjm, mjd, m, d = test_data.fixture(xml=xml)
+
+    rc = mjw.create_render_context(mjm, nworld=1, cam_res=(64, 64), render_rgb=False, render_depth=False, render_seg=True)
+    mjw.render(m, d, rc)
+
+    seg = rc.seg_data.numpy().reshape(1, 64, 64, 2)[0]
+    left_ids = set(np.unique(seg[:, :32, 0])) - {-1}
+    right_ids = set(np.unique(seg[:, 32:, 0])) - {-1}
+    self.assertTrue(left_ids, "left half of the frame should hit the left sphere")
+    self.assertTrue(right_ids, "right half of the frame should hit the right sphere")
+    self.assertFalse(left_ids & right_ids, "the two spheres are distinct geoms")
+
+  @absltest.skipIf(not _HAS_RENDERER, "MuJoCo rendering requires OpenGL")
+  def test_segmentation_orthographic_matches_mujoco(self):
+    """Orthographic segmentation should match native MuJoCo."""
+    xml = """
+      <mujoco>
+        <worldbody>
+          <camera name="cam" pos="0 -10 0" xyaxes="1 0 0 0 0 1" projection="orthographic" fovy="10"/>
+          <geom name="left_box" type="box" size="1 2 1" pos="-2 0 0" rgba="1 0 0 1"/>
+          <geom name="right_box" type="box" size="1 2 1" pos="2 0 0" rgba="0 0 1 1"/>
+        </worldbody>
+      </mujoco>
+    """
+    mjm, mjd, _m, d = test_data.fixture(xml=xml)
+    m = mjw.put_model(mjm)
+    cam_w, cam_h = 64, 64
+
+    rc = mjw.create_render_context(mjm, nworld=1, cam_res=(cam_w, cam_h), render_seg=[True])
+    mjw.render(m, d, rc)
+    warp_seg_np = rc.seg_data.numpy()[0].reshape(-1, 2)
+
+    with mujoco.Renderer(mjm, height=cam_h, width=cam_w) as renderer:
+      renderer.update_scene(mjd, camera="cam")
+      renderer.enable_segmentation_rendering()
+      mj_seg = renderer.render().reshape(-1, 2)
+
+    np.testing.assert_array_equal(warp_seg_np, mj_seg)
+
   @absltest.skipIf(not _HAS_RENDERER, "MuJoCo rendering requires OpenGL")
   def test_depth_matches_mujoco(self):
     """Depth values should match native MuJoCo (planar depth, not Euclidean)."""

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -377,46 +377,49 @@ class RenderTest(parameterized.TestCase):
 
     np.testing.assert_array_equal(warp_seg_np, mj_seg)
 
+  # The two boxes sit in diagonally opposite quadrants (bottom-left and top-right, in
+  # image space) so that a flip along either the horizontal or the vertical ray axis
+  # is caught by a single scene, unlike a left/right or top/bottom split alone, each
+  # of which is symmetric under the other axis' flip.
+  _ORTHOGRAPHIC_SCENE = """
+    <mujoco>
+      <worldbody>
+        <camera name="cam" pos="0 -10 0" xyaxes="1 0 0 0 0 1" projection="orthographic" fovy="10"/>
+        <geom name="bottom_left_box" type="box" size="1 1 1" pos="-2 0 -2" rgba="1 0 0 1"/>
+        <geom name="top_right_box" type="box" size="1 1 1" pos="2 0 2" rgba="0 0 1 1"/>
+      </worldbody>
+    </mujoco>
+  """
+
   def test_render_segmentation_orthographic(self):
     """Orthographic camera's rays must shift across pixels, depending on its offset."""
-    xml = """
-      <mujoco>
-        <worldbody>
-          <camera name="cam" pos="0 -10 0" xyaxes="1 0 0 0 0 1" projection="orthographic" fovy="10"/>
-          <geom name="left_box" type="box" size="1 2 1" pos="-2 0 0" rgba="1 0 0 1"/>
-          <geom name="right_box" type="box" size="1 2 1" pos="2 0 0" rgba="0 0 1 1"/>
-        </worldbody>
-      </mujoco>
-    """
-    mjm, mjd, m, d = test_data.fixture(xml=xml)
+    mjm, mjd, m, d = test_data.fixture(xml=self._ORTHOGRAPHIC_SCENE)
 
     rc = mjw.create_render_context(mjm, nworld=1, cam_res=(64, 64), render_rgb=False, render_depth=False, render_seg=True)
     mjw.render(m, d, rc)
 
     seg = rc.seg_data.numpy().reshape(1, 64, 64, 2)[0]
-    left_ids = set(np.unique(seg[:, :32, 0])) - {-1}
-    right_ids = set(np.unique(seg[:, 32:, 0])) - {-1}
-    self.assertTrue(left_ids, "left half of the frame should hit the left sphere")
-    self.assertTrue(right_ids, "right half of the frame should hit the right sphere")
-    self.assertFalse(left_ids & right_ids, "the two spheres are distinct geoms")
+    bottom_left_ids = set(np.unique(seg[32:, :32, 0])) - {-1}
+    top_right_ids = set(np.unique(seg[:32, 32:, 0])) - {-1}
+    self.assertTrue(bottom_left_ids, "bottom-left quadrant should hit the bottom-left box")
+    self.assertTrue(top_right_ids, "top-right quadrant should hit the top-right box")
+    self.assertFalse(bottom_left_ids & top_right_ids, "the two boxes are distinct geoms")
 
   @absltest.skipIf(not _HAS_RENDERER, "MuJoCo rendering requires OpenGL")
-  def test_segmentation_orthographic_matches_mujoco(self):
-    """Orthographic segmentation should match native MuJoCo."""
-    xml = """
-      <mujoco>
-        <worldbody>
-          <camera name="cam" pos="0 -10 0" xyaxes="1 0 0 0 0 1" projection="orthographic" fovy="10"/>
-          <geom name="left_box" type="box" size="1 2 1" pos="-2 0 0" rgba="1 0 0 1"/>
-          <geom name="right_box" type="box" size="1 2 1" pos="2 0 0" rgba="0 0 1 1"/>
-        </worldbody>
-      </mujoco>
-    """
-    mjm, mjd, _m, d = test_data.fixture(xml=xml)
+  @parameterized.named_parameters(("precomputed_rays", True), ("dynamic_rays", False))
+  def test_segmentation_orthographic_matches_mujoco(self, use_precomputed_rays: bool):
+    """Orthographic segmentation should match native MuJoCo, including vertical orientation."""
+    mjm, mjd, _m, d = test_data.fixture(xml=self._ORTHOGRAPHIC_SCENE)
     m = mjw.put_model(mjm)
     cam_w, cam_h = 64, 64
 
-    rc = mjw.create_render_context(mjm, nworld=1, cam_res=(cam_w, cam_h), render_seg=[True])
+    rc = mjw.create_render_context(
+      mjm,
+      nworld=1,
+      cam_res=(cam_w, cam_h),
+      render_seg=[True],
+      use_precomputed_rays=use_precomputed_rays,
+    )
     mjw.render(m, d, rc)
     warp_seg_np = rc.seg_data.numpy()[0].reshape(-1, 2)
 
@@ -426,6 +429,47 @@ class RenderTest(parameterized.TestCase):
       mj_seg = renderer.render().reshape(-1, 2)
 
     np.testing.assert_array_equal(warp_seg_np, mj_seg)
+
+  def test_depth_orthographic_is_correct(self):
+    """Orthographic depth should equal the true planar distance to each box's near face."""
+    mjm, mjd, m, d = test_data.fixture(xml=self._ORTHOGRAPHIC_SCENE)
+    cam_w, cam_h = 64, 64
+
+    rc = mjw.create_render_context(mjm, nworld=1, cam_res=(cam_w, cam_h), render_depth=[True], render_seg=[True])
+    mjw.render(m, d, rc)
+    depth = rc.depth_data.numpy()[0]
+    seg = rc.seg_data.numpy()[0]
+
+    # Camera is at y=-10, both boxes are centered at y=0 with half-extent 1 along y,
+    # so the true planar distance from the camera to either box's near face is 9.
+    hit = seg[:, 1] == int(mjw.ObjType.GEOM)
+    self.assertTrue(np.any(hit))
+    _assert_eq(depth[hit], 9.0, "orthographic depth")
+    self.assertTrue(np.all(depth[~hit] == 0.0))  # background
+
+  def test_rgb_orthographic_is_correct(self):
+    """Orthographic RGB should show each box's color in the correct quadrant of the frame."""
+    mjm, mjd, m, d = test_data.fixture(xml=self._ORTHOGRAPHIC_SCENE)
+    cam_w, cam_h = 64, 64
+
+    rc = mjw.create_render_context(mjm, nworld=1, cam_res=(cam_w, cam_h), render_rgb=[True], render_seg=[True])
+    mjw.render(m, d, rc)
+    rgb = _unpack_rgb(rc.rgb_data.numpy()[0]).reshape(cam_h, cam_w, 3).astype(np.int16)
+    seg = rc.seg_data.numpy()[0].reshape(cam_h, cam_w, 2)
+
+    bottom_left_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "bottom_left_box")
+    top_right_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "top_right_box")
+    bottom_left_hit = seg[32:, :32, 0] == bottom_left_id
+    top_right_hit = seg[:32, 32:, 0] == top_right_id
+    self.assertTrue(np.any(bottom_left_hit))
+    self.assertTrue(np.any(top_right_hit))
+
+    # bottom_left_box (rgba="1 0 0 1") should read red, and top_right_box
+    # (rgba="0 0 1 1") should read blue.
+    bottom_left_colors = rgb[32:, :32, :][bottom_left_hit]
+    top_right_colors = rgb[:32, 32:, :][top_right_hit]
+    self.assertTrue(np.all(bottom_left_colors[:, 0] > bottom_left_colors[:, 2]), "bottom-left box should read red, not blue")
+    self.assertTrue(np.all(top_right_colors[:, 2] > top_right_colors[:, 0]), "top-right box should read blue, not red")
 
   @absltest.skipIf(not _HAS_RENDERER, "MuJoCo rendering requires OpenGL")
   def test_depth_matches_mujoco(self):

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -89,26 +89,28 @@ def compute_ray(
     Direction of the ray in camera space, and the offset of the ray from the
     camera's center. The latter is only used for orthographic cameras.
   """
+  inv_img_h = 1.0 / float(img_h)
+
   if projection == ProjectionType.ORTHOGRAPHIC:
     # Compute ray direction
     direction = wp.vec3(0.0, 0.0, -1.0)  # always pointing forward
 
     # Compute ray offset from center
-    aspect = float(img_w) / float(img_h)
+    aspect = float(img_w) * inv_img_h
     sensor_h = fovy
     sensor_w = sensor_h * aspect
     left = -0.5 * sensor_w
     top = 0.5 * sensor_h
-    bottom = -0.5 * sensor_h
+    bottom = -top
     u = (float(px) + 0.5) / float(img_w)
-    v = (float(py) + 0.5) / float(img_h)
+    v = (float(py) + 0.5) * inv_img_h
     x = left + sensor_w * u
     y = top + (bottom - top) * v
     offset = wp.vec3(x, y, 0.0)
 
   else:  # projection == ProjectionType.PERSPECTIVE:
     # Compute ray direction
-    aspect = float(img_w) / float(img_h)
+    aspect = float(img_w) * inv_img_h
     sensor_h = sensorsize[1]
 
     # Check if we have intrinsics (sensorsize[1] != 0)
@@ -119,7 +121,7 @@ def compute_ray(
       cy = intrinsic[3]
       sensor_w = sensorsize[0]
 
-      target_aspect = float(img_w) / float(img_h)
+      target_aspect = aspect
       sensor_aspect = sensor_w / sensor_h
       if target_aspect > sensor_aspect:
         sensor_h = sensor_w / target_aspect
@@ -128,10 +130,12 @@ def compute_ray(
 
       inv_fx_znear = znear / fx
       inv_fy_znear = znear / fy
-      left = -inv_fx_znear * (sensor_w * 0.5 - cx)
-      right = inv_fx_znear * (sensor_w * 0.5 + cx)
-      top = inv_fy_znear * (sensor_h * 0.5 - cy)
-      bottom = -inv_fy_znear * (sensor_h * 0.5 + cy)
+      half_sensor_w = 0.5 * sensor_w
+      half_sensor_h = 0.5 * sensor_h
+      left = -inv_fx_znear * (half_sensor_w - cx)
+      right = inv_fx_znear * (half_sensor_w + cx)
+      top = inv_fy_znear * (half_sensor_h - cy)
+      bottom = -inv_fy_znear * (half_sensor_h + cy)
     else:
       fovy_rad = fovy * wp.static(wp.pi / 180.0)
       half_height = znear * wp.tan(0.5 * fovy_rad)
@@ -142,7 +146,7 @@ def compute_ray(
       bottom = -half_height
 
     u = (float(px) + 0.5) / float(img_w)
-    v = (float(py) + 0.5) / float(img_h)
+    v = (float(py) + 0.5) * inv_img_h
     x = left + (right - left) * u
     y = top + (bottom - top) * v
 

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -655,6 +655,10 @@ def create_render_context(
     light_attenuation_is_default = bool(np.allclose(atten, np.array([1.0, 0.0, 0.0], dtype=np.float32)))
     has_spot_lights = bool((np.asarray(mjm.light_type) == int(mujoco.mjtLightType.mjLIGHT_SPOT)).any())
 
+  has_orthographic_camera = any(
+    int(mjm.cam_projection[cam_id]) == int(ProjectionType.ORTHOGRAPHIC) for cam_id in active_cam_indices
+  )
+
   rc = RenderContext(
     nrender=ncam,
     cam_res=cam_res_arr,
@@ -722,6 +726,7 @@ def create_render_context(
     enable_per_light_ambient=enable_per_light_ambient,
     light_attenuation_is_default=light_attenuation_is_default,
     has_spot_lights=has_spot_lights,
+    has_orthographic_camera=has_orthographic_camera,
     splat_position=splat_position,
     splat_rotation=splat_rotation,
     splat_scale=splat_scale,

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -79,54 +79,85 @@ def compute_ray(
   px: int,
   py: int,
   znear: float,
-) -> wp.vec3:
-  """Compute ray direction for a pixel with per-world camera parameters.
+) -> tuple[wp.vec3, wp.vec3]:
+  """Compute ray vector for a pixel with per-world camera parameters.
 
   This combines _camera_frustum_bounds and build_primary_rays logic for use
   inside a kernel when camera parameters are batched/randomized across worlds.
+
+  Returns:
+    Direction of the ray in camera space, and the offset of the ray from the
+    camera's center. The latter is only used for orthographic cameras.
   """
   if projection == ProjectionType.ORTHOGRAPHIC:
-    return wp.vec3(0.0, 0.0, -1.0)
+    # Compute ray direction
+    direction = wp.vec3(0.0, 0.0, -1.0)  # always poiting forward
 
-  aspect = float(img_w) / float(img_h)
-  sensor_h = sensorsize[1]
+    # Compute ray offset from center
+    aspect = float(img_w) / float(img_h)
+    if sensorsize[0] != 0 and sensorsize[1] != 0:
+      # sensorsize is set - use it to derive camera FOV
+      sensor_h = sensorsize[1]
+      sensor_w = sensor_h * aspect
+    else:
+      # sensorsize is not set - use fovy to derive camera FOV
+      sensor_h = fovy
+      sensor_w = sensor_h * aspect
 
-  # Check if we have intrinsics (sensorsize[1] != 0)
-  if sensor_h != 0.0:
-    fx = intrinsic[0]
-    fy = intrinsic[1]
-    cx = intrinsic[2]
-    cy = intrinsic[3]
-    sensor_w = sensorsize[0]
+    left = -0.5 * sensor_w
+    bottom = -0.5 * sensor_h
+    u = (float(px) + 0.5) / float(img_w)
+    v = (float(py) + 0.5) / float(img_h)
+    x = left + sensor_w * u
+    y = bottom + sensor_h * v
+    offset = wp.vec3(x, y, 0.0)
 
-    target_aspect = float(img_w) / float(img_h)
-    sensor_aspect = sensor_w / sensor_h
-    if target_aspect > sensor_aspect:
-      sensor_h = sensor_w / target_aspect
-    elif target_aspect < sensor_aspect:
-      sensor_w = sensor_h * target_aspect
+  else:  # projection == ProjectionType.PERSPECTIVE:
+    # Compute ray direction
+    aspect = float(img_w) / float(img_h)
+    sensor_h = sensorsize[1]
 
-    inv_fx_znear = znear / fx
-    inv_fy_znear = znear / fy
-    left = -inv_fx_znear * (sensor_w * 0.5 - cx)
-    right = inv_fx_znear * (sensor_w * 0.5 + cx)
-    top = inv_fy_znear * (sensor_h * 0.5 - cy)
-    bottom = -inv_fy_znear * (sensor_h * 0.5 + cy)
-  else:
-    fovy_rad = fovy * wp.static(wp.pi / 180.0)
-    half_height = znear * wp.tan(0.5 * fovy_rad)
-    half_width = half_height * aspect
-    left = -half_width
-    right = half_width
-    top = half_height
-    bottom = -half_height
+    # Check if we have intrinsics (sensorsize[1] != 0)
+    if sensor_h != 0.0:
+      fx = intrinsic[0]
+      fy = intrinsic[1]
+      cx = intrinsic[2]
+      cy = intrinsic[3]
+      sensor_w = sensorsize[0]
 
-  u = (float(px) + 0.5) / float(img_w)
-  v = (float(py) + 0.5) / float(img_h)
-  x = left + (right - left) * u
-  y = top + (bottom - top) * v
+      target_aspect = float(img_w) / float(img_h)
+      sensor_aspect = sensor_w / sensor_h
+      if target_aspect > sensor_aspect:
+        sensor_h = sensor_w / target_aspect
+      elif target_aspect < sensor_aspect:
+        sensor_w = sensor_h * target_aspect
 
-  return wp.normalize(wp.vec3(x, y, -znear))
+      inv_fx_znear = znear / fx
+      inv_fy_znear = znear / fy
+      left = -inv_fx_znear * (sensor_w * 0.5 - cx)
+      right = inv_fx_znear * (sensor_w * 0.5 + cx)
+      top = inv_fy_znear * (sensor_h * 0.5 - cy)
+      bottom = -inv_fy_znear * (sensor_h * 0.5 + cy)
+    else:
+      fovy_rad = fovy * wp.static(wp.pi / 180.0)
+      half_height = znear * wp.tan(0.5 * fovy_rad)
+      half_width = half_height * aspect
+      left = -half_width
+      right = half_width
+      top = half_height
+      bottom = -half_height
+
+    u = (float(px) + 0.5) / float(img_w)
+    v = (float(py) + 0.5) / float(img_h)
+    x = left + (right - left) * u
+    y = top + (bottom - top) * v
+
+    direction = wp.normalize(wp.vec3(x, y, -znear))
+
+    # Ray offset from center not used for perspective cameras
+    offset = wp.vec3(0.0, 0.0, 0.0)
+
+  return direction, offset
 
 
 @wp.func
@@ -264,9 +295,13 @@ def _build_rays(
   znear: float,
   # Out:
   ray_out: wp.array[wp.vec3],
+  ray_offset_out: wp.array[wp.vec3],
 ):
   xid, yid = wp.tid()
-  ray_out[offset + xid + yid * img_w] = compute_ray(projection, fovy, sensorsize, intrinsic, img_w, img_h, xid, yid, znear)
+  ray_dir, ray_offset = compute_ray(projection, fovy, sensorsize, intrinsic, img_w, img_h, xid, yid, znear)
+  idx = offset + xid + yid * img_w
+  ray_out[idx] = ray_dir
+  ray_offset_out[idx] = ray_offset
 
 
 def create_render_context(
@@ -579,6 +614,7 @@ def create_render_context(
   znear = float(mjm.vis.map.znear * mjm.stat.extent)
 
   ray = wp.zeros(int(total), dtype=wp.vec3)
+  ray_offset = wp.zeros(int(total), dtype=wp.vec3)
 
   cam_projection = mjm.cam_projection
 
@@ -605,7 +641,7 @@ def create_render_context(
         ),
         znear,
       ],
-      outputs=[ray],
+      outputs=[ray, ray_offset],
     )
     offset += img_w * img_h
 
@@ -673,6 +709,7 @@ def create_render_context(
     group=wp.zeros(nworld * (bvh_ngeom + len(flex_geom_flexid)), dtype=int),
     group_root=wp.zeros(nworld, dtype=int),
     ray=ray,
+    ray_offset=ray_offset,
     rgb_data=wp.zeros((nworld, ri), dtype=wp.uint32),
     rgb_adr=wp.array(rgb_adr, dtype=int),
     depth_data=wp.zeros((nworld, di), dtype=wp.float32),

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -91,7 +91,7 @@ def compute_ray(
   """
   if projection == ProjectionType.ORTHOGRAPHIC:
     # Compute ray direction
-    direction = wp.vec3(0.0, 0.0, -1.0)  # always poiting forward
+    direction = wp.vec3(0.0, 0.0, -1.0)  # always pointing forward
 
     # Compute ray offset from center
     aspect = float(img_w) / float(img_h)

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -105,11 +105,12 @@ def compute_ray(
       sensor_w = sensor_h * aspect
 
     left = -0.5 * sensor_w
+    top = 0.5 * sensor_h
     bottom = -0.5 * sensor_h
     u = (float(px) + 0.5) / float(img_w)
     v = (float(py) + 0.5) / float(img_h)
     x = left + sensor_w * u
-    y = bottom + sensor_h * v
+    y = top + (bottom - top) * v
     offset = wp.vec3(x, y, 0.0)
 
   else:  # projection == ProjectionType.PERSPECTIVE:

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -95,15 +95,8 @@ def compute_ray(
 
     # Compute ray offset from center
     aspect = float(img_w) / float(img_h)
-    if sensorsize[0] != 0 and sensorsize[1] != 0:
-      # sensorsize is set - use it to derive camera FOV
-      sensor_h = sensorsize[1]
-      sensor_w = sensor_h * aspect
-    else:
-      # sensorsize is not set - use fovy to derive camera FOV
-      sensor_h = fovy
-      sensor_w = sensor_h * aspect
-
+    sensor_h = fovy
+    sensor_w = sensor_h * aspect
     left = -0.5 * sensor_w
     top = 0.5 * sensor_h
     bottom = -0.5 * sensor_h

--- a/mujoco_warp/_src/render_util_test.py
+++ b/mujoco_warp/_src/render_util_test.py
@@ -65,7 +65,7 @@ class RenderUtilTest(parameterized.TestCase):
     sensorsize = wp.vec2(0.0, 0.0)
     intrinsic = wp.vec4(0.0, 0.0, 0.0, 0.0)
 
-    persp_ray = render_util.compute_ray(
+    persp_dir, persp_offset = render_util.compute_ray(
       int(types.ProjectionType.PERSPECTIVE),
       fovy,
       sensorsize,
@@ -76,7 +76,7 @@ class RenderUtilTest(parameterized.TestCase):
       py,
       znear,
     )
-    ortho_ray = render_util.compute_ray(
+    ortho_dir, ortho_offset = render_util.compute_ray(
       int(types.ProjectionType.ORTHOGRAPHIC),
       fovy,
       sensorsize,
@@ -90,14 +90,24 @@ class RenderUtilTest(parameterized.TestCase):
 
     mag = np.sqrt(0.5**2 + 0.5**2 + 1.0**2)
     expected_persp = np.array([0.5 / mag, -0.5 / mag, -1.0 / mag])
-    np.testing.assert_allclose(np.array(persp_ray), expected_persp, atol=1e-5)
+    np.testing.assert_allclose(np.array(persp_dir), expected_persp, atol=1e-5)
 
     expected_ortho = np.array([0.0, 0.0, -1.0])
-    np.testing.assert_allclose(np.array(ortho_ray), expected_ortho, atol=1e-5)
+    np.testing.assert_allclose(np.array(ortho_dir), expected_ortho, atol=1e-5)
 
     self.assertFalse(
-      np.allclose(np.array(persp_ray), np.array(ortho_ray)),
+      np.allclose(np.array(persp_dir), np.array(ortho_dir)),
       "perspective != orthographic raydir",
+    )
+
+    # Perspective rays all originate at the camera center: no offset, for any pixel.
+    np.testing.assert_allclose(np.array(persp_offset), [0.0, 0.0, 0.0], atol=1e-5)
+
+    # Orthographic rays are parallel, so the per-pixel fan-out that perspective
+    # puts in the direction shows up in the offset instead.
+    self.assertFalse(
+      np.allclose(np.array(ortho_offset), [0.0, 0.0, 0.0]),
+      "orthographic offset should vary with pixel position",
     )
 
   def test_get_segmentation(self):

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2503,6 +2503,9 @@ class RenderContext:
     has_spot_lights: True iff any light in the model has `type == SPOT`.
       When False, the kernel skips the spot-cone branch (cos cutoff +
       pow exponent) per non-directional light per pixel via `wp.static`.
+    has_orthographic_camera: True iff any actively rendering camera uses
+      orthographic projection. When False, the kernel skips the ray origin
+      offset since it is always zero for perspective-only scenes.
     enable_specular: when True, evaluate the Phong specular highlight per
       light per pixel (uses `mat_specular` / `mat_shininess`). When False,
       the entire specular branch is removed at compile time. Useful for
@@ -2592,6 +2595,7 @@ class RenderContext:
   enable_per_light_ambient: bool
   light_attenuation_is_default: bool
   has_spot_lights: bool
+  has_orthographic_camera: bool
   splat_position: array("*", wp.vec3)
   splat_rotation: array("*", wp.quat)
   splat_scale: array("*", wp.vec3)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2466,7 +2466,9 @@ class RenderContext:
     upper: upper bounds
     group: groups
     group_root: group roots
-    ray: rays
+    ray: per-pixel rays direction
+    ray_offset: per-pixel ray offset from camera center (for orthographic
+      camera projections only)
     rgb_data: RGB data
     rgb_adr: RGB addresses
     depth_data: depth data
@@ -2572,6 +2574,7 @@ class RenderContext:
   group: array("*", int)
   group_root: array("*", int)
   ray: array("*", wp.vec3)
+  ray_offset: array("*", wp.vec3)
   rgb_data: array("*", wp.uint32)
   rgb_adr: array("ncam", int)
   depth_data: array("*", wp.float32)


### PR DESCRIPTION
Currently, `compute_ray` (called upon rendering context initialization) only returns the ray direction. For orthographic cameras, this is a constant (0, 0, -1), which is fine.

However, for orthographic cameras, we also need the ray's offset from the camera center. If I understand it correctly, I think this is currently missing. The result is that all pixels are looking at the same location.

To verify this, I set up this test with two boxes and a small green sphere at the center. As expected, all pixels rendered from the orthographic camera seem to be looking at the same green center pixel:

```python
import mujoco
import numpy as np
from PIL import Image, ImageFont, ImageDraw

import mujoco_warp as mjw

XML = """
<mujoco>
  <worldbody>
    <camera name="perspective_camera" pos="0 -10 0" xyaxes="1 0 0 0 0 1"/>
    <camera name="orthographic_camera" pos="0 -10 0" xyaxes="1 0 0 0 0 1" projection="orthographic" fovy="10"/>
    <geom name="left_box" type="box" size="1 2 1" pos="-2 0 0" rgba="1 0 0 1"/>
    <geom name="right_box" type="box" size="1 2 1" pos="2 0 0" rgba="0 0 1 1"/>
    <geom name="center_sphere" type="sphere" size="0.1" pos="0 0 0" rgba="0 1 0 1"/>
  </worldbody>
</mujoco>
"""


def render_camera(mjm, mjd, cam_name, width=256, height=256):
  m = mjw.put_model(mjm)
  d = mjw.put_data(mjm, mjd)
  rc = mjw.create_render_context(mjm, cam_res=(width, height), render_rgb=True, cam_active=[cam_name])
  mjw.render(m, d, rc)

  packed = rc.rgb_data.numpy()[0]
  r = (packed >> 16) & 0xFF
  g = (packed >> 8) & 0xFF
  b = packed & 0xFF
  return np.stack([r, g, b], axis=-1).reshape(height, width, 3).astype(np.uint8)


if __name__ == "__main__":
  mjm = mujoco.MjModel.from_xml_string(XML)
  mjd = mujoco.MjData(mjm)
  mujoco.mj_forward(mjm, mjd)

  img_persp = render_camera(mjm, mjd, "perspective_camera")
  img_ortho = render_camera(mjm, mjd, "orthographic_camera")

  FONT = ImageFont.load_default(size=12)
  FILL = (255, 255, 255)
  OFFSET = (10, 10)

  panels = []
  for img, label in [(img_persp, "Perspective"), (img_ortho, "Orthographic")]:
    img_pil = Image.fromarray(img)
    draw = ImageDraw.Draw(img_pil)
    draw.text(OFFSET, label, font=FONT, fill=FILL)
    panels.append(np.array(img_pil))

  gap = np.zeros((panels[0].shape[0], 10, 3), dtype=np.uint8)
  out = np.hstack([panels[0], gap, panels[1]])
  Image.fromarray(out).save("demo_ortho_bug.png")
```

<img width="522" height="256" alt="demo_ortho_bug_before" src="https://github.com/user-attachments/assets/2377f397-40f5-4673-be58-6cd85f79df17" />

I propose adding a `ray_offset` attribute to the rendering context and modifying the `render` function accordingly. The output of the same script is now like this:

<img width="522" height="256" alt="demo_ortho_bug_after" src="https://github.com/user-attachments/assets/8217f60c-5943-4135-822c-47d14dda1c97" />
