### PR TITLE
Fix create_render_context rejecting an empty cam_active

### DIFF
--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -358,6 +358,7 @@ def create_render_context(
     enabled_geom_groups: The geom groups to render.
     cam_active: List of booleans, camera names (str), or camera indices (int) indicating
                 which cameras to include in rendering. If None, all cameras are included.
+                An empty list includes no cameras.
     flex_render_smooth: Whether to render flex meshes smoothly.
     use_precomputed_rays: Use precomputed rays instead of computing during rendering.
                           When using domain randomization for camera intrinsics, set to False.
@@ -527,17 +528,20 @@ def create_render_context(
 
   # Filter active cameras
   if cam_active is not None:
-    if len(cam_active) > 0 and isinstance(cam_active[0], (bool, np.bool_)):
+    if len(cam_active) == 0:
+      # Empty selection renders no cameras, and is the only valid mask when ncam == 0.
+      active_cam_indices = []
+    elif isinstance(cam_active[0], (bool, np.bool_)):
       assert len(cam_active) == mjm.ncam, f"cam_active must have length {mjm.ncam} (got {len(cam_active)})"
       active_cam_indices = [int(i) for i in np.nonzero(cam_active)[0]]
-    elif len(cam_active) > 0 and isinstance(cam_active[0], str):
+    elif isinstance(cam_active[0], str):
       active_cam_indices = []
       for name in cam_active:
         cid = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_CAMERA, name)
         if cid == -1:
           raise ValueError(f"Camera '{name}' not found in model.")
         active_cam_indices.append(cid)
-    elif len(cam_active) > 0 and isinstance(cam_active[0], (int, np.integer)):
+    elif isinstance(cam_active[0], (int, np.integer)):
       active_cam_indices = [int(x) for x in cam_active]
     else:
       raise ValueError(f"Invalid cam_active format: {cam_active}")

--- a/mujoco_warp/_src/render_util_test.py
+++ b/mujoco_warp/_src/render_util_test.py
@@ -259,6 +259,22 @@ class RenderUtilTest(parameterized.TestCase):
     expected_total = 2 * width * height
     self.assertEqual(rc.rgb_data.shape, (1, expected_total), "rgb_data")
 
+  def test_cam_active_empty(self):
+    """Tests that an empty cam_active selects no cameras, whether or not the model has any."""
+    mjm_nocam = mujoco.MjModel.from_xml_string("""
+    <mujoco>
+      <worldbody>
+        <geom type="sphere" size="0.5"/>
+      </worldbody>
+    </mujoco>
+    """)
+    self.assertEqual(mjm_nocam.ncam, 0, "ncam")
+    self.assertEqual(mjw.create_render_context(mjm_nocam, cam_active=[]).nrender, 0, "nrender")
+
+    mjm = mujoco.MjModel.from_xml_string(_CAMERA_TEST_XML)
+    self.assertEqual(mjw.create_render_context(mjm, cam_active=[]).nrender, 0, "nrender")
+    self.assertEqual(mjw.create_render_context(mjm, cam_active=[False] * mjm.ncam).nrender, 0, "nrender")
+
   def test_rgb_only_and_depth_only(self):
     """Test that disabling rgb or depth correctly reduces the shape and invalidates the address."""
     mjm, mjd, m, d = test_data.fixture(xml=_CAMERA_TEST_XML)


### PR DESCRIPTION
`create_render_context` infers the format of `cam_active` from its first element, and every branch is guarded on the list being non-empty:

```python
if len(cam_active) > 0 and isinstance(cam_active[0], (bool, np.bool_)):
  ...
elif len(cam_active) > 0 and isinstance(cam_active[0], str):
  ...
elif len(cam_active) > 0 and isinstance(cam_active[0], (int, np.integer)):
  ...
else:
  raise ValueError(f"Invalid cam_active format: {cam_active}")
```

An empty list matches nothing and falls through to the error:

```
ValueError: Invalid cam_active format: []
```

A length-`ncam` boolean mask is empty exactly when the model has no cameras, which is routine for callers that want a render context only for its BVH and never render a frame. Raycast sensors are one such caller: on a camera-free model, `[False] * mjm.ncam` is `[]`. This worked before #1553 added the name and index forms.

This change handles the empty list up front as an empty selection, which makes the `len(cam_active) > 0` guard on the remaining branches redundant. An empty list is now also accepted when the model does have cameras, where the length assert previously rejected it.

`test_cam_active_empty` covers both cases and fails on main with the `ValueError` above. A context with `nrender == 0` still drives `refit_bvh` and BVH-accelerated `rays`, which read only BVH fields and no camera-derived state.
