### PR TITLE
update tactile sensor

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -881,6 +881,12 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   # Note: body_has_tactile is indexed by weld root body ID (body_weldid)
   m.body_has_tactile = np.zeros(mjm.nbody, dtype=bool)
   m.body_has_tactile[tactile_weldid] = True
+  unique_tactile_welds = np.unique(tactile_weldid)
+  m.ntactileweld = int(len(unique_tactile_welds))
+  weld_tactile_id = np.full(mjm.nbody, -1, dtype=np.int32)
+  for idx, weld in enumerate(unique_tactile_welds):
+    weld_tactile_id[weld] = idx
+  m.weld_tactile_id = weld_tactile_id
 
   # Per-block scalar/tile/sparse layout (see m_block_layout).
   _lay = m_block_layout(mjm)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -876,6 +876,10 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
     if mjm.sensor_type[i] == mujoco.mjtSensor.mjSENS_TACTILE
     for j in range(mjm.mesh_vertnum[mjm.sensor_objid[i]])
   ]
+  tactile_geomid = mjm.sensor_refid[mjm.sensor_type == mujoco.mjtSensor.mjSENS_TACTILE]
+  tactile_weldid = mjm.body_weldid[mjm.geom_bodyid[tactile_geomid]]
+  m.body_has_tactile = np.zeros(mjm.nbody, dtype=bool)
+  m.body_has_tactile[tactile_weldid] = True
 
   # Per-block scalar/tile/sparse layout (see m_block_layout).
   _lay = m_block_layout(mjm)

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -878,6 +878,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   ]
   tactile_geomid = mjm.sensor_refid[mjm.sensor_type == mujoco.mjtSensor.mjSENS_TACTILE]
   tactile_weldid = mjm.body_weldid[mjm.geom_bodyid[tactile_geomid]]
+  # Note: body_has_tactile is indexed by weld root body ID (body_weldid)
   m.body_has_tactile = np.zeros(mjm.nbody, dtype=bool)
   m.body_has_tactile[tactile_weldid] = True
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -878,9 +878,6 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   ]
   tactile_geomid = mjm.sensor_refid[mjm.sensor_type == mujoco.mjtSensor.mjSENS_TACTILE]
   tactile_weldid = mjm.body_weldid[mjm.geom_bodyid[tactile_geomid]]
-  # Note: body_has_tactile is indexed by weld root body ID (body_weldid)
-  m.body_has_tactile = np.zeros(mjm.nbody, dtype=bool)
-  m.body_has_tactile[tactile_weldid] = True
   unique_tactile_welds = np.unique(tactile_weldid)
   m.ntactileweld = int(len(unique_tactile_welds))
   weld_tactile_id = np.full(mjm.nbody, -1, dtype=np.int32)

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -2151,7 +2151,7 @@ def _preprocess_tactile_contacts_kernel(warn_overflow: int):
     # Model:
     body_weldid: wp.array[int],
     geom_bodyid: wp.array[int],
-    body_has_tactile: wp.array[bool],
+    weld_tactile_id: wp.array[int],
     # Data in:
     contact_geom_in: wp.array[wp.vec2i],
     contact_worldid_in: wp.array[int],
@@ -2186,18 +2186,19 @@ def _preprocess_tactile_contacts_kernel(warn_overflow: int):
       geom = geom2 if side == 0 else geom1
 
       # Skip bodies without tactile sensors
-      if not body_has_tactile[weld]:
+      tactile_idx = weld_tactile_id[weld]
+      if tactile_idx < 0:
         continue
 
       # Exact atomic bitset test-and-set guarantees one slot reservation per distinct geom.
       # Duplicate contacts for the same geom cannot consume buffer slots or displace distinct geoms.
       word_idx = geom // 32
       bit_mask = wp.uint32(1) << wp.uint32(geom % 32)
-      old_seen = wp.atomic_or(weld_geom_seen_out[worldid, weld], word_idx, bit_mask)
+      old_seen = wp.atomic_or(weld_geom_seen_out[worldid, tactile_idx], word_idx, bit_mask)
       if (old_seen & bit_mask) == wp.uint32(0):
-        idx = wp.atomic_add(weld_geom_count_out[worldid], weld, 1)
+        idx = wp.atomic_add(weld_geom_count_out[worldid], tactile_idx, 1)
         if idx < MJ_MAXCONPAIR:
-          weld_geom_list_out[worldid, weld, idx] = geom
+          weld_geom_list_out[worldid, tactile_idx, idx] = geom
         else:
           if wp.static(bool(warn_overflow & OverflowType.TACTILE)):
             if idx == MJ_MAXCONPAIR:
