### PR TITLE
Add `Option.run_rne_postconstraint` and decouple rne_postconstraint from sensor stage

### DIFF
--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -1405,7 +1405,9 @@ def forward(m: Model, d: Data):
   fwd_acceleration(m, d, factorize=True)
 
   solver.solve(m, d)
-  sensor.sensor_acc(m, d)
+  if m.opt.run_rne_postconstraint or (not (m.opt.disableflags & DisableBit.SENSOR) and m.sensor_rne_postconstraint):
+    smooth.rne_postconstraint(m, d)
+  sensor.sensor_acc(m, d, skip_rne_postconstraint=True)
 
 
 @event_scope
@@ -1448,7 +1450,9 @@ def step2(m: Model, d: Data):
   fwd_actuation(m, d)
   fwd_acceleration(m, d)
   solver.solve(m, d)
-  sensor.sensor_acc(m, d)
+  if m.opt.run_rne_postconstraint or (not (m.opt.disableflags & DisableBit.SENSOR) and m.sensor_rne_postconstraint):
+    smooth.rne_postconstraint(m, d)
+  sensor.sensor_acc(m, d, skip_rne_postconstraint=True)
 
   # integrate with Euler or implicitfast
   if m.opt.integrator in (IntegratorType.IMPLICITFAST, IntegratorType.IMPLICIT):

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -2053,6 +2053,53 @@ class DCMotorTest(parameterized.TestCase):
 
     np.testing.assert_allclose(d.qvel.numpy()[0], mjd.qvel, atol=1e-3, rtol=1e-3)
 
+  def test_run_rne_postconstraint(self):
+    """Tests run_rne_postconstraint option in forward and step2."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="body0" pos="0 0 1">
+            <freejoint/>
+            <geom type="sphere" size=".1" mass="1"/>
+            <site name="site0"/>
+          </body>
+        </worldbody>
+        <sensor>
+          <accelerometer site="site0"/>
+        </sensor>
+      </mujoco>
+      """,
+      overrides={"opt.disableflags": DisableBit.SENSOR, "opt.run_rne_postconstraint": True},
+    )
+    self.assertTrue(m.opt.run_rne_postconstraint)
+    mujoco.mj_forward(mjm, mjd)
+    mujoco.mj_rnePostConstraint(mjm, mjd)
+
+    # 1. run_rne_postconstraint=True: RNE runs in forward and step2, sensors skipped
+    d.cacc.fill_(wp.inf)
+    d.cfrc_int.fill_(wp.inf)
+    d.cfrc_ext.fill_(wp.inf)
+    mjw.forward(m, d)
+
+    _assert_eq(d.cacc.numpy()[0], mjd.cacc, "cacc")
+    _assert_eq(d.cfrc_int.numpy()[0], mjd.cfrc_int, "cfrc_int")
+    _assert_eq(d.cfrc_ext.numpy()[0], mjd.cfrc_ext, "cfrc_ext")
+    self.assertFalse(d.sensordata.numpy().any(), "Sensors should not be computed when disabled")
+
+    # Verify step2 also runs RNE
+    d.cacc.fill_(wp.inf)
+    mjw.step2(m, d)
+    _assert_eq(d.cacc.numpy()[0], mjd.cacc, "step2 cacc")
+
+    # 2. run_rne_postconstraint=False: RNE skipped when sensors disabled
+    m.opt.run_rne_postconstraint = False
+    d.cfrc_ext.fill_(wp.inf)
+    mjw.forward(m, d)
+    self.assertTrue(
+      np.isinf(d.cfrc_ext.numpy()[0]).all(), "cfrc_ext should remain inf when RNE is not requested and sensors disabled"
+    )
+
 
 if __name__ == "__main__":
   wp.init()

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -361,6 +361,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
   opt.graph_conditional = True
   opt.run_collision_detection = True
   opt.warn_overflow = int(types.OverflowType.ALL)
+  opt.run_rne_postconstraint = False
   contact_sensor_maxmatch_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_NUMERIC, "contact_sensor_maxmatch")
   if contact_sensor_maxmatch_id > -1:
     opt.contact_sensor_maxmatch = mjm.numeric_data[mjm.numeric_adr[contact_sensor_maxmatch_id]]
@@ -2872,6 +2873,8 @@ def override_model(model: types.Model | mujoco.MjModel, overrides: dict[str, Any
     "opt.graph_conditional",
     "opt.contact_sensor_maxmatch",
     "opt.warn_overflow",
+    "opt.run_collision_detection",
+    "opt.run_rne_postconstraint",
   }
   mj_only_fields = {"opt.jacobian", "vis.quality.offsamples"}
 

--- a/mujoco_warp/_src/sensor.py
+++ b/mujoco_warp/_src/sensor.py
@@ -2520,7 +2520,7 @@ def _contact_sort(maxmatch: int):
 
 
 @event_scope
-def sensor_acc(m: Model, d: Data):
+def sensor_acc(m: Model, d: Data, skip_rne_postconstraint: bool = False):
   """Compute acceleration-dependent sensor values."""
   if m.opt.disableflags & DisableBit.SENSOR:
     return
@@ -2668,7 +2668,7 @@ def sensor_acc(m: Model, d: Data):
       block_dim=m.block_dim.contact_sort,
     )
 
