### PR TITLE
Fuse sparse constraint gradient updates

### DIFF
--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -28,6 +28,7 @@ from mujoco_warp._src.types import vec6
 from mujoco_warp._src.types import vec11
 from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
+from mujoco_warp._src.warp_util import launch_world_warp_enabled
 
 wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 
@@ -3139,8 +3140,10 @@ def _efc_contact_init_flex(cone_type: types.ConeType, is_sparse: bool, newton: b
 
 
 @cache_kernel
-def _efc_contact_jac_sparse(cone_type: types.ConeType):
+def _efc_contact_jac_sparse(cone_type: types.ConeType, world_warp: bool):
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
+  WORLD_WARP = world_warp
+  EFC_STRIDE = 32 if world_warp else 1
 
   @wp.kernel(module="unique", enable_backward=False, grid_stride=False)
   def kernel(
@@ -3155,12 +3158,18 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
     geom_bodyid: wp.array[int],
     body_isdofancestor: wp.array2d[int],
     # Data in:
+    ne_in: wp.array[int],
+    nf_in: wp.array[int],
+    nl_in: wp.array[int],
+    nefc_in: wp.array[int],
     qvel_in: wp.array2d[float],
     subtree_com_in: wp.array2d[wp.vec3],
     cdof_in: wp.array2d[wp.spatial_vector],
     contact_efc_address_in: wp.array2d[int],
+    efc_id_in: wp.array2d[int],
     efc_J_rownnz_in: wp.array2d[int],
     efc_J_rowadr_in: wp.array2d[int],
+    njmax_in: int,
     nacon_in: wp.array[int],
     # In:
     condim_in: wp.array[int],
@@ -3174,46 +3183,57 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
     efc_J_out: wp.array3d[float],
     efc_Jqvel_out: wp.array2d[float],
   ):
-    conid, dimid = wp.tid()
+    tid0, tid1 = wp.tid()
+    worldid = int(0)
+    conid = int(0)
+    dimid = int(0)
+    efcid_start = int(0)
+    efcid_end = int(0)
 
-    if conid >= nacon_in[0]:
-      return
+    if wp.static(WORLD_WARP):
+      worldid = tid0
+      efcid_start = ne_in[worldid] + nf_in[worldid] + nl_in[worldid] + tid1
+      efcid_end = wp.min(nefc_in[worldid], njmax_in)
+    else:
+      conid = tid0
+      dimid = tid1
+      if conid >= nacon_in[0]:
+        return
+      efcid_start = contact_efc_address_in[conid, dimid]
+      if efcid_start < 0:
+        return
+      efcid_end = efcid_start + 1
+      worldid = worldid_in[conid]
 
-    efcid = contact_efc_address_in[conid, dimid]
-    if efcid < 0:
-      return
+    for efcid in range(efcid_start, efcid_end, wp.static(EFC_STRIDE)):
+      if wp.static(WORLD_WARP):
+        conid = efc_id_in[worldid, efcid]
+        dimid = efcid - contact_efc_address_in[conid, 0]
+      condim = condim_in[conid]
 
-    worldid = worldid_in[conid]
-    condim = condim_in[conid]
+      geom = geom_in[conid]
+      body1 = body_weldid[geom_bodyid[geom[0]]]
+      body2 = body_weldid[geom_bodyid[geom[1]]]
 
-    geom = geom_in[conid]
-    body1 = body_weldid[geom_bodyid[geom[0]]]
-    body2 = body_weldid[geom_bodyid[geom[1]]]
+      con_pos = pos_in[conid]
 
-    con_pos = pos_in[conid]
+      if not wp.static(IS_ELLIPTIC):
+        frame_0 = frame_in[conid, 0]
+        if condim > 1:
+          dimid2 = dimid / 2 + 1
+          frii = friction_in[conid, dimid2 - 1]
 
-    if not wp.static(IS_ELLIPTIC):
-      frame_0 = frame_in[conid, 0]
-      if condim > 1:
-        dimid2 = dimid / 2 + 1
-        frii = friction_in[conid, dimid2 - 1]
+      da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
+      da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
+      da = wp.max(da1, da2)
 
-    da1 = int(body_dofadr[body1] + body_dofnum[body1] - 1)
-    da2 = int(body_dofadr[body2] + body_dofnum[body2] - 1)
-    da = wp.max(da1, da2)
+      rowadr = efc_J_rowadr_in[worldid, efcid]
+      rownnz = efc_J_rownnz_in[worldid, efcid]
 
-    rowadr = efc_J_rowadr_in[worldid, efcid]
-    rownnz = efc_J_rownnz_in[worldid, efcid]
+      Jqvel = float(0.0)
+      nnz = int(0)
 
-    Jqvel = float(0.0)
-    nnz = int(0)
-    dofid = int(da)
-
-    while True:
-      if nnz >= rownnz:
-        break
-
-      if dofid == da:
+      while nnz < rownnz:
         jac1p, jac1r = support.jac_dof(
           body_parentid,
           body_rootid,
@@ -3223,7 +3243,7 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
           cdof_in,
           con_pos,
           body1,
-          dofid,
+          da,
           worldid,
         )
         jac2p, jac2r = support.jac_dof(
@@ -3235,7 +3255,7 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
           cdof_in,
           con_pos,
           body2,
-          dofid,
+          da,
           worldid,
         )
 
@@ -3272,10 +3292,10 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
               J -= Ji * frii
 
         sparseid = rowadr + nnz
-        efc_J_colind_out[worldid, 0, sparseid] = dofid
+        efc_J_colind_out[worldid, 0, sparseid] = da
         efc_J_out[worldid, 0, sparseid] = J
         nnz += 1
-        Jqvel += J * qvel_in[worldid, dofid]
+        Jqvel += J * qvel_in[worldid, da]
 
         # Advance tree pointers and recompute da for next iteration
         if da1 == da:
@@ -3283,9 +3303,8 @@ def _efc_contact_jac_sparse(cone_type: types.ConeType):
         if da2 == da:
           da2 = dof_parentid[da2]
         da = wp.max(da1, da2)
-        dofid = da
 
-    efc_Jqvel_out[worldid, efcid] = Jqvel
+      efc_Jqvel_out[worldid, efcid] = Jqvel
 
   return kernel
 
@@ -4236,8 +4255,10 @@ def _efc_contact_jac_dense_flex(tile_size: int, cone_type: types.ConeType):
 
 
 @cache_kernel
-def _efc_contact_update(cone_type: types.ConeType, flg_adhesion: bool):
+def _efc_contact_update(cone_type: types.ConeType, flg_adhesion: bool, world_warp: bool):
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
+  WORLD_WARP = world_warp
+  EFC_STRIDE = 32 if world_warp else 1
 
   @wp.kernel(module="unique", enable_backward=False, grid_stride=True)
   def kernel(
@@ -4248,8 +4269,14 @@ def _efc_contact_update(cone_type: types.ConeType, flg_adhesion: bool):
     body_invweight0: wp.array2d[wp.vec2],
     geom_bodyid: wp.array[int],
     # Data in:
+    ne_in: wp.array[int],
+    nf_in: wp.array[int],
+    nl_in: wp.array[int],
+    nefc_in: wp.array[int],
     contact_efc_address_in: wp.array2d[int],
+    efc_id_in: wp.array2d[int],
     efc_Jqvel_in: wp.array2d[float],
+    njmax_in: int,
     nacon_in: wp.array[int],
     # In:
     dist_in: wp.array[float],
@@ -4273,113 +4300,127 @@ def _efc_contact_update(cone_type: types.ConeType, flg_adhesion: bool):
     efc_aref_out: wp.array2d[float],
     efc_frictionloss_out: wp.array2d[float],
   ):
-    conid, dimid = wp.tid()
+    tid0, tid1 = wp.tid()
+    worldid = int(0)
+    conid = int(0)
+    dimid = int(0)
+    efcid_start = int(0)
+    efcid_end = int(0)
 
-    if conid >= nacon_in[0]:
-      return
-
-    if not type_in[conid] & ContactType.CONSTRAINT:
-      return
-
-    condim = condim_in[conid]
-
-    if wp.static(IS_ELLIPTIC):
-      if dimid > condim - 1:
-        return
+    if wp.static(WORLD_WARP):
+      worldid = tid0
+      efcid_start = ne_in[worldid] + nf_in[worldid] + nl_in[worldid] + tid1
+      efcid_end = wp.min(nefc_in[worldid], njmax_in)
     else:
-      if condim == 1 and dimid > 0:
+      conid = tid0
+      dimid = tid1
+      if conid >= nacon_in[0]:
         return
-      elif condim > 1 and dimid >= 2 * (condim - 1):
+      if not type_in[conid] & ContactType.CONSTRAINT:
         return
+      condim = condim_in[conid]
+      if wp.static(IS_ELLIPTIC):
+        if dimid > condim - 1:
+          return
+      else:
+        if condim == 1 and dimid > 0:
+          return
+        elif condim > 1 and dimid >= 2 * (condim - 1):
+          return
+      efcid_start = contact_efc_address_in[conid, dimid]
+      if efcid_start < 0:
+        return
+      efcid_end = efcid_start + 1
+      worldid = worldid_in[conid]
 
-    efcid = contact_efc_address_in[conid, dimid]
-    if efcid < 0:
-      return
+    for efcid in range(efcid_start, efcid_end, wp.static(EFC_STRIDE)):
+      if wp.static(WORLD_WARP):
+        conid = efc_id_in[worldid, efcid]
+        dimid = efcid - contact_efc_address_in[conid, 0]
+      condim = condim_in[conid]
 
-    worldid = worldid_in[conid]
-    timestep = opt_timestep[worldid % opt_timestep.shape[0]]
-    impratio_invsqrt = opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
+      timestep = opt_timestep[worldid % opt_timestep.shape[0]]
+      impratio_invsqrt = opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
 
-    includemargin = includemargin_in[conid]
-    pos = dist_in[conid] - includemargin
+      includemargin = includemargin_in[conid]
+      pos = dist_in[conid] - includemargin
 
-    geom = geom_in[conid]
-    Jqvel = efc_Jqvel_in[worldid, efcid]
+      geom = geom_in[conid]
+      Jqvel = efc_Jqvel_in[worldid, efcid]
 
-    body1 = geom_bodyid[geom[0]]
-    body2 = geom_bodyid[geom[1]]
+      body1 = geom_bodyid[geom[0]]
+      body2 = geom_bodyid[geom[1]]
 
-    body_invweight0_id = worldid % body_invweight0.shape[0]
-    invweight = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
+      body_invweight0_id = worldid % body_invweight0.shape[0]
+      invweight = body_invweight0[body_invweight0_id, body1][0] + body_invweight0[body_invweight0_id, body2][0]
 
-    ref = solref_in[conid]
-    pos_aref = pos
+      ref = solref_in[conid]
+      pos_aref = pos
 
-    if wp.static(IS_ELLIPTIC):
-      if dimid > 0:
-        solreffriction = solreffriction_in[conid]
+      if wp.static(IS_ELLIPTIC):
+        if dimid > 0:
+          solreffriction = solreffriction_in[conid]
 
-        # non-normal directions use solreffriction (if non-zero)
-        if solreffriction[0] or solreffriction[1]:
-          ref = solreffriction
+          # non-normal directions use solreffriction (if non-zero)
+          if solreffriction[0] or solreffriction[1]:
+            ref = solreffriction
 
-        invweight = invweight * impratio_invsqrt * impratio_invsqrt
-        friction = friction_in[conid]
+          invweight = invweight * impratio_invsqrt * impratio_invsqrt
+          friction = friction_in[conid]
 
-        if dimid > 1:
+          if dimid > 1:
+            fri0 = friction[0]
+            frii = friction[dimid - 1]
+            invweight *= fri0 * fri0 / (frii * frii)
+
+          pos_aref = 0.0
+      else:
+        if condim > 1:
+          friction = friction_in[conid]
           fri0 = friction[0]
-          frii = friction[dimid - 1]
-          fri = fri0 * fri0 / (frii * frii)
-          invweight *= fri
+          invweight = invweight + fri0 * fri0 * invweight
+          invweight = invweight * 2.0 * fri0 * fri0 * impratio_invsqrt * impratio_invsqrt
 
-        pos_aref = 0.0
-    else:
-      if condim > 1:
-        friction = friction_in[conid]
-        fri0 = friction[0]
-        invweight = invweight + fri0 * fri0 * invweight
-        invweight = invweight * 2.0 * fri0 * fri0 * impratio_invsqrt * impratio_invsqrt
+      if condim == 1:
+        efc_type = ConstraintType.CONTACT_FRICTIONLESS
+      elif wp.static(IS_ELLIPTIC):
+        efc_type = ConstraintType.CONTACT_ELLIPTIC
+      else:
+        efc_type = ConstraintType.CONTACT_PYRAMIDAL
 
-    if condim == 1:
-      efc_type = ConstraintType.CONTACT_FRICTIONLESS
-    elif wp.static(IS_ELLIPTIC):
-      efc_type = ConstraintType.CONTACT_ELLIPTIC
-    else:
-      efc_type = ConstraintType.CONTACT_PYRAMIDAL
+      _efc_row(
+        opt_disableflags,
+        worldid,
+        timestep,
+        efcid,
+        pos_aref,
+        pos,
+        invweight,
+        ref,
+        solimp_in[conid],
+        includemargin,
+        Jqvel,
+        0.0,
+        efc_type,
+        conid,
+        efc_type_out,
+        efc_id_out,
+        efc_pos_out,
+        efc_margin_out,
+        efc_D_out,
+        efc_vel_out,
+        efc_aref_out,
+        efc_frictionloss_out,
+      )
 
-    _efc_row(
-      opt_disableflags,
-      worldid,
-      timestep,
-      efcid,
-      pos_aref,
-      pos,
-      invweight,
-      ref,
-      solimp_in[conid],
-      includemargin,
-      Jqvel,
-      0.0,
-      efc_type,
-      conid,
-      efc_type_out,
-      efc_id_out,
-      efc_pos_out,
-      efc_margin_out,
-      efc_D_out,
-      efc_vel_out,
-      efc_aref_out,
-      efc_frictionloss_out,
-    )
-
-    if wp.static(flg_adhesion):
-      if adhesion_in[conid] != 0.0 and (dimid == 0 or not wp.static(IS_ELLIPTIC)):
-        efc_D = efc_D_out[worldid, efcid]
-        if efc_D > 0.0:
-          adhesion = adhesion_in[conid]
-          if not wp.static(IS_ELLIPTIC) and condim > 1:
-            adhesion = adhesion / float(2 * (condim - 1))
-          efc_aref_out[worldid, efcid] += (1.0 / efc_D) * adhesion
+      if wp.static(flg_adhesion):
+        if adhesion_in[conid] != 0.0 and (dimid == 0 or not wp.static(IS_ELLIPTIC)):
+          efc_D = efc_D_out[worldid, efcid]
+          if efc_D > 0.0:
+            adhesion = adhesion_in[conid]
+            if not wp.static(IS_ELLIPTIC) and condim > 1:
+              adhesion = adhesion / float(2 * (condim - 1))
+            efc_aref_out[worldid, efcid] += (1.0 / efc_D) * adhesion
 
   return kernel
 
@@ -5493,6 +5534,7 @@ def make_constraint(m: types.Model, d: types.Data):
     # contact
     if not (m.opt.disableflags & types.DisableBit.CONTACT):
       nmaxdim = int(m.nmaxpyramid) if m.opt.cone == types.ConeType.PYRAMIDAL else int(m.nmaxcondim)
+      world_warp = m.is_sparse and launch_world_warp_enabled(d.nworld, d.qvel.device)
 
       # Reinterpret to avoid unnecessary loads
       contact_frame_2d = wp.array(
@@ -5649,8 +5691,8 @@ def make_constraint(m: types.Model, d: types.Data):
           )
         else:
           wp.launch(
-            _efc_contact_jac_sparse(m.opt.cone),
-            dim=(d.naconmax, nmaxdim),
+            _efc_contact_jac_sparse(m.opt.cone, world_warp),
+            dim=(d.nworld, 32) if world_warp else (d.naconmax, nmaxdim),
             inputs=[
               m.body_parentid,
               m.body_rootid,
@@ -5661,12 +5703,18 @@ def make_constraint(m: types.Model, d: types.Data):
               m.dof_parentid,
               m.geom_bodyid,
               m.body_isdofancestor,
+              d.ne,
+              d.nf,
+              d.nl,
+              d.nefc,
               d.qvel,
               d.subtree_com,
               d.cdof,
               d.contact.efc_address,
+              d.efc.id,
               d.efc.J_rownnz,
               d.efc.J_rowadr,
+              d.njmax,
               d.nacon,
               d.contact.dim,
               d.contact.geom,
@@ -5842,16 +5890,22 @@ def make_constraint(m: types.Model, d: types.Data):
         )
       else:
         wp.launch(
-          _efc_contact_update(m.opt.cone, m.flg_adhesion),
-          dim=(d.naconmax, nmaxdim),
+          _efc_contact_update(m.opt.cone, m.flg_adhesion, world_warp),
+          dim=(d.nworld, 32) if world_warp else (d.naconmax, nmaxdim),
           inputs=[
             m.opt.timestep,
             m.opt.disableflags,
             m.opt.impratio_invsqrt,
             m.body_invweight0,
             m.geom_bodyid,
+            d.ne,
+            d.nf,
+            d.nl,
+            d.nefc,
             d.contact.efc_address,
+            d.efc.id,
             d.efc.Jqvel,
+            d.njmax,
             d.nacon,
             d.contact.dist,
             d.contact.dim,

--- a/mujoco_warp/_src/constraint_test.py
+++ b/mujoco_warp/_src/constraint_test.py
@@ -16,6 +16,7 @@
 """Tests for constraint functions."""
 
 import itertools
+from unittest import mock
 
 import mujoco
 import numpy as np
@@ -26,6 +27,7 @@ from absl.testing import parameterized
 import mujoco_warp as mjw
 from mujoco_warp import ConeType
 from mujoco_warp import test_data
+from mujoco_warp._src import constraint
 
 # tolerance for difference between MuJoCo and MJWarp constraint calculations,
 # mostly due to float precision
@@ -159,6 +161,36 @@ class ConstraintTest(parameterized.TestCase):
 
     _assert_eq(d.nacon.numpy()[0], mjd.ncon, "nacon")
     _assert_efc_eq(mjm, m, d, mjd, mjd.nefc, "efc", m.nv)
+
+  @parameterized.parameters(ConeType.PYRAMIDAL, ConeType.ELLIPTIC)
+  def test_contact_world_warp(self, cone):
+    """Test sparse contact construction with one warp per world."""
+    xml = """
+      <mujoco>
+        <worldbody>
+          <geom type="plane" size="1 1 0.1"/>
+          <body pos="0 0 0.09">
+            <geom type="sphere" size="0.1" condim="6" adhesion="12"/>
+            <joint type="free"/>
+          </body>
+        </worldbody>
+      </mujoco>
+    """
+    mjm, mjd, m, d = test_data.fixture(
+      xml=xml,
+      nworld=2,
+      overrides={"opt.cone": cone, "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE},
+    )
+    for arr in (d.efc.J, d.efc.D, d.efc.aref, d.efc.pos, d.efc.margin):
+      arr.fill_(wp.nan)
+
+    with mock.patch.object(constraint, "launch_world_warp_enabled", return_value=True):
+      mjw.make_constraint(m, d)
+
+    _assert_eq(d.nefc.numpy(), mjd.nefc, "nefc")
+    _assert_efc_eq(mjm, m, d, mjd, mjd.nefc, "efc", m.nv)
+    world_aref = d.efc.aref.numpy()[:, : mjd.nefc]
+    _assert_eq(world_aref, np.repeat(world_aref[:1], d.nworld, axis=0), "world_aref")
 
   @parameterized.parameters(
     *itertools.product(

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -1984,6 +1984,96 @@ def _update_constraint_init_qfrc_constraint_sparse(compact: bool, world_warp: bo
   return kernel
 
 
+@cache_kernel
+def _update_constraint_qfrc_gradient_sparse_world_warp(nv: int):
+  NV = nv
+
+  @wp.func_native(snippet="WP_TILE_SYNC();")
+  def _syncthreads():
+    pass
+
+  @wp.kernel(module="unique", enable_backward=False)
+  def kernel(
+    # Data in:
+    nefc_in: wp.array[int],
+    qfrc_smooth_in: wp.array2d[float],
+    efc_J_rownnz_in: wp.array2d[int],
+    efc_J_rowadr_in: wp.array2d[int],
+    efc_J_colind_in: wp.array3d[int],
+    efc_J_in: wp.array3d[float],
+    efc_force_in: wp.array2d[float],
+    efc_Ma_in: wp.array2d[float],
+    njmax_in: int,
+    # In:
+    state_changed_count_in: wp.array[int],
+    ctx_alpha_in: wp.array[float],
+    ctx_done_in: wp.array[bool],
+    # Data out:
+    qfrc_constraint_out: wp.array2d[float],
+    # Out:
+    ctx_grad_out: wp.array2d[float],
+    ctx_grad_dot_out: wp.array[float],
+    ctx_newton_decrement_out: wp.array[float],
+    ctx_grad_scale_out: wp.array[float],
+    ctx_search_unchanged_out: wp.array[bool],
+  ):
+    worldid, tid = wp.tid()
+
+    done = ctx_done_in[worldid]
+    changed = state_changed_count_in[worldid] != 0
+    if tid == 0:
+      ctx_search_unchanged_out[worldid] = done or not changed
+
+    if done:
+      return
+
+    # Stable-state worlds stay on the previous gradient/search ray. Their
+    # public qfrc_constraint value is recovered once the solve completes.
+    if not changed:
+      if tid == 0:
+        sigma = ctx_grad_scale_out[worldid]
+        new_sigma = sigma - ctx_alpha_in[worldid]
+        ratio = float(0.0)
+        if sigma != 0.0:
+          ratio = new_sigma / sigma
+        ratio_sq = ratio * ratio
+        ctx_grad_dot_out[worldid] *= ratio_sq
+        ctx_newton_decrement_out[worldid] *= ratio_sq
+        ctx_grad_scale_out[worldid] = new_sigma
+      return
+
+    for dofid in range(tid, wp.static(NV), wp.static(32)):
+      qfrc_constraint_out[worldid, dofid] = 0.0
+    _syncthreads()
+
+    for efcid in range(tid, wp.min(nefc_in[worldid], njmax_in), wp.static(32)):
+      force = efc_force_in[worldid, efcid]
+      if force == 0.0:
+        continue
+      rownnz = efc_J_rownnz_in[worldid, efcid]
+      rowadr = efc_J_rowadr_in[worldid, efcid]
+      for i in range(rownnz):
+        sparseid = rowadr + i
+        colind = efc_J_colind_in[worldid, 0, sparseid]
+        wp.atomic_add(qfrc_constraint_out[worldid], colind, efc_J_in[worldid, 0, sparseid] * force)
+    _syncthreads()
+
+    local_grad_dot = float(0.0)
+    for dofid in range(tid, wp.static(NV), wp.static(32)):
+      grad = efc_Ma_in[worldid, dofid] - qfrc_smooth_in[worldid, dofid] - qfrc_constraint_out[worldid, dofid]
+      ctx_grad_out[worldid, dofid] = grad
+      local_grad_dot += grad * grad
+
+    grad_dot_tile = wp.tile(local_grad_dot, preserve_type=True)
+    grad_dot_sum = wp.tile_reduce(wp.add, grad_dot_tile)
+    if tid == 0:
+      ctx_grad_dot_out[worldid] = grad_dot_sum[0]
+      ctx_newton_decrement_out[worldid] = 0.0
+      ctx_grad_scale_out[worldid] = 1.0
+
+  return kernel
+
+
 @wp.kernel
 def _qfrc_constraint_from_grad(
   # Data in:
@@ -2148,52 +2238,6 @@ def _update_gradient_h_incremental_sparse(compact: bool):
   return kernel
 
 
-def _update_constraint_qfrc(
-  m: types.Model,
-  d: types.Data,
-  ctx: SolverContext | InverseContext,
-  stable_fast: bool = False,
-):
-  """Update generalized constraint forces from the current EFC forces."""
-  # qfrc_constraint = efc_J.T @ efc_force. Fast-path worlds with no state flips
-  # skip the rebuild; the public value is recovered after the solve.
-  changed = ctx.state_changed_count if stable_fast else d.nefc
-  sc = _sparse_compact(ctx)
-  if m.is_sparse or sc:
-    dj = ctx.compact_d_full if sc else d
-    wp.launch(
-      _zero_qfrc_constraint_sparse,
-      dim=(d.nworld, m.nv),
-      inputs=[changed, ctx.done],
-      outputs=[d.qfrc_constraint],
-    )
-    world_warp = m.is_sparse and launch_world_warp_enabled(d.nworld, d.qacc.device)
-    wp.launch(
-      _update_constraint_init_qfrc_constraint_sparse(sc, world_warp),
-      dim=(d.nworld, 32 if world_warp else d.njmax),
-      inputs=[
-        d.nefc,
-        dj.efc.J_rownnz,
-        dj.efc.J_rowadr,
-        dj.efc.J_colind,
-        dj.efc.J,
-        d.efc.force,
-        dj.dof_cdof,
-        d.njmax,
-        changed,
-        ctx.done,
-      ],
-      outputs=[d.qfrc_constraint],
-    )
-  else:
-    wp.launch(
-      _update_constraint_init_qfrc_constraint_dense(stable_fast),
-      dim=(d.nworld, m.nv),
-      inputs=[d.nefc, d.efc.J, d.efc.force, d.njmax, changed, ctx.done],
-      outputs=[d.qfrc_constraint],
-    )
-
-
 def _update_constraint(
   m: types.Model,
   d: types.Data,
@@ -2201,7 +2245,7 @@ def _update_constraint(
   track_changes: bool = False,
   stable_fast: bool = False,
 ):
-  """Update constraint arrays after each solve iteration."""
+  """Update constraint arrays and generalized forces after each solve iteration."""
   world_warp = m.is_sparse and launch_world_warp_enabled(d.nworld, d.qacc.device)
   wp.launch(
     _update_constraint_efc(track_changes, world_warp),
@@ -2226,7 +2270,43 @@ def _update_constraint(
     ],
     outputs=[d.efc.force, d.efc.state, ctx.quad_changed_ids, ctx.quad_changed_count, ctx.state_changed_count],
   )
-  _update_constraint_qfrc(m, d, ctx, stable_fast)
+
+  # qfrc_constraint = efc_J.T @ efc_force. Fast-path worlds with no state flips
+  # skip the rebuild; the public value is recovered after the solve.
+  changed = ctx.state_changed_count if stable_fast else d.nefc
+  sc = _sparse_compact(ctx)
+  if m.is_sparse or sc:
+    dj = ctx.compact_d_full if sc else d
+    wp.launch(
+      _zero_qfrc_constraint_sparse,
+      dim=(d.nworld, m.nv),
+      inputs=[changed, ctx.done],
+      outputs=[d.qfrc_constraint],
+    )
+    wp.launch(
+      _update_constraint_init_qfrc_constraint_sparse(sc, world_warp),
+      dim=(d.nworld, 32 if world_warp else d.njmax),
+      inputs=[
+        d.nefc,
+        dj.efc.J_rownnz,
+        dj.efc.J_rowadr,
+        dj.efc.J_colind,
+        dj.efc.J,
+        d.efc.force,
+        dj.dof_cdof,
+        d.njmax,
+        changed,
+        ctx.done,
+      ],
+      outputs=[d.qfrc_constraint],
+    )
+  else:
+    wp.launch(
+      _update_constraint_init_qfrc_constraint_dense(stable_fast),
+      dim=(d.nworld, m.nv),
+      inputs=[d.nefc, d.efc.J, d.efc.force, d.njmax, changed, ctx.done],
+      outputs=[d.qfrc_constraint],
+    )
 
 
 @cache_kernel
@@ -3332,26 +3412,31 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext, compact:
     raise ValueError(f"Unknown solver type: {m.opt.solver}")
 
 
-def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverContext, stable_fast: bool = False):
+def _update_gradient_incremental(
+  m: types.Model,
+  d: types.Data,
+  ctx: SolverContext,
+  gradient_ready: bool = False,
+):
   """Incremental gradient update: update H for changed constraints + re-factorize.
 
   Skips the full J^T*D*J rebuild by applying only the delta from constraints
   that changed QUADRATIC state, then re-factorizes and solves.
   """
-  changed = ctx.state_changed_count if stable_fast else d.nefc
-  wp.launch(
-    _update_gradient_zero_grad_dot(stable_fast),
-    dim=d.nworld,
-    inputs=[changed, ctx.alpha, ctx.done],
-    outputs=[ctx.grad_dot, ctx.newton_decrement, ctx.grad_scale, ctx.search_unchanged],
-  )
+  if not gradient_ready:
+    wp.launch(
+      _update_gradient_zero_grad_dot(True),
+      dim=d.nworld,
+      inputs=[ctx.state_changed_count, ctx.alpha, ctx.done],
+      outputs=[ctx.grad_dot, ctx.newton_decrement, ctx.grad_scale, ctx.search_unchanged],
+    )
 
-  wp.launch(
-    _update_gradient_grad(stable_fast),
-    dim=(d.nworld, m.nv),
-    inputs=[d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, changed, ctx.done],
-    outputs=[ctx.grad, ctx.grad_dot],
-  )
+    wp.launch(
+      _update_gradient_grad(True),
+      dim=(d.nworld, m.nv),
+      inputs=[d.qfrc_smooth, d.qfrc_constraint, d.efc.Ma, ctx.state_changed_count, ctx.done],
+      outputs=[ctx.grad, ctx.grad_dot],
+    )
 
   # Update upper triangle of H with delta from changed constraints.
   sc = _sparse_compact(ctx)
@@ -3390,7 +3475,7 @@ def _update_gradient_incremental(m: types.Model, d: types.Data, ctx: SolverConte
       outputs=[ctx.h],
     )
 
-  _cholesky_factorize_solve(m, d, ctx, skip_unchanged=True, skip_noflip=stable_fast)
+  _cholesky_factorize_solve(m, d, ctx, skip_unchanged=True, skip_noflip=True)
 
 
 @wp.kernel
@@ -3683,12 +3768,38 @@ def _solver_iteration(
   # only changed by a scalar along the same ray. Skip their qfrc/grad/
   # solve/search updates and track the scalar in ctx.grad_scale.
   if fuse_constraint_update:
-    _update_constraint_qfrc(m, d, ctx, stable_fast=incremental)
+    wp.launch_tiled(
+      _update_constraint_qfrc_gradient_sparse_world_warp(m.nv),
+      dim=d.nworld,
+      inputs=[
+        d.nefc,
+        d.qfrc_smooth,
+        d.efc.J_rownnz,
+        d.efc.J_rowadr,
+        d.efc.J_colind,
+        d.efc.J,
+        d.efc.force,
+        d.efc.Ma,
+        d.njmax,
+        ctx.state_changed_count,
+        ctx.alpha,
+        ctx.done,
+      ],
+      outputs=[
+        d.qfrc_constraint,
+        ctx.grad,
+        ctx.grad_dot,
+        ctx.newton_decrement,
+        ctx.grad_scale,
+        ctx.search_unchanged,
+      ],
+      block_dim=32,
+    )
   else:
     _update_constraint(m, d, ctx, track_changes=incremental, stable_fast=incremental)
 
   if incremental:
-    _update_gradient_incremental(m, d, ctx, stable_fast=incremental)
+    _update_gradient_incremental(m, d, ctx, gradient_ready=fuse_constraint_update)
   else:
     _update_gradient(m, d, ctx, compact=compact)
 

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -33,6 +33,7 @@ from mujoco_warp._src.types import OverflowType
 from mujoco_warp._src.types import SolverContext
 from mujoco_warp._src.warp_util import cache_kernel
 from mujoco_warp._src.warp_util import event_scope
+from mujoco_warp._src.warp_util import launch_world_warp_enabled
 
 wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 
@@ -94,7 +95,12 @@ def _create_solver_context(m: types.Model, d: types.Data) -> SolverContext:
     search=wp.empty((nworld, nv), dtype=float),
     mv=wp.empty((nworld, nv), dtype=float),
     jv=wp.empty((nworld, njmax), dtype=float),
-    quad=wp.empty((nworld, njmax), dtype=wp.vec3),
+    # Pyramidal line-search kernels evaluate directly from Jaref/jv/D. Their
+    # compile-time specialization never indexes quad, so retain storage only
+    # for elliptic-cone kernels.
+    quad=wp.empty((nworld, njmax), dtype=wp.vec3)
+    if m.opt.cone == types.ConeType.ELLIPTIC
+    else wp.empty((nworld, 0), dtype=wp.vec3),
     alpha=wp.empty((nworld,), dtype=float),
     grad_scale=wp.empty((nworld,), dtype=float),
     improvement=wp.empty((nworld,), dtype=float),
@@ -839,6 +845,7 @@ def _linesearch_iterative_kernel(
   fuse_jv: bool,
   is_sparse: bool,
   incremental: bool,
+  fuse_constraint_update: bool,
   warn_overflow: int,
 ):
   """Factory for iterative linesearch kernel.
@@ -849,6 +856,7 @@ def _linesearch_iterative_kernel(
     fuse_jv: Whether to compute jv = J @ search in-kernel (efficient for small nv).
     is_sparse: Use sparse matrix representation for constraint Jacobian.
     incremental: Use incremental linesearch updates.
+    fuse_constraint_update: Update pyramidal constraint force/state and change counters in-kernel.
     warn_overflow: Overflow warning bitmask.
   """
   LS_ITERATIONS = ls_iterations
@@ -856,6 +864,7 @@ def _linesearch_iterative_kernel(
   FUSE_JV = fuse_jv
   INCREMENTAL = incremental
   IS_SPARSE = is_sparse
+  FUSE_CONSTRAINT_UPDATE = fuse_constraint_update
 
   # Native snippet for CUDA __syncthreads()
   @wp.func_native(snippet="WP_TILE_SYNC();")
@@ -909,6 +918,8 @@ def _linesearch_iterative_kernel(
     ctx_done_in: wp.array[bool],
     # Data out:
     qacc_out: wp.array2d[float],
+    efc_force_out: wp.array2d[float],
+    efc_state_out: wp.array2d[int],
     efc_Ma_out: wp.array2d[float],
     overflow_out: wp.array[int],
     # Out:
@@ -918,8 +929,17 @@ def _linesearch_iterative_kernel(
     ctx_improvement_out: wp.array[float],
     ctx_alpha_out: wp.array[float],
     ctx_ls_exhausted_out: wp.array[bool],
+    quad_changed_ids_out: wp.array2d[int],
+    quad_changed_count_out: wp.array[int],
+    state_changed_count_out: wp.array[int],
   ):
     worldid, tid = wp.tid()
+
+    if wp.static(FUSE_CONSTRAINT_UPDATE):
+      if tid == 0:
+        quad_changed_count_out[worldid] = 0
+        state_changed_count_out[worldid] = 0
+      _syncthreads()
 
     if ctx_done_in[worldid]:
       return
@@ -1327,15 +1347,50 @@ def _linesearch_iterative_kernel(
       qacc_out[worldid, dofid] += alpha * ctx_search_in[worldid, dofid]
       efc_Ma_out[worldid, dofid] += alpha * ctx_mv_in[worldid, dofid]
 
-    # Jaref update
+    # Jaref update. The sparse pyramidal Newton path also evaluates the
+    # constraint from the accepted Jaref while the row is resident.
     for efcid in range(tid, nefc, wp.block_dim()):
-      ctx_Jaref_out[worldid, efcid] += alpha * ctx_jv_in[worldid, efcid]
+      new_jaref = ctx_Jaref_in[worldid, efcid] + alpha * ctx_jv_in[worldid, efcid]
+      ctx_Jaref_out[worldid, efcid] = new_jaref
+
+      if wp.static(FUSE_CONSTRAINT_UPDATE):
+        old_state = efc_state_out[worldid, efcid]
+        is_equality = efcid < ne
+        is_friction = (not is_equality) and (efcid < ne + nf)
+        frictionloss = efc_frictionloss_in[worldid, efcid] if is_friction else 0.0
+        res = _eval_constraint(
+          is_equality,
+          is_friction,
+          False,
+          new_jaref,
+          efc_D_in[worldid, efcid],
+          frictionloss,
+          efcid,
+          -1,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+        )
+        new_state = int(res[1])
+        efc_force_out[worldid, efcid] = res[0]
+        efc_state_out[worldid, efcid] = new_state
+
+        if (old_state == types.ConstraintState.QUADRATIC.value) != (new_state == types.ConstraintState.QUADRATIC.value):
+          quad_changed_ids_out[worldid, wp.atomic_add(quad_changed_count_out, worldid, 1)] = efcid
+        if old_state != new_state:
+          wp.atomic_add(state_changed_count_out, worldid, 1)
 
     if tid == 0:
       ctx_improvement_out[worldid] = improvement
       ctx_alpha_out[worldid] = alpha
       if wp.static(INCREMENTAL):
-        ctx_ls_exhausted_out[worldid] = wp.abs(alpha) < noise_floor
+        ls_exhausted = wp.abs(alpha) < noise_floor
+        ctx_ls_exhausted_out[worldid] = ls_exhausted
+        if wp.static(FUSE_CONSTRAINT_UPDATE):
+          if ls_exhausted:
+            wp.atomic_add(state_changed_count_out, worldid, 1)
       if not ls_converged:
         if wp.static(bool(warn_overflow & OverflowType.LS_ITERATIONS)):
           wp.printf(
@@ -1348,7 +1403,7 @@ def _linesearch_iterative_kernel(
   return kernel
 
 
-def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fuse_jv: bool):
+def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fuse_jv: bool, fuse_constraint_update: bool):
   """Iterative linesearch with parallel reductions over efc rows and dofs.
 
   Args:
@@ -1356,6 +1411,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
     d: Data.
     ctx: SolverContext.
     fuse_jv: Whether jv is computed in-kernel (True) or pre-computed (False).
+    fuse_constraint_update: Whether to update pyramidal constraint state in the line-search kernel.
   """
   wp.launch_tiled(
     _linesearch_iterative_kernel(
@@ -1364,6 +1420,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
       fuse_jv,
       m.is_sparse,
       _use_incremental(m),
+      fuse_constraint_update,
       int(m.opt.warn_overflow),
     ),
     dim=d.nworld,
@@ -1401,6 +1458,8 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
     ],
     outputs=[
       d.qacc,
+      d.efc.force,
+      d.efc.state,
       d.efc.Ma,
       d.overflow,
       ctx.Jaref,
@@ -1409,6 +1468,9 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: SolverContext, fus
       ctx.improvement,
       ctx.alpha,
       ctx.ls_exhausted,
+      ctx.quad_changed_ids,
+      ctx.quad_changed_count,
+      ctx.state_changed_count,
     ],
     block_dim=m.block_dim.linesearch_iterative,
   )
@@ -1507,7 +1569,7 @@ def _linesearch_jv_fused_kernel(is_sparse: bool, nv: int, dofs_per_thread: int, 
 
 
 @event_scope
-def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext):
+def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext, fuse_constraint_update: bool = False):
   """Linesearch for constraint solver.
 
   When state changes are tracked, worlds with ctx.search_unchanged reuse last
@@ -1518,6 +1580,7 @@ def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext):
     m: Model
     d: Data
     ctx: SolverContext
+    fuse_constraint_update: Whether to update pyramidal constraint state in the line-search kernel.
   """
   # mv and jv are pure functions of the search direction, and M and J are
   # constant within a solve, so worlds whose search was kept reuse last
@@ -1527,12 +1590,10 @@ def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext):
   # mv = M @ search (common to both parallel and iterative)
   _mul_m_compact_aware(m, d, ctx, ctx.mv, ctx.search, skip)
 
-  # Fuse jv computation in-kernel for small nv (iterative only, dense only)
-  # Sparse mode requires pre-computed jv since in-kernel uses dense indexing
-  # the sparse-compact J path reads the full model's sparse J structures;
-  # dense full models keep the gathered dense cJ path
+  # Fuse small dense Jv unconditionally. Sparse Jv uses the world-warp path
+  # only when the batch supplies enough independent warps to fill the GPU.
   sc = _sparse_compact(ctx)
-  fuse_jv = m.nv <= 50 and not m.is_sparse and not sc
+  fuse_jv = m.nv <= 50 and not sc and (not m.is_sparse or launch_world_warp_enabled(d.nworld, d.qacc.device))
 
   # jv = J @ search (when not fused into iterative kernel)
   if not fuse_jv:
@@ -1560,7 +1621,7 @@ def _linesearch(m: types.Model, d: types.Data, ctx: SolverContext):
       outputs=[ctx.jv],
     )
 
-  _linesearch_iterative(m, d, ctx, fuse_jv)
+  _linesearch_iterative(m, d, ctx, fuse_jv, fuse_constraint_update)
 
 
 @cache_kernel
@@ -1607,8 +1668,9 @@ def _solve_init_efc(
 
 
 @cache_kernel
-def _solve_init_jaref_kernel(is_sparse: bool, nv: int, dofs_per_thread: int, compact: bool):
+def _solve_init_jaref_kernel(is_sparse: bool, nv: int, dofs_per_thread: int, compact: bool, world_warp: bool):
   COMPACT = compact
+  WORLD_WARP = world_warp
 
   @wp.kernel(module="unique", enable_backward=False, grid_stride=True)
   def kernel(
@@ -1621,12 +1683,29 @@ def _solve_init_jaref_kernel(is_sparse: bool, nv: int, dofs_per_thread: int, com
     efc_J_in: wp.array3d[float],
     efc_aref_in: wp.array2d[float],
     dof_cdof_in: wp.array2d[int],
+    njmax_in: int,
     # Out:
     ctx_Jaref_out: wp.array2d[float],
   ):
     worldid, efcid, dofstart = wp.tid()
 
-    if efcid >= nefc_in[worldid]:
+    if wp.static(is_sparse and WORLD_WARP):
+      for active_efcid in range(efcid, wp.min(nefc_in[worldid], njmax_in), 32):
+        jaref = float(0.0)
+        rownnz = efc_J_rownnz_in[worldid, active_efcid]
+        rowadr = efc_J_rowadr_in[worldid, active_efcid]
+        for i in range(rownnz):
+          sparseid = rowadr + i
+          colind = efc_J_colind_in[worldid, 0, sparseid]
+          if wp.static(COMPACT):
+            colind = dof_cdof_in[worldid, colind]
+            if colind < 0:
+              continue
+          jaref += efc_J_in[worldid, 0, sparseid] * qacc_in[worldid, colind]
+        ctx_Jaref_out[worldid, active_efcid] = jaref - efc_aref_in[worldid, active_efcid]
+      return
+
+    if efcid >= wp.min(nefc_in[worldid], njmax_in):
       return
 
     jaref = float(0.0)
@@ -1697,8 +1776,10 @@ def _solve_init_search_cg_tiled(
 
 
 @cache_kernel
-def _update_constraint_efc(track_changes: bool):
+def _update_constraint_efc(track_changes: bool, world_warp: bool):
   TRACK_CHANGES = track_changes
+  WORLD_WARP = world_warp
+  EFC_STRIDE = 32 if world_warp else 1
 
   @wp.kernel(module="unique", enable_backward=False, grid_stride=False)
   def kernel(
@@ -1715,6 +1796,7 @@ def _update_constraint_efc(track_changes: bool):
     efc_id_in: wp.array2d[int],
     efc_D_in: wp.array2d[float],
     efc_frictionloss_in: wp.array2d[float],
+    njmax_in: int,
     nacon_in: wp.array[int],
     # In:
     ctx_Jaref_in: wp.array2d[float],
@@ -1728,7 +1810,7 @@ def _update_constraint_efc(track_changes: bool):
     quad_changed_count_out: wp.array[int],
     state_changed_count_out: wp.array[int],
   ):
-    worldid, efcid = wp.tid()
+    worldid, tid = wp.tid()
 
     if ctx_done_in[worldid]:
       return
@@ -1736,89 +1818,92 @@ def _update_constraint_efc(track_changes: bool):
     # The linesearch flags worlds whose accepted step was rounding noise (stale
     # ray exhausted); count it as a state change so the fast path rebuilds them.
     if wp.static(TRACK_CHANGES):
-      if efcid == 0 and ctx_ls_exhausted_in[worldid]:
+      if tid == 0 and ctx_ls_exhausted_in[worldid]:
         wp.atomic_add(state_changed_count_out, worldid, 1)
 
-    if efcid >= nefc_in[worldid]:
-      return
-
-    # Read old state before overwriting
-    if wp.static(TRACK_CHANGES):
-      old_state = efc_state_out[worldid, efcid]
-
-    efc_D = efc_D_in[worldid, efcid]
-    Jaref = ctx_Jaref_in[worldid, efcid]
-
-    ne = ne_in[worldid]
-    nf = nf_in[worldid]
-
-    is_equality = efcid < ne
-    is_friction = (not is_equality) and (efcid < ne + nf)
-    is_elliptic = efc_type_in[worldid, efcid] == types.ConstraintType.CONTACT_ELLIPTIC
-
-    frictionloss = efc_frictionloss_in[worldid, efcid] if is_friction else 0.0
-
-    efcid0 = -1
-    jaref0 = float(0.0)
-    D0 = float(0.0)
-    mu = float(0.0)
-    ufrictionj = float(0.0)
-    TT = float(0.0)
-
-    if is_elliptic:
-      conid = efc_id_in[worldid, efcid]
-      if conid >= nacon_in[0]:
+    efcid_end = wp.min(nefc_in[worldid], njmax_in)
+    if wp.static(not WORLD_WARP):
+      if tid >= efcid_end:
         return
-      efcid0 = contact_efc_address_in[conid, 0]
-      if efcid0 < 0:
-        return
+      efcid_end = tid + 1
 
-      dim = contact_dim_in[conid]
-      friction = contact_friction_in[conid]
-      mu = friction[0] * opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
-      jaref0 = ctx_Jaref_in[worldid, efcid0]
-      D0 = efc_D_in[worldid, efcid0]
+    for efcid in range(tid, efcid_end, wp.static(EFC_STRIDE)):
+      # Read old state before overwriting
+      if wp.static(TRACK_CHANGES):
+        old_state = efc_state_out[worldid, efcid]
 
-      for j in range(1, dim):
-        efcidj = contact_efc_address_in[conid, j]
-        if efcidj < 0:
-          return
-        frictionj = friction[j - 1]
-        uj = ctx_Jaref_in[worldid, efcidj] * frictionj
-        TT += uj * uj
-        if efcid == efcidj:
-          ufrictionj = uj * frictionj
+      ne = ne_in[worldid]
+      nf = nf_in[worldid]
 
-    res = _eval_constraint(
-      is_equality,
-      is_friction,
-      is_elliptic,
-      Jaref,
-      efc_D,
-      frictionloss,
-      efcid,
-      efcid0,
-      jaref0,
-      D0,
-      mu,
-      ufrictionj,
-      TT,
-    )
+      is_equality = efcid < ne
+      is_friction = (not is_equality) and (efcid < ne + nf)
+      is_elliptic = efc_type_in[worldid, efcid] == types.ConstraintType.CONTACT_ELLIPTIC
 
-    new_state = int(res[1])
-    efc_force_out[worldid, efcid] = res[0]
-    efc_state_out[worldid, efcid] = new_state
+      frictionloss = efc_frictionloss_in[worldid, efcid] if is_friction else 0.0
 
-    if wp.static(TRACK_CHANGES):
-      old_quad = old_state == types.ConstraintState.QUADRATIC.value
-      new_quad = new_state == types.ConstraintState.QUADRATIC.value
-      if old_quad != new_quad:
-        idx = wp.atomic_add(quad_changed_count_out, worldid, 1)
-        quad_changed_ids_out[worldid, idx] = efcid
-      # LINEARNEG <-> LINEARPOS friction transitions change the force without
-      # changing the quadratic flag (or H); the fast path must still see them.
-      if old_state != new_state:
-        wp.atomic_add(state_changed_count_out, worldid, 1)
+      efcid0 = -1
+      jaref0 = float(0.0)
+      D0 = float(0.0)
+      mu = float(0.0)
+      ufrictionj = float(0.0)
+      TT = float(0.0)
+
+      if is_elliptic:
+        conid = efc_id_in[worldid, efcid]
+        if conid >= nacon_in[0]:
+          continue
+        efcid0 = contact_efc_address_in[conid, 0]
+        if efcid0 < 0:
+          continue
+
+        dim = contact_dim_in[conid]
+        friction = contact_friction_in[conid]
+        mu = friction[0] * opt_impratio_invsqrt[worldid % opt_impratio_invsqrt.shape[0]]
+        jaref0 = ctx_Jaref_in[worldid, efcid0]
+        D0 = efc_D_in[worldid, efcid0]
+
+        valid = bool(True)
+        for j in range(1, dim):
+          efcidj = contact_efc_address_in[conid, j]
+          if efcidj < 0:
+            valid = False
+            break
+          else:
+            frictionj = friction[j - 1]
+            uj = ctx_Jaref_in[worldid, efcidj] * frictionj
+            TT += uj * uj
+            if efcid == efcidj:
+              ufrictionj = uj * frictionj
+        if not valid:
+          continue
+
+      res = _eval_constraint(
+        is_equality,
+        is_friction,
+        is_elliptic,
+        ctx_Jaref_in[worldid, efcid],
+        efc_D_in[worldid, efcid],
+        frictionloss,
+        efcid,
+        efcid0,
+        jaref0,
+        D0,
+        mu,
+        ufrictionj,
+        TT,
+      )
+
+      new_state = int(res[1])
+      efc_force_out[worldid, efcid] = res[0]
+      efc_state_out[worldid, efcid] = new_state
+
+      if wp.static(TRACK_CHANGES):
+        if (old_state == types.ConstraintState.QUADRATIC.value) != (new_state == types.ConstraintState.QUADRATIC.value):
+          quad_changed_ids_out[worldid, wp.atomic_add(quad_changed_count_out, worldid, 1)] = efcid
+        # LINEARNEG <-> LINEARPOS friction transitions change the force without
+        # changing the quadratic flag (or H); the fast path must still see them.
+        if old_state != new_state:
+          wp.atomic_add(state_changed_count_out, worldid, 1)
 
   return kernel
 
@@ -1844,8 +1929,10 @@ def _zero_qfrc_constraint_sparse(
 
 
 @cache_kernel
-def _update_constraint_init_qfrc_constraint_sparse(compact: bool):
+def _update_constraint_init_qfrc_constraint_sparse(compact: bool, world_warp: bool):
   COMPACT = compact
+  WORLD_WARP = world_warp
+  EFC_STRIDE = 32 if world_warp else 1
 
   @wp.kernel(module="unique", enable_backward=False, grid_stride=True)
   def kernel(
@@ -1857,13 +1944,14 @@ def _update_constraint_init_qfrc_constraint_sparse(compact: bool):
     efc_J_in: wp.array3d[float],
     efc_force_in: wp.array2d[float],
     dof_cdof_in: wp.array2d[int],
+    njmax_in: int,
     # In:
     state_changed_count_in: wp.array[int],
     ctx_done_in: wp.array[bool],
     # Data out:
     qfrc_constraint_out: wp.array2d[float],
   ):
-    worldid, efcid = wp.tid()
+    worldid, tid = wp.tid()
 
     if ctx_done_in[worldid]:
       return
@@ -1871,24 +1959,27 @@ def _update_constraint_init_qfrc_constraint_sparse(compact: bool):
     if state_changed_count_in[worldid] == 0:
       return
 
-    if efcid >= nefc_in[worldid]:
-      return
+    efcid_end = wp.min(nefc_in[worldid], njmax_in)
+    if wp.static(not WORLD_WARP):
+      if tid >= efcid_end:
+        return
+      efcid_end = tid + 1
 
-    force = efc_force_in[worldid, efcid]
-    if force == 0.0:
-      return
+    for efcid in range(tid, efcid_end, wp.static(EFC_STRIDE)):
+      force = efc_force_in[worldid, efcid]
+      if force == 0.0:
+        continue
 
-    rownnz = efc_J_rownnz_in[worldid, efcid]
-    rowadr = efc_J_rowadr_in[worldid, efcid]
-    for i in range(rownnz):
-      sparseid = rowadr + i
-      colind = efc_J_colind_in[worldid, 0, sparseid]
-      if wp.static(COMPACT):
-        colind = dof_cdof_in[worldid, colind]
-        if colind < 0:
-          continue
-      efc_J = efc_J_in[worldid, 0, sparseid]
-      wp.atomic_add(qfrc_constraint_out[worldid], colind, efc_J * force)
+      rownnz = efc_J_rownnz_in[worldid, efcid]
+      rowadr = efc_J_rowadr_in[worldid, efcid]
+      for i in range(rownnz):
+        sparseid = rowadr + i
+        colind = efc_J_colind_in[worldid, 0, sparseid]
+        if wp.static(COMPACT):
+          colind = dof_cdof_in[worldid, colind]
+          if colind < 0:
+            continue
+        wp.atomic_add(qfrc_constraint_out[worldid], colind, efc_J_in[worldid, 0, sparseid] * force)
 
   return kernel
 
@@ -2057,39 +2148,13 @@ def _update_gradient_h_incremental_sparse(compact: bool):
   return kernel
 
 
-def _update_constraint(
+def _update_constraint_qfrc(
   m: types.Model,
   d: types.Data,
   ctx: SolverContext | InverseContext,
-  track_changes: bool = False,
   stable_fast: bool = False,
 ):
-  """Update constraint arrays after each solve iteration."""
-  efc_inputs = [
-    m.opt.impratio_invsqrt,
-    d.ne,
-    d.nf,
-    d.nefc,
-    d.contact.friction,
-    d.contact.dim,
-    d.contact.efc_address,
-    d.efc.type,
-    d.efc.id,
-    d.efc.D,
-    d.efc.frictionloss,
-    d.nacon,
-    ctx.Jaref,
-    ctx.ls_exhausted,
-    ctx.done,
-  ]
-
-  wp.launch(
-    _update_constraint_efc(track_changes),
-    dim=(d.nworld, d.njmax),
-    inputs=efc_inputs,
-    outputs=[d.efc.force, d.efc.state, ctx.quad_changed_ids, ctx.quad_changed_count, ctx.state_changed_count],
-  )
-
+  """Update generalized constraint forces from the current EFC forces."""
   # qfrc_constraint = efc_J.T @ efc_force. Fast-path worlds with no state flips
   # skip the rebuild; the public value is recovered after the solve.
   changed = ctx.state_changed_count if stable_fast else d.nefc
@@ -2102,10 +2167,22 @@ def _update_constraint(
       inputs=[changed, ctx.done],
       outputs=[d.qfrc_constraint],
     )
+    world_warp = m.is_sparse and launch_world_warp_enabled(d.nworld, d.qacc.device)
     wp.launch(
-      _update_constraint_init_qfrc_constraint_sparse(sc),
-      dim=(d.nworld, d.njmax),
-      inputs=[d.nefc, dj.efc.J_rownnz, dj.efc.J_rowadr, dj.efc.J_colind, dj.efc.J, d.efc.force, dj.dof_cdof, changed, ctx.done],
+      _update_constraint_init_qfrc_constraint_sparse(sc, world_warp),
+      dim=(d.nworld, 32 if world_warp else d.njmax),
+      inputs=[
+        d.nefc,
+        dj.efc.J_rownnz,
+        dj.efc.J_rowadr,
+        dj.efc.J_colind,
+        dj.efc.J,
+        d.efc.force,
+        dj.dof_cdof,
+        d.njmax,
+        changed,
+        ctx.done,
+      ],
       outputs=[d.qfrc_constraint],
     )
   else:
@@ -2115,6 +2192,41 @@ def _update_constraint(
       inputs=[d.nefc, d.efc.J, d.efc.force, d.njmax, changed, ctx.done],
       outputs=[d.qfrc_constraint],
     )
+
+
+def _update_constraint(
+  m: types.Model,
+  d: types.Data,
+  ctx: SolverContext | InverseContext,
+  track_changes: bool = False,
+  stable_fast: bool = False,
+):
+  """Update constraint arrays after each solve iteration."""
+  world_warp = m.is_sparse and launch_world_warp_enabled(d.nworld, d.qacc.device)
+  wp.launch(
+    _update_constraint_efc(track_changes, world_warp),
+    dim=(d.nworld, 32 if world_warp else d.njmax),
+    inputs=[
+      m.opt.impratio_invsqrt,
+      d.ne,
+      d.nf,
+      d.nefc,
+      d.contact.friction,
+      d.contact.dim,
+      d.contact.efc_address,
+      d.efc.type,
+      d.efc.id,
+      d.efc.D,
+      d.efc.frictionloss,
+      d.njmax,
+      d.nacon,
+      ctx.Jaref,
+      ctx.ls_exhausted,
+      ctx.done,
+    ],
+    outputs=[d.efc.force, d.efc.state, ctx.quad_changed_ids, ctx.quad_changed_count, ctx.state_changed_count],
+  )
+  _update_constraint_qfrc(m, d, ctx, stable_fast)
 
 
 @cache_kernel
@@ -3539,15 +3651,26 @@ def _solver_iteration(
   nsolving: wp.array[int],
   compact: bool = False,
 ):
-  _linesearch(m, d, ctx)
+  # Fuse the high-world-count sparse pyramidal Newton path: it already computes
+  # Jv and accepted Jaref in one warp per world. Low-occupancy, compact/island,
+  # elliptic, dense, CG, and large-nv paths retain the generic launches.
+  incremental = _use_incremental(m)
+  fuse_constraint_update = (
+    incremental
+    and m.is_sparse
+    and not compact
+    and not _sparse_compact(ctx)
+    and m.opt.cone == types.ConeType.PYRAMIDAL
+    and m.nv <= 50
+    and launch_world_warp_enabled(d.nworld, d.qacc.device)
+  )
+  _linesearch(m, d, ctx, fuse_constraint_update)
 
   # Incremental H is only valid for non-elliptic cones. The elliptic cone
   # path in _update_constraint_efc has early returns that skip state change
   # tracking, and the additional JTCJ Hessian term depends on Jaref which
   # changes every iteration.
-  incremental = _use_incremental(m)
-
-  if incremental:
+  if incremental and not fuse_constraint_update:
     # Must complete before _update_constraint_efc which atomically increments.
     wp.launch(
       _zero_change_counters,
@@ -3559,7 +3682,10 @@ def _solver_iteration(
   # flips this iteration were exactly quadratic over the step, so grad/search
   # only changed by a scalar along the same ray. Skip their qfrc/grad/
   # solve/search updates and track the scalar in ctx.grad_scale.
-  _update_constraint(m, d, ctx, track_changes=incremental, stable_fast=incremental)
+  if fuse_constraint_update:
+    _update_constraint_qfrc(m, d, ctx, stable_fast=incremental)
+  else:
+    _update_constraint(m, d, ctx, track_changes=incremental, stable_fast=incremental)
 
   if incremental:
     _update_gradient_incremental(m, d, ctx, stable_fast=incremental)
@@ -3660,10 +3786,22 @@ def init_context(m: types.Model, d: types.Data, ctx: SolverContext | InverseCont
   if sc:
     dofs_per_thread = m.nv
     threads_per_efc = 1
+  sparse = sc or m.is_sparse
+  world_warp = m.is_sparse and launch_world_warp_enabled(d.nworld, d.qacc.device)
   wp.launch(
-    _solve_init_jaref_kernel(sc or m.is_sparse, m.nv, dofs_per_thread, sc),
-    dim=(d.nworld, d.njmax, threads_per_efc),
-    inputs=[d.nefc, d.qacc, dj.efc.J_rownnz, dj.efc.J_rowadr, dj.efc.J_colind, dj.efc.J, d.efc.aref, dj.dof_cdof],
+    _solve_init_jaref_kernel(sparse, m.nv, dofs_per_thread, sc, world_warp),
+    dim=(d.nworld, 32 if world_warp else d.njmax, threads_per_efc),
+    inputs=[
+      d.nefc,
+      d.qacc,
+      dj.efc.J_rownnz,
+      dj.efc.J_rowadr,
+      dj.efc.J_colind,
+      dj.efc.J,
+      d.efc.aref,
+      dj.dof_cdof,
+      d.njmax,
+    ],
     outputs=[ctx.Jaref],
   )
 

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -15,6 +15,8 @@
 
 """Tests for solver functions."""
 
+from unittest import mock
+
 import mujoco
 import numpy as np
 import warp as wp
@@ -416,6 +418,36 @@ class SolverTest(parameterized.TestCase):
       _assert_eq(efc_sorted_state, mjd_sorted_state, "efc_state")
       _assert_eq(efc_sorted_force, mjd_sorted_force, "efc_force")
       _assert_eq(qfrc_constraint, mjd.qfrc_constraint, "qfrc_constraint")
+
+  def test_sparse_world_warp_matches_generic_solver(self):
+    """Forced world-warp solver launches match the generic sparse path."""
+    mjm, mjd, m, _ = test_data.fixture(
+      "constraints.xml",
+      keyframe=2,
+      overrides={
+        "opt.cone": ConeType.PYRAMIDAL,
+        "opt.solver": SolverType.NEWTON,
+        "opt.jacobian": mujoco.mjtJacobian.mjJAC_SPARSE,
+        "opt.iterations": 5,
+        "opt.ls_iterations": 10,
+      },
+    )
+    self.assertTrue(m.is_sparse)
+    self.assertLessEqual(m.nv, 50)
+
+    d_generic = mjw.put_data(mjm, mjd, nworld=4)
+    d_world_warp = mjw.put_data(mjm, mjd, nworld=4)
+    with mock.patch.object(solver, "launch_world_warp_enabled", return_value=False):
+      solver.solve(m, d_generic)
+    with mock.patch.object(solver, "launch_world_warp_enabled", return_value=True):
+      solver.solve(m, d_world_warp)
+
+    nefc = int(d_generic.nefc.numpy().max())
+    _assert_eq(d_world_warp.qacc.numpy(), d_generic.qacc.numpy(), "qacc")
+    _assert_eq(d_world_warp.qfrc_constraint.numpy(), d_generic.qfrc_constraint.numpy(), "qfrc_constraint")
+    _assert_eq(d_world_warp.efc.force.numpy()[:, :nefc], d_generic.efc.force.numpy()[:, :nefc], "efc_force")
+    np.testing.assert_array_equal(d_world_warp.efc.state.numpy()[:, :nefc], d_generic.efc.state.numpy()[:, :nefc])
+    np.testing.assert_array_equal(d_world_warp.solver_niter.numpy(), d_generic.solver_niter.numpy())
 
   @parameterized.product(
     cone=(ConeType.PYRAMIDAL, ConeType.ELLIPTIC),

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -449,6 +449,42 @@ class SolverTest(parameterized.TestCase):
     np.testing.assert_array_equal(d_world_warp.efc.state.numpy()[:, :nefc], d_generic.efc.state.numpy()[:, :nefc])
     np.testing.assert_array_equal(d_world_warp.solver_niter.numpy(), d_generic.solver_niter.numpy())
 
+  def test_sparse_constraint_gradient_fusion(self):
+    """Fused world-warp force and gradient updates preserve all fast-path states."""
+    nworld, nv, njmax = 3, 3, 2
+    nefc = wp.array([2, 2, 2], dtype=int)
+    rownnz = wp.array(np.tile([[2, 2]], (nworld, 1)), dtype=int)
+    rowadr = wp.array(np.tile([[0, 2]], (nworld, 1)), dtype=int)
+    colind = wp.array(np.tile([[[0, 1, 1, 2]]], (nworld, 1, 1)), dtype=int)
+    jacobian = wp.array(np.tile([[[1.0, 2.0, -1.0, 0.5]]], (nworld, 1, 1)), dtype=float)
+    force = wp.array([[2.0, -3.0], [1.0, 1.0], [4.0, -2.0]], dtype=float)
+    qfrc_smooth = wp.array([[0.5, -1.0, 2.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], dtype=float)
+    ma = wp.array([[3.0, 10.0, 0.5], [1.0, 1.0, 1.0], [2.0, 2.0, 2.0]], dtype=float)
+    changed = wp.array([1, 0, 1], dtype=int)
+    alpha = wp.array([0.1, 0.5, 0.2], dtype=float)
+    done = wp.array([False, False, True], dtype=bool)
+    qfrc = wp.array([[9.0, 9.0, 9.0], [9.0, 8.0, 7.0], [6.0, 5.0, 4.0]], dtype=float)
+    grad = wp.array([[8.0, 8.0, 8.0], [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=float)
+    grad_dot = wp.array([99.0, 14.0, 5.0], dtype=float)
+    decrement = wp.array([88.0, 8.0, 6.0], dtype=float)
+    grad_scale = wp.array([3.0, 2.0, 7.0], dtype=float)
+    search_unchanged = wp.zeros(nworld, dtype=bool)
+
+    wp.launch_tiled(
+      solver._update_constraint_qfrc_gradient_sparse_world_warp(nv),
+      dim=nworld,
+      inputs=[nefc, qfrc_smooth, rownnz, rowadr, colind, jacobian, force, ma, njmax, changed, alpha, done],
+      outputs=[qfrc, grad, grad_dot, decrement, grad_scale, search_unchanged],
+      block_dim=32,
+    )
+
+    np.testing.assert_allclose(qfrc.numpy(), [[2.0, 7.0, -1.5], [9.0, 8.0, 7.0], [6.0, 5.0, 4.0]])
+    np.testing.assert_allclose(grad.numpy(), [[0.5, 4.0, 0.0], [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    np.testing.assert_allclose(grad_dot.numpy(), [16.25, 7.875, 5.0])
+    np.testing.assert_allclose(decrement.numpy(), [0.0, 4.5, 6.0])
+    np.testing.assert_allclose(grad_scale.numpy(), [1.0, 1.5, 7.0])
+    np.testing.assert_array_equal(search_unchanged.numpy(), [False, True, True])
+
   @parameterized.product(
     cone=(ConeType.PYRAMIDAL, ConeType.ELLIPTIC),
     jacobian=(mujoco.mjtJacobian.mjJAC_DENSE, mujoco.mjtJacobian.mjJAC_SPARSE),

--- a/mujoco_warp/_src/warp_util.py
+++ b/mujoco_warp/_src/warp_util.py
@@ -167,6 +167,11 @@ def cache_kernel(func):
   return wrapper
 
 
+def launch_world_warp_enabled(nworld: int, device) -> bool:
+  """Return whether one warp per world supplies at least four GPU occupancy waves."""
+  return device.is_cuda and nworld >= 4 * device.sm_count
+
+
 def check_toolkit_driver():
   wp.init()
   if wp.get_device().is_cuda:


### PR DESCRIPTION
This is the third implementation change in the sparse Newton optimization stack. It is stacked on #1642, which is stacked on #1638, so the required implementation merge order is #1638 → #1642 → this PR. Until those prerequisites land, GitHub will also show their commits in this diff. The isolated comparison is `54266e6` → `b72320e`.

The specialized sparse solver path rebuilds Jᵀf, updates the gradient and its norm, and maintains stable-ray bookkeeping in consecutive launches. This change performs that work in one warp-per-world kernel when the small-DoF pyramidal line-search specialization is active. Generic sparse, dense, elliptic, compact, CG, large-DoF, and low-world-count paths remain unchanged. Because the fused path removes the second caller of the intermediate qfrc-only wrapper introduced in #1642, that wrapper is folded back into its owning constraint update rather than retained as one-use indirection.

On physical GPU0, an RTX 5090, I ran five interleaved warm-cache processes per revision and report medians:

- Single-Panda diagnostic, 4,096 worlds, `nconmax=32`, `njmax=64`: 7.732M → 7.816M steps/s (+1.09%), step 119.816 → 119.122 ns (-0.58%), and solve 26.860 → 26.339 ns (-1.94%).
- Five-Panda benchmark from #1637, 4,096 worlds, `nconmax=64`, `njmax=192`: 3.146M → 3.154M steps/s (+0.26%), step fell 0.20%, and solve fell 0.87%.
- Sparse Humanoid, 8,192 worlds: 6.468M → 6.551M steps/s (+1.29%), step fell 1.37%, and solve fell 2.67%.

The corrected current-main → full-stack comparison on the single-Panda 32/64 diagnostic is 7.540M → 7.816M steps/s (+3.66%), with step -2.61%, solve -8.46%, and `make_constraint` -5.53%. On the permanent five-Panda benchmark, full-stack wall throughput is within run spread (-0.35%), while step improves 0.75%, solve 2.38%, and `make_constraint` 1.86%. These replace the earlier 37–50% figures from oversized 600/3,000 capacities.

All worlds converged with matching workload and iteration statistics. Validated with kernel-level changed/stable/done coverage, the inherited forced-dispatch solver test, all pre-commit checks, and `uv run pytest -n 8`: 1,359 passed and 29 skipped.