### PR TITLE
Report only individual overflow flags in testspeed

### DIFF
--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -271,7 +271,8 @@ def _main(argv: Sequence[str]):
         print(f"\nSimulation aborted: overflow detected in {n_worlds} world{'s' if n_worlds > 1 else ''}:")
         for wid in world_ids[:10]:
           mask = overflows[wid]
-          active_flags = [f.name for f in OverflowType if mask & f.value]
+          # skip composite members (e.g. ALL) so only the individual overflows are reported
+          active_flags = [f.name for f in OverflowType if f.value and not (f.value & (f.value - 1)) and mask & f.value]
           print(f"  World {wid}: {', '.join(active_flags)}")
         if n_worlds > 10:
           print(f"  ... and {n_worlds - 10} more worlds (reporting truncated to first 10)")


### PR DESCRIPTION
`OverflowType.ALL` was added as a composite member in #1615, and the per-world overflow report in `mjwarp-testspeed` builds its flag list by iterating every member of the enum, so `ALL` matches whenever any bit is set. A run that overflows one thing reports as though everything overflowed:

```
Simulation aborted: overflow detected in 32 worlds:
  World 0: BROADPHASE, ALL
```

Python 3.11 and later leave composite aliases out when iterating a `Flag`, so this only shows up on 3.10, which is the minimum the project supports.

This filters the listing to single-bit members, so the same run prints `World 0: BROADPHASE`. There is no test module for `testspeed.py` so I did not add a test; `uv run pytest -n 8` passes (1328 passed, 29 skipped) and `ruff format --check` and `ruff check` are clean.