-  if m.sensor_rne_postconstraint:
+  if not skip_rne_postconstraint and m.sensor_rne_postconstraint:
     smooth.rne_postconstraint(m, d)
 
   wp.launch(

--- a/mujoco_warp/_src/sensor_test.py
+++ b/mujoco_warp/_src/sensor_test.py
@@ -940,6 +940,36 @@ class SensorTest(parameterized.TestCase):
     # Verify Warp sensor is triggered
     self.assertTrue(warp_sensordata.any(), "Warp sensordata should not be all zeros")
 
+  def test_sensor_acc_skip_rne_postconstraint(self):
+    """Tests skip_rne_postconstraint parameter in sensor_acc."""
+    _, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <worldbody>
+          <body name="body0" pos="0 0 1">
+            <freejoint/>
+            <geom type="sphere" size=".1" mass="1"/>
+            <site name="site0"/>
+          </body>
+        </worldbody>
+        <sensor>
+          <accelerometer site="site0"/>
+        </sensor>
+      </mujoco>
+      """
+    )
+    self.assertFalse(m.opt.run_rne_postconstraint)
+
+    # Default (skip_rne_postconstraint=False): RNE runs and populates cacc
+    d.cacc.zero_()
+    mjw.sensor_acc(m, d)
+    self.assertTrue(d.cacc.numpy().any())
+
+    # skip_rne_postconstraint=True: RNE is skipped, cacc remains zeros
+    d.cacc.zero_()
+    mjw.sensor_acc(m, d, skip_rne_postconstraint=True)
+    self.assertFalse(d.cacc.numpy().any())
+
 
 if __name__ == "__main__":
   wp.init()

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -904,6 +904,8 @@ class Option:
     run_collision_detection: if False, skips collision detection and allows user-populated
       contacts during the physics step (as opposed to DisableBit.CONTACT which explicitly
       zeros out the contacts at each step)
+    run_rne_postconstraint: if True, evaluates rne_postconstraint after the solver step even if
+      sensors are disabled or no sensors are present
     contact_sensor_maxmatch: max number of contacts considered by contact sensor matching criteria
                              contacts matched after this value is exceded will be ignored
     warn_overflow: overflow warning bitmask (OverflowType)
@@ -935,6 +937,7 @@ class Option:
   broadphase_filter: BroadphaseFilter
   graph_conditional: bool
   run_collision_detection: bool
+  run_rne_postconstraint: bool
   contact_sensor_maxmatch: int
   warn_overflow: int
 


### PR DESCRIPTION
### Add `Option.run_rne_postconstraint` and decouple RNE post-constraint from sensor stage

Fixes #1625

## Problem

In MuJoCo, `mj_rnePostConstraint` evaluates body spatial accelerations (`d.cacc`), internal forces (`d.cfrc_int`), and external forces (`d.cfrc_ext`). In MuJoCo Warp, this was previously called exclusively inside `sensor.sensor_acc(m, d)`.

However, if sensors are disabled (`m.opt.disableflags & DisableBit.SENSOR`) or if a model contains no acceleration-dependent sensors (`not m.sensor_rne_postconstraint`), `smooth.rne_postconstraint(m, d)` was completely skipped. Downstream consumers (such as Newton / Isaac Lab in Newton issue #4109) rely on `cacc`, `cfrc_ext`, and `cfrc_int` for spatial acceleration and contact force computations in deterministic simulations where sensors are intentionally disabled. Without running `rne_postconstraint`, these fields remain unpopulated or stale.

## Solution

1. **Add `Option.run_rne_postconstraint: bool`**:
   - Added `run_rne_postconstraint: bool = False` to `mjw.Option` and initialized it in `put_model()`.
   - Added `"opt.run_rne_postconstraint"` to `mjw_only_fields` in `io.override_model` so it can be configured via model overrides.

2. **Decouple Post-Constraint RNE in `forward` & `step2`**:
   - In `forward.py`, evaluate `smooth.rne_postconstraint(m, d)` immediately following `solver.solve(m, d)` when:
     ```python
     if m.opt.run_rne_postconstraint or (not (m.opt.disableflags & DisableBit.SENSOR) and m.sensor_rne_postconstraint):
       smooth.rne_postconstraint(m, d)
     ```
   - Then call `sensor.sensor_acc(m, d, skip_rne_postconstraint=True)`.

3. **Update `sensor_acc` API with `skip_rne_postconstraint`**:
   - Added `skip_rne_postconstraint: bool = False` parameter to `sensor.sensor_acc(m, d)`.
   - When `skip_rne_postconstraint=True`, `sensor_acc` skips internal evaluation of `smooth.rne_postconstraint`.
   - Standalone and inverse dynamics invocations default to `False`, preserving backwards-compatible behavior.

## Testing

- Added `test_sensor_acc_skip_rne_postconstraint` in `mujoco_warp/_src/sensor_test.py` to verify unit-level behavior of `skip_rne_postconstraint` and ensure `m.opt.run_rne_postconstraint` defaults to `False`.
- Added `test_run_rne_postconstraint` in `mujoco_warp/_src/forward_test.py` to verify that when `DisableBit.SENSOR` is active and `run_rne_postconstraint=True`, `cacc`, `cfrc_int`, and `cfrc_ext` match upstream MuJoCo across `forward()` and `step2()` while `sensordata` remains empty, and that setting `run_rne_postconstraint=False` bypasses computation.