### PR TITLE
cylinder multiccd

### DIFF
--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -889,8 +889,8 @@ def ccd_kernel_builder(
 
     if wp.static(
       (use_multiccd or (geomtype1 == GeomType.BOX and geomtype2 == GeomType.BOX))
-      and (geomtype1 == GeomType.BOX or geomtype1 == GeomType.MESH)
-      and (geomtype2 == GeomType.BOX or geomtype2 == GeomType.MESH)
+      and (geomtype1 == GeomType.BOX or geomtype1 == GeomType.MESH or geomtype1 == GeomType.CYLINDER)
+      and (geomtype2 == GeomType.BOX or geomtype2 == GeomType.MESH or geomtype2 == GeomType.CYLINDER)
     ):
       if wp.static(geomtype1 == GeomType.MESH):
         # verify that geom1 mesh data is present for multicontact
@@ -1242,6 +1242,9 @@ def convex_narrowphase(m: Model, d: Data, ctx: CollisionContext, collision_table
     nboxbox = 0
   nboxmesh, _ = _pair_count(GeomType.BOX.value, GeomType.MESH.value)
   nmeshmesh, _ = _pair_count(GeomType.MESH.value, GeomType.MESH.value)
+  ncylcyl, _ = _pair_count(GeomType.CYLINDER.value, GeomType.CYLINDER.value)
+  ncylbox, _ = _pair_count(GeomType.CYLINDER.value, GeomType.BOX.value)
+  ncylmesh, _ = _pair_count(GeomType.CYLINDER.value, GeomType.MESH.value)
 
   epa_iterations = 16 if nboxbox == ncollision else m.opt.ccd_iterations
 
@@ -1252,8 +1255,11 @@ def convex_narrowphase(m: Model, d: Data, ctx: CollisionContext, collision_table
   npolygonmax = 4 if nboxbox > 0 else 0
   nmeshdegmax = 3 if nboxbox > 0 else 0
 
-  # need to allocate more memory if there's meshes
-  if use_multiccd and nmeshmesh + nboxmesh > 0:
+  # need to allocate more memory if there are cylinders or meshes
+  if use_multiccd and ncylcyl + ncylbox + ncylmesh > 0:
+    npolygonmax = max(m.npolygonmax, 16)
+    nmeshdegmax = max(m.nmeshdegmax, 3)
+  elif use_multiccd and nmeshmesh + nboxmesh > 0:
     minval = 4 if nboxmesh else npolygonmax
     npolygonmax = max(m.npolygonmax, minval)
     nmeshdegmax = max(m.nmeshdegmax, 3)

--- a/mujoco_warp/_src/collision_convex.py
+++ b/mujoco_warp/_src/collision_convex.py
@@ -1251,6 +1251,7 @@ def convex_narrowphase(m: Model, d: Data, ctx: CollisionContext, collision_table
   # set to true to enable multiccd
   use_multiccd = m.opt.disableflags & DisableBit.MULTICCD == 0
 
+  # note: box<->box multicontact is independent of the use_multiccd flag
   # need at least 4 (square sides) if there's a box collision needing multiccd
   npolygonmax = 4 if nboxbox > 0 else 0
   nmeshdegmax = 3 if nboxbox > 0 else 0

--- a/mujoco_warp/_src/collision_driver_test.py
+++ b/mujoco_warp/_src/collision_driver_test.py
@@ -1423,6 +1423,107 @@ class CollisionTest(parameterized.TestCase):
     self.assertAlmostEqual(dot, 1.0, places=4, msg=f"Frame normal misaligned for {type1}-{type2} at z={z2}")
     self.assertAlmostEqual(float(d.contact.dist.numpy()[0]), expected_dist, places=4)
 
+  @parameterized.named_parameters(
+    (
+      "cylinder_box_face_to_face",
+      "box",
+      "1 1 1",
+      "",
+      "cylinder",
+      "0.5 1",
+      1.99,
+      "",
+      4,
+      None,
+    ),
+    (
+      "cylinder_box_horizontal_issue_1555",
+      "box",
+      "1 1 1",
+      "",
+      "cylinder",
+      "0.5 1",
+      1.49,
+      ' euler="90 0 0"',
+      2,
+      (-1.0, 1.0),
+    ),
+    (
+      "cylinder_cylinder_face_to_face",
+      "cylinder",
+      "1 1",
+      "",
+      "cylinder",
+      "1 1",
+      1.99,
+      "",
+      4,
+      None,
+    ),
+    (
+      "cylinder_cylinder_side_to_side",
+      "cylinder",
+      "1 1",
+      ' euler="90 0 0"',
+      "cylinder",
+      "1 1",
+      1.99,
+      ' euler="90 0 0"',
+      1,
+      None,
+    ),
+  )
+  def test_cylinder_multiccd(
+    self,
+    geom1_type: str,
+    geom1_size: str,
+    geom1_euler: str,
+    geom2_type: str,
+    geom2_size: str,
+    z2: float,
+    geom2_euler: str,
+    expected_ncon: int,
+    expected_y_coords: tuple[float, float] | None,
+  ):
+    """Test cylinder MultiCCD contacts and fallback with MultiCCD disabled."""
+    _, _, m, d = test_data.fixture(
+      xml=f"""
+      <mujoco>
+        <worldbody>
+          <geom type="{geom1_type}" size="{geom1_size}" pos="0 0 0"{geom1_euler}/>
+          <body pos="0 0 {z2}">
+            <freejoint/>
+            <geom type="{geom2_type}" size="{geom2_size}"{geom2_euler}/>
+          </body>
+        </worldbody>
+      </mujoco>
+      """
+    )
+    d.nacon.fill_(-1)
+    d.contact.dist.fill_(wp.inf)
+    d.contact.pos.fill_(wp.inf)
+    d.contact.frame.fill_(wp.inf)
+    mjw.collision(m, d)
+    self.assertEqual(int(d.nacon.numpy()[0]), expected_ncon)
+    self.assertTrue(np.all(np.isfinite(d.contact.dist.numpy()[:expected_ncon])))
+
+    if expected_y_coords is not None:
+      pos = d.contact.pos.numpy()[:expected_ncon]
+      # Check that contact points are at the two ends of the horizontal cylinder axis
+      y_coords = sorted([float(p[1]) for p in pos])
+      self.assertAlmostEqual(y_coords[0], expected_y_coords[0], delta=0.05)
+      self.assertAlmostEqual(y_coords[1], expected_y_coords[1], delta=0.05)
+
+    # with MultiCCD disabled, should find 1 contact
+    m.opt.disableflags |= int(types.DisableBit.MULTICCD)
+    d.nacon.fill_(-1)
+    d.contact.dist.fill_(wp.inf)
+    d.contact.pos.fill_(wp.inf)
+    d.contact.frame.fill_(wp.inf)
+    mjw.collision(m, d)
+    self.assertEqual(int(d.nacon.numpy()[0]), 1)
+    self.assertTrue(np.isfinite(float(d.contact.dist.numpy()[0])))
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -56,6 +56,10 @@ _FACE_DELETED_BIT = wp.constant(wp.uint32(0x80000000))
 _FACE_INVALID_BIT = wp.constant(wp.uint32(0x40000000))
 _FACE_INVALID_OR_DELETED_MASK = wp.constant(wp.uint32(0xC0000000))
 
+# Precomputed circle coordinates for 16-gon cylinder face approximation
+_CYLINDER_COS_16 = wp.static(tuple(math.cos(i * math.pi / 8.0) for i in range(16)))
+_CYLINDER_SIN_16 = wp.static(tuple(math.sin(i * math.pi / 8.0) for i in range(16)))
+
 
 @wp.struct
 class GJKResult:
@@ -149,7 +153,8 @@ def support(geom: Geom, geomtype: int, dir: wp.vec3) -> SupportPoint:
       res[0] = local_dir[0] * scl
       res[1] = local_dir[1] * scl
     # set result in Z direction
-    res[2] = wp.sign(local_dir[2]) * geom.size[1]
+    res[2] = wp.where(local_dir[2] >= 0.0, geom.size[1], -geom.size[1])
+    sp.vertex_index = wp.where(local_dir[2] >= 0.0, 0, 1)
     sp.point = geom.rot @ res + geom.pos
   elif geomtype == GeomType.MESH:
     max_dist = float(FLOAT_MIN)
@@ -1943,6 +1948,81 @@ def _mesh_face(
   return nvert
 
 
+# try recovering the cylinder normal from vertex index
+@wp.func
+def _cylinder_normals(
+  # In:
+  feature_dim: int,
+  feature_index: wp.vec3i,
+  mat: wp.mat33,
+  # Out:
+  normal_out: wp.array[wp.vec3],
+  index_out: wp.array[int],
+) -> int:
+  if feature_dim == 1:
+    sgn = wp.where(feature_index[0] != 0, -1.0, 1.0)
+    normal_out[0] = mat[:, 2] * sgn
+    index_out[0] = feature_index[0]
+    return 1
+  return 0
+
+
+# recover edge of a cylinder from collision point
+@wp.func
+def _cylinder_edge_normals(
+  # In:
+  dim: int,
+  mat: wp.mat33,
+  size: wp.vec3,
+  v: wp.vec3,
+  v1i: int,
+  # Out:
+  normal_out: wp.array[wp.vec3],
+  endvert_out: wp.array[wp.vec3],
+) -> int:
+  if dim == 1 or dim == 2:
+    sgn = wp.where(v1i != 0, 1.0, -1.0)
+    res = mat[:, 2] * sgn
+    normal_out[0] = res
+    endvert_out[0] = v + res * (2.0 * size[1])
+    return 1
+  return 0
+
+
+# recover face of a cylinder (approximated as a 16-gon) from its index
+@wp.func
+def _cylinder_face(
+  # In:
+  mat: wp.mat33,
+  pos: wp.vec3,
+  size: wp.vec3,
+  idx: int,
+  # Out:
+  face_out: wp.array[wp.vec3],
+) -> int:
+  sgn = wp.where(idx != 0, -1.0, 1.0)
+  center = mat[:, 2] * (sgn * size[1]) + pos
+  col0 = mat[:, 0] * size[0]
+  col1 = mat[:, 1] * (size[0] * sgn)
+  face_out[0] = col0 * wp.static(_CYLINDER_COS_16[0]) - col1 * wp.static(_CYLINDER_SIN_16[0]) + center
+  face_out[1] = col0 * wp.static(_CYLINDER_COS_16[1]) - col1 * wp.static(_CYLINDER_SIN_16[1]) + center
+  face_out[2] = col0 * wp.static(_CYLINDER_COS_16[2]) - col1 * wp.static(_CYLINDER_SIN_16[2]) + center
+  face_out[3] = col0 * wp.static(_CYLINDER_COS_16[3]) - col1 * wp.static(_CYLINDER_SIN_16[3]) + center
+  face_out[4] = col0 * wp.static(_CYLINDER_COS_16[4]) - col1 * wp.static(_CYLINDER_SIN_16[4]) + center
+  face_out[5] = col0 * wp.static(_CYLINDER_COS_16[5]) - col1 * wp.static(_CYLINDER_SIN_16[5]) + center
+  face_out[6] = col0 * wp.static(_CYLINDER_COS_16[6]) - col1 * wp.static(_CYLINDER_SIN_16[6]) + center
+  face_out[7] = col0 * wp.static(_CYLINDER_COS_16[7]) - col1 * wp.static(_CYLINDER_SIN_16[7]) + center
+  face_out[8] = col0 * wp.static(_CYLINDER_COS_16[8]) - col1 * wp.static(_CYLINDER_SIN_16[8]) + center
+  face_out[9] = col0 * wp.static(_CYLINDER_COS_16[9]) - col1 * wp.static(_CYLINDER_SIN_16[9]) + center
+  face_out[10] = col0 * wp.static(_CYLINDER_COS_16[10]) - col1 * wp.static(_CYLINDER_SIN_16[10]) + center
+  face_out[11] = col0 * wp.static(_CYLINDER_COS_16[11]) - col1 * wp.static(_CYLINDER_SIN_16[11]) + center
+  face_out[12] = col0 * wp.static(_CYLINDER_COS_16[12]) - col1 * wp.static(_CYLINDER_SIN_16[12]) + center
+  face_out[13] = col0 * wp.static(_CYLINDER_COS_16[13]) - col1 * wp.static(_CYLINDER_SIN_16[13]) + center
+  face_out[14] = col0 * wp.static(_CYLINDER_COS_16[14]) - col1 * wp.static(_CYLINDER_SIN_16[14]) + center
+  face_out[15] = col0 * wp.static(_CYLINDER_COS_16[15]) - col1 * wp.static(_CYLINDER_SIN_16[15]) + center
+  return 16
+
+
 @wp.func
 def _plane_normal(v1: wp.vec3, v2: wp.vec3, n: wp.vec3) -> Tuple[float, wp.vec3]:
   v3 = v1 + n
@@ -2191,6 +2271,8 @@ def multicontact(
   dir_neg = -dir
 
   # get all possible face normals for each geom
+  nnorms1 = 0
+  nnorms2 = 0
   if geomtype1 == GeomType.BOX:
     nnorms1 = _box_normals(nface1, feature_index1, geom1.rot, dir_neg, n1, idx1)
   elif geomtype1 == GeomType.MESH:
@@ -2207,6 +2289,9 @@ def multicontact(
       n1,
       idx1,
     )
+  elif geomtype1 == GeomType.CYLINDER:
+    nnorms1 = _cylinder_normals(nface1, feature_index1, geom1.rot, n1, idx1)
+
   if geomtype2 == GeomType.BOX:
     nnorms2 = _box_normals(nface2, feature_index2, geom2.rot, dir, n2, idx2)
   elif geomtype2 == GeomType.MESH:
@@ -2223,6 +2308,8 @@ def multicontact(
       n2,
       idx2,
     )
+  elif geomtype2 == GeomType.CYLINDER:
+    nnorms2 = _cylinder_normals(nface2, feature_index2, geom2.rot, n2, idx2)
 
   # determine if any two face normals match
   is_edge_contact_geom1 = 0
@@ -2256,6 +2343,8 @@ def multicontact(
           n1,
           endvert,
         )
+      elif geomtype1 == GeomType.CYLINDER:
+        nnorms1 = _cylinder_edge_normals(nface1, geom1.rot, geom1.size, feature_vertex1[0], feature_index1[0], n1, endvert)
       nres, res = _aligned_face_edge(n1, nnorms1, n2, nnorms2, dir)
       if not nres:
         return 1, witness1, witness2, dists
@@ -2288,6 +2377,8 @@ def multicontact(
           n2,
           endvert,
         )
+      elif geomtype2 == GeomType.CYLINDER:
+        nnorms2 = _cylinder_edge_normals(nface2, geom2.rot, geom2.size, feature_vertex2[0], feature_index2[0], n2, endvert)
       nres, res = _aligned_face_edge(n2, nnorms2, n1, nnorms1, dir_neg)
       if not nres:
         return 1, witness1, witness2, dists
@@ -2319,6 +2410,8 @@ def multicontact(
         ind,
         face1,
       )
+    elif geomtype1 == GeomType.CYLINDER:
+      nface1 = _cylinder_face(geom1.rot, geom1.pos, geom1.size, ind, face1)
 
   # recover geom2 matching edge or face
   if is_edge_contact_geom2:
@@ -2339,6 +2432,8 @@ def multicontact(
         idx2[j],
         face2,
       )
+    elif geomtype2 == GeomType.CYLINDER:
+      nface2 = _cylinder_face(geom2.rot, geom2.pos, geom2.size, idx2[j], face2)
 
   # face1 is an edge; clip face1 against face2
   if is_edge_contact_geom1:
@@ -2575,8 +2670,10 @@ def epa_phase(
   if geom1.margin != 0.0 or geom2.margin != 0.0:
     idx = -1
 
-  # multicontact only supported for boxes and meshes
-  if (geomtype1 != GeomType.BOX and geomtype1 != GeomType.MESH) or (geomtype2 != GeomType.BOX and geomtype2 != GeomType.MESH):
+  # multicontact only supported for boxes, cylinders, and meshes
+  if (geomtype1 != GeomType.BOX and geomtype1 != GeomType.MESH and geomtype1 != GeomType.CYLINDER) or (
+    geomtype2 != GeomType.BOX and geomtype2 != GeomType.MESH and geomtype2 != GeomType.CYLINDER
+  ):
     idx = -1
 
   return dist, 1, x1, x2, idx

--- a/mujoco_warp/_src/collision_gjk.py
+++ b/mujoco_warp/_src/collision_gjk.py
@@ -2004,22 +2004,8 @@ def _cylinder_face(
   center = mat[:, 2] * (sgn * size[1]) + pos
   col0 = mat[:, 0] * size[0]
   col1 = mat[:, 1] * (size[0] * sgn)
-  face_out[0] = col0 * wp.static(_CYLINDER_COS_16[0]) - col1 * wp.static(_CYLINDER_SIN_16[0]) + center
-  face_out[1] = col0 * wp.static(_CYLINDER_COS_16[1]) - col1 * wp.static(_CYLINDER_SIN_16[1]) + center
-  face_out[2] = col0 * wp.static(_CYLINDER_COS_16[2]) - col1 * wp.static(_CYLINDER_SIN_16[2]) + center
-  face_out[3] = col0 * wp.static(_CYLINDER_COS_16[3]) - col1 * wp.static(_CYLINDER_SIN_16[3]) + center
-  face_out[4] = col0 * wp.static(_CYLINDER_COS_16[4]) - col1 * wp.static(_CYLINDER_SIN_16[4]) + center
-  face_out[5] = col0 * wp.static(_CYLINDER_COS_16[5]) - col1 * wp.static(_CYLINDER_SIN_16[5]) + center
-  face_out[6] = col0 * wp.static(_CYLINDER_COS_16[6]) - col1 * wp.static(_CYLINDER_SIN_16[6]) + center
-  face_out[7] = col0 * wp.static(_CYLINDER_COS_16[7]) - col1 * wp.static(_CYLINDER_SIN_16[7]) + center
-  face_out[8] = col0 * wp.static(_CYLINDER_COS_16[8]) - col1 * wp.static(_CYLINDER_SIN_16[8]) + center
-  face_out[9] = col0 * wp.static(_CYLINDER_COS_16[9]) - col1 * wp.static(_CYLINDER_SIN_16[9]) + center
-  face_out[10] = col0 * wp.static(_CYLINDER_COS_16[10]) - col1 * wp.static(_CYLINDER_SIN_16[10]) + center
-  face_out[11] = col0 * wp.static(_CYLINDER_COS_16[11]) - col1 * wp.static(_CYLINDER_SIN_16[11]) + center
-  face_out[12] = col0 * wp.static(_CYLINDER_COS_16[12]) - col1 * wp.static(_CYLINDER_SIN_16[12]) + center
-  face_out[13] = col0 * wp.static(_CYLINDER_COS_16[13]) - col1 * wp.static(_CYLINDER_SIN_16[13]) + center
-  face_out[14] = col0 * wp.static(_CYLINDER_COS_16[14]) - col1 * wp.static(_CYLINDER_SIN_16[14]) + center
-  face_out[15] = col0 * wp.static(_CYLINDER_COS_16[15]) - col1 * wp.static(_CYLINDER_SIN_16[15]) + center
+  for i in range(wp.static(16)):
+    face_out[i] = col0 * wp.static(_CYLINDER_COS_16[i]) - col1 * wp.static(_CYLINDER_SIN_16[i]) + center
   return 16
 
 

--- a/mujoco_warp/_src/collision_gjk_test.py
+++ b/mujoco_warp/_src/collision_gjk_test.py
@@ -48,7 +48,8 @@ def _geom_dist(
   overflow_out: wp.array | None = None,
 ):
   # we run multiccd on static scenes so these need to be initialized
-  npolygonmax = 10 if multiccd else 0
+  has_cylinder = GeomType.CYLINDER in (m.geom_type.numpy()[gid1], m.geom_type.numpy()[gid2])
+  npolygonmax = (16 if has_cylinder else 10) if multiccd else 0
   nmeshdegmax = 10 if multiccd else 0
   epa_vert = wp.empty(10 + 2 * m.opt.ccd_iterations, dtype=wp.vec3)
   epa_vert_index = wp.empty(10 + 2 * m.opt.ccd_iterations, dtype=int)
@@ -524,6 +525,25 @@ class GJKTest(parameterized.TestCase):
     )
     _, ncon, _, _ = _geom_dist(m, d, 0, 1, multiccd=True)
     self.assertEqual(ncon, 4)
+
+  @parameterized.named_parameters(
+    ("vertical", 1.9, "", 4),
+    ("horizontal", 1.4, ' euler="90 0 0"', 2),
+  )
+  def test_cylinder_box_ccd(self, pos_z: float, euler: str, expected_ncon: int):
+    """Test cylinder-box multiccd."""
+    _, _, m, d = test_data.fixture(
+      xml=f"""
+       <mujoco>
+         <worldbody>
+           <geom name="geom1" type="box" pos="0 0 0" size="10 10 1"/>
+           <geom name="geom2" type="cylinder" pos="0 0 {pos_z}"{euler} size="0.5 1"/>
+         </worldbody>
+       </mujoco>
+       """
+    )
+    _, ncon, _, _ = _geom_dist(m, d, 0, 1, multiccd=True)
+    self.assertEqual(ncon, expected_ncon)
 
   def test_mesh_mesh_ccd(self):
     """Test mesh-mesh multiccd."""

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -631,6 +631,9 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
           (types.GeomType.BOX, types.GeomType.BOX),
           (types.GeomType.BOX, types.GeomType.MESH),
           (types.GeomType.MESH, types.GeomType.MESH),
+          (types.GeomType.CYLINDER, types.GeomType.CYLINDER),
+          (types.GeomType.CYLINDER, types.GeomType.BOX),
+          (types.GeomType.CYLINDER, types.GeomType.MESH),
         ):
           if m.geom_pair_type_count[geom_trid_index(int(g1), int(g2))] > 0:
             unsupported_multiccd_pairs.append((g1.name, g2.name))

--- a/mujoco_warp/_src/io_test.py
+++ b/mujoco_warp/_src/io_test.py
@@ -2663,9 +2663,6 @@ class IOTest(parameterized.TestCase):
 
   # TODO(team): remove after implementing multicontact support for CCD pairs.
   @parameterized.parameters(
-    ("cylinder", "box"),
-    ("cylinder", "cylinder"),
-    ("cylinder", "mesh"),
     ("capsule", "cylinder"),
     ("capsule", "mesh"),
   )
@@ -2706,6 +2703,49 @@ class IOTest(parameterized.TestCase):
       mjwarp.put_model(mjm)
 
     mjm.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_MULTICCD
+    with warnings.catch_warnings():
+      warnings.simplefilter("error")
+      mjwarp.put_model(mjm)
+
+  @parameterized.parameters(
+    ("cylinder", "box"),
+    ("cylinder", "cylinder"),
+    ("cylinder", "mesh"),
+  )
+  def test_supported_cylinder_multiccd_no_warning(self, geom1_type, geom2_type):
+    """Tests that supported cylinder MultiCCD pairs emit no warning."""
+
+    def _make_geom_xml(gtype: str) -> str:
+      if gtype == "mesh":
+        return '<geom type="mesh" mesh="m"/>'
+      elif gtype in ("cylinder", "capsule"):
+        return f'<geom type="{gtype}" size=".1 .1"/>'
+      elif gtype == "sphere":
+        return '<geom type="sphere" size=".1"/>'
+      else:
+        return f'<geom type="{gtype}" size=".1 .1 .1"/>'
+
+    mesh_asset = '<mesh name="m" vertex="0 0 0 1 0 0 0 1 0 0 0 1"/>' if "mesh" in (geom1_type, geom2_type) else ""
+    mjm = mujoco.MjModel.from_xml_string(
+      f"""
+      <mujoco>
+        <asset>
+          {mesh_asset}
+        </asset>
+        <worldbody>
+          <body>
+            <freejoint/>
+            {_make_geom_xml(geom1_type)}
+          </body>
+          <body pos="0 0 .5">
+            <freejoint/>
+            {_make_geom_xml(geom2_type)}
+          </body>
+        </worldbody>
+      </mujoco>
+      """
+    )
+
     with warnings.catch_warnings():
       warnings.simplefilter("error")
       mjwarp.put_model(mjm)


### PR DESCRIPTION
This PR ports cylinder MultiCCD (multi-contact CCD) support from MuJoCo commit [c9d9976](https://github.com/google-deepmind/mujoco/commit/c9d9976101da9f1ab8bd5d93bba0fa63f942f358). This resolves #1555, where horizontal cylinders resting on flat surfaces generated a single alternating contact that rocked back and forth instead of establishing a stable 2-point line support manifold.

Changes introduced:
- Precomputed 16-gon circle coordinates (`_CYLINDER_COS_16` and `_CYLINDER_SIN_16`) via `wp.static` with trigonometric functions in `collision_gjk.py`.
- Updated cylinder `support` in `collision_gjk.py` to record `vertex_index` for cap identification.
- Added `_cylinder_normals`, `_cylinder_edge_normals`, and `_cylinder_face` routines in `collision_gjk.py` using matrix column slicing and direct scaling to recover cap normals, axis line segments, and reconstructed 16-gon cap polygons.
- Integrated cylinder cap normal detection, edge-face feature alignment, and polygonal clipping into `multicontact`, and enabled cylinder handling in `epa_phase`.
- Enabled cylinder collision pairs in `ccd_kernel_builder` in `collision_convex.py`. In `convex_narrowphase`, buffer allocations are expanded to `npolygonmax = max(m.npolygonmax, 16)` and `nmeshdegmax = max(m.nmeshdegmax, 3)` conditionally when cylinder MultiCCD pairs are present, preserving lean buffer sizes for existing box/mesh scenes.
- Updated `io.py` to whitelist supported cylinder MultiCCD pairs (`CYLINDER-CYLINDER`, `CYLINDER-BOX`, and `CYLINDER-MESH`) so they no longer trigger unsupported warnings.
- Added parameterized tests in `collision_driver_test.py` covering face-to-face, horizontal cylinder-on-box (verifying the 2 stable contacts for #1555), cylinder-cylinder collisions, and the single-contact fallback when MultiCCD is disabled.
- Added parameterized unit tests in `collision_gjk_test.py` for vertical and horizontal cylinder-box configurations, and added validation in `io_test.py` to ensure supported cylinder pairs emit no warnings.
