### PR TITLE
update overflow warnings

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -167,7 +167,7 @@ def ccd_hfield_kernel_builder(
   gjk_iterations: int,
   epa_iterations: int,
   geomgeomid: int,
-  warn_overflow: bool,
+  warn_overflow: int,
 ):
   """Kernel builder for heightfield CCD collisions (no multiccd args)."""
 
@@ -290,8 +290,12 @@ def ccd_hfield_kernel_builder(
 
     ccdid = wp.atomic_add(nccd_in, wp.static(geomgeomid), 1)
     if ccdid >= naccdmax_in:
-      if wp.static(warn_overflow):
-        wp.printf("CCD overflow - please increase naccdmax to %u\n", ccdid)
+      if wp.static(bool(warn_overflow & OverflowType.CCD)):
+        wp.printf(
+          "CCD overflow - please increase naccdmax beyond %u\n"
+          "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.CCD (or = 0 for all)\n",
+          naccdmax_in,
+        )
       wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.CCD))
       return
 
@@ -429,9 +433,11 @@ def ccd_hfield_kernel_builder(
         # add both triangles from this cell
         for i in range(2):
           if count >= MJ_MAXCONPAIR:
-            if wp.static(warn_overflow):
+            if wp.static(bool(warn_overflow & OverflowType.HFIELD)):
               wp.printf(
-                "height field collision overflow, number of collisions >= %u - please adjust resolution: \n decrease the number of hfield rows/cols or modify size of colliding geom\n",
+                "height field collision overflow, number of collisions >= %u - please adjust resolution: \n"
+                "decrease the number of hfield rows/cols or modify size of colliding geom\n"
+                "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.HFIELD (or = 0 for all)\n",
                 MJ_MAXCONPAIR,
               )
             wp.atomic_or(overflow_out, worldid, OverflowType.HFIELD)
@@ -479,7 +485,7 @@ def ccd_hfield_kernel_builder(
             epa_pr,
             epa_norm2,
             epa_horizon,
-            wp.static(warn_overflow),
+            wp.static(bool(warn_overflow & OverflowType.EPA_HORIZON)),
             worldid,
             overflow_out,
           )
@@ -739,7 +745,7 @@ def ccd_kernel_builder(
   use_multiccd: bool,
   geomgeomid: int,
   block_dim: int,
-  warn_overflow: bool,
+  warn_overflow: int,
 ):
   """Kernel builder for non-heightfield CCD collisions (no hfield args)."""
 
@@ -834,8 +840,12 @@ def ccd_kernel_builder(
     if needs_epa:
       ccdid = wp.atomic_add(nccd_in, geomgeomid, 1)
       if ccdid >= naccdmax_in:
-        if wp.static(warn_overflow):
-          wp.printf("CCD overflow - please increase naccdmax to %u\n", ccdid)
+        if wp.static(bool(warn_overflow & OverflowType.CCD)):
+          wp.printf(
+            "CCD overflow - please increase naccdmax beyond %u\n"
+            "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.CCD (or = 0 for all)\n",
+            naccdmax_in,
+          )
         wp.atomic_or(overflow_out, worldid, OverflowType.CCD)
         return
       dist, ncollision, w1, w2, multiccd_idx = epa_phase(
@@ -852,7 +862,7 @@ def ccd_kernel_builder(
         epa_pr_in[ccdid],
         epa_norm2_in[ccdid],
         epa_horizon_in[ccdid],
-        wp.static(warn_overflow),
+        wp.static(bool(warn_overflow & OverflowType.EPA_HORIZON)),
         worldid,
         overflow_out,
       )
@@ -1287,7 +1297,7 @@ def convex_narrowphase(m: Model, d: Data, ctx: CollisionContext, collision_table
     count, geomgeomid = _pair_count(g1, g2)
     if (g1 == GeomType.HFIELD or g2 == GeomType.HFIELD) and count:
       wp.launch(
-        ccd_hfield_kernel_builder(g1, g2, m.opt.ccd_iterations, epa_iterations, geomgeomid, bool(m.opt.warn_overflow)),
+        ccd_hfield_kernel_builder(g1, g2, m.opt.ccd_iterations, epa_iterations, geomgeomid, int(m.opt.warn_overflow)),
         dim=d.naconmax,
         inputs=[
           m.opt.ccd_tolerance,
@@ -1388,7 +1398,7 @@ def convex_narrowphase(m: Model, d: Data, ctx: CollisionContext, collision_table
         use_multiccd,
         geomgeomid,
         m.block_dim.convex_ccd,
-        bool(m.opt.warn_overflow),
+        int(m.opt.warn_overflow),
       )
       ccd_grid = _ccd_grid_size(ccd_k, d.naconmax, d.ncollision.device)
       wp.launch(

--- a/mujoco_warp/_src/collision_flex.py
+++ b/mujoco_warp/_src/collision_flex.py
@@ -217,8 +217,9 @@ def _write_candidate(
   if candid >= max_candidates:
     if warn_overflow:
       wp.printf(
-        "flex candidate overflow - please increase naconmax to %u\n",
-        candid + 1,
+        "flex candidate overflow - please increase naconmax beyond %u\n"
+        "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.NARROWPHASE (or = 0 for all)\n",
+        max_candidates,
       )
     wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.NARROWPHASE))
     return
@@ -561,7 +562,7 @@ def _collide_mesh_convex(
 
 
 @cache_kernel
-def _flex_plane_narrowphase(warn_overflow: bool):
+def _flex_plane_narrowphase(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
@@ -654,7 +655,7 @@ def _flex_plane_narrowphase(warn_overflow: bool):
           -1,
           local_vertid,
           worldid,
-          wp.static(warn_overflow),
+          wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)),
           overflow_out,
           cand_dist_out,
           cand_pos_out,
@@ -671,7 +672,7 @@ def _flex_plane_narrowphase(warn_overflow: bool):
 
 
 @cache_kernel
-def _flex_geom_vertex_narrowphase_detect(warn_overflow: bool):
+def _flex_geom_vertex_narrowphase_detect(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
@@ -811,8 +812,12 @@ def _flex_geom_vertex_narrowphase_detect(warn_overflow: bool):
       if gtype == int(GeomType.MESH):
         ccdid = wp.atomic_add(nccd, 0, 1)
         if ccdid >= naccdmax_in:
-          if wp.static(warn_overflow):
-            wp.printf("CCD overflow in flex narrowphase - please increase naccdmax to %u\n", ccdid + 1)
+          if wp.static(bool(warn_overflow & OverflowType.CCD)):
+            wp.printf(
+              "CCD overflow in flex narrowphase - please increase naccdmax beyond %u\n"
+              "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.CCD (or = 0 for all)\n",
+              naccdmax_in,
+            )
           wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.CCD))
           continue
 
@@ -863,7 +868,7 @@ def _flex_geom_vertex_narrowphase_detect(warn_overflow: bool):
           epa_horizon[ccdid],
           tolerance,
           ccd_iterations,
-          wp.static(warn_overflow),
+          wp.static(bool(warn_overflow & OverflowType.EPA_HORIZON)),
           overflow_out,
           cand_dist_out,
           cand_pos_out,
@@ -878,8 +883,12 @@ def _flex_geom_vertex_narrowphase_detect(warn_overflow: bool):
       elif gtype == int(GeomType.ELLIPSOID):
         ccdid = wp.atomic_add(nccd, 0, 1)
         if ccdid >= naccdmax_in:
-          if wp.static(warn_overflow):
-            wp.printf("CCD overflow in flex narrowphase - please increase naccdmax to %u\n", ccdid + 1)
+          if wp.static(bool(warn_overflow & OverflowType.CCD)):
+            wp.printf(
+              "CCD overflow in flex narrowphase - please increase naccdmax beyond %u\n"
+              "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.CCD (or = 0 for all)\n",
+              naccdmax_in,
+            )
           wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.CCD))
           continue
 
@@ -918,7 +927,7 @@ def _flex_geom_vertex_narrowphase_detect(warn_overflow: bool):
             epa_pr[ccdid],
             epa_norm2[ccdid],
             epa_horizon[ccdid],
-            wp.static(warn_overflow),
+            wp.static(bool(warn_overflow & OverflowType.EPA_HORIZON)),
             worldid,
             overflow_out,
           )
@@ -942,7 +951,7 @@ def _flex_geom_vertex_narrowphase_detect(warn_overflow: bool):
               -1,
               local_vertid,
               worldid,
-              wp.static(warn_overflow),
+              wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)),
               overflow_out,
               cand_dist_out,
               cand_pos_out,