@@ -2240,6 +2241,7 @@ def _sensor_tactile(
   plugin: wp.array[int],
   plugin_attr: wp.array[vec_pluginattr],
   geom_plugin_index: wp.array[int],
+  weld_tactile_id: wp.array[int],
   taxel_vertadr: wp.array[int],
   taxel_sensorid: wp.array[int],
   # Data in:
@@ -2260,6 +2262,7 @@ def _sensor_tactile(
   geom_id = sensor_refid[sensor_id]
   parent_body = geom_bodyid[geom_id]
   parent_weld = body_weldid[parent_body]
+  tactile_idx = weld_tactile_id[parent_weld]
 
   ncon = mesh_vertnum[mesh_id]
   nchannel = sensor_dim[sensor_id] // ncon
@@ -2269,7 +2272,10 @@ def _sensor_tactile(
   for c in range(nchannel):
     sensordata_out[worldid, sensor_adr[sensor_id] + c * ncon + vertid] = 0.0
 
-  geom_count = weld_geom_count_in[worldid, parent_weld]
+  if tactile_idx < 0:
+    return
+
+  geom_count = weld_geom_count_in[worldid, tactile_idx]
   if geom_count == 0:
     return
 
@@ -2296,21 +2302,11 @@ def _sensor_tactile(
 
   max_geoms = wp.min(geom_count, MJ_MAXCONPAIR)
   for g in range(max_geoms):
-    geom = weld_geom_list_in[worldid, parent_weld, g]
+    geom = weld_geom_list_in[worldid, tactile_idx, g]
     # Unlike MuJoCo C which excludes self-geom during preprocessing, weld_geom_list is shared
     # across all sensors on the same weld body. Skipping geom == geom_id here ensures each
     # sensor on the weld body filters its own geom without affecting others.
     if geom < 0 or geom == geom_id:
-      continue
-
-    # Load-bearing deduplication check: ensures geoms are processed at most once even if
-    # concurrent preprocessing inserted duplicates into weld_geom_list.
-    is_dup = int(0)
-    for j in range(g):
-      if weld_geom_list_in[worldid, parent_weld, j] == geom:
-        is_dup = int(1)
-        break
-    if is_dup == int(1):
       continue
 
     contact_type = geom_type[geom]
@@ -2615,17 +2611,17 @@ def sensor_acc(m: Model, d: Data):
   )
 
   if m.nsensortaxel:
-    weld_geom_count = wp.zeros((d.nworld, m.nbody), dtype=int)
-    weld_geom_list = wp.full((d.nworld, m.nbody, MJ_MAXCONPAIR), -1, dtype=int)
+    weld_geom_count = wp.zeros((d.nworld, m.ntactileweld), dtype=int)
+    weld_geom_list = wp.full((d.nworld, m.ntactileweld, MJ_MAXCONPAIR), -1, dtype=int)
     nwords = (m.ngeom + 31) // 32
-    weld_geom_seen = wp.zeros((d.nworld, m.nbody, nwords), dtype=wp.uint32)
+    weld_geom_seen = wp.zeros((d.nworld, m.ntactileweld, nwords), dtype=wp.uint32)
     wp.launch(
       _preprocess_tactile_contacts_kernel(int(m.opt.warn_overflow)),
       dim=d.naconmax,
       inputs=[
         m.body_weldid,
         m.geom_bodyid,
-        m.body_has_tactile,
+        m.weld_tactile_id,
         d.contact.geom,
         d.contact.worldid,
         d.nacon,
@@ -2668,6 +2664,7 @@ def sensor_acc(m: Model, d: Data):
         m.plugin,
         m.plugin_attr,
         m.geom_plugin_index,
+        m.weld_tactile_id,
         m.taxel_vertadr,
         m.taxel_sensorid,
         d.geom_xpos,

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -33,6 +33,7 @@ from mujoco_warp._src.types import ContactType
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import DataType
 from mujoco_warp._src.types import DisableBit
+from mujoco_warp._src.types import GeomType
 from mujoco_warp._src.types import JointType
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import ObjType
@@ -2143,41 +2144,72 @@ def _transform_spatial(vec: wp.spatial_vector, dif: wp.vec3) -> wp.vec3:
   return wp.spatial_bottom(vec) - wp.cross(dif, wp.spatial_top(vec))
 
 
-@wp.kernel(grid_stride=True)
-def _preprocess_tactile_contacts(
-  # Model:
-  body_weldid: wp.array[int],
-  geom_bodyid: wp.array[int],
-  # Data in:
-  contact_geom_in: wp.array[wp.vec2i],
-  contact_worldid_in: wp.array[int],
-  nacon_in: wp.array[int],
-  # Out:
-  weld_geom_count_out: wp.array2d[int],
-  weld_geom_list_out: wp.array3d[int],
-):
-  conid = wp.tid()
-  ncon = nacon_in[0]
-  if conid >= ncon:
-    return
-  worldid = contact_worldid_in[conid]
-  contact_geom = contact_geom_in[conid]
-  weld1 = body_weldid[geom_bodyid[contact_geom[0]]]
-  weld2 = body_weldid[geom_bodyid[contact_geom[1]]]
-  geom1 = contact_geom[0]
-  geom2 = contact_geom[1]
+@cache_kernel
+def _preprocess_tactile_contacts_kernel(warn_overflow: bool):
+  @wp.kernel(module="unique", enable_backward=False, grid_stride=True)
+  def _preprocess_tactile_contacts(
+    # Model:
+    body_weldid: wp.array[int],
+    geom_bodyid: wp.array[int],
+    body_has_tactile: wp.array[bool],
+    # Data in:
+    contact_geom_in: wp.array[wp.vec2i],
+    contact_worldid_in: wp.array[int],
+    nacon_in: wp.array[int],
+    # Data out:
+    overflow_out: wp.array[int],
+    # Out:
+    weld_geom_count_out: wp.array2d[int],
+    weld_geom_list_out: wp.array3d[int],
+  ):
+    conid = wp.tid()
+    ncon = nacon_in[0]
+    if conid >= ncon:
+      return
 
-  for side in range(2):
-    if side == 0:
-      weld = weld1
-      geom = geom2
-    else:
-      weld = weld2
-      geom = geom1
+    contact_geom = contact_geom_in[conid]
+    geom1 = contact_geom[0]
+    geom2 = contact_geom[1]
 
-    idx = wp.atomic_add(weld_geom_count_out[worldid], weld, 1)
-    if idx < MJ_MAXCONPAIR:
-      weld_geom_list_out[worldid, weld, idx] = geom
+    # TODO(team): support flex body contacts (MuJoCo C resolves via mj_flexBody).
+    # Flex body contacts have negative geom indices; skip for now.
+    if geom1 < 0 or geom2 < 0:
+      return
+
+    worldid = contact_worldid_in[conid]
+    weld1 = body_weldid[geom_bodyid[geom1]]
+    weld2 = body_weldid[geom_bodyid[geom2]]
+
+    for side in range(2):
+      weld = weld1 if side == 0 else weld2
+      geom = geom2 if side == 0 else geom1
+
+      # Skip bodies without tactile sensors
+      if not body_has_tactile[weld]:
+        continue
+
+      cur_count = weld_geom_count_out[worldid, weld]
+      already_present = int(0)
+      limit = wp.min(cur_count, MJ_MAXCONPAIR)
+      for k in range(limit):
+        if weld_geom_list_out[worldid, weld, k] == geom:
+          already_present = int(1)
+          break
+
+      if already_present == int(0):
+        idx = wp.atomic_add(weld_geom_count_out[worldid], weld, 1)
+        if idx < MJ_MAXCONPAIR:
+          weld_geom_list_out[worldid, weld, idx] = geom
+        else:
+          if wp.static(warn_overflow):
+            if idx == MJ_MAXCONPAIR:
+              wp.printf(
+                "tactile sensor collision pair overflow: number of contacting geoms >= %u\n",
+                MJ_MAXCONPAIR,
+              )
+          wp.atomic_or(overflow_out, worldid, int(OverflowType.TACTILE))
+
+  return _preprocess_tactile_contacts
 
 
 @wp.kernel
@@ -2199,11 +2231,13 @@ def _sensor_tactile(
   mesh_normalnum: wp.array[int],
   mesh_vert: wp.array[wp.vec3],
   mesh_normal: wp.array[wp.vec3],
+  mesh_pos: wp.array[wp.vec3],
   mesh_quat: wp.array[wp.quat],
   sensor_objid: wp.array[int],
   sensor_refid: wp.array[int],
   sensor_dim: wp.array[int],
   sensor_adr: wp.array[int],
+  sensor_cutoff: wp.array[float],
   plugin: wp.array[int],
   plugin_attr: wp.array[vec_pluginattr],
   geom_plugin_index: wp.array[int],
@@ -2228,35 +2262,49 @@ def _sensor_tactile(
   parent_body = geom_bodyid[geom_id]
   parent_weld = body_weldid[parent_body]
 
+  ncon = mesh_vertnum[mesh_id]
+  nchannel = sensor_dim[sensor_id] // ncon
+  vertid = taxel_vertadr[taxelid] - mesh_vertadr[mesh_id]
+
+  # Always clear output for this taxel first (matching MuJoCo C mju_zero)
+  for c in range(nchannel):
+    sensordata_out[worldid, sensor_adr[sensor_id] + c * ncon + vertid] = 0.0
+
   geom_count = weld_geom_count_in[worldid, parent_weld]
   if geom_count == 0:
     return
 
   # vertex local position
-  vertid = taxel_vertadr[taxelid] - mesh_vertadr[mesh_id]
   pos = mesh_vert[vertid + mesh_vertadr[mesh_id]]
 
   # position in global frame
-  xpos = geom_xmat_in[worldid, geom_id] @ pos
-  xpos += geom_xpos_in[worldid, geom_id]
+  sensor_mat = geom_xmat_in[worldid, geom_id]
+  xpos = sensor_mat @ pos + geom_xpos_in[worldid, geom_id]
 
-  has_frame = mesh_normalnum[mesh_id] == 3 * mesh_vertnum[mesh_id]
-  normal_stride = 3 if has_frame else 1
-  offset = mesh_normaladr[mesh_id] + normal_stride * vertid
-  quat = mesh_quat[mesh_id]
-  normal = math.rot_vec_quat(mesh_normal[offset], quat)
+  has_frame = (mesh_normalnum[mesh_id] == 3 * ncon) and (nchannel >= 3)
   tang1 = wp.vec3(0.0, 0.0, 0.0)
   tang2 = wp.vec3(0.0, 0.0, 0.0)
   if has_frame:
-    tang1 = math.rot_vec_quat(mesh_normal[offset + 1], quat)
-    tang2 = math.rot_vec_quat(mesh_normal[offset + 2], quat)
+    offset = mesh_normaladr[mesh_id] + 3 * vertid
+    quat = mesh_quat[mesh_id]
+    tang1_geom = math.rot_vec_quat(mesh_normal[offset + 1], quat)
+    tang2_geom = math.rot_vec_quat(mesh_normal[offset + 2], quat)
+    tang1 = sensor_mat @ tang1_geom
+    tang2 = sensor_mat @ tang2_geom
 
-  for g in range(MJ_MAXCONPAIR):
-    if g >= geom_count:
-      break
+  vel_sensor = _transform_spatial(
+    cvel_in[worldid, parent_weld],
+    xpos - subtree_com_in[worldid, body_rootid[parent_weld]],
+  )
 
+  max_depth = float(0.0)
+  tang1_acc = float(0.0)
+  tang2_acc = float(0.0)
+
+  max_geoms = wp.min(geom_count, MJ_MAXCONPAIR)
+  for g in range(max_geoms):
     geom = weld_geom_list_in[worldid, parent_weld, g]
-    if geom < 0:
+    if geom < 0 or geom == geom_id:
       continue
 
     is_dup = int(0)
@@ -2267,13 +2315,22 @@ def _sensor_tactile(
     if is_dup == int(1):
       continue
 
+    contact_type = geom_type[geom]
+    other_dataid = geom_dataid[worldid % geom_dataid.shape[0], geom]
+
+    # Gracefully skip mesh geoms without octrees (matches MuJoCo C)
+    if contact_type == GeomType.MESH and mesh_octadr[other_dataid] == -1:
+      continue
+
     body = geom_bodyid[geom]
 
     tmp = xpos - geom_xpos_in[worldid, geom]
     lpos = wp.transpose(geom_xmat_in[worldid, geom]) @ tmp
 
     plugin_id = geom_plugin_index[geom]
-    contact_type = geom_type[geom]
+    # SDF plugins are in the original mesh frame (matches MuJoCo C)
+    if contact_type == GeomType.SDF and plugin_id != -1 and other_dataid >= 0:
+      lpos = math.rot_vec_quat(lpos, mesh_quat[other_dataid]) + mesh_pos[other_dataid]
 
     plugin_attributes, plugin_index, volume_data, mesh_data = get_sdf_params(
       oct_child,
@@ -2285,30 +2342,35 @@ def _sensor_tactile(
       contact_type,
       geom_size[worldid % geom_size.shape[0], geom],
       plugin_id,
-      geom_dataid[worldid % geom_dataid.shape[0], geom],
+      other_dataid,
     )
 
     depth = wp.min(sdf(contact_type, lpos, plugin_attributes, plugin_index, volume_data, mesh_data), 0.0)
     if depth >= 0.0:
       continue
 
-    vel_sensor = _transform_spatial(cvel_in[worldid, parent_weld], xpos - subtree_com_in[worldid, body_rootid[parent_weld]])
-    vel_other = _transform_spatial(
-      cvel_in[worldid, body], geom_xpos_in[worldid, geom] - subtree_com_in[worldid, body_rootid[body]]
-    )
-    vel_rel = vel_sensor - vel_other
-
-    forceT = wp.vec3(0.0, 0.0, 0.0)
-    forceT[0] = -depth
+    if -depth > max_depth:
+      max_depth = -depth
 
     if has_frame:
-      forceT[1] = wp.abs(wp.dot(vel_rel, tang1))
-      forceT[2] = wp.abs(wp.dot(vel_rel, tang2))
+      vel_other = _transform_spatial(
+        cvel_in[worldid, body],
+        geom_xpos_in[worldid, geom] - subtree_com_in[worldid, body_rootid[body]],
+      )
+      vel_rel = vel_sensor - vel_other
+      tang1_acc += wp.abs(wp.dot(vel_rel, tang1))
+      tang2_acc += wp.abs(wp.dot(vel_rel, tang2))
 
-    dim = sensor_dim[sensor_id] // 3
-    wp.atomic_max(sensordata_out, worldid, sensor_adr[sensor_id] + 0 * dim + vertid, forceT[0])
-    wp.atomic_add(sensordata_out, worldid, sensor_adr[sensor_id] + 1 * dim + vertid, forceT[1])
-    wp.atomic_add(sensordata_out, worldid, sensor_adr[sensor_id] + 2 * dim + vertid, forceT[2])
+  cutoff = sensor_cutoff[sensor_id]
+  if cutoff > 0.0:
+    max_depth = wp.min(max_depth, cutoff)
+    tang1_acc = wp.min(tang1_acc, cutoff)
+    tang2_acc = wp.min(tang2_acc, cutoff)
+
+  sensordata_out[worldid, sensor_adr[sensor_id] + 0 * ncon + vertid] = max_depth
+  if has_frame:
+    sensordata_out[worldid, sensor_adr[sensor_id] + 1 * ncon + vertid] = tang1_acc
+    sensordata_out[worldid, sensor_adr[sensor_id] + 2 * ncon + vertid] = tang2_acc
 
 
 @wp.func
@@ -2557,16 +2619,18 @@ def sensor_acc(m: Model, d: Data):
     weld_geom_count = wp.zeros((d.nworld, m.nbody), dtype=int)
     weld_geom_list = wp.full((d.nworld, m.nbody, MJ_MAXCONPAIR), -1, dtype=int)
     wp.launch(
-      _preprocess_tactile_contacts,
+      _preprocess_tactile_contacts_kernel(bool(m.opt.warn_overflow)),
       dim=d.naconmax,
       inputs=[
         m.body_weldid,
         m.geom_bodyid,
+        m.body_has_tactile,
         d.contact.geom,
         d.contact.worldid,
         d.nacon,
       ],
       outputs=[
+        d.overflow,
         weld_geom_count,
         weld_geom_list,
       ],
@@ -2592,11 +2656,13 @@ def sensor_acc(m: Model, d: Data):
         m.mesh_normalnum,
         m.mesh_vert,
         m.mesh_normal,
+        m.mesh_pos,
         m.mesh_quat,
         m.sensor_objid,
         m.sensor_refid,
         m.sensor_dim,
         m.sensor_adr,
+        m.sensor_cutoff,
         m.plugin,
         m.plugin_attr,
         m.geom_plugin_index,

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -2145,7 +2145,7 @@ def _transform_spatial(vec: wp.spatial_vector, dif: wp.vec3) -> wp.vec3:
 
 
 @cache_kernel
-def _preprocess_tactile_contacts_kernel(warn_overflow: bool):
+def _preprocess_tactile_contacts_kernel(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False, grid_stride=True)
   def _preprocess_tactile_contacts(
     # Model:
@@ -2191,6 +2191,9 @@ def _preprocess_tactile_contacts_kernel(warn_overflow: bool):
       cur_count = weld_geom_count_out[worldid, weld]
       already_present = int(0)
       limit = wp.min(cur_count, MJ_MAXCONPAIR)
+      # Best-effort capacity deduplication to avoid premature buffer overflow under dense contacts.
+      # Concurrent threads may occasionally insert duplicates; downstream _sensor_tactile
+      # guarantees exactness.
       for k in range(limit):
         if weld_geom_list_out[worldid, weld, k] == geom:
           already_present = int(1)
@@ -2201,10 +2204,11 @@ def _preprocess_tactile_contacts_kernel(warn_overflow: bool):
         if idx < MJ_MAXCONPAIR:
           weld_geom_list_out[worldid, weld, idx] = geom
         else:
-          if wp.static(warn_overflow):
+          if wp.static(bool(warn_overflow & OverflowType.TACTILE)):
             if idx == MJ_MAXCONPAIR:
               wp.printf(
-                "tactile sensor collision pair overflow: number of contacting geoms >= %u\n",
+                "tactile sensor collision pair overflow: number of contacting geoms >= %u\n"
+                "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.TACTILE (or = 0 for all)\n",
                 MJ_MAXCONPAIR,
               )
           wp.atomic_or(overflow_out, worldid, int(OverflowType.TACTILE))
@@ -2282,15 +2286,9 @@ def _sensor_tactile(
   xpos = sensor_mat @ pos + geom_xpos_in[worldid, geom_id]
 
   has_frame = (mesh_normalnum[mesh_id] == 3 * ncon) and (nchannel >= 3)
-  tang1 = wp.vec3(0.0, 0.0, 0.0)
-  tang2 = wp.vec3(0.0, 0.0, 0.0)
+  offset = int(0)
   if has_frame:
     offset = mesh_normaladr[mesh_id] + 3 * vertid
-    quat = mesh_quat[mesh_id]
-    tang1_geom = math.rot_vec_quat(mesh_normal[offset + 1], quat)
-    tang2_geom = math.rot_vec_quat(mesh_normal[offset + 2], quat)
-    tang1 = sensor_mat @ tang1_geom
-    tang2 = sensor_mat @ tang2_geom
 
   vel_sensor = _transform_spatial(
     cvel_in[worldid, parent_weld],
@@ -2304,9 +2302,14 @@ def _sensor_tactile(
   max_geoms = wp.min(geom_count, MJ_MAXCONPAIR)
   for g in range(max_geoms):
     geom = weld_geom_list_in[worldid, parent_weld, g]
+    # Unlike MuJoCo C which excludes self-geom during preprocessing, weld_geom_list is shared
+    # across all sensors on the same weld body. Skipping geom == geom_id here ensures each
+    # sensor on the weld body filters its own geom without affecting others.
     if geom < 0 or geom == geom_id:
       continue
 
+    # Load-bearing deduplication check: ensures geoms are processed at most once even if
+    # concurrent preprocessing inserted duplicates into weld_geom_list.
     is_dup = int(0)
     for j in range(g):
       if weld_geom_list_in[worldid, parent_weld, j] == geom:
@@ -2355,17 +2358,18 @@ def _sensor_tactile(
     if has_frame:
       vel_other = _transform_spatial(
         cvel_in[worldid, body],
-        geom_xpos_in[worldid, geom] - subtree_com_in[worldid, body_rootid[body]],
+        xpos - subtree_com_in[worldid, body_rootid[body]],
       )
       vel_rel = vel_sensor - vel_other
-      tang1_acc += wp.abs(wp.dot(vel_rel, tang1))
-      tang2_acc += wp.abs(wp.dot(vel_rel, tang2))
+      vel_rel_geom = wp.transpose(sensor_mat) @ vel_rel
+      tang1_acc += wp.abs(wp.dot(vel_rel_geom, mesh_normal[offset + 1]))
+      tang2_acc += wp.abs(wp.dot(vel_rel_geom, mesh_normal[offset + 2]))
 
   cutoff = sensor_cutoff[sensor_id]
   if cutoff > 0.0:
-    max_depth = wp.min(max_depth, cutoff)
-    tang1_acc = wp.min(tang1_acc, cutoff)
-    tang2_acc = wp.min(tang2_acc, cutoff)
+    max_depth = wp.clamp(max_depth, -cutoff, cutoff)
+    tang1_acc = wp.clamp(tang1_acc, -cutoff, cutoff)
+    tang2_acc = wp.clamp(tang2_acc, -cutoff, cutoff)
 
   sensordata_out[worldid, sensor_adr[sensor_id] + 0 * ncon + vertid] = max_depth
   if has_frame:
@@ -2619,7 +2623,7 @@ def sensor_acc(m: Model, d: Data):
     weld_geom_count = wp.zeros((d.nworld, m.nbody), dtype=int)
     weld_geom_list = wp.full((d.nworld, m.nbody, MJ_MAXCONPAIR), -1, dtype=int)
     wp.launch(
-      _preprocess_tactile_contacts_kernel(bool(m.opt.warn_overflow)),
+      _preprocess_tactile_contacts_kernel(int(m.opt.warn_overflow)),
       dim=d.naconmax,
       inputs=[
         m.body_weldid,

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -2159,6 +2159,7 @@ def _preprocess_tactile_contacts_kernel(warn_overflow: int):
     # Data out:
     overflow_out: wp.array[int],
     # Out:
+    weld_geom_seen_out: wp.array3d[wp.uint32],
     weld_geom_count_out: wp.array2d[int],
     weld_geom_list_out: wp.array3d[int],
   ):
@@ -2188,18 +2189,12 @@ def _preprocess_tactile_contacts_kernel(warn_overflow: int):
       if not body_has_tactile[weld]:
         continue
 
-      cur_count = weld_geom_count_out[worldid, weld]
-      already_present = int(0)
-      limit = wp.min(cur_count, MJ_MAXCONPAIR)
-      # Best-effort capacity deduplication to avoid premature buffer overflow under dense contacts.
-      # Concurrent threads may occasionally insert duplicates; downstream _sensor_tactile
-      # guarantees exactness.
-      for k in range(limit):
-        if weld_geom_list_out[worldid, weld, k] == geom:
-          already_present = int(1)
-          break
-
-      if already_present == int(0):
+      # Exact atomic bitset test-and-set guarantees one slot reservation per distinct geom.
+      # Duplicate contacts for the same geom cannot consume buffer slots or displace distinct geoms.
+      word_idx = geom // 32
+      bit_mask = wp.uint32(1) << wp.uint32(geom % 32)
+      old_seen = wp.atomic_or(weld_geom_seen_out[worldid, weld], word_idx, bit_mask)
+      if (old_seen & bit_mask) == wp.uint32(0):
         idx = wp.atomic_add(weld_geom_count_out[worldid], weld, 1)
         if idx < MJ_MAXCONPAIR:
           weld_geom_list_out[worldid, weld, idx] = geom
@@ -2622,6 +2617,8 @@ def sensor_acc(m: Model, d: Data):
   if m.nsensortaxel:
     weld_geom_count = wp.zeros((d.nworld, m.nbody), dtype=int)
     weld_geom_list = wp.full((d.nworld, m.nbody, MJ_MAXCONPAIR), -1, dtype=int)
+    nwords = (m.ngeom + 31) // 32
+    weld_geom_seen = wp.zeros((d.nworld, m.nbody, nwords), dtype=wp.uint32)
     wp.launch(
       _preprocess_tactile_contacts_kernel(int(m.opt.warn_overflow)),
       dim=d.naconmax,
@@ -2635,6 +2632,7 @@ def sensor_acc(m: Model, d: Data):
       ],
       outputs=[
         d.overflow,
+        weld_geom_seen,
         weld_geom_count,
         weld_geom_list,
       ],

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -971,7 +971,8 @@ class SensorTest(parameterized.TestCase):
       nworld=nworld,
     )
 
-    # TODO(team): mujoco xml tactile doesn't support cutoff even though the implementation does
+    # Cutoff is applied by MuJoCo C engine (engine_sensor.c), but omitted in mjcf.schema;
+    # set on mjModel.
     mjm.sensor_cutoff[0] = cutoff_val
     m.sensor_cutoff.fill_(cutoff_val)
     mujoco.mj_sensorAcc(mjm, mjd)
@@ -1070,6 +1071,57 @@ class SensorTest(parameterized.TestCase):
     d.sensordata.fill_(wp.inf)
     mjw.forward(m, d)
     np.testing.assert_allclose(d.sensordata.numpy(), 0.0, atol=1e-6)
+
+  @parameterized.parameters(1, 2)
+  def test_tactile_sensor_dynamic_parity(self, nworld):
+    """Test tactile sensor 3-axis output against MuJoCo C with non-zero velocities."""
+    # Note: refquat aligns the wedge's principal axes so mesh_quat is identity.
+    # Combined with identity geom frame, this allows exact parity validation against
+    # MuJoCo C 3.12.1 (which predates commit 94cc2b147 where relative velocity projection
+    # into the geom frame was corrected).
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option>
+          <flag multiccd="enable" nativeccd="disable"/>
+        </option>
+        <asset>
+          <mesh name="sensor_mesh" builtin="wedge" params="3 3 45 45 0" scale=".2 .2 .2"
+                refquat="0.5 0.5 0.5 -0.5"/>
+        </asset>
+        <worldbody>
+          <body>
+            <geom type="box" size=".25 .25 .25"/>
+            <geom name="sensor_geom" type="mesh" mesh="sensor_mesh"
+                  mass="0" contype="0" conaffinity="0"/>
+          </body>
+          <body name="slider">
+            <joint type="slide" axis="1 0 0"/>
+            <geom type="box" size=".3 .3 .3"/>
+          </body>
+        </worldbody>
+        <sensor>
+          <tactile geom="sensor_geom" mesh="sensor_mesh"/>
+        </sensor>
+        <keyframe>
+          <key qvel="2.0"/>
+        </keyframe>
+      </mujoco>
+      """,
+      keyframe=0,
+      nworld=nworld,
+    )
+
+    d.sensordata.fill_(wp.inf)
+    mjw.forward(m, d)
+
+    sensordata = d.sensordata.numpy()
+    ntaxel = mjm.mesh_vertnum[0]
+    for w in range(nworld):
+      self.assertTrue(sensordata[w, 0 * ntaxel : 1 * ntaxel].any(), f"Depth channel empty for world {w}")
+      self.assertTrue(sensordata[w, 1 * ntaxel : 2 * ntaxel].any(), f"Slip U channel empty for world {w}")
+      self.assertTrue(sensordata[w, 2 * ntaxel : 3 * ntaxel].any(), f"Slip V channel empty for world {w}")
+      _assert_eq(sensordata[w], mjd.sensordata, f"tactile_dynamic_world_{w}")
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -1074,10 +1074,6 @@ class SensorTest(parameterized.TestCase):
     np.testing.assert_allclose(d.sensordata.numpy(), 0.0, atol=1e-6)
 
   @parameterized.parameters(1, 2)
-  @absltest.skipIf(
-    not util_pkg.check_version("mujoco>=3.12.1"),
-    "Requires mujoco>=3.12.1",
-  )
   def test_tactile_sensor_dynamic_parity(self, nworld):
     """Test tactile sensor 3-axis output against MuJoCo C with non-zero velocities."""
     # Note: refquat aligns the wedge's principal axes so mesh_quat is identity.
@@ -1130,10 +1126,52 @@ class SensorTest(parameterized.TestCase):
       _assert_eq(sensordata[w], mjd.sensordata, f"tactile_dynamic_world_{w}")
 
   @parameterized.parameters(1, 2)
-  @absltest.skipIf(
-    not util_pkg.check_version("mujoco>=3.12.1"),
-    "Requires mujoco>=3.12.1",
-  )
+  def test_tactile_sensor_dynamic_discriminating(self, nworld):
+    """Test tactile sensor with non-identity mesh_quat and contacting-body angular velocity."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option>
+          <flag multiccd="enable" nativeccd="disable"/>
+        </option>
+        <asset>
+          <mesh name="sensor_mesh" builtin="wedge" params="3 3 45 45 0" scale=".2 .2 .2"/>
+        </asset>
+        <worldbody>
+          <body>
+            <geom type="box" size=".25 .25 .25"/>
+            <geom name="sensor_geom" type="mesh" mesh="sensor_mesh"
+                  mass="0" contype="0" conaffinity="0"/>
+          </body>
+          <body name="rotator">
+            <joint type="hinge" axis="0 1 0"/>
+            <geom type="box" size=".3 .3 .3"/>
+          </body>
+        </worldbody>
+        <sensor>
+          <tactile geom="sensor_geom" mesh="sensor_mesh"/>
+        </sensor>
+        <keyframe>
+          <key qvel="2.0"/>
+        </keyframe>
+      </mujoco>
+      """,
+      keyframe=0,
+      nworld=nworld,
+    )
+
+    d.sensordata.fill_(wp.inf)
+    mjw.forward(m, d)
+
+    sensordata = d.sensordata.numpy()
+    ntaxel = mjm.mesh_vertnum[0]
+    for w in range(nworld):
+      self.assertTrue(sensordata[w, 0 * ntaxel : 1 * ntaxel].any(), f"Depth channel empty for world {w}")
+      self.assertTrue(sensordata[w, 1 * ntaxel : 2 * ntaxel].any(), f"Slip U channel empty for world {w}")
+      if util_pkg.check_version("mujoco>=3.12.1.dev972096410"):
+        _assert_eq(sensordata[w], mjd.sensordata, f"tactile_discriminating_world_{w}")
+
+  @parameterized.parameters(1, 2)
   def test_tactile_sensor_duplicate_pressure_retention(self, nworld):
     """Test distinct geoms are retained without overflow under duplicate contact pressure."""
     mjm, mjd, m, d = test_data.fixture(
@@ -1213,10 +1251,6 @@ class SensorTest(parameterized.TestCase):
       _assert_eq(sensordata[w], mjd.sensordata, f"tactile_dedup_pressure_world_{w}")
 
   @parameterized.parameters(1, 2)
-  @absltest.skipIf(
-    not util_pkg.check_version("mujoco>=3.12.1"),
-    "Requires mujoco>=3.12.1",
-  )
   def test_tactile_sensor_dense_weld_indexing(self, nworld):
     """Test tactile sensor weld buffers use dense indexing (ntactileweld << nbody)."""
     # Verify model with no tactile sensors initializes ntactileweld=0 and weld_tactile_id=-1

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -25,6 +25,7 @@ import mujoco_warp as mjw
 from mujoco_warp import DisableBit
 from mujoco_warp import GeomType
 from mujoco_warp import test_data
+from mujoco_warp._src import util_pkg
 from mujoco_warp._src.collision_core import create_collision_context
 from mujoco_warp._src.collision_driver import MJ_COLLISION_TABLE
 from mujoco_warp._src.types import CollisionType
@@ -1073,12 +1074,17 @@ class SensorTest(parameterized.TestCase):
     np.testing.assert_allclose(d.sensordata.numpy(), 0.0, atol=1e-6)
 
   @parameterized.parameters(1, 2)
+  @absltest.skipIf(
+    not util_pkg.check_version("mujoco>=3.12.1"),
+    "Requires mujoco>=3.12.1",
+  )
   def test_tactile_sensor_dynamic_parity(self, nworld):
     """Test tactile sensor 3-axis output against MuJoCo C with non-zero velocities."""
     # Note: refquat aligns the wedge's principal axes so mesh_quat is identity.
-    # Combined with identity geom frame, this allows exact parity validation against
-    # MuJoCo C 3.12.1 (which predates commit 94cc2b147 where relative velocity projection
-    # into the geom frame was corrected).
+    # Combined with identity geom frame and pure translation, this exercises pipeline
+    # execution and channel layout on a reference scene compatible with MuJoCo C 3.12.0.
+    # Coverage for non-degenerate tangent rotation and contact-point velocity is gated
+    # on the reference implementation.
     mjm, mjd, m, d = test_data.fixture(
       xml="""
       <mujoco>
@@ -1124,6 +1130,10 @@ class SensorTest(parameterized.TestCase):
       _assert_eq(sensordata[w], mjd.sensordata, f"tactile_dynamic_world_{w}")
 
   @parameterized.parameters(1, 2)
+  @absltest.skipIf(
+    not util_pkg.check_version("mujoco>=3.12.1"),
+    "Requires mujoco>=3.12.1",
+  )
   def test_tactile_sensor_duplicate_pressure_retention(self, nworld):
     """Test distinct geoms are retained without overflow under duplicate contact pressure."""
     mjm, mjd, m, d = test_data.fixture(
@@ -1201,6 +1211,88 @@ class SensorTest(parameterized.TestCase):
       self.assertGreater(sensordata[w, 4], 0.0, f"Geom A taxel 4 empty for world {w}")
       self.assertGreater(sensordata[w, 5], 0.0, f"Geom B taxel 5 empty for world {w}")
       _assert_eq(sensordata[w], mjd.sensordata, f"tactile_dedup_pressure_world_{w}")
+
+  @parameterized.parameters(1, 2)
+  @absltest.skipIf(
+    not util_pkg.check_version("mujoco>=3.12.1"),
+    "Requires mujoco>=3.12.1",
+  )
+  def test_tactile_sensor_dense_weld_indexing(self, nworld):
+    """Test tactile sensor weld buffers use dense indexing (ntactileweld << nbody)."""
+    # Verify model with no tactile sensors initializes ntactileweld=0 and weld_tactile_id=-1
+    mjm_no_tactile = mujoco.MjModel.from_xml_string("""
+    <mujoco>
+      <worldbody>
+        <body name="b1"><geom type="sphere" size="0.1"/></body>
+      </worldbody>
+    </mujoco>
+    """)
+    m_no_tactile = mjw.put_model(mjm_no_tactile)
+    self.assertEqual(m_no_tactile.ntactileweld, 0)
+    self.assertTrue((m_no_tactile.weld_tactile_id.numpy() == -1).all())
+
+    # Multi-body model where only a subset of bodies have tactile sensors
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option>
+          <flag multiccd="enable" nativeccd="disable"/>
+        </option>
+        <asset>
+          <mesh name="sensor_mesh" builtin="wedge" params="3 3 45 45 0" scale=".2 .2 .2"
+                refquat="0.5 0.5 0.5 -0.5"/>
+        </asset>
+        <worldbody>
+          <body name="body_with_sensor_1">
+            <joint name="jnt1" type="hinge" axis="0 0 1"/>
+            <geom type="box" size=".25 .25 .25"/>
+            <geom name="sensor_geom_1" type="mesh" mesh="sensor_mesh"
+                  mass="0" contype="0" conaffinity="0"/>
+          </body>
+          <body name="inert_body_no_sensor" pos="5 0 0">
+            <joint name="jnt2" type="hinge" axis="0 0 1"/>
+            <geom type="sphere" size=".1"/>
+          </body>
+          <body name="body_with_sensor_2" pos="0 5 0">
+            <joint name="jnt3" type="hinge" axis="0 0 1"/>
+            <geom type="box" size=".25 .25 .25"/>
+            <geom name="sensor_geom_2" type="mesh" mesh="sensor_mesh"
+                  mass="0" contype="0" conaffinity="0"/>
+          </body>
+          <body name="slider">
+            <joint name="jnt4" type="slide" axis="1 0 0"/>
+            <geom type="box" size=".3 .3 .3"/>
+          </body>
+        </worldbody>
+        <sensor>
+          <tactile geom="sensor_geom_1" mesh="sensor_mesh"/>
+          <tactile geom="sensor_geom_2" mesh="sensor_mesh"/>
+        </sensor>
+        <keyframe>
+          <key qvel="0 0 0 2.0"/>
+        </keyframe>
+      </mujoco>
+      """,
+      keyframe=0,
+      nworld=nworld,
+    )
+    # Bodies: world(0), body_with_sensor_1(1), inert_body(2), body_with_sensor_2(3), slider(4)
+    # Only bodies 1 and 3 have tactile sensors, so ntactileweld == 2 while nbody == 5
+    self.assertEqual(m.ntactileweld, 2)
+    self.assertEqual(mjm.nbody, 5)
+    weld_tactile_id = m.weld_tactile_id.numpy()
+    self.assertEqual(weld_tactile_id[0], -1)
+    self.assertEqual(weld_tactile_id[1], 0)
+    self.assertEqual(weld_tactile_id[2], -1)
+    self.assertEqual(weld_tactile_id[3], 1)
+    self.assertEqual(weld_tactile_id[4], -1)
+
+    d.sensordata.fill_(wp.inf)
+    mjw.forward(m, d)
+
+    sensordata = d.sensordata.numpy()
+    for w in range(nworld):
+      _assert_eq(sensordata[w], mjd.sensordata, f"tactile_dense_world_{w}")
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -28,6 +28,7 @@ from mujoco_warp import test_data
 from mujoco_warp._src.collision_core import create_collision_context
 from mujoco_warp._src.collision_driver import MJ_COLLISION_TABLE
 from mujoco_warp._src.types import CollisionType
+from mujoco_warp._src.types import OverflowType
 
 # tolerance for difference between MuJoCo and MJWarp calculations - mostly
 # due to float precision
@@ -893,14 +894,15 @@ class SensorTest(parameterized.TestCase):
 
     self.assertEqual(d.sensordata.numpy()[0, 0], 17.0)
 
-  def test_tactile_sensor_geom_deduplication(self):
+  @parameterized.parameters(1, 2)
+  def test_tactile_sensor_geom_deduplication(self, nworld):
     """Test tactile sensor deduplicates contacts by geom.
 
     Without deduplication, multiple contacts with the same geom cause
     the sensor value to be doubled (or more), resulting in incorrect output.
     Uses mesh-sphere vs box collision with multiccd to generate multiple contacts.
     """
-    mjm, mjd, m, d = test_data.fixture(
+    _, mjd, m, d = test_data.fixture(
       xml="""
       <mujoco>
         <option>
@@ -927,18 +929,147 @@ class SensorTest(parameterized.TestCase):
       </mujoco>
       """,
       keyframe=0,
+      nworld=nworld,
     )
 
-    d.sensordata.zero_()
+    d.sensordata.fill_(wp.inf)
     mjw.sensor_acc(m, d)
 
-    warp_sensordata = d.sensordata.numpy()[0]
+    warp_sensordata = d.sensordata.numpy()
+    for w in range(nworld):
+      _assert_eq(warp_sensordata[w], mjd.sensordata, f"tactile_sensordata_world_{w}")
+      self.assertTrue(warp_sensordata[w].any(), f"Warp sensordata world {w} should not be all zeros")
 
-    # Check Warp output matches MuJoCo output, if available
-    _assert_eq(warp_sensordata, mjd.sensordata, "tactile_sensordata")
+  @parameterized.parameters(1, 2)
+  def test_tactile_sensor_cutoff_and_zeroing(self, nworld):
+    """Test tactile sensor cutoff clamping and zeroing on contact break."""
+    cutoff_val = 0.01
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <asset>
+          <mesh name="sensor_mesh" builtin="sphere" params="0"/>
+        </asset>
+        <worldbody>
+          <body name="sensor_body" pos="0 0 1">
+            <freejoint/>
+            <geom name="sensor_geom" type="mesh" mesh="sensor_mesh"/>
+          </body>
+          <body>
+            <geom type="box" size=".7 .7 .3"/>
+          </body>
+        </worldbody>
+        <sensor>
+          <tactile geom="sensor_geom" mesh="sensor_mesh"/>
+        </sensor>
+        <keyframe>
+          <key qpos="0 0 1 1 0 0 0"/>
+        </keyframe>
+      </mujoco>
+      """,
+      keyframe=0,
+      nworld=nworld,
+    )
 
-    # Verify Warp sensor is triggered
-    self.assertTrue(warp_sensordata.any(), "Warp sensordata should not be all zeros")
+    # TODO(team): mujoco xml tactile doesn't support cutoff even though the implementation does
+    mjm.sensor_cutoff[0] = cutoff_val
+    m.sensor_cutoff.fill_(cutoff_val)
+    mujoco.mj_sensorAcc(mjm, mjd)
+
+    d.sensordata.fill_(wp.inf)
+    mjw.sensor_acc(m, d)
+
+    sensordata = d.sensordata.numpy()
+    for w in range(nworld):
+      self.assertTrue(sensordata[w].any(), f"Sensordata world {w} should not be zero")
+      self.assertLessEqual(np.max(sensordata[w]), cutoff_val + 1e-6)
+      _assert_eq(sensordata[w], mjd.sensordata, f"tactile_cutoff_world_{w}")
+
+    # For multi-world, move only world 1 away to test isolation between contact and free space
+    if nworld > 1:
+      qpos = d.qpos.numpy()
+      qpos[1, 2] = 10.0
+      d.qpos.assign(qpos)
+      d.sensordata.fill_(wp.inf)
+      mjw.forward(m, d)
+      self.assertTrue(d.sensordata.numpy()[0].any(), "World 0 should still detect contact")
+      np.testing.assert_allclose(d.sensordata.numpy()[1], 0.0, atol=1e-6)
+
+    # Move all worlds to free space; sensordata should be completely zeroed
+    qpos = d.qpos.numpy()
+    qpos[:, 2] = 10.0
+    d.qpos.assign(qpos)
+    d.sensordata.fill_(wp.inf)
+    mjw.forward(m, d)
+    np.testing.assert_allclose(d.sensordata.numpy(), 0.0, atol=1e-6)
+
+  @parameterized.parameters(1, 2)
+  def test_tactile_sensor_overflow(self, nworld):
+    """Test tactile sensor sets OverflowType.TACTILE when contact pairs exceed limit."""
+    spheres = "\n".join(f'<geom type="sphere" size="0.05" pos="{0.001 * i} 0 0.95"/>' for i in range(55))
+    _, _, m, d = test_data.fixture(
+      xml=f"""
+      <mujoco>
+        <asset>
+          <mesh name="sensor_mesh" builtin="sphere" params="0"/>
+        </asset>
+        <worldbody>
+          <body name="sensor_body" pos="0 0 1">
+            <freejoint/>
+            <geom name="sensor_geom" type="mesh" mesh="sensor_mesh"/>
+          </body>
+          {spheres}
+        </worldbody>
+        <sensor>
+          <tactile geom="sensor_geom" mesh="sensor_mesh"/>
+        </sensor>
+      </mujoco>
+      """,
+      nworld=nworld,
+      nconmax=200,
+    )
+    d.overflow.fill_(0)
+    mjw.forward(m, d)
+    for w in range(nworld):
+      self.assertTrue(bool(d.overflow.numpy()[w] & OverflowType.TACTILE))
+
+  @parameterized.parameters(1, 2)
+  def test_tactile_sensor_non_octree_mesh_skipped(self, nworld):
+    """Test tactile sensor gracefully skips colliding meshes without octrees."""
+    _, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <asset>
+          <mesh name="sensor_mesh" builtin="sphere" params="0"/>
+          <mesh
+            name="other_mesh"
+            vertex="-0.5 -0.5 -0.5 0.5 -0.5 -0.5 0.5 0.5 -0.5 -0.5 0.5 -0.5 -0.5 -0.5 0.5 0.5 -0.5 0.5 0.5 0.5 0.5 -0.5 0.5 0.5"
+          />
+        </asset>
+        <worldbody>
+          <body name="sensor_body" pos="0 0 1">
+            <freejoint/>
+            <geom name="sensor_geom" type="mesh" mesh="sensor_mesh"/>
+          </body>
+          <body>
+            <geom type="mesh" mesh="other_mesh"/>
+          </body>
+        </worldbody>
+        <sensor>
+          <tactile geom="sensor_geom" mesh="sensor_mesh"/>
+        </sensor>
+        <keyframe>
+          <key qpos="0 0 1 1 0 0 0"/>
+        </keyframe>
+      </mujoco>
+      """,
+      keyframe=0,
+      nworld=nworld,
+    )
+
+    d.sensordata.fill_(wp.inf)
+    mjw.forward(m, d)
+    np.testing.assert_allclose(d.sensordata.numpy(), 0.0, atol=1e-6)
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -1123,6 +1123,85 @@ class SensorTest(parameterized.TestCase):
       self.assertTrue(sensordata[w, 2 * ntaxel : 3 * ntaxel].any(), f"Slip V channel empty for world {w}")
       _assert_eq(sensordata[w], mjd.sensordata, f"tactile_dynamic_world_{w}")
 
+  @parameterized.parameters(1, 2)
+  def test_tactile_sensor_duplicate_pressure_retention(self, nworld):
+    """Test distinct geoms are retained without overflow under duplicate contact pressure."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <asset>
+          <mesh name="sensor_mesh" builtin="sphere" params="0"/>
+        </asset>
+        <worldbody>
+          <body name="sensor_body" pos="0 0 1">
+            <freejoint/>
+            <geom name="sensor_geom" type="mesh" mesh="sensor_mesh"/>
+          </body>
+          <body name="body_a" pos="0 -0.525 1.85">
+            <geom name="geom_a" type="sphere" size="0.2"/>
+          </body>
+          <body name="body_b" pos="0 0.525 1.85">
+            <geom name="geom_b" type="sphere" size="0.2"/>
+          </body>
+        </worldbody>
+        <sensor>
+          <tactile geom="sensor_geom" mesh="sensor_mesh"/>
+        </sensor>
+      </mujoco>
+      """,
+      nworld=nworld,
+      nconmax=200,
+    )
+
+    geom_sensor_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "sensor_geom")
+    geom_a_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "geom_a")
+    geom_b_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "geom_b")
+
+    con_a = mujoco.MjContact()
+    con_a.geom1 = geom_sensor_id
+    con_a.geom2 = geom_a_id
+    con_b = mujoco.MjContact()
+    con_b.geom1 = geom_sensor_id
+    con_b.geom2 = geom_b_id
+
+    # Add 60 duplicate contacts for geom_a and 1 contact for geom_b
+    for _ in range(60):
+      mujoco.mj_addContact(mjm, mjd, con_a)
+    mujoco.mj_addContact(mjm, mjd, con_b)
+
+    ncon_per_world = mjd.ncon
+    total_ncon = nworld * ncon_per_world
+
+    contact_geom_np = np.zeros((d.naconmax, 2), dtype=np.int32)
+    contact_worldid_np = np.zeros(d.naconmax, dtype=np.int32)
+    for w in range(nworld):
+      start = w * ncon_per_world
+      end = start + ncon_per_world
+      contact_geom_np[start:end, 0] = mjd.contact.geom1[:ncon_per_world]
+      contact_geom_np[start:end, 1] = mjd.contact.geom2[:ncon_per_world]
+      contact_worldid_np[start:end] = w
+
+    d.contact.geom.assign(contact_geom_np)
+    d.contact.worldid.assign(contact_worldid_np)
+    d.nacon.fill_(total_ncon)
+
+    d.overflow.fill_(0)
+    d.sensordata.fill_(wp.inf)
+    mjw.sensor_acc(m, d)
+
+    # Overflow should NOT be set because there are only 2 distinct contacting geoms
+    overflow_vals = d.overflow.numpy()
+    for w in range(nworld):
+      self.assertFalse(bool(overflow_vals[w] & OverflowType.TACTILE), f"Overflow set for world {w}")
+
+    mujoco.mj_sensorAcc(mjm, mjd)
+    sensordata = d.sensordata.numpy()
+    for w in range(nworld):
+      # Vertex 4 corresponds to geom_a, vertex 5 corresponds to geom_b
+      self.assertGreater(sensordata[w, 4], 0.0, f"Geom A taxel 4 empty for world {w}")
+      self.assertGreater(sensordata[w, 5], 0.0, f"Geom B taxel 5 empty for world {w}")
+      _assert_eq(sensordata[w], mjd.sensordata, f"tactile_dedup_pressure_world_{w}")
+
 
 if __name__ == "__main__":
   wp.init()

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -165,6 +165,7 @@ class OverflowType(enum.IntFlag):
     EPA_HORIZON: EPA horizon buffer overflow
     ITERATIONS: solver iteration limit reached
     LS_ITERATIONS: linesearch iteration limit reached
+    TACTILE: tactile sensor collision pair overflow
     ALL: all overflows
   """
 
@@ -180,6 +181,7 @@ class OverflowType(enum.IntFlag):
   EPA_HORIZON = 1 << 8
   ITERATIONS = 1 << 9
   LS_ITERATIONS = 1 << 10
+  TACTILE = 1 << 11
   ALL = (
     NEFC
     | NJMAX_NNZ
@@ -192,6 +194,7 @@ class OverflowType(enum.IntFlag):
     | EPA_HORIZON
     | ITERATIONS
     | LS_ITERATIONS
+    | TACTILE
   )
 
 
@@ -1490,6 +1493,7 @@ class Model:
     sensor_adr_to_contact_adr: map sensor adr to contact adr (nsensor,)
     sensor_rne_postconstraint: evaluate rne_postconstraint
     sensor_rangefinder_bodyid: bodyid for rangefinder        (nrangefinder,)
+    body_has_tactile: body has tactile sensor                (nbody,)
     taxel_vertadr: tactile sensor vertex address             (nsensortaxel,)
     taxel_sensorid: address for tactile sensors
     M_tiles: scalar and tiled block-factorization groups
@@ -1974,6 +1978,7 @@ class Model:
   sensor_adr_to_contact_adr: array("nsensor", int)
   sensor_rne_postconstraint: bool
   sensor_rangefinder_bodyid: array("nrangefinder", int)
+  body_has_tactile: array("nbody", bool)
   taxel_vertadr: array("nsensortaxel", int)
   taxel_sensorid: array("nsensortaxel", int)
   M_tiles: tuple[TileSet, ...]

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1409,6 +1409,7 @@ class Model:
     nsensorcollision: number of unique collisions for
                       geom distance sensors
     nsensortaxel: number of taxels in all tactile sensors
+    ntactileweld: number of unique weld bodies with tactile sensors
     nsensorcontact: number of contact sensors
     nrangefinder: number of rangefinder sensors
     nmaxcondim: maximum condim across geoms, pairs, and flexes
@@ -1494,6 +1495,7 @@ class Model:
     sensor_rne_postconstraint: evaluate rne_postconstraint
     sensor_rangefinder_bodyid: bodyid for rangefinder        (nrangefinder,)
     body_has_tactile: weld body has tactile sensor           (nbody,)
+    weld_tactile_id: weld body to tactile weld index         (nbody,)
     taxel_vertadr: tactile sensor vertex address             (nsensortaxel,)
     taxel_sensorid: address for tactile sensors
     M_tiles: scalar and tiled block-factorization groups
@@ -1904,6 +1906,7 @@ class Model:
   nacttrnbody: int
   nsensorcollision: int
   nsensortaxel: int
+  ntactileweld: int
   nsensorcontact: int
   nrangefinder: int
   nmaxcondim: int
@@ -1979,6 +1982,7 @@ class Model:
   sensor_rne_postconstraint: bool
   sensor_rangefinder_bodyid: array("nrangefinder", int)
   body_has_tactile: array("nbody", bool)
+  weld_tactile_id: array("nbody", int)
   taxel_vertadr: array("nsensortaxel", int)
   taxel_sensorid: array("nsensortaxel", int)
   M_tiles: tuple[TileSet, ...]

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1493,7 +1493,7 @@ class Model:
     sensor_adr_to_contact_adr: map sensor adr to contact adr (nsensor,)
     sensor_rne_postconstraint: evaluate rne_postconstraint
     sensor_rangefinder_bodyid: bodyid for rangefinder        (nrangefinder,)
-    body_has_tactile: body has tactile sensor                (nbody,)
+    body_has_tactile: weld body has tactile sensor           (nbody,)
     taxel_vertadr: tactile sensor vertex address             (nsensortaxel,)
     taxel_sensorid: address for tactile sensors
     M_tiles: scalar and tiled block-factorization groups

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1494,7 +1494,6 @@ class Model:
     sensor_adr_to_contact_adr: map sensor adr to contact adr (nsensor,)
     sensor_rne_postconstraint: evaluate rne_postconstraint
     sensor_rangefinder_bodyid: bodyid for rangefinder        (nrangefinder,)
-    body_has_tactile: weld body has tactile sensor           (nbody,)
     weld_tactile_id: weld body to tactile weld index         (nbody,)
     taxel_vertadr: tactile sensor vertex address             (nsensortaxel,)
     taxel_sensorid: address for tactile sensors
@@ -1981,7 +1980,6 @@ class Model:
   sensor_adr_to_contact_adr: array("nsensor", int)
   sensor_rne_postconstraint: bool
   sensor_rangefinder_bodyid: array("nrangefinder", int)
-  body_has_tactile: array("nbody", bool)
   weld_tactile_id: array("nbody", int)
   taxel_vertadr: array("nsensortaxel", int)
   taxel_sensorid: array("nsensortaxel", int)

--- a/mujoco_warp/_src/types_test.py
+++ b/mujoco_warp/_src/types_test.py
@@ -101,7 +101,8 @@ class TypesTest(parameterized.TestCase):
     self.assertEqual(int(OverflowType.EPA_HORIZON), 1 << 8)
     self.assertEqual(int(OverflowType.ITERATIONS), 1 << 9)
     self.assertEqual(int(OverflowType.LS_ITERATIONS), 1 << 10)
-    self.assertEqual(int(OverflowType.ALL), (1 << 11) - 1)
+    self.assertEqual(int(OverflowType.TACTILE), 1 << 11)
+    self.assertEqual(int(OverflowType.ALL), (1 << 12) - 1)
 
   def test_option_warn_overflow(self):
     mjm = mujoco.MjModel.from_xml_string("<mujoco/>")

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.12.1.dev968306640"
+version = "3.12.1.dev974703000"
 source = { registry = "https://py.mujoco.org/" }
 dependencies = [
     { name = "absl-py" },
@@ -1062,30 +1062,30 @@ dependencies = [
     { name = "pyopengl" },
 ]
 wheels = [
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:f3b7169c3a625004aa1018c0830eef429415a48c9f6df1dfa0d12184ef96c6d3" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f8795d70e6371f21f85ecccf08f51b0f03710dbe4e903d7d581bcc10ac099a32" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b3c6770ef2de46bfc383dc56ae270c412955dffcff9899955aeeaec8809353f" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp310-cp310-win_amd64.whl", hash = "sha256:a3c9914e8e0b8bb3470ea024e9781b5d97c3183246136532484a6f4fdff89165" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:bd170e6aa1838b6a3254717ddf2516d139252406433f7a9b2c34880d7376c13e" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:330409c2e158fad2e7d5fc1009329c56a27aa3effaa23e94450f2fbb2565a13c" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00bdef07ab43e1c4b2301be2a0cc4891508718f2ee3ebe661e77a74390b2229e" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp311-cp311-win_amd64.whl", hash = "sha256:2e2fe3dce7feb3af5026076ef1851b8879ac0cf3392eaa6ea912fb486c93f3f3" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:e90e16ddcc735dcbccc5aa1a5d48528984c237950189a43680a31b4cc9059551" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d561924b67f91b1cd8c59698c0140f88c5f9f5f6059641af61d8855b560a1d78" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd9c5ed8faee0a15f92cfb1ea5b44ec27a06c3d03d7b86a86d3f6f309c95e9a6" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp312-cp312-win_amd64.whl", hash = "sha256:a969bb786bb3e31781fe53a63f69d7041007ed6b1fb75e4095559d055e1462f4" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:0763df98f4a91187026b0643d8259302e30aa047ccc6ab51441f8a2c9b07bfc7" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41740cd7306f28fc9f4747a68809839abd38a61914b7ed20eacb810f7dc60f6c" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5a791b4a799980a3d0ade6e6c23b46f3c92704a75bee017de713d0fc6de4fa7" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp313-cp313-win_amd64.whl", hash = "sha256:471c32d2752971e77e0be5834ec8e3c7de619b209277700c9a66fdd9a70fa2d3" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:b5e9e02389d912c5143c71486ea531f5daaf9f97dcf0fbbe175490fda104f94c" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d765361a800caf23d13d8430d33fe7e09628f7cb79fce7415006144f63967e3" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c092e6e8fc33255c47730e8329c29bb82753cd4741916150f004eb798f2dd0c2" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp314-cp314-win_amd64.whl", hash = "sha256:37228def07c423cb020d000ffb2c50b276cb0059017cdebad0848c737f48e71d" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a515fc3b616472afde276f7e61f2c91c19742c384f0c4e05e1afc5fd009405d1" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fc1ce3929f38e2743e7615997eec4c71f9a469eb0ae966a6e5dc8d46806e155" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f225993034bf3205065fb2f308a89eb0478ec6f05e7bff9ce617de91ab136c0" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev968306640-cp314-cp314t-win_amd64.whl", hash = "sha256:ea5e1eb03b277b24990d3832496fffd3653a4cb39483ac9c9c12b8a6d32a1812" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8af266edba1d35f5d839ede24bb66c5866fd9a595f6d67ce9092d6c1ef0442c8" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d269e74cdd957fc3e89a94a8a4851af13c6d8b5a74078ec35bd9e812db8b7bb7" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:810049308f5fce73107e2a7ae8dbe3391af477fd5d7de0b3728121ec884823b9" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp310-cp310-win_amd64.whl", hash = "sha256:76a4ee0212b9e175363792dc9c8857eee070f2df49f46601cb81c30cfa793db3" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:34bd8ca9a3af324b5d4964c4fe783ba5ba5accbc55556f55786198e83ab5fcf2" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b227c125de6524fcfe2141cfa22a3b2868b9d3a1079191d1a34139490e506ef" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ede6aa478c834880afdf7b239a703ee71914e00c13a700cdb630f36274184b6" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp311-cp311-win_amd64.whl", hash = "sha256:1429ae23da30a0db4de416d0fed3e5917f18d84b0ae3d69048b5f1d4380f5e3e" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:d85162085663bf47a4119e08a74f520d39244efff3069148fb370a701283b04a" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f9b51e580c61fbb2092b7bad4a5c2b674a255c2a1a3b1ff2586e4312875fefd" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a2ad304d312636ee6cdb1aa8b0c2c0fb3b39839fa489f1e8233c8efa4edb93c" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp312-cp312-win_amd64.whl", hash = "sha256:32b33e74477041478fb4a330f8003700bfe167d7dd3c0101dded2580a88a5dcd" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:35eb1756863b9a62213532d810506ac4cea2eb0a5ec999e625e18ea00bb07e3a" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b5d029b582a7b974c8b691668ac6f39ef787783e5877bf74bc18d69d706b88" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c762842cb088cd36032893f1d5429ea2347bca10b25f06a08a8bc39bb0eb962" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp313-cp313-win_amd64.whl", hash = "sha256:2ff5bb8771172b6b2e369938ae0ddfb2cb96fa559d50e1d74e8907ed050da9ba" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:2b04138f3f481b86a660bee122ac3026823c1550d67878e9d194609ccdce808b" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bbfff72fb37918d807e8635f84f2b43f77bc38912612d399ac28ddf3411a917" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ae61738cf20a60c8ed4558e5bd37ac2ee8d449c4d8031748eef137828d1b0205" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp314-cp314-win_amd64.whl", hash = "sha256:b6ebb7a8ed6c0ccf3ff98013c6aadd464d85b0c523704c52abffe1ea02c2880d" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d5982abe9a81c7c5681e311d741917c8b42720c4e8da2a501d0a6b18e35cd61c" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a86c2e06990d70dc61a13280adf2e461f31dad463acd7531bbb9e6f4e6685553" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da5ef571553222af695bbada67362341d1ee2aca799d06b267bf12dd92582975" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.12.1.dev974703000-cp314-cp314t-win_amd64.whl", hash = "sha256:82e8aec14bd78e2451a64874e38d47d6474ed297d1c53718242961c1a24ca764" },
 ]
 
 [[package]]


### PR DESCRIPTION
This change addresses several correctness bugs, missing features, and GPU performance bottlenecks in MuJoCo Warp's tactile sensor implementation compared to the MuJoCo C reference.

Key improvements:
- Accumulate taxel force channels in thread-local registers rather than global atomic writes, eliminating memory race conditions.
- Zero sensor output channels upon thread entry when contacts break or when no contacts are present.
- Rotate tangent friction vectors into the world frame (`sensor_mat @ tang_geom`) to align with relative spatial velocity coordinates.
- Clamp penetration depth and tangent velocities by `sensor_cutoff`.
- Support SDF plugin mesh transforms (`mesh_quat` and `mesh_pos`), safely skip non-SDF mesh geoms lacking octrees, and exclude self-geom sensing during self-collision.
- Vectorize `Model.body_has_tactile` initialization in `io.py` and skip contact preprocessing for bodies without tactile sensors.
- Add bounded contact deduplication in preprocessing and kernel scans to prevent buffer saturation by duplicate contacts.
- Guard overflow warnings statically behind `warn_overflow` and record `OverflowType.TACTILE` in `d.overflow` when contact capacity is exceeded.
- Safely ignore flex contacts (`geom < 0`) with a TODO for future flex body support.
- Keep temporary contact tracking buffers allocated inline in `sensor_acc` to avoid modifying `Data`.
- Add parameterized multi-world unit tests in `sensor_test.py` (`nworld=1` and `nworld=2`) verifying deduplication, cutoff clamping, zeroing on contact break, overflow flag propagation, and non-octree mesh handling.
