### PR TITLE
Fetch pinned benchmark assets without requiring git 2.49

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -66,21 +66,23 @@ def _ensure_pinned_clone(source: str, ref: str, dst: Path):
   """Make dst a shallow checkout of ref from source, reusing it if it already is one."""
   if (dst / ".git").exists():
     return
-  # a dst without .git is a leftover from an interrupted fetch, rebuild it rather than trust it
-  shutil.rmtree(dst, ignore_errors=True)
+  # a dst without .git is a leftover from an interrupted fetch, rebuild it rather than trust it.
+  # rmtree only handles directories, so clear a file or symlink at dst separately or the rename
+  # below fails
+  if dst.is_dir() and not dst.is_symlink():
+    shutil.rmtree(dst, ignore_errors=True)
+  elif dst.exists() or dst.is_symlink():
+    dst.unlink(missing_ok=True)
   # "git clone --revision" does this in one step but needs git >= 2.49, newer than the git in
   # current LTS distros. fetch into a sibling directory and rename it into place so a failed or
   # interrupted fetch cannot leave a partial dst that later runs mistake for a good checkout.
   dst.parent.mkdir(parents=True, exist_ok=True)
-  staging = Path(tempfile.mkdtemp(prefix=f".{dst.name}.", dir=dst.parent))
-  try:
+  with tempfile.TemporaryDirectory(prefix=f".{dst.name}.", dir=dst.parent) as tmp_dir:
+    staging = Path(tmp_dir)
     _git("init", "--quiet", staging.as_posix())
     _git("fetch", "--quiet", "--depth", "1", source, ref, cwd=staging)
     _git("checkout", "--quiet", "FETCH_HEAD", cwd=staging)
-  except BaseException:
-    shutil.rmtree(staging, ignore_errors=True)
-    raise
-  staging.rename(dst)
+    staging.rename(dst)
 
 
 def _uv_run(*args, cwd: Path | None = None):

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -62,6 +62,27 @@ def _git(*args, cwd: Path | None = None, check: bool = True):
   return subprocess.run(("git",) + args, cwd=cwd, env=env, check=check, capture_output=True, text=True)
 
 
+def _ensure_pinned_clone(source: str, ref: str, dst: Path):
+  """Make dst a shallow checkout of ref from source, reusing it if it already is one."""
+  if (dst / ".git").exists():
+    return
+  # a dst without .git is a leftover from an interrupted fetch, rebuild it rather than trust it
+  shutil.rmtree(dst, ignore_errors=True)
+  # "git clone --revision" does this in one step but needs git >= 2.49, newer than the git in
+  # current LTS distros. fetch into a sibling directory and rename it into place so a failed or
+  # interrupted fetch cannot leave a partial dst that later runs mistake for a good checkout.
+  dst.parent.mkdir(parents=True, exist_ok=True)
+  staging = Path(tempfile.mkdtemp(prefix=f".{dst.name}.", dir=dst.parent))
+  try:
+    _git("init", "--quiet", staging.as_posix())
+    _git("fetch", "--quiet", "--depth", "1", source, ref, cwd=staging)
+    _git("checkout", "--quiet", "FETCH_HEAD", cwd=staging)
+  except BaseException:
+    shutil.rmtree(staging, ignore_errors=True)
+    raise
+  staging.rename(dst)
+
+
 def _uv_run(*args, cwd: Path | None = None):
   """Run a uv command, returning CompletedProcess."""
   log.info("Command: uv run %s", " ".join(args))
@@ -105,9 +126,7 @@ def _assemble_benchmark(bm: dict):
 
     # repo clones are stored in the format: <assets_root>/_git/<repo_source>/<repo_ref>
     repo_dir = Path(_ARGS.assets_root) / "_git" / Path(repo["source"]).stem / repo["ref"]
-    if not repo_dir.exists():
-      repo_dir.mkdir(parents=True, exist_ok=True)
-      _git("clone", repo["source"], repo_dir.as_posix(), "--depth", "1", "--revision", repo["ref"])
+    _ensure_pinned_clone(repo["source"], repo["ref"], repo_dir)
 
     if "*" in repo_path:
       parts = Path(repo_path).parts

--- a/benchmarks/sweep.py
+++ b/benchmarks/sweep.py
@@ -86,21 +86,23 @@ def _ensure_pinned_clone(source: str, ref: str, dst: Path):
   """Make dst a shallow checkout of ref from source, reusing it if it already is one."""
   if (dst / ".git").exists():
     return
-  # a dst without .git is a leftover from an interrupted fetch, rebuild it rather than trust it
-  shutil.rmtree(dst, ignore_errors=True)
+  # a dst without .git is a leftover from an interrupted fetch, rebuild it rather than trust it.
+  # rmtree only handles directories, so clear a file or symlink at dst separately or the rename
+  # below fails
+  if dst.is_dir() and not dst.is_symlink():
+    shutil.rmtree(dst, ignore_errors=True)
+  elif dst.exists() or dst.is_symlink():
+    dst.unlink(missing_ok=True)
   # "git clone --revision" does this in one step but needs git >= 2.49, newer than the git in
   # current LTS distros. fetch into a sibling directory and rename it into place so a failed or
   # interrupted fetch cannot leave a partial dst that later runs mistake for a good checkout.
   dst.parent.mkdir(parents=True, exist_ok=True)
-  staging = Path(tempfile.mkdtemp(prefix=f".{dst.name}.", dir=dst.parent))
-  try:
+  with tempfile.TemporaryDirectory(prefix=f".{dst.name}.", dir=dst.parent) as tmp_dir:
+    staging = Path(tmp_dir)
     _git("init", "--quiet", staging.as_posix())
     _git("fetch", "--quiet", "--depth", "1", source, ref, cwd=staging)
     _git("checkout", "--quiet", "FETCH_HEAD", cwd=staging)