@@ -991,7 +1000,7 @@ def _flex_geom_vertex_narrowphase_detect(warn_overflow: bool):
             -1,
             local_vertid,
             worldid,
-            wp.static(warn_overflow),
+            wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)),
             overflow_out,
             cand_dist_out,
             cand_pos_out,
@@ -1185,7 +1194,7 @@ def _flex_sap_project(
 
 
 @cache_kernel
-def _flex_sap_sweep(is_self: bool, warn_overflow: bool):
+def _flex_sap_sweep(is_self: bool, warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
@@ -1326,8 +1335,12 @@ def _flex_sap_sweep(is_self: bool, warn_overflow: bool):
 
       idx = wp.atomic_add(ncollision_out, 0, 1)
       if idx >= max_pairs:
-        if wp.static(warn_overflow):
-          wp.printf("Flex SAP buffer overflow - please increase naconmax to %u\n", idx + 1)
+        if wp.static(bool(warn_overflow & OverflowType.BROADPHASE)):
+          wp.printf(
+            "Flex SAP buffer overflow - please increase naconmax beyond %u\n"
+            "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.BROADPHASE (or = 0 for all)\n",
+            max_pairs,
+          )
         wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.BROADPHASE))
         return
 
@@ -1338,7 +1351,7 @@ def _flex_sap_sweep(is_self: bool, warn_overflow: bool):
 
 
 @cache_kernel
-def _flex_narrowphase(warn_overflow: bool):
+def _flex_narrowphase(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
@@ -1473,7 +1486,7 @@ def _flex_narrowphase(warn_overflow: bool):
             e1,
             e2,
             worldid,
-            wp.static(warn_overflow),
+            wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)),
             overflow_out,
             cand_dist_out,
             cand_pos_out,
@@ -1487,8 +1500,12 @@ def _flex_narrowphase(warn_overflow: bool):
           )
     else:
       if pairid >= naccdmax_in:
-        if wp.static(warn_overflow):
-          wp.printf("CCD overflow in flex narrowphase - please increase naccdmax to %u\n", pairid + 1)
+        if wp.static(bool(warn_overflow & OverflowType.CCD)):
+          wp.printf(
+            "CCD overflow in flex narrowphase - please increase naccdmax beyond %u\n"
+            "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.CCD (or = 0 for all)\n",
+            naccdmax_in,
+          )
         wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.CCD))
         return
 
@@ -1548,7 +1565,7 @@ def _flex_narrowphase(warn_overflow: bool):
         epa_pr_out[pairid],
         epa_norm2_out[pairid],
         epa_horizon_out[pairid],
-        wp.static(warn_overflow),
+        wp.static(bool(warn_overflow & OverflowType.EPA_HORIZON)),
         worldid,
         overflow_out,
       )
@@ -1568,7 +1585,7 @@ def _flex_narrowphase(warn_overflow: bool):
           e1,
           e2,
           worldid,
-          wp.static(warn_overflow),
+          wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)),
           overflow_out,
           cand_dist_out,
           cand_pos_out,
@@ -1585,7 +1602,7 @@ def _flex_narrowphase(warn_overflow: bool):
 
 
 @cache_kernel
-def _flex_narrowphase_elem_detect(warn_overflow: bool):
+def _flex_narrowphase_elem_detect(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False, grid_stride=False)
   def kernel(
     # Model:
@@ -1821,8 +1838,12 @@ def _flex_narrowphase_elem_detect(warn_overflow: bool):
       if gtype == int(GeomType.MESH):
         ccdid = wp.atomic_add(nccd, 0, 1)
         if ccdid >= naccdmax_in:
-          if wp.static(warn_overflow):
-            wp.printf("CCD overflow in flex narrowphase - please increase naccdmax to %u\n", ccdid + 1)
+          if wp.static(bool(warn_overflow & OverflowType.CCD)):
+            wp.printf(
+              "CCD overflow in flex narrowphase - please increase naccdmax beyond %u\n"
+              "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.CCD (or = 0 for all)\n",
+              naccdmax_in,
+            )
           wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.CCD))
           continue
 
@@ -1867,7 +1888,7 @@ def _flex_narrowphase_elem_detect(warn_overflow: bool):
           epa_horizon[ccdid],
           tolerance,
           ccd_iterations,
-          wp.static(warn_overflow),
+          wp.static(bool(warn_overflow & OverflowType.EPA_HORIZON)),
           overflow_out,
           cand_dist_out,
           cand_pos_out,
@@ -1902,7 +1923,7 @@ def _flex_narrowphase_elem_detect(warn_overflow: bool):
           elemid,
           -1,
           worldid,
-          wp.static(warn_overflow),
+          wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)),
           overflow_out,
           cand_dist_out,
           cand_pos_out,
@@ -1918,8 +1939,12 @@ def _flex_narrowphase_elem_detect(warn_overflow: bool):
       else:
         ccdid = wp.atomic_add(nccd, 0, 1)
         if ccdid >= naccdmax_in:
