### PR TITLE
elliptic cone hessian update

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -2452,8 +2452,8 @@ def _update_gradient_JTDAJ_dense_tiled(nv_pad: int, tile_size: int, njmax: int, 
 def _elliptic_hessian_entry_from_projections(
   # In:
   dm: float,
-  mu_over_t: float,
-  mu_n_over_ttt: float,
+  mu: float,
+  mu_n_over_t: float,
   tangent_diag: float,
   z01: float,
   z02: float,
@@ -2464,8 +2464,8 @@ def _elliptic_hessian_entry_from_projections(
   # Contract the diagonal-plus-rank-one curvature without materializing the cone Hessian.
   return dm * (
     z01 * z02
-    - mu_over_t * (z01 * projection2 + z02 * projection1)
-    + mu_n_over_ttt * projection1 * projection2
+    - mu * (z01 * projection2 + z02 * projection1)
+    + mu_n_over_t * projection1 * projection2
     + tangent_diag * tangent_dot
   )
 
@@ -2555,17 +2555,17 @@ def _update_gradient_JTCJ_dense(
         tangent_dot += z1 * z2
 
     t = wp.max(wp.sqrt(tt), types.MJ_MINVAL)
-    ttt = wp.max(t * t * t, types.MJ_MINVAL)
-    mu_tinv = math.safe_div(mu, t)
+    inv_t = math.safe_div(1.0, t)
+    mu_n_over_t = mu * n * inv_t
     h = _elliptic_hessian_entry_from_projections(
       dm,
-      mu_tinv,
-      mu * math.safe_div(n, ttt),
-      mu2 - n * mu_tinv,
+      mu,
+      mu_n_over_t,
+      mu2 - mu_n_over_t,
       z01,
       z02,
-      projection1,
-      projection2,
+      projection1 * inv_t,
+      projection2 * inv_t,
       tangent_dot,
     )
 
@@ -2845,15 +2845,17 @@ def _JTDACJ_sparse(compact: bool, cone_type: types.ConeType, max_condim: int):
           tt += u * u
 
       t = wp.max(wp.sqrt(tt), types.MJ_MINVAL)
-      ttt = wp.max(t * t * t, types.MJ_MINVAL)
-      mu_over_t = math.safe_div(mu, t)
-      mu_n_over_ttt = mu * math.safe_div(n, ttt)
-      tangent_diag = mu2 - n * mu_over_t
+      inv_t = math.safe_div(1.0, t)
+      for dim in range(1, wp.static(condim)):
+        terms[dim] = terms[dim] * inv_t
 
-      # Layout: tangent u[1:6], scales[6:12], dm, mu/t, mu*n/t^3, tangent diagonal.
+      mu_n_over_t = mu * n * inv_t
+      tangent_diag = mu2 - mu_n_over_t
+
+      # Layout: normalized tangent u/t[1:6], scales[6:12], dm, mu, mu*n/t, tangent diagonal.
       terms[12] = dm
-      terms[13] = mu_over_t
-      terms[14] = mu_n_over_ttt
+      terms[13] = mu
+      terms[14] = mu_n_over_t
       terms[15] = tangent_diag
       return terms
 

--- a/mujoco_warp/_src/solver_test.py
+++ b/mujoco_warp/_src/solver_test.py
@@ -85,18 +85,19 @@ def _elliptic_dense_hessian_reference(m, d, ctx):
       jac[dim] = efc_J[worldid, efcid, : m.nv]
 
     t = max(np.linalg.norm(u[1:]), types.MJ_MINVAL)
-    ttt = max(t * t * t, types.MJ_MINVAL)
+    inv_t = 1.0 / t
+    mu_n_over_t = mu * u[0] * inv_t
     cone = np.zeros((condim, condim))
     for dim1 in range(condim):
       for dim2 in range(dim1 + 1):
         if dim1 == 0 and dim2 == 0:
           value = 1.0
         elif dim2 == 0:
-          value = -mu / t * u[dim1]
+          value = -mu * (u[dim1] * inv_t)
         else:
-          value = mu * u[0] / ttt * u[dim1] * u[dim2]
+          value = mu_n_over_t * (u[dim1] * inv_t) * (u[dim2] * inv_t)
           if dim1 == dim2:
-            value += mu2 - mu * u[0] / t
+            value += mu2 - mu_n_over_t
         value *= dm * scale[dim1] * scale[dim2]
         cone[dim1, dim2] = value
         cone[dim2, dim1] = value
@@ -153,18 +154,19 @@ def _elliptic_sparse_hessian_reference(m, d, ctx):
       jac[dim, cols] = efc_J[worldid, 0, rowadr : rowadr + rownnz]
 
     t = max(np.linalg.norm(u[1:]), types.MJ_MINVAL)
-    ttt = max(t * t * t, types.MJ_MINVAL)
+    inv_t = 1.0 / t
+    mu_n_over_t = mu * u[0] * inv_t
     cone = np.zeros((condim, condim))
     for dim1 in range(condim):
       for dim2 in range(dim1 + 1):
         if dim1 == 0 and dim2 == 0:
           value = 1.0
         elif dim2 == 0:
-          value = -mu / t * u[dim1]
+          value = -mu * (u[dim1] * inv_t)
         else:
-          value = mu * u[0] / ttt * u[dim1] * u[dim2]
+          value = mu_n_over_t * (u[dim1] * inv_t) * (u[dim2] * inv_t)
           if dim1 == dim2:
-            value += mu2 - mu * u[0] / t
+            value += mu2 - mu_n_over_t
         value *= dm * scale[dim1] * scale[dim2]
         cone[dim1, dim2] = value
         cone[dim2, dim1] = value
@@ -878,6 +880,35 @@ class SolverTest(parameterized.TestCase):
       rtol=1e-5,
       atol=1e-6,
     )
+
+  @parameterized.parameters("dense", "sparse")
+  def test_elliptic_hessian_scale_invariance(self, jacobian):
+    """Cone curvature is degree-0 homogeneous: scaling Jaref leaves Hessian unchanged."""
+    mjm, mjd, m, _ = test_data.fixture(
+      xml=f"""
+      <mujoco>
+        <option cone="elliptic" solver="Newton" jacobian="{jacobian}"/>
+        <worldbody>
+          <geom type="plane" size="1 1 .1" friction="1 0.01 0.001"/>
+          <body pos="0 0 0.02"><freejoint/><geom type="box" size="0.04 0.05 0.03" mass="0.5"/></body>
+        </worldbody>
+      </mujoco>
+      """
+    )
+    mjd.qvel[0] = 1.5
+    mujoco.mj_forward(mjm, mjd)
+
+    d = mjw.put_data(mjm, mjd)
+    ctx = solver._create_solver_context(m, d)
+    solver.init_context(m, d, ctx, grad=True)
+    jaref = ctx.Jaref.numpy().copy()
+
+    def _get_h(scale):
+      ctx.Jaref = wp.array(jaref * scale, dtype=float, device=ctx.Jaref.device)
+      solver._update_gradient(m, d, ctx)
+      return ctx.h.numpy()[:, : m.nv, : m.nv].copy()
+
+    np.testing.assert_allclose(_get_h(1e-8), _get_h(1.0), rtol=1e-5, atol=1e-6)
 
   @parameterized.parameters(
     (ConeType.PYRAMIDAL, SolverType.CG, 25, 5),


### PR DESCRIPTION
### Fix indefinite elliptic cone Hessians near the apex by removing inconsistent $t^3$ clamp

Fixes #1657

note: the current implementation seems to be based on the mjx implementation: https://github.com/google-deepmind/mujoco/blob/51d4338a229364269820a127468f4b5e13d3bf8f/mjx/mujoco/mjx/_src/solver.py#L343

---

### Context & Problem

In `mujoco_warp/_src/solver.py`, elliptic cone curvature was assembled with an independent clamp on $t^3$:
```python
t = wp.max(wp.sqrt(tt), types.MJ_MINVAL)
ttt = wp.max(t * t * t, types.MJ_MINVAL)
```

In the middle cone zone (where $-t/\mu < n < \mu t$ with $t = \|u\|_2 > 0$), the local curvature of the cone cost contains:
- Normal block: $1$
- Normal-tangent coupling: $-\mu \frac{u}{t}$
- Tangent block: $\left(\mu^2 - \frac{\mu n}{t}\right) I + \frac{\mu n}{t^3} u u^T$

Because `MJ_MINVAL` is $10^{-15}$, whenever `MJ_MINVAL` $< t < \sqrt[3]{\text{MJMINVAL}} \approx 10^{-5}$, $t^3$ is smaller than $10^{-15}$ and was clamped to $10^{-15}$, while $t$ and $n$ remained unclamped. This suppressed the positive rank-one term $\frac{\mu n}{t^3} u u^T$ by up to $10^9\times$.

As a result:
1. **Loss of degree-0 homogeneity**: The cone Hessian is degree-0 homogeneous in the constraint residual; the cubic clamp broke this scale invariance.
2. **Loss of positive semidefiniteness**: The Schur complement along $u$ became negative ($-\mu n / t < 0$ when $n > 0$), making the Hessian indefinite.
3. **Solver failure**: The indefinite Hessian caused Cholesky factorization in the Newton solver to fail and produce NaNs for near-stationary contacts.

---

### Solution

Eliminate $t^3$ entirely by writing the rank-one contraction in terms of unit-normalized projections $\hat{p} = \frac{u^T z}{t}$:

$$
\frac{\mu n}{t^3} (u^T z_1)(u^T z_2) = \left(\frac{\mu n}{t}\right) \left(\frac{u^T z_1}{t}\right) \left(\frac{u^T z_2}{t}\right) = \left(\frac{\mu n}{t}\right) \hat{p}_1 \hat{p}_2
$$

With $t \ge \text{MJMINVAL}$, we precompute `inv_t = math.safe_div(1.0, t)` and `mu_n_over_t = mu * n * inv_t`. The contracted Hessian entry evaluates:

```python
dm * (
    z01 * z02
    - mu * (z01 * p2 + z02 * p1)
    + mu_n_over_t * p1 * p2
    + (mu**2 - mu_n_over_t) * tangent_dot
)
```

This matches MuJoCo C's analytical cone curvature identically while avoiding cubic denominators.

#### Key Changes
- **`_elliptic_hessian_entry_from_projections`**: Updated signature to accept `mu`, `mu_n_over_t`, and normalized projections `p1, p2`.
- **`_update_gradient_JTCJ_dense`**: Precomputes `inv_t` and `mu_n_over_t = mu * n * inv_t`, scaling tangent projections by `inv_t`.
- **`_JTDACJ_sparse` (`make_curvature_terms`)**: Scales tangent terms by `inv_t` so stored rows are unit-normalized directions $u / t$.
- **Test references**: Updated `_elliptic_dense_hessian_reference` and `_elliptic_sparse_hessian_reference` to remove `ttt`.
- **New test**: Added `test_elliptic_hessian_scale_invariance` to verify that scaling `ctx.Jaref` leaves the Hessian unchanged for both dense and sparse Jacobians.