### PR TITLE
Add object-local texture projection and skip unused image uploads

### DIFF
--- a/mujoco_warp/_src/render.py
+++ b/mujoco_warp/_src/render.py
@@ -182,6 +182,8 @@ def sample_texture(
   tex: wp.Texture2D,
   pos: wp.vec3,
   rot: wp.mat33,
+  size: wp.vec3,
+  normal: wp.vec3,
   mesh_facetexcoord: wp.array[wp.vec3i],
   mesh_texcoord: wp.array[wp.vec2],
   mesh_texcoord_offsets: wp.array[int],
@@ -203,21 +205,54 @@ def sample_texture(
     uv = wp.vec2(0.5 * local[0], -0.5 * local[1])
     offset = wp.vec2(-0.5, -0.5)
 
+  has_texcoords = bool(False)
   if geom_type[geom_id] == GeomType.MESH:
     if f < 0 or mesh_id < 0:
       return wp.vec3(0.0, 0.0, 0.0)
 
     texcoord_offset = mesh_texcoord_offsets[mesh_id]
     if texcoord_offset >= 0:
-      # Some meshes may have no texcoord. The corresponding elements for these meshes in
-      # mjm.mesh_texcoordadr (passed here as mesh_texcoord_offsets) are marked as -1, in
-      # which case uv stays at its initialized value of (0.0, 0.0).
       face_adr = mesh_faceadr[mesh_id] + f
       coords = mesh_facetexcoord[face_adr]
-      uv0 = mesh_texcoord[texcoord_offset + coords[0]]
-      uv1 = mesh_texcoord[texcoord_offset + coords[1]]
-      uv2 = mesh_texcoord[texcoord_offset + coords[2]]
-      uv = uv0 * bary_u + uv1 * bary_v + uv2 * (1.0 - bary_u - bary_v)
+      if coords[0] >= 0 and coords[1] >= 0 and coords[2] >= 0:
+        uv0 = mesh_texcoord[texcoord_offset + coords[0]]
+        uv1 = mesh_texcoord[texcoord_offset + coords[1]]
+        uv2 = mesh_texcoord[texcoord_offset + coords[2]]
+        uv = uv0 * bary_u + uv1 * bary_v + uv2 * (1.0 - bary_u - bary_v)
+        has_texcoords = True
+
+  if not has_texcoords and (
+    geom_type[geom_id] == GeomType.BOX
+    or geom_type[geom_id] == GeomType.SPHERE
+    or geom_type[geom_id] == GeomType.ELLIPSOID
+    or geom_type[geom_id] == GeomType.CYLINDER
+    or geom_type[geom_id] == GeomType.CAPSULE
+    or geom_type[geom_id] == GeomType.MESH
+  ):
+    # Object-local box projection: the pattern follows rotation and per-world
+    # dimensions. Select one face rather than blending three texture samples;
+    # this introduces seams where the dominant normal axis changes.
+    local = wp.transpose(rot) @ (hit_point - pos)
+    local_normal = wp.transpose(rot) @ normal
+    extent = size
+    if geom_type[geom_id] == GeomType.SPHERE:
+      extent = wp.vec3(size[0], size[0], size[0])
+    elif geom_type[geom_id] == GeomType.CYLINDER:
+      extent = wp.vec3(size[0], size[0], size[1])
+    elif geom_type[geom_id] == GeomType.CAPSULE:
+      extent = wp.vec3(size[0], size[0], size[1] + size[0])
+    point = wp.vec3(
+      local[0] / wp.max(extent[0], 1.0e-8),
+      local[1] / wp.max(extent[1], 1.0e-8),
+      local[2] / wp.max(extent[2], 1.0e-8),
+    )
+    axis = wp.vec3(wp.abs(local_normal[0]), wp.abs(local_normal[1]), wp.abs(local_normal[2]))
+    uv = wp.vec2(point[0], point[1])
+    if axis[0] > axis[1] and axis[0] > axis[2]:
+      uv = wp.vec2(point[1], point[2])
+    elif axis[1] > axis[2]:
+      uv = wp.vec2(point[0], point[2])
+    uv = 0.5 * (uv + wp.vec2(1.0, 1.0))
 
   u = uv[0] * tex_repeat[0] + offset[0]
   v = uv[1] * tex_repeat[1] + offset[1]
@@ -1014,6 +1049,8 @@ def _build_megakernel(m: Model, rc: RenderContext):
               textures[tex_id],
               geom_xpos_in[worldid, geom_id],
               geom_xmat_in[worldid, geom_id],
+              geom_size[worldid % geom_size.shape[0], geom_id],
+              normal,
               mesh_facetexcoord,
               mesh_texcoord,
               mesh_texcoord_offsets,

--- a/mujoco_warp/_src/render_test.py
+++ b/mujoco_warp/_src/render_test.py
@@ -53,6 +53,152 @@ def _sample_splats(position, scale, rgba):
   }
 
 
+class ObjectTextureTest(parameterized.TestCase):
+  """Checks spatial texture patterns, including randomized models."""
+
+  @staticmethod
+  def _scene(geom_type="box", size=".25 .25 .25", mesh_uv=False):
+    mesh_attribute = 'mesh="cube"' if geom_type == "mesh" else ""
+    texcoord_attribute = 'texcoord="' + "0.125 0.125 " * 8 + '"' if mesh_uv else ""
+    return mujoco.MjModel.from_xml_string(f"""
+      <mujoco>
+        <visual><headlight active="0"/></visual>
+        <asset>
+          <texture name="red_green" type="2d" builtin="checker" width="16" height="16"
+                   rgb1="1 0 0" rgb2="0 1 0"/>
+          <texture name="blue_yellow" type="2d" builtin="checker" width="16" height="16"
+                   rgb1="0 0 1" rgb2="1 1 0"/>
+          <material name="object" texture="red_green" rgba="1 1 1 1" emission="1"/>
+          <mesh name="cube" {texcoord_attribute}
+                vertex="-.25 -.25 -.25  .25 -.25 -.25  .25 .25 -.25  -.25 .25 -.25
+                        -.25 -.25 .25  .25 -.25 .25  .25 .25 .25  -.25 .25 .25"/>
+        </asset>
+        <worldbody>
+          <camera name="camera" pos="0 0 1" resolution="32 32" fovy="45" output="rgb"/>
+          <body name="object">
+            <freejoint/>
+            <geom type="{geom_type}" size="{size}" material="object" {mesh_attribute}/>
+          </body>
+        </worldbody>
+      </mujoco>
+    """)
+
+  @staticmethod
+  def _context(mjm, nworld=1):
+    return mjw.create_render_context(
+      mjm, nworld=nworld, use_shadows=False, use_ambient_lighting=False, use_precomputed_rays=False
+    )
+
+  @staticmethod
+  def _pixels(m, d, rc):
+    mjw.refit_bvh(m, d, rc)
+    mjw.render(m, d, rc)
+    return _unpack_rgb(rc.rgb_data.numpy()).reshape(-1, 32, 32, 3).astype(float) / 255.0
+
+  @parameterized.named_parameters(
+    ("box", "box", ".25 .25 .25"),
+    ("sphere", "sphere", ".25"),
+    ("ellipsoid", "ellipsoid", ".25 .2 .3"),
+    ("cylinder", "cylinder", ".25 .25"),
+    ("capsule", "capsule", ".25 .15"),
+    ("mesh_without_uvs", "mesh", "1 1 1"),
+  )
+  def test_spatial_pattern_and_per_world_texture_swap(self, geom_type, size):
+    mjm = self._scene(geom_type, size)
+    mjd = mujoco.MjData(mjm)
+    mujoco.mj_forward(mjm, mjd)
+    m = mjw.put_model(mjm, batch_sizes={"mat_texid": 2})
+    d = mjw.put_data(mjm, mjd, nworld=2)
+    rc = self._context(mjm, nworld=2)
+    ids = m.mat_texid.numpy()
+    ids[:, 0, 1] = [mjm.texture("red_green").id, mjm.texture("blue_yellow").id]
+    m.mat_texid.assign(ids)
+    first = self._pixels(m, d, rc)
+    # Sampling a single texel cannot produce both regions of either checkerboard.
+    self.assertTrue(np.any(first[0, ..., 0] - first[0, ..., 1] > 0.2))
+    self.assertTrue(np.any(first[0, ..., 1] - first[0, ..., 0] > 0.2))
+    self.assertTrue(np.any(first[1, ..., 2] - first[1, ..., 0] > 0.2))
+    self.assertTrue(np.any(first[1, ..., 0] - first[1, ..., 2] > 0.2))
+    ids[:, 0, 1] = ids[::-1, 0, 1]
+    m.mat_texid.assign(ids)
+    second = self._pixels(m, d, rc)
+    np.testing.assert_array_equal(second, first[::-1])
+
+  def test_explicit_mesh_uvs_override_projection(self):
+    mjm = self._scene("mesh", "1 1 1", mesh_uv=True)
+    mjd = mujoco.MjData(mjm)
+    mujoco.mj_forward(mjm, mjd)
+    pixels = self._pixels(mjw.put_model(mjm), mjw.put_data(mjm, mjd), self._context(mjm))
+    # Constant UVs select exactly one checker color despite the varying hit points.
+    red = np.any(pixels[..., 0] - pixels[..., 1] > 0.2)
+    green = np.any(pixels[..., 1] - pixels[..., 0] > 0.2)
+    self.assertNotEqual(red, green)
+
+  @parameterized.parameters("0 0 0", "0.3 -0.2 0.1")
+  def test_texture_rotates_with_object(self, position):
+    mjm = self._scene()
+    translation = np.fromstring(position, sep=" ")
+    mjm.cam_pos[0] += translation
+    mjd = mujoco.MjData(mjm)
+    mjd.qpos[:3] = translation
+    mujoco.mj_forward(mjm, mjd)
+    m, rc = mjw.put_model(mjm), self._context(mjm)
+    first = self._pixels(m, mjw.put_data(mjm, mjd), rc)
+    # A quarter turn keeps the silhouette and rotates the checkerboard.
+    mjd.qpos[3:] = [np.sqrt(0.5), 0, 0, np.sqrt(0.5)]
+    mujoco.mj_forward(mjm, mjd)
+    second = self._pixels(m, mjw.put_data(mjm, mjd), rc)
+    self.assertGreater(np.mean(np.abs(first - second)), 0.1)
+    np.testing.assert_allclose(second, np.rot90(first, axes=(1, 2)), atol=1.0 / 255)
+
+  @parameterized.named_parameters(
+    ("x", [np.sqrt(0.5), np.sqrt(0.5), 0, 0], [0, -1, 0]),
+    ("y", [np.sqrt(0.5), 0, np.sqrt(0.5), 0], [1, 0, 0]),
+  )
+  def test_projection_axis_rotates_with_object(self, quaternion, camera_position):
+    mjm = self._scene(size=".25 .2 .3")
+    mjd = mujoco.MjData(mjm)
+    mujoco.mj_forward(mjm, mjd)
+    m, rc = mjw.put_model(mjm), self._context(mjm)
+    first = self._pixels(m, mjw.put_data(mjm, mjd), rc)
+    # Rotate camera and object together: world normals change but local UVs do not.
+    mjm.cam_pos[0] = camera_position
+    mjm.cam_quat[0] = quaternion
+    mjd.qpos[3:] = quaternion
+    mujoco.mj_forward(mjm, mjd)
+    second = self._pixels(m, mjw.put_data(mjm, mjd), rc)
+    np.testing.assert_allclose(second, first, atol=1.0 / 255)
+
+  @parameterized.named_parameters(
+    ("box", "box", ".25 .2 .3"),
+    ("sphere", "sphere", ".25"),
+    ("ellipsoid", "ellipsoid", ".25 .2 .3"),
+    ("cylinder", "cylinder", ".25 .3"),
+    ("capsule", "capsule", ".25 .15"),
+  )
+  def test_per_world_sizes(self, geom_type, size):
+    mjm = self._scene(geom_type, size)
+    # Oblique orthographic rays exercise side projection and all three extents.
+    mjm.cam_projection[0] = mujoco.mjtProjection.mjPROJ_ORTHOGRAPHIC
+    mjm.cam_fovy[0] = 1.0
+    mjm.cam_pos[0] = [1, 0, 1]
+    mjm.cam_quat[0] = [np.cos(np.pi / 8), 0, np.sin(np.pi / 8), 0]
+    mjd = mujoco.MjData(mjm)
+    mujoco.mj_forward(mjm, mjd)
+    m = mjw.put_model(mjm, batch_sizes={"geom_size": 2, "cam_fovy": 2})
+    sizes = m.geom_size.numpy()
+    sizes[1] *= 0.5
+    m.geom_size.assign(sizes)
+    fovy = m.cam_fovy.numpy()
+    fovy[1] *= 0.5
+    m.cam_fovy.assign(fovy)
+    pixels = self._pixels(m, mjw.put_data(mjm, mjd, nworld=2), self._context(mjm, nworld=2))
+    self.assertTrue(np.any(pixels[0, ..., 0] - pixels[0, ..., 1] > 0.2))
+    self.assertTrue(np.any(pixels[0, ..., 1] - pixels[0, ..., 0] > 0.2))
+    # Scaling the object and view together preserves both silhouette and pattern.
+    np.testing.assert_allclose(pixels[0], pixels[1], atol=1.0 / 255)
+
+
 class RenderTest(parameterized.TestCase):
   def test_render_splat(self):
     xml = """

--- a/mujoco_warp/_src/render_util.py
+++ b/mujoco_warp/_src/render_util.py
@@ -61,7 +61,12 @@ def create_warp_texture(mjm: mujoco.MjModel, tex_id: int) -> wp.array:
   wp.launch(
     _convert_texture_data,
     dim=(tex_width, tex_height),
-    inputs=[tex_width, tex_adr, nchannel, wp.array(mjm.tex_data, dtype=wp.uint8)],
+    inputs=[
+      tex_width,
+      0,
+      nchannel,
+      wp.array(mjm.tex_data[tex_adr : tex_adr + tex_width * tex_height * nchannel], dtype=wp.uint8),
+    ],
     outputs=[tex_data],
   )
   return wp.Texture2D(tex_data, filter_mode=wp.TextureFilterMode.LINEAR)
@@ -509,13 +514,6 @@ def create_render_context(
       flex_bvh_id[f] = fmesh.id
       flex_group_root[:, f] = group_root.numpy()
 
-  textures_registry = []
-  # Only materialize GPU textures when the caller actually needs them.
-  if use_textures:
-    for i in range(mjm.ntex):
-      textures_registry.append(create_warp_texture(mjm, i))
-  textures = wp.array(textures_registry, dtype=wp.Texture2D)
-
   # Locate skybox texture
   skybox_tex_ids = np.nonzero(mjm.tex_type == mujoco.mjtTexture.mjTEXTURE_SKYBOX)[0] if mjm.ntex else np.array([], dtype=int)
   if render_skybox and skybox_tex_ids.size > 0:
@@ -605,6 +603,14 @@ def create_render_context(
     raise ValueError(f"render_depth length ({len(render_depth)}) does not match active camera count ({ncam}).")
   if len(render_seg) != ncam:
     raise ValueError(f"render_seg length ({len(render_seg)}) does not match active camera count ({ncam}).")
+
+  textures_registry = []
+  # Depth and segmentation do not sample textures. Resolve camera outputs and the
+  # skybox first; a skybox still needs images when surface textures are disabled.
+  if any(render_rgb) and (use_textures or render_skybox):
+    for i in range(mjm.ntex):
+      textures_registry.append(create_warp_texture(mjm, i))
+  textures = wp.array(textures_registry, dtype=wp.Texture2D)
 
   rgb_adr = -1 * np.ones(ncam, dtype=int)
   depth_adr = -1 * np.ones(ncam, dtype=int)

--- a/mujoco_warp/_src/render_util_test.py
+++ b/mujoco_warp/_src/render_util_test.py
@@ -14,11 +14,15 @@
 # ==============================================================================
 """Tests for render utility functions."""
 
+import io
+from unittest import mock
+
 import mujoco
 import numpy as np
 import warp as wp
 from absl.testing import absltest
 from absl.testing import parameterized
+from PIL import Image
 
 import mujoco_warp as mjw
 from mujoco_warp import test_data
@@ -48,6 +52,98 @@ _CAMERA_TEST_XML = """
 
 
 class RenderUtilTest(parameterized.TestCase):
+  @parameterized.parameters(1, 3, 4)
+  def test_texture_upload_slice(self, nchannel):
+    """Each upload contains only its image, with channels and row ordering preserved."""
+    pixels = np.arange(3 * 2 * nchannel, dtype=np.uint8).reshape(2, 3, nchannel)
+    image = Image.fromarray(pixels[..., 0] if nchannel == 1 else pixels)
+    png = io.BytesIO()
+    image.save(png, format="PNG")
+    mjm = mujoco.MjModel.from_xml_string(
+      f"""
+      <mujoco>
+        <asset>
+          <texture name="first" type="2d" builtin="flat" width="4" height="5"/>
+          <texture name="second" type="2d" file="second.png" nchannel="{nchannel}"/>
+        </asset>
+      </mujoco>
+    """,
+      assets={"second.png": png.getvalue()},
+    )
+    mjm.tex_data[:] = np.arange(mjm.tex_data.size, dtype=np.uint8)
+    tex_id = mjm.texture("second").id
+    adr = mjm.tex_adr[tex_id]
+    self.assertGreater(adr, 0)
+    with mock.patch.object(wp, "launch", wraps=wp.launch) as launch:
+      texture = render_util.create_warp_texture(mjm, tex_id)
+    self.assertNotEqual(texture.id, wp.uint64(0))
+    upload = launch.call_args.kwargs["inputs"][-1].numpy()
+    expected_bytes = mjm.tex_data[adr : adr + 3 * 2 * nchannel]
+    np.testing.assert_array_equal(upload, expected_bytes)
+    converted = launch.call_args.kwargs["outputs"][0].numpy()
+    expected = np.zeros((2, 3, 4))
+    expected[..., : min(nchannel, 3)] = expected_bytes.reshape(2, 3, nchannel)[..., :3] / 255.0
+    expected[..., 3] = 1.0
+    np.testing.assert_allclose(converted, expected, atol=1e-7)
+
+  @parameterized.named_parameters(
+    ("default_rgb", {}, True),
+    ("default_depth", {"cam_active": ["depth"]}, False),
+    ("default_seg", {"cam_active": ["seg"]}, False),
+    ("explicit_depth", {"render_rgb": False, "render_depth": True}, False),
+    ("explicit_seg", {"render_rgb": False, "render_seg": True}, False),
+    ("override_depth_default", {"cam_active": ["depth"], "render_rgb": True}, True),
+    ("filtered_rgb_list", {"cam_active": [False, True, False], "render_rgb": [True, False, False]}, False),
+    ("active_rgb_list", {"cam_active": [1], "render_rgb": [True]}, True),
+    ("empty_cameras", {"cam_active": [], "render_rgb": True}, False),
+    ("no_surface_textures", {"use_textures": False}, False),
+    ("skybox_only", {"use_textures": False, "render_skybox": True}, True),
+    ("depth_with_skybox", {"render_rgb": False, "render_depth": True, "render_skybox": True}, False),
+  )
+  def test_texture_upload_camera_outputs(self, options, upload):
+    """Only resolved RGB cameras need images, including skyboxes without surface textures."""
+    mjm, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <asset>
+          <texture name="surface" type="2d" builtin="checker" width="4" height="4"/>
+          <texture name="sky" type="skybox" builtin="flat" width="4" height="4" rgb1="1 0 0" rgb2="1 0 0"/>
+          <material name="mat" texture="surface"/>
+        </asset>
+        <worldbody>
+          <camera name="rgb" pos="0 0 1" resolution="8 8" output="rgb"/>
+          <camera name="depth" pos="0 0 1" resolution="8 8" output="depth"/>
+          <camera name="seg" pos="0 0 1" resolution="8 8" output="segmentation"/>
+          <geom type="sphere" size=".1" material="mat"/>
+        </worldbody>
+      </mujoco>
+    """
+    )
+    with mock.patch.object(render_util, "create_warp_texture", wraps=render_util.create_warp_texture) as create:
+      rc = mjw.create_render_context(mjm, **options)
+    self.assertEqual(create.call_count, mjm.ntex if upload else 0)
+    self.assertLen(rc.textures_registry, mjm.ntex if upload else 0)
+    self.assertEqual(rc.textures.shape, (mjm.ntex if upload else 0,))
+    # Exercise depth/seg kernels with an empty texture registry and RGB skybox sampling.
+    if rc.nrender:
+      mjw.render(m, d, rc)
+      if options.get("render_skybox") and options.get("use_textures") is False:
+        # The corner ray misses the sphere and sees the red skybox.
+        self.assertEqual(int(rc.rgb_data.numpy()[0, 0]) & 0xFFFFFF, 0xFF0000)
+
+  def test_missing_skybox_does_not_upload_images(self):
+    mjm = mujoco.MjModel.from_xml_string("""
+      <mujoco>
+        <asset><texture name="surface" type="2d" builtin="flat" width="4" height="4"/></asset>
+        <worldbody><camera resolution="8 8" output="rgb"/></worldbody>
+      </mujoco>
+    """)
+    with mock.patch.object(render_util, "create_warp_texture", wraps=render_util.create_warp_texture) as create:
+      rc = mjw.create_render_context(mjm, use_textures=False, render_skybox=True)
+    create.assert_not_called()
+    self.assertEmpty(rc.textures_registry)
+    self.assertFalse(rc.render_skybox)
+
   def test_create_warp_texture(self):
     """Tests that create_warp_texture creates a valid texture."""
     mjm, mjd, m, d = test_data.fixture("ray.xml")


### PR DESCRIPTION
Primitives and meshes without UVs currently sample a single texture coordinate, so checkerboard materials render as solid colors. Add object-local box projection for boxes, spheres, ellipsoids, cylinders, capsules, and meshes without valid UVs. The pattern follows object rotation and per-world dimensions, while plane mapping and valid mesh UV interpolation keep their existing behavior. Projection selects the dominant local normal axis and uses one texture lookup per surface hit; the tradeoff is seams at axis transitions and distortion on curved surfaces.

Texture conversion now uploads only the selected image's byte slice instead of the whole texture bank for each image. Render contexts resolve active cameras and their RGB outputs before uploading images, avoiding uploads for depth/segmentation-only contexts and RGB contexts with both surface textures and skyboxes disabled. An enabled skybox still gets its images when surface textures are disabled.

Regression tests cover spatial checker patterns and per-world texture swaps on all six geometry types, explicit mesh UV precedence, translated/rotated objects, local projection-axis selection, per-world primitive sizes, camera defaults and overrides, camera filtering, skybox-only rendering, and image-slice conversion for one-, three-, and four-channel PNGs. Material selection uses the existing `put_model(batch_sizes={"mat_texid": nworld})` API.

Validated on macOS with Warp 1.15.0 CPU and MuJoCo 3.12.1.dev974703000:

- `uv run pytest -n 8 --cpu mujoco_warp/_src/render_test.py mujoco_warp/_src/render_util_test.py -q`: 104 passed, 1 CUDA-only test skipped.
- `uv run pytest -n 8 --cpu --maxfail=8`: 1,389 passed, 34 skipped, 1 failure in the unchanged `IOTest.test_put_data_nefc_zero_dense` (`mjd.nefc` is 1 instead of 0). The same failure reproduces on unmodified upstream commit `917a14b`, where 1,357 tests passed and 34 were skipped.
- Pre-commit checks for the changed files passed, including Ruff, formatting, and kernel analysis.