-          if wp.static(warn_overflow):
-            wp.printf("CCD overflow in flex narrowphase - please increase naccdmax to %u\n", ccdid + 1)
+          if wp.static(bool(warn_overflow & OverflowType.CCD)):
+            wp.printf(
+              "CCD overflow in flex narrowphase - please increase naccdmax beyond %u\n"
+              "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.CCD (or = 0 for all)\n",
+              naccdmax_in,
+            )
           wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.CCD))
           continue
 
@@ -1952,7 +1977,7 @@ def _flex_narrowphase_elem_detect(warn_overflow: bool):
             epa_pr[ccdid],
             epa_norm2[ccdid],
             epa_horizon[ccdid],
-            wp.static(warn_overflow),
+            wp.static(bool(warn_overflow & OverflowType.EPA_HORIZON)),
             worldid,
             overflow_out,
           )
@@ -1979,7 +2004,7 @@ def _flex_narrowphase_elem_detect(warn_overflow: bool):
               elemid,
               -1,
               worldid,
-              wp.static(warn_overflow),
+              wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)),
               overflow_out,
               cand_dist_out,
               cand_pos_out,
@@ -2164,7 +2189,7 @@ def _filter_flex_candidates_sorted(
 
 
 @cache_kernel
-def _write_filtered_contacts(warn_overflow: bool):
+def _write_filtered_contacts(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
@@ -2298,10 +2323,11 @@ def _write_filtered_contacts(warn_overflow: bool):
 
     id_ = wp.atomic_add(nacon_out, 0, 1)
     if id_ >= naconmax_in:
-      if wp.static(warn_overflow):
+      if wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)):
         wp.printf(
-          "flex contact overflow - please increase naconmax to %u\n",
-          id_ + 1,
+          "flex contact overflow - please increase naconmax beyond %u\n"
+          "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.NARROWPHASE (or = 0 for all)\n",
+          naconmax_in,
         )
       wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.NARROWPHASE))
       return
@@ -2374,7 +2400,7 @@ def _find_group_starts(
 
 
 @cache_kernel
-def _populate_group_starts(warn_overflow: bool):
+def _populate_group_starts(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # In:
@@ -2397,10 +2423,11 @@ def _populate_group_starts(warn_overflow: bool):
     if flex_group_temp_in[si] == 1:
       g = flex_group_ids_in[si] - 1
       if g >= flex_group_start_indices_out.shape[0]:
-        if wp.static(warn_overflow):
+        if wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)):
           wp.printf(
-            "flex candidate group overflow - please increase naconmax to %u\n",
-            g + 1,
+            "flex candidate group overflow - please increase naconmax beyond %u\n"
+            "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.NARROWPHASE (or = 0 for all)\n",
+            flex_group_start_indices_out.shape[0],
           )
         worldid = cand_worldid[filter_val_in[si]]
         wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.NARROWPHASE))
