### PR TITLE
Add optional supersampling to the renderer

### DIFF
--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -704,6 +704,12 @@ def _build_megakernel(m: Model, rc: RenderContext):
   # Static parameters extracted for JAX FFI closure.
   rc_static = {f.name: getattr(rc, f.name) for f in dataclasses.fields(rc) if f.type in (int, wp.uint32, bool, float, wp.vec3)}
   rc_static["enable_specular_or_emission"] = rc.enable_specular or rc.enable_emission
+  bg = int(rc.background_color)
+  rc_static["background_color_vec3"] = wp.vec3(
+    float((bg >> 16) & 0xFF) / 255.0,
+    float((bg >> 8) & 0xFF) / 255.0,
+    float(bg & 0xFF) / 255.0,
+  )
   M_NLIGHT = m.nlight
 
   aa = rc.samples_per_pixel * rc.samples_per_pixel > 1
@@ -926,7 +932,8 @@ def _build_megakernel(m: Model, rc: RenderContext):
         dist,
       )
 
-    if render_seg[camid] and geom_id != -1:
+    # Depth and seg are single-sample outputs: only the first pass writes them.
+    if ray_base == 0 and render_seg[camid] and geom_id != -1:
       if geom_id == -2:
         seg_out[worldid, seg_adr[camid] + rayid_local] = wp.vec2i(mesh_id, int(ObjType.FLEX))
       else:
@@ -934,7 +941,7 @@ def _build_megakernel(m: Model, rc: RenderContext):
 
     # Early Out
     if geom_id == -1:
-      if render_depth[camid]:
+      if ray_base == 0 and render_depth[camid]:
         depth = 0.0
         if wp.static(has_splats):
           if splat_depth > 0.0:
@@ -952,25 +959,13 @@ def _build_megakernel(m: Model, rc: RenderContext):
         store_pixel(worldid, rgb_adr[camid] + rayid_local, skybox_color, rgb_out, aa_accum_out)
       elif render_rgb[camid]:
         if wp.static(has_splats):
-          packed = wp.static(rc_static["background_color"])
-          background = wp.vec3(
-            float((packed >> wp.uint32(16)) & wp.uint32(0xFF)),
-            float((packed >> wp.uint32(8)) & wp.uint32(0xFF)),
-            float(packed & wp.uint32(0xFF)),
-          ) * wp.static(1.0 / 255.0)
-          pixel_color = splat_color + background * splat_transmittance
+          pixel_color = splat_color + wp.static(rc_static["background_color_vec3"]) * splat_transmittance
           store_pixel(worldid, rgb_adr[camid] + rayid_local, pixel_color, rgb_out, aa_accum_out)
         elif wp.static(aa):
-          packed = wp.static(rc_static["background_color"])
           store_pixel(
             worldid,
             rgb_adr[camid] + rayid_local,
-            wp.vec3(
-              float((packed >> wp.uint32(16)) & wp.uint32(0xFF)),
-              float((packed >> wp.uint32(8)) & wp.uint32(0xFF)),
-              float(packed & wp.uint32(0xFF)),
-            )
-            * wp.static(1.0 / 255.0),
+            wp.static(rc_static["background_color_vec3"]),
             rgb_out,
             aa_accum_out,
           )
@@ -978,7 +973,7 @@ def _build_megakernel(m: Model, rc: RenderContext):
           rgb_out[worldid, rgb_adr[camid] + rayid_local] = wp.static(rc_static["background_color"])
       return
 
-    if render_depth[camid]:
+    if ray_base == 0 and render_depth[camid]:
       # Planar depth: project Euclidean distance onto the camera's optical axis.
       # In camera-local coordinates, the optical axis is -Z. The Z-component of the
       # normalized ray direction is negative, so -ray_dir_local_cam[2] gives cos(θ)

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -675,6 +675,40 @@ def _make_compute_lighting(cast_ray_first_hit: wp.Function) -> wp.Function:
   return compute_lighting
 
 
