### PR TITLE
Fix sparse joint-limit capacity estimate

### DIFF
--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -1426,7 +1426,7 @@ def _default_njmax_nnz(mjm: mujoco.MjModel, nconmax: int, njmax: int) -> int:
   # limit constraints (assume all active)
   for i in range(mjm.njnt):
     if mjm.jnt_limited[i]:
-      jnt_type = mjm.jnt_type[i]
+      jnt_type = int(mjm.jnt_type[i])
       if jnt_type == mujoco.mjtJoint.mjJNT_BALL:
         total_nnz += 3
       elif jnt_type in (mujoco.mjtJoint.mjJNT_SLIDE, mujoco.mjtJoint.mjJNT_HINGE):

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -512,8 +512,8 @@ class IOTest(parameterized.TestCase):
         <option jacobian="sparse"/>
         <worldbody>
           <body>
-            <joint type="slide" limited="true" range="-1 1" frictionloss="1"/>
-            <joint type="hinge" limited="true" range="-1 1" frictionloss="1"/>
+            <joint type="slide" limited="true" range="-1 1"/>
+            <joint type="hinge" limited="true" range="-1 1"/>
             <geom size="0.1" contype="0" conaffinity="0"/>
           </body>
         </worldbody>
@@ -521,7 +521,7 @@ class IOTest(parameterized.TestCase):
       """
     )
 
-    self.assertEqual(io._default_njmax_nnz(mjm, nconmax=0, njmax=4), 4)
+    self.assertEqual(io._default_njmax_nnz(mjm, nconmax=0, njmax=2), 2)
 
   def test_make_put_data(self):
     """Tests that make_data and put_data are producing the same shapes for all arrays."""

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -504,6 +504,25 @@ class IOTest(parameterized.TestCase):
   def test_augmented_cholesky_nvmax_padding(self, nvmax, expected):
     self.assertEqual(io._nvmax_pad(nvmax), expected)
 
+  def test_default_njmax_nnz_includes_scalar_joint_limits(self):
+    """Include slide and hinge limits in the sparse Jacobian capacity."""
+    mjm = mujoco.MjModel.from_xml_string(
+      """
+      <mujoco>
+        <option jacobian="sparse"/>
+        <worldbody>
+          <body>
+            <joint type="slide" limited="true" range="-1 1" frictionloss="1"/>
+            <joint type="hinge" limited="true" range="-1 1" frictionloss="1"/>
+            <geom size="0.1" contype="0" conaffinity="0"/>
+          </body>
+        </worldbody>
+      </mujoco>
+      """
+    )
+
+    self.assertEqual(io._default_njmax_nnz(mjm, nconmax=0, njmax=4), 4)
+
   def test_make_put_data(self):
     """Tests that make_data and put_data are producing the same shapes for all arrays."""
     mjm, _, _, d = test_data.fixture("pendula.xml", nvmax=None)


### PR DESCRIPTION
Issue: The equality operator of the `mujoco._enums.mjtJoint` enum evaluates to `False` for numpy types. This can lead to underestimation of the maximum number of constraint nonzeros in `_default_njmax_nnz`, as the following check evaluates to `False` since the enum's equality operator is used:

```python
     elif jnt_type in (mujoco.mjtJoint.mjJNT_SLIDE, mujoco.mjtJoint.mjJNT_HINGE):
```

This change converts `jnt_type` to native int before the membership test.

Example with MuJoCo 3.12.1:
```python
import mujoco

model = mujoco.MjModel.from_xml_string(
    """
    <mujoco>
      <worldbody>
        <body>
          <joint type="hinge"/>
          <geom size="0.1"/>
        </body>
      </worldbody>
    </mujoco>
    """
)

array_value = model.jnt_type[0]
enum_value = mujoco.mjtJoint.mjJNT_HINGE

print(type(array_value), type(enum_value))
# <class 'numpy.int32'> <class 'mujoco._enums.mjtJoint'>
print(array_value == enum_value)
# True
print(enum_value == array_value)
# False
print(array_value in (enum_value,))
# False
print(int(array_value) in (enum_value,))
# True
```