@@ -2723,7 +2750,7 @@ def _filter_and_write_contacts(
     nmax_groups = d.nworld * world_stride
 
     wp.launch(
-      _populate_group_starts(bool(m.opt.warn_overflow)),
+      _populate_group_starts(int(m.opt.warn_overflow)),
       dim=d.naconmax,
       inputs=[
         ws.flex_group_temp,
@@ -2760,7 +2787,7 @@ def _filter_and_write_contacts(
     )
 
   wp.launch(
-    _write_filtered_contacts(bool(m.opt.warn_overflow)),
+    _write_filtered_contacts(int(m.opt.warn_overflow)),
     dim=d.naconmax,
     inputs=[
       m.geom_type,
@@ -2826,7 +2853,7 @@ def _detect_plane_flex_candidates(
     return
 
   wp.launch(
-    _flex_plane_narrowphase(bool(m.opt.warn_overflow)),
+    _flex_plane_narrowphase(int(m.opt.warn_overflow)),
     dim=(d.nworld, m.nflexvert),
     inputs=[
       m.ngeom,
@@ -2873,7 +2900,7 @@ def _detect_1d_geom_candidates(
 
   epa_iterations = m.opt.ccd_iterations
   wp.launch(
-    _flex_geom_vertex_narrowphase_detect(bool(m.opt.warn_overflow)),
+    _flex_geom_vertex_narrowphase_detect(int(m.opt.warn_overflow)),
     dim=(d.nworld, m.nflexvert),
     inputs=[
       m.ngeom,
@@ -2948,7 +2975,7 @@ def _detect_elem_geom_candidates(
 
   epa_iterations = m.opt.ccd_iterations
   wp.launch(
-    _flex_narrowphase_elem_detect(bool(m.opt.warn_overflow)),
+    _flex_narrowphase_elem_detect(int(m.opt.warn_overflow)),
     dim=(d.nworld, m.nflexelem),
     inputs=[
       m.ngeom,
@@ -3112,7 +3139,7 @@ def _run_flex_narrowphase(
   epa_iterations = m.opt.ccd_iterations
   workspace_verts = wp.empty(d.naconmax * 8, dtype=wp.vec3)
   wp.launch(
-    _flex_narrowphase(bool(m.opt.warn_overflow)),
+    _flex_narrowphase(int(m.opt.warn_overflow)),
     dim=d.naconmax,
     inputs=[
       m.opt.ccd_tolerance,
@@ -3211,7 +3238,7 @@ def _flex_sap_collision(
   d.ncollision.zero_()
 
   wp.launch(
-    _flex_sap_sweep(is_self, bool(m.opt.warn_overflow)),
+    _flex_sap_sweep(is_self, int(m.opt.warn_overflow)),
     dim=nsweep,
     inputs=[
       m.flex_contype,

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -1417,7 +1417,11 @@ def _epa(
     pt.nhorizon = _add_edge(pt, face[2], face[0])
     if pt.nhorizon == -1:
       if warn_overflow:
-        wp.printf("Warning: EPA horizon = %d isn't large enough.\n", pt.horizon.shape[0])
+        wp.printf(
+          "Warning: EPA horizon = %d isn't large enough.\n"
+          "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.EPA_HORIZON (or = 0 for all)\n",
+          pt.horizon.shape[0],
+        )
       wp.atomic_or(overflow_out, worldid, OverflowType.EPA_HORIZON)
       idx = -1
       break
@@ -1436,7 +1440,11 @@ def _epa(
         pt.nhorizon = _add_edge(pt, face[2], face[0])
         if pt.nhorizon == -1:
           if warn_overflow:
-            wp.printf("Warning: EPA horizon = %d isn't large enough.\n", pt.horizon.shape[0])
+            wp.printf(
+              "Warning: EPA horizon = %d isn't large enough.\n"
+              "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.EPA_HORIZON (or = 0 for all)\n",
+              pt.horizon.shape[0],
+            )
           wp.atomic_or(overflow_out, worldid, OverflowType.EPA_HORIZON)
           idx = -1
           break

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -219,7 +219,7 @@ def _next_activation(
 
 
 @cache_kernel
-def _next_time_builder(warn_overflow: bool):
+def _next_time_builder(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False)
   def _next_time(
     # Model:
@@ -245,29 +245,45 @@ def _next_time_builder(warn_overflow: bool):
     nefc = nefc_in[worldid]
 
     if nefc > njmax_in:
-      if wp.static(warn_overflow):
-        wp.printf("nefc overflow - please increase njmax to %u\n", nefc)
+      if wp.static(bool(warn_overflow & OverflowType.NEFC)):
+        wp.printf(
+          "nefc overflow - please increase njmax beyond %u\n"
+          "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.NEFC (or = 0 for all)\n",
+          njmax_in,
+        )
       overflow_out[worldid] = overflow_out[worldid] | OverflowType.NEFC
     elif nefc > 0 and is_sparse:
       efcid = wp.min(nefc, njmax_in) - 1
       efc_nnz = efc_J_rowadr_in[worldid, efcid] + efc_J_rownnz_in[worldid, efcid]
       if efc_nnz > njmax_nnz_in:
-        if wp.static(warn_overflow):
-          wp.printf("njmax_nnz overflow - please increase njmax_nnz to %u\n", efc_nnz)
+        if wp.static(bool(warn_overflow & OverflowType.NJMAX_NNZ)):
+          wp.printf(
+            "njmax_nnz overflow - please increase njmax_nnz beyond %u\n"
+            "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.NJMAX_NNZ (or = 0 for all)\n",
+            njmax_nnz_in,
+          )
         overflow_out[worldid] = overflow_out[worldid] | OverflowType.NJMAX_NNZ
 
     ncollision = ncollision_in[0]
     if ncollision > naconmax_in:
-      if worldid == 0 and wp.static(warn_overflow):
-        nconmax = int(wp.ceil(float(ncollision) / float(nworld_in)))
-        wp.printf("broadphase overflow - please increase nconmax to %u or naconmax to %u\n", nconmax, ncollision)
+      if worldid == 0 and wp.static(bool(warn_overflow & OverflowType.BROADPHASE)):
+        wp.printf(
+          "broadphase overflow - please increase nconmax beyond %u or naconmax beyond %u\n"
+          "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.BROADPHASE (or = 0 for all)\n",
+          naconmax_in // nworld_in,
+          naconmax_in,
+        )
       overflow_out[worldid] = overflow_out[worldid] | OverflowType.BROADPHASE
 
     nacon = nacon_in[0]
     if nacon > naconmax_in:
-      if worldid == 0 and wp.static(warn_overflow):
-        nconmax = int(wp.ceil(float(nacon) / float(nworld_in)))
-        wp.printf("narrowphase overflow - please increase nconmax to %u or naconmax to %u\n", nconmax, nacon)
+      if worldid == 0 and wp.static(bool(warn_overflow & OverflowType.NARROWPHASE)):
+        wp.printf(
+          "narrowphase overflow - please increase nconmax beyond %u or naconmax beyond %u\n"
+          "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.NARROWPHASE (or = 0 for all)\n",
+          naconmax_in // nworld_in,
+          naconmax_in,
+        )
       overflow_out[worldid] = overflow_out[worldid] | OverflowType.NARROWPHASE
 
   return _next_time
@@ -321,7 +337,7 @@ def _advance(m: Model, d: Data, qacc: wp.array, qvel: Optional[wp.array] = None)
   history.insert_ctrl_history(m, d)
 
   wp.launch(
-    _next_time_builder(bool(m.opt.warn_overflow)),
+    _next_time_builder(int(m.opt.warn_overflow)),
     dim=d.nworld,
     inputs=[
       m.opt.timestep,

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -360,7 +360,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   opt.broadphase_filter = types.BroadphaseFilter.PLANE | types.BroadphaseFilter.SPHERE | types.BroadphaseFilter.OBB
   opt.graph_conditional = True
   opt.run_collision_detection = True
-  opt.warn_overflow = True
+  opt.warn_overflow = int(types.OverflowType.ALL)
   contact_sensor_maxmatch_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_NUMERIC, "contact_sensor_maxmatch")
   if contact_sensor_maxmatch_id > -1:
     opt.contact_sensor_maxmatch = mjm.numeric_data[mjm.numeric_adr[contact_sensor_maxmatch_id]]
@@ -2856,6 +2856,7 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
     "opt.enableflags": types.EnableBit,
     "opt.integrator": types.IntegratorType,
     "opt.solver": types.SolverType,
+    "opt.warn_overflow": types.OverflowType,
   }
   # MuJoCo pybind11 enums don't support iteration, so we provide explicit mappings
   mj_enum_fields = {
@@ -2870,6 +2871,7 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
     "opt.broadphase_filter",
     "opt.graph_conditional",
     "opt.contact_sensor_maxmatch",
+    "opt.warn_overflow",
   }
   mj_only_fields = {"opt.jacobian", "vis.quality.offsamples"}
 

--- a/mujoco_warp/_src/island.py
+++ b/mujoco_warp/_src/island.py
@@ -20,6 +20,7 @@ from mujoco_warp._src.types import ConstraintType
 from mujoco_warp._src.types import EqType
 from mujoco_warp._src.types import ObjType
 from mujoco_warp._src.types import OverflowType
+from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
 
 wp.set_module_options({"default_grid_stride": False})
@@ -877,48 +878,51 @@ def _reset_compact_maps(
     cdof_dof_out[worldid, idx] = -1
 
 
-@wp.kernel
-def _compact_dofs(
-  # Model:
-  ntree: int,
-  tree_dofadr: wp.array[int],
-  tree_dofnum: wp.array[int],
-  # Data in:
-  tree_awake_in: wp.array2d[int],
-  nvmax_in: int,
-  # In:
-  warn_overflow: bool,
-  # Data out:
-  ncdof_out: wp.array[int],
-  dof_cdof_out: wp.array2d[int],
-  cdof_dof_out: wp.array2d[int],
-  overflow_out: wp.array[int],
-):
-  worldid = wp.tid()
-  count = int(0)
-  for t in range(ntree):
-    if tree_awake_in[worldid, t] == 1:
-      adr = tree_dofadr[t]
-      num = tree_dofnum[t]
-      for j in range(num):
-        dof = adr + j
-        if count < nvmax_in:
-          dof_cdof_out[worldid, dof] = count
-          cdof_dof_out[worldid, count] = dof
-        count += 1
+@cache_kernel
+def _compact_dofs_builder(warn_overflow: int):
+  @wp.kernel(module="unique", enable_backward=False)
+  def _compact_dofs(
+    # Model:
+    ntree: int,
+    tree_dofadr: wp.array[int],
+    tree_dofnum: wp.array[int],
+    # Data in:
+    tree_awake_in: wp.array2d[int],
+    nvmax_in: int,
+    # Data out:
+    ncdof_out: wp.array[int],
+    dof_cdof_out: wp.array2d[int],
+    cdof_dof_out: wp.array2d[int],
+    overflow_out: wp.array[int],
+  ):
+    worldid = wp.tid()
+    count = int(0)
+    for t in range(ntree):
+      if tree_awake_in[worldid, t] == 1:
+        adr = tree_dofadr[t]
+        num = tree_dofnum[t]
+        for j in range(num):
+          dof = adr + j
+          if count < nvmax_in:
+            dof_cdof_out[worldid, dof] = count
+            cdof_dof_out[worldid, count] = dof
+          count += 1
 
-  if count > nvmax_in:
-    if warn_overflow:
-      wp.printf(
-        "nvmax overflow: world %d needs %d active DOFs but nvmax = %d (behavior undefined)\n",
-        worldid,
-        count,
-        nvmax_in,
-      )
-    overflow_out[worldid] = overflow_out[worldid] | OverflowType.NVMAX
-    ncdof_out[worldid] = nvmax_in
-  else:
-    ncdof_out[worldid] = count
+    if count > nvmax_in:
+      if wp.static(bool(warn_overflow & OverflowType.NVMAX)):
+        wp.printf(
+          "nvmax overflow: world %d needs %d active DOFs but nvmax = %d (behavior undefined)\n"
+          "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.NVMAX (or = 0 for all)\n",
+          worldid,
+          count,
+          nvmax_in,
+        )
+      overflow_out[worldid] = overflow_out[worldid] | OverflowType.NVMAX
+      ncdof_out[worldid] = nvmax_in
+    else:
+      ncdof_out[worldid] = count
+
+  return _compact_dofs
 
 
 @event_scope
@@ -931,8 +935,8 @@ def update_active_dofs(m: types.Model, d: types.Data):
     outputs=[d.dof_cdof, d.cdof_dof],
   )
   wp.launch(
-    _compact_dofs,
+    _compact_dofs_builder(int(m.opt.warn_overflow)),
     dim=(d.nworld,),
-    inputs=[m.ntree, m.tree_dofadr, m.tree_dofnum, d.tree_awake, d.nvmax, m.opt.warn_overflow],
+    inputs=[m.ntree, m.tree_dofadr, m.tree_dofnum, d.tree_awake, d.nvmax],
     outputs=[d.ncdof, d.dof_cdof, d.cdof_dof, d.overflow],
   )

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -2330,145 +2330,156 @@ def _check_match(body_parentid: wp.array[int], body: int, geom: int, objtype: in
   return False
 
 
-@wp.kernel
-def _contact_match(
-  # Model:
-  opt_cone: int,
-  opt_contact_sensor_maxmatch: int,
-  opt_warn_overflow: bool,
-  body_parentid: wp.array[int],
-  geom_bodyid: wp.array[int],
-  site_type: wp.array[int],
-  site_size: wp.array[wp.vec3],
-  sensor_objtype: wp.array[int],
-  sensor_objid: wp.array[int],
-  sensor_reftype: wp.array[int],
-  sensor_refid: wp.array[int],
-  sensor_intprm: wp.array2d[int],
-  sensor_contact_adr: wp.array[int],
-  # Data in:
-  site_xpos_in: wp.array2d[wp.vec3],
-  site_xmat_in: wp.array2d[wp.mat33],
-  contact_dist_in: wp.array[float],
-  contact_pos_in: wp.array[wp.vec3],
-  contact_frame_in: wp.array[wp.mat33],
-  contact_friction_in: wp.array[vec5],
-  contact_dim_in: wp.array[int],
-  contact_geom_in: wp.array[wp.vec2i],
-  contact_efc_address_in: wp.array2d[int],
-  contact_worldid_in: wp.array[int],
-  contact_type_in: wp.array[int],
-  contact_adhesion_in: wp.array[float],
-  efc_force_in: wp.array2d[float],
-  njmax_in: int,
-  nacon_in: wp.array[int],
-  # Data out:
-  overflow_out: wp.array[int],
-  # Out:
-  sensor_contact_nmatch_out: wp.array2d[int],
-  sensor_contact_matchid_out: wp.array3d[int],
-  sensor_contact_criteria_out: wp.array3d[float],
-  sensor_contact_direction_out: wp.array3d[float],
-):
-  contactsensorid, contactid = wp.tid()
-  sensorid = sensor_contact_adr[contactsensorid]
+@cache_kernel
+def _contact_match_builder(warn_overflow: int):
+  @wp.kernel(module="unique", enable_backward=False)
+  def _contact_match(
+    # Model:
+    opt_cone: int,
+    opt_contact_sensor_maxmatch: int,
+    body_parentid: wp.array[int],
+    geom_bodyid: wp.array[int],
+    site_type: wp.array[int],
+    site_size: wp.array[wp.vec3],
+    sensor_objtype: wp.array[int],
+    sensor_objid: wp.array[int],
+    sensor_reftype: wp.array[int],
+    sensor_refid: wp.array[int],
+    sensor_intprm: wp.array2d[int],
+    sensor_contact_adr: wp.array[int],
+    # Data in:
+    site_xpos_in: wp.array2d[wp.vec3],
+    site_xmat_in: wp.array2d[wp.mat33],
+    contact_dist_in: wp.array[float],
+    contact_pos_in: wp.array[wp.vec3],
+    contact_frame_in: wp.array[wp.mat33],
+    contact_friction_in: wp.array[vec5],
+    contact_dim_in: wp.array[int],
+    contact_geom_in: wp.array[wp.vec2i],
+    contact_efc_address_in: wp.array2d[int],
+    contact_worldid_in: wp.array[int],
+    contact_type_in: wp.array[int],
+    contact_adhesion_in: wp.array[float],
+    efc_force_in: wp.array2d[float],
+    njmax_in: int,
+    nacon_in: wp.array[int],
+    # Data out:
+    overflow_out: wp.array[int],
+    # Out:
+    sensor_contact_nmatch_out: wp.array2d[int],
+    sensor_contact_matchid_out: wp.array3d[int],
+    sensor_contact_criteria_out: wp.array3d[float],
+    sensor_contact_direction_out: wp.array3d[float],
+  ):
+    contactsensorid, contactid = wp.tid()
+    sensorid = sensor_contact_adr[contactsensorid]
 
-  if contactid >= nacon_in[0]:
-    return
-
-  if not contact_type_in[contactid] & ContactType.CONSTRAINT:
-    return
-
-  # sensor information
-  objtype = sensor_objtype[sensorid]
-  objid = sensor_objid[sensorid]
-  reftype = sensor_reftype[sensorid]
-  refid = sensor_refid[sensorid]
-  reduce = sensor_intprm[sensorid, 1]
-
-  worldid = contact_worldid_in[contactid]
-
-  # site filter
-  if objtype == ObjType.SITE:
-    if not inside_geom(
-      site_xpos_in[worldid, objid], site_xmat_in[worldid, objid], site_size[objid], site_type[objid], contact_pos_in[contactid]
-    ):
+    if contactid >= nacon_in[0]:
       return
 
-  # unknown-unknown match
-  if objtype == ObjType.UNKNOWN and reftype == ObjType.UNKNOWN:
-    dir = 1.0
-  else:
-    # contact information
-    geom = contact_geom_in[contactid]
-    geom1 = geom[0]
-    geom2 = geom[1]
-    body1 = geom_bodyid[geom1]
-    body2 = geom_bodyid[geom2]
-
-    # check match of sensor objects with contact objects
-    match11 = _check_match(body_parentid, body1, geom1, objtype, objid)
-    match12 = _check_match(body_parentid, body2, geom2, objtype, objid)
-    match21 = _check_match(body_parentid, body1, geom1, reftype, refid)
-    match22 = _check_match(body_parentid, body2, geom2, reftype, refid)
-
-    # if a sensor object is specified, it must be involved in the contact
-    if not match11 and not match12:
-      return
-    if not match21 and not match22:
+    if not contact_type_in[contactid] & ContactType.CONSTRAINT:
       return
 
-    # determine direction
-    dir = 1.0
-    if objtype != ObjType.UNKNOWN and reftype != ObjType.UNKNOWN:
-      # both obj1 and obj2 specified: direction depends on order
-      order_regular = match11 and match22
-      order_reverse = match12 and match21
-      if not order_regular and not order_reverse:
+    # sensor information
+    objtype = sensor_objtype[sensorid]
+    objid = sensor_objid[sensorid]
+    reftype = sensor_reftype[sensorid]
+    refid = sensor_refid[sensorid]
+    reduce = sensor_intprm[sensorid, 1]
+
+    worldid = contact_worldid_in[contactid]
+
+    # site filter
+    if objtype == ObjType.SITE:
+      if not inside_geom(
+        site_xpos_in[worldid, objid],
+        site_xmat_in[worldid, objid],
+        site_size[objid],
+        site_type[objid],
+        contact_pos_in[contactid],
+      ):
         return
-      if order_reverse and not order_regular:
-        dir = -1.0
-    elif objtype != ObjType.UNKNOWN:
-      if not match11:
-        dir = -1.0
-    elif reftype != ObjType.UNKNOWN:
-      if not match22:
-        dir = -1.0
 
-  contactmatchid = wp.atomic_add(sensor_contact_nmatch_out[worldid], contactsensorid, 1)
+    # unknown-unknown match
+    if objtype == ObjType.UNKNOWN and reftype == ObjType.UNKNOWN:
+      dir = 1.0
+    else:
+      # contact information
+      geom = contact_geom_in[contactid]
+      geom1 = geom[0]
+      geom2 = geom[1]
+      body1 = geom_bodyid[geom1]
+      body2 = geom_bodyid[geom2]
 
-  if contactmatchid >= opt_contact_sensor_maxmatch:
-    if opt_warn_overflow:
-      wp.printf("contact match overflow: please increase Option.contact_sensor_maxmatch to %u\n", contactmatchid)
-    wp.atomic_or(overflow_out, worldid, OverflowType.CONTACT_MATCH)
-    return
+      # check match of sensor objects with contact objects
+      match11 = _check_match(body_parentid, body1, geom1, objtype, objid)
+      match12 = _check_match(body_parentid, body2, geom2, objtype, objid)
+      match21 = _check_match(body_parentid, body1, geom1, reftype, refid)
+      match22 = _check_match(body_parentid, body2, geom2, reftype, refid)
 
-  sensor_contact_matchid_out[worldid, contactsensorid, contactmatchid] = contactid
+      # if a sensor object is specified, it must be involved in the contact
+      if not match11 and not match12:
+        return
+      if not match21 and not match22:
+        return
 
-  if reduce == 1:  # mindist
-    sensor_contact_criteria_out[worldid, contactsensorid, contactmatchid] = contact_dist_in[contactid]
-  elif reduce == 2:  # maxforce
-    contact_force = support.contact_force_fn(
-      opt_cone,
-      contact_frame_in,
-      contact_friction_in,
-      contact_dim_in,
-      contact_efc_address_in,
-      contact_adhesion_in,
-      efc_force_in,
-      njmax_in,
-      nacon_in,
-      worldid,
-      contactid,
-      False,
-    )
-    force_magnitude = (
-      contact_force[0] * contact_force[0] + contact_force[1] * contact_force[1] + contact_force[2] * contact_force[2]
-    )
-    sensor_contact_criteria_out[worldid, contactsensorid, contactmatchid] = -force_magnitude
+      # determine direction
+      dir = 1.0
+      if objtype != ObjType.UNKNOWN and reftype != ObjType.UNKNOWN:
+        # both obj1 and obj2 specified: direction depends on order
+        order_regular = match11 and match22
+        order_reverse = match12 and match21
+        if not order_regular and not order_reverse:
+          return
+        if order_reverse and not order_regular:
+          dir = -1.0
+      elif objtype != ObjType.UNKNOWN:
+        if not match11:
+          dir = -1.0
+      elif reftype != ObjType.UNKNOWN:
+        if not match22:
+          dir = -1.0
 
-  # contact direction
-  sensor_contact_direction_out[worldid, contactsensorid, contactmatchid] = dir
+    contactmatchid = wp.atomic_add(sensor_contact_nmatch_out[worldid], contactsensorid, 1)
+
+    if contactmatchid >= opt_contact_sensor_maxmatch:
+      if wp.static(bool(warn_overflow & OverflowType.CONTACT_MATCH)):
+        wp.printf(
+          "contact match overflow: please increase Option.contact_sensor_maxmatch beyond %u\n"
+          "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.CONTACT_MATCH (or = 0 for all)\n",
+          opt_contact_sensor_maxmatch,
+        )
+      wp.atomic_or(overflow_out, worldid, OverflowType.CONTACT_MATCH)
+      return
+
+    sensor_contact_matchid_out[worldid, contactsensorid, contactmatchid] = contactid
+
+    if reduce == 1:  # mindist
+      sensor_contact_criteria_out[worldid, contactsensorid, contactmatchid] = contact_dist_in[contactid]
+    elif reduce == 2:  # maxforce
+      contact_force = support.contact_force_fn(
+        opt_cone,
+        contact_frame_in,
+        contact_friction_in,
+        contact_dim_in,
+        contact_efc_address_in,
+        contact_adhesion_in,
+        efc_force_in,
+        njmax_in,
+        nacon_in,
+        worldid,
+        contactid,
+        False,
+      )
+      force_magnitude = (
+        contact_force[0] * contact_force[0] + contact_force[1] * contact_force[1] + contact_force[2] * contact_force[2]
+      )
+      sensor_contact_criteria_out[worldid, contactsensorid, contactmatchid] = -force_magnitude
+
+    # contact direction
+    sensor_contact_direction_out[worldid, contactsensorid, contactmatchid] = dir
+
+  return _contact_match
 
 
 @cache_kernel
@@ -2614,12 +2625,11 @@ def sensor_acc(m: Model, d: Data):
     sensor_contact_criteria.fill_(1.0e32)
 
     wp.launch(
-      _contact_match,
+      _contact_match_builder(int(m.opt.warn_overflow)),
       dim=(m.sensor_contact_adr.size, d.naconmax),
       inputs=[
         m.opt.cone,
         m.opt.contact_sensor_maxmatch,
-        m.opt.warn_overflow,
         m.body_parentid,
         m.geom_bodyid,
         m.site_type,

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -839,7 +839,7 @@ def _linesearch_iterative_kernel(
   fuse_jv: bool,
   is_sparse: bool,
   incremental: bool,
-  warn_overflow: bool,
+  warn_overflow: int,
 ):
   """Factory for iterative linesearch kernel.
 
@@ -848,8 +848,8 @@ def _linesearch_iterative_kernel(
     cone_type: Friction cone type (PYRAMIDAL or ELLIPTIC) for compile-time optimization.
     fuse_jv: Whether to compute jv = J @ search in-kernel (efficient for small nv).
     is_sparse: Use sparse matrix representation for constraint Jacobian.
-    incremental: State changes are tracked: flag exhausted rays, reuse jv on unchanged search.
-    warn_overflow: Whether to print overflow warnings.
+    incremental: Use incremental linesearch updates.
+    warn_overflow: Overflow warning bitmask.
   """
   LS_ITERATIONS = ls_iterations
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
@@ -1337,9 +1337,10 @@ def _linesearch_iterative_kernel(
       if wp.static(INCREMENTAL):
         ctx_ls_exhausted_out[worldid] = wp.abs(alpha) < noise_floor
       if not ls_converged:
-        if wp.static(warn_overflow):
+        if wp.static(bool(warn_overflow & OverflowType.LS_ITERATIONS)):
           wp.printf(
-            "linesearch iterations limit reached - please increase ls_iterations beyond %u\n",
+            "linesearch iterations limit reached - please increase ls_iterations beyond %u\n"
+            "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.LS_ITERATIONS (or = 0 for all)\n",
             wp.static(LS_ITERATIONS),
           )
         wp.atomic_or(overflow_out, worldid, wp.static(OverflowType.LS_ITERATIONS))
@@ -1363,7 +1364,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
       fuse_jv,
       m.is_sparse,
       _use_incremental(m),
-      bool(m.opt.warn_overflow),
+      int(m.opt.warn_overflow),
     ),
     dim=d.nworld,
     inputs=[
@@ -3399,7 +3400,7 @@ def _solve_search_update_cg_tiled(
 
 
 @cache_kernel
-def _solve_cg_finalize(warn_overflow: bool):
+def _solve_cg_finalize(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
@@ -3441,8 +3442,12 @@ def _solve_cg_finalize(warn_overflow: bool):
     done = (improvement < tolerance) or (gradient < tolerance)
     if done or solver_niter_out[worldid] == opt_iterations:
       if not done and solver_niter_out[worldid] == opt_iterations:
-        if wp.static(warn_overflow):
-          wp.printf("solver iterations limit reached - please increase iterations beyond %u\n", opt_iterations)
+        if wp.static(bool(warn_overflow & OverflowType.ITERATIONS)):
+          wp.printf(
+            "solver iterations limit reached - please increase iterations beyond %u\n"
+            "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.ITERATIONS (or = 0 for all)\n",
+            opt_iterations,
+          )
         overflow_out[worldid] = overflow_out[worldid] | OverflowType.ITERATIONS
       ctx_done_out[worldid] = True
       wp.atomic_add(nsolving_out, 0, -1)
@@ -3451,7 +3456,7 @@ def _solve_cg_finalize(warn_overflow: bool):
 
 
 @cache_kernel
-def _solve_done(warn_overflow: bool):
+def _solve_done(warn_overflow: int):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
     # Model:
@@ -3488,8 +3493,12 @@ def _solve_done(warn_overflow: bool):
       # if the solver has converged or the maximum number of iterations has been reached then
       # mark this world as done and remove it from the number of unconverged worlds
       if not done and solver_niter_out[worldid] == opt_iterations:
-        if wp.static(warn_overflow):
-          wp.printf("solver iterations limit reached - please increase iterations beyond %u\n", opt_iterations)
+        if wp.static(bool(warn_overflow & OverflowType.ITERATIONS)):
+          wp.printf(
+            "solver iterations limit reached - please increase iterations beyond %u\n"
+            "To disable the print warning: m.opt.warn_overflow &= ~mjw.OverflowType.ITERATIONS (or = 0 for all)\n",
+            opt_iterations,
+          )
         overflow_out[worldid] = overflow_out[worldid] | OverflowType.ITERATIONS
       ctx_done_out[worldid] = True
       wp.atomic_add(nsolving_out, 0, -1)
@@ -3572,7 +3581,7 @@ def _solver_iteration(
       block_dim=m.block_dim.solve_beta_accumulate,
     )
     wp.launch(
-      _solve_cg_finalize(bool(m.opt.warn_overflow)),
+      _solve_cg_finalize(int(m.opt.warn_overflow)),
       dim=d.nworld,
       inputs=[
         m.nv,
@@ -3603,7 +3612,7 @@ def _solver_iteration(
 
   else:
     wp.launch(
-      _solve_done(bool(m.opt.warn_overflow)),
+      _solve_done(int(m.opt.warn_overflow)),
       dim=d.nworld,
       inputs=[
         m.nv,

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -215,7 +215,7 @@ class SolverTest(parameterized.TestCase):
     overflow = wp.zeros(1, dtype=int)
 
     wp.launch(
-      solver._solve_done(False),
+      solver._solve_done(types.OverflowType.NONE),
       dim=1,
       inputs=[
         1,
@@ -243,7 +243,7 @@ class SolverTest(parameterized.TestCase):
     overflow = wp.zeros(1, dtype=int)
 
     wp.launch(
-      solver._solve_done(False),
+      solver._solve_done(types.OverflowType.NONE),
       dim=1,
       inputs=[
         1,
@@ -272,7 +272,7 @@ class SolverTest(parameterized.TestCase):
     beta = wp.zeros(1, dtype=float)
 
     wp.launch(
-      solver._solve_cg_finalize(False),
+      solver._solve_cg_finalize(types.OverflowType.NONE),
       dim=1,
       inputs=[
         1,

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -153,6 +153,7 @@ class OverflowType(enum.IntFlag):
   """Bitmask for physics and collision overflows.
 
   Attributes:
+    NONE: no overflow
     NEFC: nefc > njmax
     NJMAX_NNZ: njmax_nnz overflow
     BROADPHASE: broadphase overflow / flex broadphase overflow
@@ -164,8 +165,10 @@ class OverflowType(enum.IntFlag):
     EPA_HORIZON: EPA horizon buffer overflow
     ITERATIONS: solver iteration limit reached
     LS_ITERATIONS: linesearch iteration limit reached
+    ALL: all overflows
   """
 
+  NONE = 0
   NEFC = 1 << 0
   NJMAX_NNZ = 1 << 1
   BROADPHASE = 1 << 2
@@ -177,6 +180,19 @@ class OverflowType(enum.IntFlag):
   EPA_HORIZON = 1 << 8
   ITERATIONS = 1 << 9
   LS_ITERATIONS = 1 << 10
+  ALL = (
+    NEFC
+    | NJMAX_NNZ
+    | BROADPHASE
+    | NARROWPHASE
+    | CCD
+    | HFIELD
+    | CONTACT_MATCH
+    | NVMAX
+    | EPA_HORIZON
+    | ITERATIONS
+    | LS_ITERATIONS
+  )
 
 
 class CamLightType(enum.IntEnum):
@@ -890,7 +906,7 @@ class Option:
       zeros out the contacts at each step)
     contact_sensor_maxmatch: max number of contacts considered by contact sensor matching criteria
                              contacts matched after this value is exceded will be ignored
-    warn_overflow: warn if overflow is encountered
+    warn_overflow: overflow warning bitmask (OverflowType)
   """
 
   timestep: array("*", float)
@@ -920,7 +936,17 @@ class Option:
   graph_conditional: bool
   run_collision_detection: bool
   contact_sensor_maxmatch: int
-  warn_overflow: bool
+  warn_overflow: int
+
+  @property
+  def warn_overflow(self) -> int:
+    return self._warn_overflow
+
+  @warn_overflow.setter
+  def warn_overflow(self, value: bool | int):
+    if isinstance(value, bool):
+      value = int(OverflowType.ALL) if value else 0
+    self._warn_overflow = value
 
   # TODO(team): remove in future version
   @property

--- a/mujoco_warp/_src/types_test.py
+++ b/mujoco_warp/_src/types_test.py
@@ -23,9 +23,12 @@ import warp as wp
 from absl.testing import absltest
 from absl.testing import parameterized
 
+from mujoco_warp._src.io import override_model
+from mujoco_warp._src.io import put_model
 from mujoco_warp._src.types import Data
 from mujoco_warp._src.types import Model
 from mujoco_warp._src.types import Option
+from mujoco_warp._src.types import OverflowType
 from mujoco_warp._src.types import TileSet
 
 
@@ -84,6 +87,49 @@ class TypesTest(parameterized.TestCase):
         attrs.append(line.split(":")[0].strip())
 
     self.assertListEqual(attrs, [f.name for f in dataclasses.fields(mjw_class)])
+
+  def test_overflow_type_flags(self):
+    self.assertEqual(int(OverflowType.NONE), 0)
+    self.assertEqual(int(OverflowType.NEFC), 1 << 0)
+    self.assertEqual(int(OverflowType.NJMAX_NNZ), 1 << 1)
+    self.assertEqual(int(OverflowType.BROADPHASE), 1 << 2)
+    self.assertEqual(int(OverflowType.NARROWPHASE), 1 << 3)
+    self.assertEqual(int(OverflowType.CCD), 1 << 4)
+    self.assertEqual(int(OverflowType.HFIELD), 1 << 5)
+    self.assertEqual(int(OverflowType.CONTACT_MATCH), 1 << 6)
+    self.assertEqual(int(OverflowType.NVMAX), 1 << 7)
+    self.assertEqual(int(OverflowType.EPA_HORIZON), 1 << 8)
+    self.assertEqual(int(OverflowType.ITERATIONS), 1 << 9)
+    self.assertEqual(int(OverflowType.LS_ITERATIONS), 1 << 10)
+    self.assertEqual(int(OverflowType.ALL), (1 << 11) - 1)
+
+  def test_option_warn_overflow(self):
+    mjm = mujoco.MjModel.from_xml_string("<mujoco/>")
+    m = put_model(mjm)
+
+    # Defaults to ALL
+    self.assertEqual(m.opt.warn_overflow, int(OverflowType.ALL))
+
+    # Setting boolean False converts to 0
+    m.opt.warn_overflow = False
+    self.assertEqual(m.opt.warn_overflow, 0)
+
+    # Setting boolean True converts to OverflowType.ALL
+    m.opt.warn_overflow = True
+    self.assertEqual(m.opt.warn_overflow, int(OverflowType.ALL))
+
+    # Setting selective bitmask
+    m.opt.warn_overflow &= ~OverflowType.NEFC
+    self.assertEqual(m.opt.warn_overflow, int(OverflowType.ALL) & ~OverflowType.NEFC)
+    self.assertFalse(bool(m.opt.warn_overflow & OverflowType.NEFC))
+    self.assertTrue(bool(m.opt.warn_overflow & OverflowType.CCD))
+
+    # Test override_model support
+    override_model(m, {"opt.warn_overflow": 0})
+    self.assertEqual(m.opt.warn_overflow, 0)
+
+    override_model(m, {"opt.warn_overflow": "CCD"})
+    self.assertEqual(m.opt.warn_overflow, int(OverflowType.CCD))
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -169,7 +169,7 @@ def _main(argv: Sequence[str]):
   mjm = cli.load_model(path)
   free_mem_at_init = wp.get_device(device).free_memory
   m, d, rc, ctrls = cli.init_structs(_FUNCS[_FUNCTION.value], mjm)
-  m.opt.warn_overflow = _OVERFLOW_BEHAVIOR.value == "continue"
+  m.opt.warn_overflow = int(OverflowType.ALL) if _OVERFLOW_BEHAVIOR.value == "continue" else 0
   timestep = m.opt.timestep.numpy()[0]
 
   if _FORMAT.value == "human":


### PR DESCRIPTION
Currently, `Option.warn_overflow` is a boolean that controls GPU overflow warning prints globally. Users cannot silence benign or expected warnings (such as line search iterations) without disabling all other critical overflow prints.

This change converts `Option.warn_overflow` into an integer bitmask using `OverflowType`, matching `Data.overflow`. Kernel builders and launch sites now guard prints with compile-time static checks on specific flags (`wp.static(bool(warn_overflow & OverflowType.<FLAG>))`). A property setter preserves backward compatibility by coercing `True` to `OverflowType.ALL` and `False` to `0`. Warning messages are also standardized to report the reached limit using a "beyond %u" format alongside instructions to silence the warning.

* Add `NONE = 0` and `ALL` to `OverflowType`.
* Refactor `Option.warn_overflow` to an integer bitmask defaulting to `OverflowType.ALL`, with boolean backward compatibility.
* Guard print statements across forward, collision, solver, island, and sensor kernels with specific `OverflowType` bits.
* Standardize warning prints to use the "beyond %u" format and include instructions on disabling the warning.
* Add unit tests for bitmask operations, boolean coercion, and `override_model` support.