+@wp.kernel
+def _aa_accumulate(
+  # In:
+  rgb: wp.array2d[wp.uint32],
+  # Out:
+  accum: wp.array2d[wp.vec3],
+):
+  worldid, i = wp.tid()
+  c = rgb[worldid, i]
+  accum[worldid, i] += wp.vec3(
+    float(c & wp.uint32(0xFF)),
+    float((c >> wp.uint32(8)) & wp.uint32(0xFF)),
+    float((c >> wp.uint32(16)) & wp.uint32(0xFF)),
+  )
+
+
+@wp.kernel
+def _aa_resolve(
+  # In:
+  accum: wp.array2d[wp.vec3],
+  inv_n: float,
+  # Out:
+  rgb: wp.array2d[wp.uint32],
+):
+  worldid, i = wp.tid()
+  c = accum[worldid, i] * inv_n
+  rgb[worldid, i] = (
+    wp.uint32(wp.clamp(c[0], 0.0, 255.0))
+    | (wp.uint32(wp.clamp(c[1], 0.0, 255.0)) << wp.uint32(8))
+    | (wp.uint32(wp.clamp(c[2], 0.0, 255.0)) << wp.uint32(16))
+    | (wp.uint32(255) << wp.uint32(24))
+  )
+
+
 def _build_megakernel(m: Model, rc: RenderContext):
   """Construct the specialised megakernel for this context."""
   has_splats = rc.splat_count > 0
@@ -741,6 +775,7 @@ def _build_megakernel(m: Model, rc: RenderContext):
     cam_id_map: wp.array[int],
     ray: wp.array[wp.vec3],
     ray_offset: wp.array[wp.vec3],
+    ray_base: int,
     rgb_adr: wp.array[int],
     depth_adr: wp.array[int],
     seg_adr: wp.array[int],
@@ -798,8 +833,8 @@ def _build_megakernel(m: Model, rc: RenderContext):
     mujoco_cam_id = cam_id_map[camid]
 
     if wp.static(rc_static["use_precomputed_rays"]):
-      ray_dir_local_cam = ray[rayid]
-      ray_offset_local_cam = ray_offset[rayid]
+      ray_dir_local_cam = ray[ray_base + rayid]
+      ray_offset_local_cam = ray_offset[ray_base + rayid]
     else:
       img_w = cam_res[camid][0]
       img_h = cam_res[camid][1]
@@ -1157,89 +1192,100 @@ def render(m: Model, d: Data, rc: RenderContext):
     rc._megakernel = _build_megakernel(m, rc)
   _render_megakernel = rc._megakernel
 