-  except BaseException:
-    shutil.rmtree(staging, ignore_errors=True)
-    raise
-  staging.rename(dst)
+    staging.rename(dst)
 
 
 def _uv_run(*args, cwd: Path | None = None):

--- a/benchmarks/sweep.py
+++ b/benchmarks/sweep.py
@@ -82,6 +82,27 @@ def _git(*args, cwd: Path | None = None, check: bool = True):
   return subprocess.run(("git",) + args, cwd=cwd, env=env, check=check, capture_output=True, text=True)
 
 
+def _ensure_pinned_clone(source: str, ref: str, dst: Path):
+  """Make dst a shallow checkout of ref from source, reusing it if it already is one."""
+  if (dst / ".git").exists():
+    return
+  # a dst without .git is a leftover from an interrupted fetch, rebuild it rather than trust it
+  shutil.rmtree(dst, ignore_errors=True)
+  # "git clone --revision" does this in one step but needs git >= 2.49, newer than the git in
+  # current LTS distros. fetch into a sibling directory and rename it into place so a failed or
+  # interrupted fetch cannot leave a partial dst that later runs mistake for a good checkout.
+  dst.parent.mkdir(parents=True, exist_ok=True)
+  staging = Path(tempfile.mkdtemp(prefix=f".{dst.name}.", dir=dst.parent))
+  try:
+    _git("init", "--quiet", staging.as_posix())
+    _git("fetch", "--quiet", "--depth", "1", source, ref, cwd=staging)
+    _git("checkout", "--quiet", "FETCH_HEAD", cwd=staging)
+  except BaseException:
+    shutil.rmtree(staging, ignore_errors=True)
+    raise
+  staging.rename(dst)
+
+
 def _uv_run(*args, cwd: Path | None = None):
   """Run a uv command, returning CompletedProcess."""
   log.info("Command: uv run %s", " ".join(args))
@@ -125,9 +146,7 @@ def _assemble_benchmark(bm: dict):
 
     # repo clones are stored in the format: <assets_root>/_git/<repo_source>/<repo_ref>
     repo_dir = Path(_ARGS.assets_root) / "_git" / Path(repo["source"]).stem / repo["ref"]
-    if not repo_dir.exists():
-      repo_dir.mkdir(parents=True, exist_ok=True)
-      _git("clone", repo["source"], repo_dir.as_posix(), "--depth", "1", "--revision", repo["ref"])
+    _ensure_pinned_clone(repo["source"], repo["ref"], repo_dir)
 
     if "*" in repo_path:
       parts = Path(repo_path).parts


### PR DESCRIPTION
Fixes #1634.

`benchmarks/run.py` and `benchmarks/sweep.py` fetch their pinned menagerie assets with `git clone --revision`, which needs git 2.49 (March 2025). That is newer than the git in Ubuntu 22.04 (2.34.1), Ubuntu 24.04 (2.43.0) and Debian trixie (2.47.3), so on those machines any benchmark with external assets dies right away on ``error: unknown option `revision'``. This swaps the clone for `git init` plus `git fetch --depth 1 <source> <ref>` and a checkout of `FETCH_HEAD`, which gets the same single pinned commit and works back to at least git 2.34.1. I went with the fallback rather than documenting a minimum git version since it costs one extra subprocess call and keeps the scripts runnable on stock LTS images, but happy to switch to a version check and a clear error message if you would rather raise the floor. All four sources the benchmarks pin are on github.com, and I checked that each of their pinned refs fetches this way on 2.34.1.

The second half is the cache poisoning, which is independent of git version. The cache directory was created before the clone ran, so any failed or interrupted fetch left an empty directory at the cache path; on later runs the `if not repo_dir.exists()` guard accepted it and fell through to a `copytree` that raised `FileNotFoundError`. Upgrading git did not help, you had to know to delete the directory. The fetch now lands in a sibling directory that is renamed into place only on success, and the guard keys on `.git` instead of bare existence, which also means a directory left behind by the current code heals itself on the next run rather than needing a manual `rm`. The staging directory is created inside the cache directory's parent so the rename stays on one filesystem.

Two things I deliberately left alone, in case you would rather they were handled. A cache entry that somehow has a `.git` but an incomplete worktree is still trusted; validating it would mean comparing `rev-parse HEAD` against the ref, which would refetch on every run for anyone who pins a branch name instead of a SHA. And two runs sharing an `assets_root` will now have the loser of the rename race fail with `ENOTEMPTY` rather than quietly interleaving two clones into one directory, which is louder than before but still not actually handled.

Both files carry their own copy of the helper, matching how `_git` and `_assemble_benchmark` are already duplicated between them.

Verified on Ubuntu 22.04 with git 2.34.1, warp-lang 1.15.0, mujoco 3.12.1, H100. `uv run python3 benchmarks/run.py -f unitree_g1` runs all three benchmarks to completion starting from the empty poisoned cache directory my earlier failed run had left behind, with no manual cleanup, and reports `converged_worlds: 8192` for each. Fetch by SHA checked against all four pinned sources (mujoco_menagerie, mujoco, aloha_sim, myo_sim), and a deliberately bad ref confirmed to leave nothing at the cache path in both files. `uv run pytest -n 8` passes (1349 passed, 29 skipped), though `norecursedirs` excludes `benchmarks/`, so that is a no-collateral-damage check rather than coverage of this change.
