### PR TITLE
Honor use_textures in create_render_context

### DIFF
--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -496,10 +496,7 @@ def create_render_context(
       flex_group_root[:, f] = group_root.numpy()
 
   textures_registry = []
-  # Only materialize GPU textures when the caller actually needs them. The
-  # loop below calls wp.Texture2D, which requires backend texture-object
-  # support (hipArray textures are unsupported on some non-CUDA backends);
-  # raycast-only contexts pass use_textures=False and never sample textures.
+  # Only materialize GPU textures when the caller actually needs them.
   if use_textures:
     for i in range(mjm.ntex):
       textures_registry.append(create_warp_texture(mjm, i))

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -496,8 +496,13 @@ def create_render_context(
       flex_group_root[:, f] = group_root.numpy()
 
   textures_registry = []
-  for i in range(mjm.ntex):
-    textures_registry.append(create_warp_texture(mjm, i))
+  # Only materialize GPU textures when the caller actually needs them. The
+  # loop below calls wp.Texture2D, which requires backend texture-object
+  # support (hipArray textures are unsupported on some non-CUDA backends);
+  # raycast-only contexts pass use_textures=False and never sample textures.
+  if use_textures:
+    for i in range(mjm.ntex):
+      textures_registry.append(create_warp_texture(mjm, i))
   textures = wp.array(textures_registry, dtype=wp.Texture2D)
 
   # Locate skybox texture

--- a/mujoco_warp/_src/render_util_test.py
+++ b/mujoco_warp/_src/render_util_test.py
@@ -179,6 +179,32 @@ class RenderUtilTest(parameterized.TestCase):
     group_np = rc.group.numpy()
     _assert_eq(group_np, np.repeat(np.arange(nworld), rc.bvh_ngeom), "render context group values")
 
+  def test_use_textures_flag(self):
+    """create_render_context honors use_textures: skip texture materialization when False."""
+    textured_xml = """
+    <mujoco>
+      <asset>
+        <texture name="tex" type="2d" builtin="flat" rgb1="1 0 0" width="4" height="4"/>
+        <material name="mat" texture="tex"/>
+      </asset>
+      <worldbody>
+        <camera name="cam" pos="0 -3 2" xyaxes="1 0 0 0 0.6 0.8" resolution="16 16" output="rgb"/>
+        <geom type="plane" size="5 5 0.1" material="mat"/>
+        <geom type="sphere" size="0.5" pos="0 0 1" material="mat"/>
+      </worldbody>
+    </mujoco>
+    """
+    mjm, mjd, m, d = test_data.fixture(xml=textured_xml)
+    self.assertGreater(mjm.ntex, 0, "test model must contain at least one texture")
+
+    rc_off = mjw.create_render_context(mjm, cam_res=(16, 16), use_textures=False)
+    self.assertEqual(len(rc_off.textures_registry), 0, "no textures should be created when use_textures=False")
+    self.assertFalse(rc_off.use_textures)
+
+    rc_on = mjw.create_render_context(mjm, cam_res=(16, 16), render_rgb=True, use_textures=True)
+    self.assertEqual(len(rc_on.textures_registry), mjm.ntex, "all model textures should be created when use_textures=True")
+    self.assertTrue(rc_on.use_textures)
+
   def test_output_buffers(self):
     """Test that the output rgb and depth buffers have correct shapes and addresses."""
     mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)

--- a/mujoco_warp/_src/render_util_test.py
+++ b/mujoco_warp/_src/render_util_test.py
@@ -181,7 +181,8 @@ class RenderUtilTest(parameterized.TestCase):
 
   def test_use_textures_flag(self):
     """create_render_context honors use_textures: skip texture materialization when False."""
-    textured_xml = """
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
     <mujoco>
       <asset>
         <texture name="tex" type="2d" builtin="flat" rgb1="1 0 0" width="4" height="4"/>
@@ -194,14 +195,14 @@ class RenderUtilTest(parameterized.TestCase):
       </worldbody>
     </mujoco>
     """
-    mjm, mjd, m, d = test_data.fixture(xml=textured_xml)
+    )
     self.assertGreater(mjm.ntex, 0, "test model must contain at least one texture")
 
     rc_off = mjw.create_render_context(mjm, cam_res=(16, 16), use_textures=False)
     self.assertEqual(len(rc_off.textures_registry), 0, "no textures should be created when use_textures=False")
     self.assertFalse(rc_off.use_textures)
 
-    rc_on = mjw.create_render_context(mjm, cam_res=(16, 16), render_rgb=True, use_textures=True)
+    rc_on = mjw.create_render_context(mjm, cam_res=(16, 16), use_textures=True)
     self.assertEqual(len(rc_on.textures_registry), mjm.ntex, "all model textures should be created when use_textures=True")
     self.assertTrue(rc_on.use_textures)
 


### PR DESCRIPTION
`create_render_context` takes a `use_textures` parameter (default `True`) and its docstring documents it as "Whether to use textures", but the implementation ignores it: the texture-creation loop always calls `create_warp_texture` (which allocates a `wp.Texture2D`) for every texture in the model, even when the caller passed `use_textures=False`. Raycast-only callers that never sample a texture still pay the full texture-materialization cost, and on backends without texture-object support this fails hard. Concretely, `wp.Texture2D` maps to a hipArray texture object on ROCm/HIP, which is not supported there, so `create_render_context` raises "operation not supported" (CUDA error 801) even for a pure raycast context that requested no textures.

This change guards the texture-creation loop with the existing `use_textures` flag, so `use_textures=False` skips texture allocation entirely. When `use_textures=True` the behavior is unchanged: `textures_registry` is populated exactly as before, and `textures` stays a `wp.array(..., dtype=wp.Texture2D)` (empty when nothing is created, which already happened for models with `ntex == 0`). The added test asserts the registry is empty when `use_textures=False` and fully populated when `use_textures=True` on a model that contains a texture.

One note on testing: I develop on AMD (MI300X/ROCm) via the ROCm Warp fork, which is currently based on Warp 1.13. mujoco_warp `main` requires `warp-lang>=1.15` (it uses `wp.kernel(grid_stride=...)`, unavailable in 1.13), so I could not execute the GPU test suite on my hardware. I verified `ruff check` and `ruff format` pass and the changed modules compile, and confirmed the change against the surrounding code by inspection. I would appreciate a maintainer running the render tests on CUDA to confirm.