-  wp.launch(
-    kernel=_render_megakernel,
-    dim=(d.nworld, rc.total_rays),
-    inputs=[
-      m.geom_type,
-      m.geom_dataid,
-      m.geom_matid,
-      m.geom_size,
-      m.geom_rgba,
-      m.cam_projection,
-      m.cam_fovy,
-      m.cam_sensorsize,
-      m.cam_intrinsic,
-      m.light_type,
-      m.light_castshadow,
-      m.light_active,
-      m.light_attenuation,
-      m.light_cutoff,
-      m.light_exponent,
-      m.light_ambient,
-      m.light_diffuse,
-      m.light_specular,
-      m.flex_vertadr,
-      m.flex_edge,
-      m.flex_radius,
-      m.mesh_faceadr,
-      m.mesh_normaladr,
-      m.mesh_normal,
-      m.mat_texid,
-      m.mat_texrepeat,
-      m.mat_emission,
-      m.mat_specular,
-      m.mat_shininess,
-      m.mat_rgba,
-      d.geom_xpos,
-      d.geom_xmat,
-      d.cam_xpos,
-      d.cam_xmat,
-      d.light_xpos,
-      d.light_xdir,
-      d.flexvert_xpos,
-      rc.nrender,
-      rc.use_shadows,
-      rc.bvh_ngeom,
-      rc.bvh_nflexgeom,
-      rc.cam_res,
-      rc.cam_id_map,
-      rc.ray,
-      rc.ray_offset,
-      rc.rgb_adr,
-      rc.depth_adr,
-      rc.seg_adr,
-      rc.render_rgb,
-      rc.render_depth,
-      rc.render_seg,
-      rc.bvh_id,
-      rc.group_root,
-      rc.flex_bvh_id,
-      rc.flex_group_root,
-      rc.enabled_geom_ids,
-      rc.mesh_bvh_id,
-      rc.mesh_facetexcoord,
-      rc.mesh_facenormal,
-      rc.mesh_texcoord,
-      rc.mesh_texcoord_offsets,
-      rc.hfield_bvh_id,
-      rc.flex_rgba,
-      rc.flex_geom_flexid,
-      rc.flex_geom_edgeid,
-      rc.skybox_tex_id,
-      rc.skybox_face_width,
-      rc.textures,
-      rc.splat_position,
-      rc.splat_rotation,
-      rc.splat_scale,
-      rc.splat_rgba,
-      rc.splat_bvh_id,
-      rc.splat_group_root,
-    ],
-    outputs=[
-      rc.rgb_data,
-      rc.depth_data,
-      rc.seg_data,
-    ],
-    block_dim=m.block_dim.render,
-  )
+  nsamples = rc.samples_per_pixel * rc.samples_per_pixel
+  if nsamples > 1:
+    rc.aa_accum.zero_()
+
+  for sample in range(nsamples):
+    wp.launch(
+      kernel=_render_megakernel,
+      dim=(d.nworld, rc.total_rays),
+      inputs=[
+        m.geom_type,
+        m.geom_dataid,
+        m.geom_matid,
+        m.geom_size,
+        m.geom_rgba,
+        m.cam_projection,
+        m.cam_fovy,
+        m.cam_sensorsize,
+        m.cam_intrinsic,
+        m.light_type,
+        m.light_castshadow,
+        m.light_active,
+        m.light_attenuation,
+        m.light_cutoff,
+        m.light_exponent,
+        m.light_ambient,
+        m.light_diffuse,
+        m.light_specular,
+        m.flex_vertadr,
+        m.flex_edge,
+        m.flex_radius,
+        m.mesh_faceadr,
+        m.mesh_normaladr,
+        m.mesh_normal,
+        m.mat_texid,
+        m.mat_texrepeat,
+        m.mat_emission,
+        m.mat_specular,
+        m.mat_shininess,
+        m.mat_rgba,
+        d.geom_xpos,
+        d.geom_xmat,
+        d.cam_xpos,
+        d.cam_xmat,
+        d.light_xpos,
+        d.light_xdir,
+        d.flexvert_xpos,
+        rc.nrender,
+        rc.use_shadows,
+        rc.bvh_ngeom,
+        rc.bvh_nflexgeom,
+        rc.cam_res,
+        rc.cam_id_map,
+        rc.ray,
+        rc.ray_offset,
+        sample * rc.total_rays,
+        rc.rgb_adr,
+        rc.depth_adr,
+        rc.seg_adr,
+        rc.render_rgb,
+        rc.render_depth,
+        rc.render_seg,
+        rc.bvh_id,
+        rc.group_root,
+        rc.flex_bvh_id,
+        rc.flex_group_root,
+        rc.enabled_geom_ids,
+        rc.mesh_bvh_id,
+        rc.mesh_facetexcoord,
+        rc.mesh_facenormal,
+        rc.mesh_texcoord,
+        rc.mesh_texcoord_offsets,
+        rc.hfield_bvh_id,
+        rc.flex_rgba,
+        rc.flex_geom_flexid,
+        rc.flex_geom_edgeid,
+        rc.skybox_tex_id,
+        rc.skybox_face_width,
+        rc.textures,
+        rc.splat_position,
+        rc.splat_rotation,
+        rc.splat_scale,
+        rc.splat_rgba,
+        rc.splat_bvh_id,
+        rc.splat_group_root,
+      ],
+      outputs=[
+        rc.rgb_data,
+        rc.depth_data,
+        rc.seg_data,
+      ],
+      block_dim=m.block_dim.render,
+    )
+    if nsamples > 1:
+      wp.launch(_aa_accumulate, dim=rc.rgb_data.shape, inputs=[rc.rgb_data], outputs=[rc.aa_accum])
+
+  if nsamples > 1:
+    wp.launch(_aa_resolve, dim=rc.rgb_data.shape, inputs=[rc.aa_accum, 1.0 / float(nsamples)], outputs=[rc.rgb_data])

--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -676,36 +676,17 @@ def _make_compute_lighting(cast_ray_first_hit: wp.Function) -> wp.Function:
 
 
 @wp.kernel
-def _aa_accumulate(
-  # In:
-  rgb: wp.array2d[wp.uint32],
-  # Out:
-  accum: wp.array2d[wp.vec3],
-):
-  worldid, i = wp.tid()
-  c = rgb[worldid, i]
-  accum[worldid, i] += wp.vec3(
-    float(c & wp.uint32(0xFF)),
-    float((c >> wp.uint32(8)) & wp.uint32(0xFF)),
-    float((c >> wp.uint32(16)) & wp.uint32(0xFF)),
-  )
-
-
-@wp.kernel
 def _aa_resolve(
   # In:
   accum: wp.array2d[wp.vec3],
   inv_n: float,
   # Out:
-  rgb: wp.array2d[wp.uint32],
+  rgb_out: wp.array2d[wp.uint32],
 ):
   worldid, i = wp.tid()
   c = accum[worldid, i] * inv_n
