### PR TITLE
add benchmarks to nightly testing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly dependency check
+name: Nightly dependency check and benchmarks
 
 on:
   schedule:
@@ -18,9 +18,11 @@ jobs:
       matrix:
         python-version: ["3.10", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.9.27"
           python-version: ${{ matrix.python-version }}
@@ -35,3 +37,22 @@ jobs:
       - name: Test with pytest
         run: |
           uv run --with pytest --with pytest-xdist pytest -n 2
+
+  benchmarks:
+    if: github.event_name != 'schedule' || github.repository == 'google-deepmind/mujoco_warp'
+    name: Run benchmark suite and verify zero overflows (CPU)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.9.27"
+          python-version: "3.10"
+      - name: Set up Python
+        run: uv python install
+      - name: Run benchmark suite
+        run: |
+          uv run python3 benchmarks/run.py --nworld=1

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -138,6 +138,9 @@ def _run_benchmark(bm: dict, input_dir: Path) -> dict:
     "--measure_solver=true",
     "--measure_alloc=true",
   ]
+  if _ARGS.nworld is not None:
+    bm = {**bm, "nworld": _ARGS.nworld}
+
   for field, value in bm.items():
     if field == "replay":
       cmd.append(f"--replay={(benchmark_root / value)}")
@@ -192,6 +195,7 @@ def main():
     type=lambda v: v.lower() not in ("false", "0"),
     help="clear warp caches (kernel, LTO, CUDA compute)",
   )
+  parser.add_argument("--nworld", type=int, default=None, help="override number of parallel worlds")
 
   _ARGS = parser.parse_args()
 

--- a/mujoco_warp/_src/cli.py
+++ b/mujoco_warp/_src/cli.py
@@ -15,6 +15,7 @@
 
 """Shared utilities and flags for MJWarp CLI tools."""
 
+import contextlib
 import time
 from typing import Callable, Tuple, get_type_hints
 
