### PR TITLE
Support list and tuple flags in benchmarks sweep

### DIFF
--- a/benchmarks/sweep.py
+++ b/benchmarks/sweep.py
@@ -166,7 +166,12 @@ def _run_benchmark(bm: dict, input_dir: Path, *, mock: bool) -> dict:
     elif field == "nstep":
       cmd.append(f"--nstep={10 if mock else bm['nstep']}")
     elif field not in ("name", "assets", "mjcf", "_dir"):
-      cmd.append(f"--{field}={bm[field]}")
+      value = bm[field]
+      if isinstance(value, (list, tuple)):
+        for item in value:
+          cmd.append(f"--{field}={item}")
+      else:
+        cmd.append(f"--{field}={value}")
 
   return json.loads(_uv_run(*cmd, cwd=input_dir).stdout)
 


### PR DESCRIPTION
part 1 for updating the nightly benchmarks website with the aloha clutter vision benchmark

When running benchmarks that configure multi-value arguments (such as the multi-camera and render modality lists in aloha_clutter_vision), sweep.py passed the field as a single stringified list rather than repeated flags. This caused mjwarp-testspeed to fail argument parsing, so benchmarks with list-valued configuration options were skipped during automated sweeps.

This change updates _run_benchmark in benchmarks/sweep.py to unpack list and tuple values into repeated command-line flags, matching the existing behavior in benchmarks/run.py.