-  rgb[worldid, i] = (
-    wp.uint32(wp.clamp(c[0], 0.0, 255.0))
-    | (wp.uint32(wp.clamp(c[1], 0.0, 255.0)) << wp.uint32(8))
-    | (wp.uint32(wp.clamp(c[2], 0.0, 255.0)) << wp.uint32(16))
-    | (wp.uint32(255) << wp.uint32(24))
+  rgb_out[worldid, i] = pack_rgba_to_uint32(
+    wp.clamp(c[0], 0.0, 255.0), wp.clamp(c[1], 0.0, 255.0), wp.clamp(c[2], 0.0, 255.0), 255.0
   )
 
 
@@ -724,6 +705,25 @@ def _build_megakernel(m: Model, rc: RenderContext):
   rc_static = {f.name: getattr(rc, f.name) for f in dataclasses.fields(rc) if f.type in (int, wp.uint32, bool, float, wp.vec3)}
   rc_static["enable_specular_or_emission"] = rc.enable_specular or rc.enable_emission
   M_NLIGHT = m.nlight
+
+  aa = rc.samples_per_pixel * rc.samples_per_pixel > 1
+
+  @wp.func
+  def store_pixel(
+    # In:
+    worldid: int,
+    adr: int,
+    color: wp.vec3,
+    # Out:
+    rgb_out: wp.array2d[wp.uint32],
+    aa_accum_out: wp.array2d[wp.vec3],
+  ):
+    # Supersampling sums in float here rather than re-reading the packed byte
+    # image, so the passes neither round-trip through memory nor quantise early.
+    if wp.static(aa):
+      aa_accum_out[worldid, adr] += color * 255.0
+    else:
+      rgb_out[worldid, adr] = pack_rgba_to_uint32(color[0] * 255.0, color[1] * 255.0, color[2] * 255.0, 255.0)
 
   @wp.kernel(module="unique", enable_backward=False, grid_stride=False, module_options={"fast_math": rc.use_fast_math})
   def _render_megakernel(
@@ -807,6 +807,7 @@ def _build_megakernel(m: Model, rc: RenderContext):
     splat_group_root: wp.array[int],
     # Out:
     rgb_out: wp.array2d[wp.uint32],
+    aa_accum_out: wp.array2d[wp.vec3],
     depth_out: wp.array2d[float],
     seg_out: wp.array2d[wp.vec2i],
   ):
@@ -948,12 +949,7 @@ def _build_megakernel(m: Model, rc: RenderContext):
         )
         if wp.static(has_splats):
           skybox_color = splat_color + skybox_color * splat_transmittance
-        rgb_out[worldid, rgb_adr[camid] + rayid_local] = pack_rgba_to_uint32(
-          skybox_color[0] * 255.0,
-          skybox_color[1] * 255.0,
-          skybox_color[2] * 255.0,
-          255.0,
-        )
+        store_pixel(worldid, rgb_adr[camid] + rayid_local, skybox_color, rgb_out, aa_accum_out)
       elif render_rgb[camid]:
         if wp.static(has_splats):
           packed = wp.static(rc_static["background_color"])
@@ -963,8 +959,20 @@ def _build_megakernel(m: Model, rc: RenderContext):
             float(packed & wp.uint32(0xFF)),
           ) * wp.static(1.0 / 255.0)
           pixel_color = splat_color + background * splat_transmittance
