### PR TITLE
Support enum negation in model overrides and respect warn_overflow in testspeed

### DIFF
--- a/benchmarks/unitree_g1/__init__.py
+++ b/benchmarks/unitree_g1/__init__.py
@@ -13,6 +13,7 @@ BENCHMARKS = [
     "nconmax": 48,
     "njmax": 192,
     "replay": "shuffle_dance.npz",
+    "override": "opt.warn_overflow=~ITERATIONS|~LS_ITERATIONS",
     "assets": [(ASSETS[0], "unitree_g1/assets", "assets")],
   },
   {
@@ -22,6 +23,7 @@ BENCHMARKS = [
     "nconmax": 48,
     "njmax": 192,
     "replay": "shuffle_dance.npz",
+    "override": "opt.warn_overflow=~ITERATIONS|~LS_ITERATIONS",
     "assets": [(ASSETS[0], "unitree_g1/assets", "assets")],
   },
   {
@@ -36,6 +38,7 @@ BENCHMARKS = [
     "render_height": 64,
     "render_depth": False,
     "replay": "shuffle_dance.npz",
+    "override": "opt.warn_overflow=~ITERATIONS|~LS_ITERATIONS",
     "assets": [(ASSETS[0], "unitree_g1/assets", "assets")],
   },
 ]

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -2914,12 +2914,18 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
       elif key in enum_fields and isinstance(val, str):
         # special case: enum value
         enum_members = val.split("|")
-        val = 0
+        enum_cls = enum_fields[key]
+        val = int(getattr(obj, attr)) if any(m.strip().startswith("~") for m in enum_members) else 0
         for enum_member in enum_members:
           enum_member = enum_member.strip().upper()
-          if enum_member not in enum_fields[key].__members__:
-            raise ValueError(f"Unrecognized enum value for {enum_fields[key].__name__}: {enum_member}")
-          val |= int(enum_fields[key][enum_member])
+          is_negated = enum_member.startswith("~")
+          name = enum_member[1:].strip() if is_negated else enum_member
+          if name not in enum_cls.__members__:
+            raise ValueError(f"Unrecognized enum value for {enum_cls.__name__}: {enum_member}")
+          if is_negated:
+            val &= ~int(enum_cls[name])
+          else:
+            val |= int(enum_cls[name])
       elif typ is bool and isinstance(val, str):
         # special case: "true", "TRUE", "false", "FALSE" etc.
         if val.upper() not in ("TRUE", "FALSE"):

--- a/mujoco_warp/_src/types_test.py
+++ b/mujoco_warp/_src/types_test.py
@@ -131,6 +131,11 @@ class TypesTest(parameterized.TestCase):
     override_model(m, {"opt.warn_overflow": "CCD"})
     self.assertEqual(m.opt.warn_overflow, int(OverflowType.CCD))
 
+    m = put_model(mjm)
+    override_model(m, ["opt.warn_overflow=~ITERATIONS|~LS_ITERATIONS"])
+    expected = int(OverflowType.ALL) & ~OverflowType.ITERATIONS & ~OverflowType.LS_ITERATIONS
+    self.assertEqual(m.opt.warn_overflow, expected)
+
 
 if __name__ == "__main__":
   wp.init()

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -169,7 +169,8 @@ def _main(argv: Sequence[str]):
   mjm = cli.load_model(path)
   free_mem_at_init = wp.get_device(device).free_memory
   m, d, rc, ctrls = cli.init_structs(_FUNCS[_FUNCTION.value], mjm)
-  m.opt.warn_overflow = int(OverflowType.ALL) if _OVERFLOW_BEHAVIOR.value == "continue" else 0
+  warn_overflow = m.opt.warn_overflow
+  m.opt.warn_overflow = warn_overflow if _OVERFLOW_BEHAVIOR.value == "continue" else 0
   timestep = m.opt.timestep.numpy()[0]
 
   if _FORMAT.value == "human":
@@ -264,7 +265,7 @@ def _main(argv: Sequence[str]):
     trace = _sum_trace(trace, step_trace)
 
     if _OVERFLOW_BEHAVIOR.value == "error":
-      overflows = d.overflow.numpy()
+      overflows = d.overflow.numpy() & warn_overflow
       if np.any(overflows != 0):
         world_ids = np.where(overflows != 0)[0]
         n_worlds = len(world_ids)


### PR DESCRIPTION
Unitree G1 benchmarks (`unitree_g1_flat`, `unitree_g1_hfield`, `unitree_g1_hfield_render`) reach linesearch iteration limits during rollout, which causes `mjwarp-testspeed` to abort under `--overflow_behavior=error` and generates millions of lines of GPU kernel warning prints under `continue`. In addition, `testspeed.py` unconditionally overwrote `m.opt.warn_overflow` during setup, ignoring any user-configured overflow mask, and `override_model` only supported additive enum syntax with no mechanism to clear specific bitmask flags.

This PR adds generic bitwise negation (`~`) support to `override_model` for enum fields, updates `testspeed.py` to respect the model's configured `warn_overflow` mask during simulation and error checks, and configures `opt.warn_overflow=~ITERATIONS|~LS_ITERATIONS` on the G1 benchmarks so they run to completion without early termination or print spam.

- In `mujoco_warp/_src/io.py`, `override_model` now recognizes `~MEMBER` for enum fields and clears the corresponding bit from the attribute's current value.
- In `mujoco_warp/testspeed.py`, `warn_overflow` is preserved from `m.opt.warn_overflow` rather than clobbered, and the error callback masks `d.overflow` against `warn_overflow` so only un-suppressed overflow types trigger an abort.
- In `benchmarks/unitree_g1/__init__.py`, added `override: opt.warn_overflow=~ITERATIONS|~LS_ITERATIONS` across the G1 benchmarks.
- In `mujoco_warp/_src/types_test.py`, added a test case verifying enum negation in `override_model`.