@@ -258,15 +259,19 @@ def unroll(
   Returns:
     jit_duration: Time to JIT capture the function.
   """
-  with wp.ScopedDevice(wp.get_device(DEVICE.value)):
+  device = wp.get_device(DEVICE.value)
+  with wp.ScopedDevice(device):
     with warp_util.EventTracer(enabled=EVENT_TRACE.value) as tracer:
       jit_beg = time.perf_counter()
-      with wp.ScopedCapture() as capture:
+      if device.is_cuda:
+        with wp.ScopedCapture() as capture:
+          fn(*(m, d) if rc is None else (m, d, rc))
+      else:
         fn(*(m, d) if rc is None else (m, d, rc))
       jit_end = time.perf_counter()
 
       for i in range(NSTEP.value):
-        with wp.ScopedStream(wp.get_stream()):
+        with wp.ScopedStream(wp.get_stream()) if device.is_cuda else contextlib.nullcontext():
           if ctrls is not None:
             center = wp.array(ctrls[i], dtype=wp.float32)
             wp.launch(
@@ -287,7 +292,10 @@ def unroll(
             wp.synchronize()
 
           run_beg = time.perf_counter()
-          wp.capture_launch(capture.graph)
+          if device.is_cuda:
+            wp.capture_launch(capture.graph)
+          else:
+            fn(*(m, d) if rc is None else (m, d, rc))
           wp.synchronize()
           run_end = time.perf_counter()
 

--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -66,7 +66,7 @@ class EventTracer:
     global _STACK
     if _STACK is not None:
       raise ValueError("only one EventTracer can run at a time")
-    if enabled:
+    if enabled and wp.get_device().is_cuda:
       _STACK = {}
 
   def __enter__(self):

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -150,8 +150,6 @@ def _main(argv: Sequence[str]):
   wp.config.quiet = flags.FLAGS["verbosity"].value < 1
   wp.init()
   device = wp.get_device(cli.DEVICE.value)
-  if device == "cpu":
-    raise ValueError("testspeed available for gpu only")
 
   if _CLEAR_WARP_CACHE.value:
     wp.clear_kernel_cache()
@@ -167,7 +165,7 @@ def _main(argv: Sequence[str]):
     print(f"Loading model from: {path}...\n")
 
   mjm = cli.load_model(path)
-  free_mem_at_init = wp.get_device(device).free_memory
+  free_mem_at_init = wp.get_device(device).free_memory if wp.get_device(device).is_cuda else 0
   m, d, rc, ctrls = cli.init_structs(_FUNCS[_FUNCTION.value], mjm)
   m.opt.warn_overflow = int(OverflowType.ALL) if _OVERFLOW_BEHAVIOR.value == "continue" else 0
   timestep = m.opt.timestep.numpy()[0]
@@ -279,13 +277,20 @@ def _main(argv: Sequence[str]):
         sys.exit(1)
 
   if _FUNCTION.value == "render":
-    with wp.ScopedCapture() as step_capture:
-      mjw.step(m, d)
+    if wp.get_device(device).is_cuda:
+      with wp.ScopedCapture() as step_capture:
+        mjw.step(m, d)
 
-    def render_callback(step, step_trace, latency):
-      callback(step, step_trace, latency)
-      wp.capture_launch(step_capture.graph)
-      wp.synchronize()
+      def render_callback(step, step_trace, latency):
+        callback(step, step_trace, latency)
+        wp.capture_launch(step_capture.graph)
+        wp.synchronize()
+    else:
+
+      def render_callback(step, step_trace, latency):
+        callback(step, step_trace, latency)
+        mjw.step(m, d)
+        wp.synchronize()
 
     # TODO(team): Support specifying multiple functions to benchmark them together,
     # e.g., `mjwarp-testspeed --function=refit_bvh --function=render`
@@ -301,7 +306,7 @@ def _main(argv: Sequence[str]):
   steps = cli.NWORLD.value * cli.NSTEP.value
   model_mem = _dataclass_memory(m)
   data_mem = _dataclass_memory(d)
-  total_mem = free_mem_at_init - wp.get_device(device).free_memory
+  total_mem = (free_mem_at_init - wp.get_device(device).free_memory) if wp.get_device(device).is_cuda else 0
 
   if _FORMAT.value == "human":
     print(f"""
@@ -344,11 +349,11 @@ Total converged worlds: {nconverged} / {d.nworld}""")
       _print_table(matrix, ("mean", "std", "min", "max"), "solver niter")
 
     if _MEMORY.value:
-      device_mem = wp.get_device(device).total_memory
+      device_mem = getattr(wp.get_device(device), "total_memory", 0) or 1
       for mem, name in [(model_mem, "\nModel"), (data_mem, "Data")]:
         mem_total = sum(mem.values())
         print(f"{name} memory {mem_total / 1024**2:.2f} MiB ({100 * mem_total / device_mem:.2f}% of device memory):")
-        fields = [(f, c) for f, c in mem.items() if c / total_mem >= 0.01]
+        fields = [(f, c) for f, c in mem.items() if total_mem > 0 and c / total_mem >= 0.01]
         for field, capacity in fields:
           print(f" {field}: {capacity / 1024**2:.2f} MiB ({100 * capacity / device_mem:.2f}%)")
         if not fields:


### PR DESCRIPTION
### Motivation
Recent benchmark failures (#1622, #1623) in the repository went unnoticed because benchmarks are not run automatically in continuous integration. We want an automated check in CI to verify that all benchmark scenes run reliably without failing, crashing, or encountering simulation overflows. Running benchmarks with fewer worlds (`--nworld=1`) reduces suite runtime enabling fast, automated verification without dedicated GPU infrastructure.

This change enables CPU execution in `testspeed.py` and adds an automated benchmark verification job to the nightly GitHub Actions workflow. On CPU devices, CUDA graph capture (`wp.ScopedCapture`) and stream scoping are bypassed in favor of sequential rollout execution, CUDA memory queries are safely guarded, and event timing stacks are conditionally initialized. `benchmarks/run.py` gains an `--nworld` argument to allow overriding the number of parallel worlds across benchmarks, and `.github/workflows/nightly.yml` runs `benchmarks/run.py --nworld=1` nightly to catch simulation overflows and regressions.

* Bypass CUDA graph capture and stream scoping in mujoco_warp/_src/cli.py when running on CPU.
* Enable CPU execution in mujoco_warp/testspeed.py by removing the GPU-only restriction, adding CPU render step execution, and guarding GPU memory queries.
* Safely guard CUDA event timing stacks in mujoco_warp/_src/warp_util.py on non-CUDA devices.
* Add an optional --nworld override argument to benchmarks/run.py.
* Add the nightly benchmarks verification job running --nworld=1 to .github/workflows/nightly.yml.