-          rgb_out[worldid, rgb_adr[camid] + rayid_local] = pack_rgba_to_uint32(
-            pixel_color[0] * 255.0, pixel_color[1] * 255.0, pixel_color[2] * 255.0, 255.0
+          store_pixel(worldid, rgb_adr[camid] + rayid_local, pixel_color, rgb_out, aa_accum_out)
+        elif wp.static(aa):
+          packed = wp.static(rc_static["background_color"])
+          store_pixel(
+            worldid,
+            rgb_adr[camid] + rayid_local,
+            wp.vec3(
+              float((packed >> wp.uint32(16)) & wp.uint32(0xFF)),
+              float((packed >> wp.uint32(8)) & wp.uint32(0xFF)),
+              float(packed & wp.uint32(0xFF)),
+            )
+            * wp.static(1.0 / 255.0),
+            rgb_out,
+            aa_accum_out,
           )
         else:
           rgb_out[worldid, rgb_adr[camid] + rayid_local] = wp.static(rc_static["background_color"])
@@ -1164,12 +1172,7 @@ def _build_megakernel(m: Model, rc: RenderContext):
     if wp.static(has_splats):
       hit_color = splat_color + hit_color * splat_transmittance
 
-    rgb_out[worldid, rgb_adr[camid] + rayid_local] = pack_rgba_to_uint32(
-      hit_color[0] * 255.0,
-      hit_color[1] * 255.0,
-      hit_color[2] * 255.0,
-      255.0,
-    )
+    store_pixel(worldid, rgb_adr[camid] + rayid_local, hit_color, rgb_out, aa_accum_out)
 
   return _render_megakernel
 
@@ -1279,13 +1282,12 @@ def render(m: Model, d: Data, rc: RenderContext):
       ],
       outputs=[
         rc.rgb_data,
+        rc.aa_accum,
         rc.depth_data,
         rc.seg_data,
       ],
       block_dim=m.block_dim.render,
     )
-    if nsamples > 1:
-      wp.launch(_aa_accumulate, dim=rc.rgb_data.shape, inputs=[rc.rgb_data], outputs=[rc.aa_accum])
 
   if nsamples > 1:
     wp.launch(_aa_resolve, dim=rc.rgb_data.shape, inputs=[rc.aa_accum, 1.0 / float(nsamples)], outputs=[rc.rgb_data])

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -955,6 +955,33 @@ class RenderTest(parameterized.TestCase):
       self.assertGreater(int(floor.min()), 0)
       self.assertLess(int(floor.min()), int(floor.max()))
 
+  def test_supersampling_antialiases_edges(self):
+    # At one sample a slanted silhouette is binary: geom or background, nothing
+    # between. More samples must add blends without moving those two levels.
+    xml = """
+    <mujoco>
+      <worldbody>
+        <light pos="0 -2 2" dir="0 1 -1" directional="true" diffuse="1 1 1"/>
+        <camera pos="0 -2 0" xyaxes="1 0 0 0 0 1" fovy="30"/>
+        <geom type="box" size="0.3 0.3 0.3" euler="0 22 0" rgba="0.9 0.9 0.9 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    blended = []
+    for samples in (1, 2, 3):
+      mjm, _, m, d = test_data.fixture(xml=xml)
+      rc = mjw.create_render_context(mjm, cam_res=(64, 64), render_rgb=True, samples_per_pixel=samples)
+      mjw.render(m, d, rc)
+      red = _unpack_rgb(rc.rgb_data.numpy()[0])[..., 0].astype(int)
+      value, count = np.unique(red, return_counts=True)
+      flat = value[count > 40]
+      blended.append(int(np.count_nonzero((red > flat.min() + 2) & (red < flat.max() - 2))))
+      self.assertEqual(flat.tolist(), [25, 255])
+
+    self.assertEqual(blended[0], 0)
+    self.assertGreater(blended[1], 50)
+    self.assertGreater(blended[2], blended[1])
+
 
 if __name__ == "__main__":
   wp.init()

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -982,6 +982,96 @@ class RenderTest(parameterized.TestCase):
     self.assertGreater(blended[1], 50)
     self.assertGreater(blended[2], blended[1])
 
+  def test_supersampling_preserves_segmentation_and_depth(self):
+    # Depth and seg come from a single sample: extra samples must not dilate the
+    # segmentation silhouette or disturb the background depth.
+    coverage = []
+    for samples in (1, 2):
+      mjm, _, m, d = test_data.fixture(
+        xml="""
+      <mujoco>
+        <worldbody>
+          <light pos="0 -2 2" dir="0 1 -1" directional="true"/>
+          <camera pos="0 -2 0" xyaxes="1 0 0 0 0 1" fovy="30"/>
+          <geom type="box" size="0.3 0.3 0.3" euler="0 22 0" rgba="0.9 0.9 0.9 1"/>
+        </worldbody>
+      </mujoco>
+      """
+      )
+      rc = mjw.create_render_context(
+        mjm, cam_res=(64, 64), render_rgb=True, render_depth=True, render_seg=True, samples_per_pixel=samples
+      )
+      mjw.render(m, d, rc)
+      hits = rc.seg_data.numpy()[0][:, 0] >= 0
+      coverage.append(int(np.count_nonzero(hits)))
+      self.assertTrue(np.all(rc.depth_data.numpy()[0][~hits] == 0.0))
+
+    self.assertLess(abs(coverage[1] - coverage[0]), 10)
+
+  def test_supersampling_validation(self):
+    mjm, _, _, _ = test_data.fixture(
+      xml="""
+    <mujoco>
+      <worldbody>
+        <camera pos="0 -1 0" xyaxes="1 0 0 0 0 1"/>
+        <geom type="sphere" size="0.1"/>
+      </worldbody>
+    </mujoco>
+    """
+    )
+    with self.assertRaisesRegex(ValueError, "at least 1"):
+      mjw.create_render_context(mjm, samples_per_pixel=0)
+    with self.assertRaisesRegex(ValueError, "use_precomputed_rays"):
+      mjw.create_render_context(mjm, samples_per_pixel=2, use_precomputed_rays=False)
+    with self.assertRaisesRegex(ValueError, "render_rgb"):
+      mjw.create_render_context(mjm, samples_per_pixel=2, render_rgb=False)
+
+  def test_supersampling_multi_camera_mixed_outputs(self):
+    # aa_accum spans only the RGB pixels; a depth-only camera must not widen it.
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+    <mujoco>
+      <worldbody>
+        <camera pos="0 -2 0" xyaxes="1 0 0 0 0 1" fovy="30"/>
+        <camera pos="0 0 2" xyaxes="1 0 0 0 1 0" fovy="30"/>
+        <geom type="box" size="0.2 0.2 0.2" rgba="1 0 0 1"/>
+      </worldbody>
+    </mujoco>
+    """
+    )
+    rc = mjw.create_render_context(
+      mjm,
+      cam_res=[(32, 32), (32, 32)],
+      render_rgb=[True, False],
+      render_depth=[False, True],
+      samples_per_pixel=2,
+    )
+    mjw.render(m, d, rc)
+
+    self.assertEqual(rc.aa_accum.shape, (1, 32 * 32))
+    self.assertGreater(np.count_nonzero(rc.rgb_data.numpy()[0]), 0)
+    self.assertGreater(np.count_nonzero(rc.depth_data.numpy()[0]), 0)
+
+  def test_supersampling_batched_worlds(self):
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+    <mujoco>
+      <worldbody>
+        <light pos="0 -2 2" dir="0 1 -1" directional="true"/>
+        <camera pos="0 -2 0" xyaxes="1 0 0 0 0 1" fovy="30"/>
+        <geom type="box" size="0.3 0.3 0.3" euler="0 22 0" rgba="0.9 0.9 0.9 1"/>
+      </worldbody>
+    </mujoco>
+    """,
+      nworld=4,
+    )
+    rc = mjw.create_render_context(mjm, nworld=4, cam_res=(32, 32), render_rgb=True, samples_per_pixel=2)
+    mjw.render(m, d, rc)
+
+    for world in range(4):
+      red = _unpack_rgb(rc.rgb_data.numpy()[world])[..., 0]
+      self.assertGreater(len(np.unique(red)), 2)
+
 
 if __name__ == "__main__":
   wp.init()

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -291,12 +291,17 @@ def _build_rays(
   sensorsize: wp.vec2,
   intrinsic: wp.vec4,
   znear: float,
+  n: int,
+  sx: int,
+  sy: int,
   # Out:
   ray_out: wp.array[wp.vec3],
   ray_offset_out: wp.array[wp.vec3],
 ):
   xid, yid = wp.tid()
-  ray_dir, ray_offset = compute_ray(projection, fovy, sensorsize, intrinsic, img_w, img_h, xid, yid, znear)
+  ray_dir, ray_offset = compute_ray(
+    projection, fovy, sensorsize, intrinsic, img_w * n, img_h * n, xid * n + sx, yid * n + sy, znear
+  )
   idx = offset + xid + yid * img_w
   ray_out[idx] = ray_dir
   ray_offset_out[idx] = ray_offset
@@ -321,6 +326,7 @@ def create_render_context(
   render_skybox: bool = False,
   enable_backface_culling: bool = True,
   shadow_light_fraction: float = 0.3,
+  samples_per_pixel: int = 1,
   enable_vertex_normals: bool = True,
   enable_specular: bool = True,
   enable_emission: bool = True,
@@ -359,6 +365,7 @@ def create_render_context(
                    Requires the model to contain a texture with type `mjTEXTURE_SKYBOX`.
     shadow_light_fraction: Fraction of a light's direct contribution reaching an
       occluded point. 0 is a true shadow.
+    samples_per_pixel: Sub-pixel samples per axis, averaged. Costs n*n renders.
     enable_vertex_normals: Shade meshes from their authored vertex normals,
       matching mjr_uploadMesh. When False, use the face normal.
     enable_backface_culling: Drop primitive-ray hits whose normal faces away from
@@ -617,37 +624,48 @@ def create_render_context(
 
   znear = float(mjm.vis.map.znear * mjm.stat.extent)
 
-  ray = wp.zeros(int(total), dtype=wp.vec3)
-  ray_offset = wp.zeros(int(total), dtype=wp.vec3)
+  if samples_per_pixel < 1:
+    raise ValueError("samples_per_pixel must be at least 1.")
+  if samples_per_pixel > 1 and not use_precomputed_rays:
+    raise ValueError("samples_per_pixel > 1 requires use_precomputed_rays=True: dynamic rays carry no sub-pixel jitter.")
+  nsamples = samples_per_pixel * samples_per_pixel
+  ray = wp.zeros(int(total) * nsamples, dtype=wp.vec3)
+  ray_offset = wp.zeros(int(total) * nsamples, dtype=wp.vec3)
 
   cam_projection = mjm.cam_projection
 
-  offset = 0
-  for idx, cam_id_val in enumerate(active_cam_indices):
-    cam_id = int(cam_id_val)
-    img_w = int(cam_res_np[idx][0])
-    img_h = int(cam_res_np[idx][1])
-    wp.launch(
-      kernel=_build_rays,
-      dim=(img_w, img_h),
-      inputs=[
-        offset,
-        img_w,
-        img_h,
-        int(mjm.cam_projection[cam_id]),
-        float(mjm.cam_fovy[cam_id]),
-        wp.vec2(float(mjm.cam_sensorsize[cam_id, 0]), float(mjm.cam_sensorsize[cam_id, 1])),
-        wp.vec4(
-          float(mjm.cam_intrinsic[cam_id, 0]),
-          float(mjm.cam_intrinsic[cam_id, 1]),
-          float(mjm.cam_intrinsic[cam_id, 2]),
-          float(mjm.cam_intrinsic[cam_id, 3]),
-        ),
-        znear,
-      ],
-      outputs=[ray, ray_offset],
-    )
-    offset += img_w * img_h
+  for sample in range(nsamples):
+    offset = sample * int(total)
+    for idx, cam_id_val in enumerate(active_cam_indices):
+      cam_id = int(cam_id_val)
+      img_w = int(cam_res_np[idx][0])
+      img_h = int(cam_res_np[idx][1])
+      wp.launch(
+        kernel=_build_rays,
+        dim=(img_w, img_h),
+        inputs=[
+          offset,
+          img_w,
+          img_h,
+          int(mjm.cam_projection[cam_id]),
+          float(mjm.cam_fovy[cam_id]),
+          wp.vec2(float(mjm.cam_sensorsize[cam_id, 0]), float(mjm.cam_sensorsize[cam_id, 1])),
+          wp.vec4(
+            float(mjm.cam_intrinsic[cam_id, 0]),
+            float(mjm.cam_intrinsic[cam_id, 1]),
+            float(mjm.cam_intrinsic[cam_id, 2]),
+            float(mjm.cam_intrinsic[cam_id, 3]),
+          ),
+          znear,
+          samples_per_pixel,
+          sample % samples_per_pixel,
+          sample // samples_per_pixel,
+        ],
+        outputs=[ray, ray_offset],
+      )
+      offset += img_w * img_h
+
+  aa_accum = wp.zeros((nworld, int(total)), dtype=wp.vec3) if nsamples > 1 else wp.zeros(0, dtype=wp.vec3)
 
   bvh_ngeom = len(geom_enabled_idx)
 
@@ -732,6 +750,8 @@ def create_render_context(
     total_rays=int(total),
     enable_backface_culling=enable_backface_culling,
     shadow_light_fraction=shadow_light_fraction,
+    samples_per_pixel=samples_per_pixel,
+    aa_accum=aa_accum,
     geom_ray_types=geom_ray_types,
     enable_vertex_normals=enable_vertex_normals,
     enable_specular=enable_specular,

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -628,6 +628,8 @@ def create_render_context(
     raise ValueError("samples_per_pixel must be at least 1.")
   if samples_per_pixel > 1 and not use_precomputed_rays:
     raise ValueError("samples_per_pixel > 1 requires use_precomputed_rays=True: dynamic rays carry no sub-pixel jitter.")
+  if samples_per_pixel > 1 and ri == 0:
+    raise ValueError("samples_per_pixel > 1 requires at least one camera with render_rgb=True.")
   nsamples = samples_per_pixel * samples_per_pixel
   ray = wp.zeros(int(total) * nsamples, dtype=wp.vec3)
   ray_offset = wp.zeros(int(total) * nsamples, dtype=wp.vec3)
@@ -665,7 +667,7 @@ def create_render_context(
       )
       offset += img_w * img_h
 
-  aa_accum = wp.zeros((nworld, int(total) if nsamples > 1 else 1), dtype=wp.vec3)
+  aa_accum = wp.zeros((nworld, ri if nsamples > 1 else 1), dtype=wp.vec3)
 
   bvh_ngeom = len(geom_enabled_idx)
 

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -665,7 +665,7 @@ def create_render_context(
       )
       offset += img_w * img_h
 
-  aa_accum = wp.zeros((nworld, int(total)), dtype=wp.vec3) if nsamples > 1 else wp.zeros(0, dtype=wp.vec3)
+  aa_accum = wp.zeros((nworld, int(total) if nsamples > 1 else 1), dtype=wp.vec3)
 
   bvh_ngeom = len(geom_enabled_idx)
 

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -2500,6 +2500,8 @@ class RenderContext:
     mesh_texcoord_offsets: mesh texture coordinate offsets
     mesh_facetexcoord: mesh face texture coordinates
     mesh_facenormal: per-face indices into Model.mesh_normal
+    samples_per_pixel: sub-pixel samples per axis; 1 disables supersampling
+    aa_accum: colour accumulator, unused when samples_per_pixel is 1
     textures: textures
     textures_registry: texture registry
     hfield_registry: hfield BVH id to warp mesh mapping
@@ -2615,6 +2617,8 @@ class RenderContext:
   mesh_texcoord_offsets: array("nmesh", int)
   mesh_facetexcoord: array("nmeshface", wp.vec3i)
   mesh_facenormal: array("nmeshface", wp.vec3i)
+  samples_per_pixel: int
+  aa_accum: array("*", wp.vec3)
   textures: array("*", wp.Texture2D)
   textures_registry: list[wp.Texture2D]
   hfield_registry: dict


### PR DESCRIPTION
This PR adds anti-aliasing via supersampling. `create_render_context(samples_per_pixel=n)` casts n^2 rays per pixel instead of one, spread evenly across the pixel, and averages the result. The default of 1 leaves the renderer unchanged.

Only RGB is averaged: depth and segmentation keep a single sample, since averaging object IDs is meaningless. Supersampling requires precomputed rays (the default).

![supersampling](https://raw.githubusercontent.com/kevinzakka/mujoco_warp/baa4279d8f7766fd871cde7d478634f3accbbe6f/images/supersampling.png)

*A slanted silhouette at 1, 2, and 4 samples per pixel.*

![supersampling closeup](https://raw.githubusercontent.com/kevinzakka/mujoco_warp/baa4279d8f7766fd871cde7d478634f3accbbe6f/images/supersampling_closeup.png)

*The same edge rendered at 96x96 and magnified: 1 spp is a binary staircase, 4 spp blends by coverage.*

![aa on a wrist camera](https://raw.githubusercontent.com/kevinzakka/mujoco_warp/baa4279d8f7766fd871cde7d478634f3accbbe6f/images/nanoeval_aa.png)

*1 vs 2 spp from a robot wrist camera. Look at the table's back edge and the shadow boundaries.*

Cost is the expected n^2 renders, slightly sublinear thanks to fixed per-launch overheads (clutter scene, 2048 worlds, 4 cameras @ 64x64, RGB + depth + segmentation, shadows; RTX 5090):

| samples_per_pixel | ms/step | vs 1 spp |
|---|---|---|
| 1 | 111.0 | 1.0x |
| 2 | 409.1 | 3.7x |
| 3 | 921.5 | 8.3x |

At the default `samples_per_pixel=1` the `aloha_clutter_vision` benchmark is unchanged from main (7,921 steps/s on both).


