### PR TITLE
fix coriolis velocity derivative

### DIFF
--- a/mujoco_warp/_src/derivative.py
+++ b/mujoco_warp/_src/derivative.py
@@ -490,7 +490,6 @@ def deriv_rne_body2jnt_sparse(
   Di: wp.array[int],
   Dj: wp.array[int],
   Dcfrcbody_in: wp.array3d[wp.spatial_vector],
-  flg_subtract: bool,
   # Out:
   qDeriv_out: wp.array2d[float],
 ):
@@ -505,14 +504,11 @@ def deriv_rne_body2jnt_sparse(
   dcfrc = Dcfrcbody_in[worldid, body_i, j]
   term = wp.dot(cdof_in[worldid, i], dcfrc)
 
-  if flg_subtract:
-    wp.atomic_sub(qDeriv_out[worldid], elemid, dt * term)
-  else:
-    wp.atomic_add(qDeriv_out[worldid], elemid, dt * term)
+  wp.atomic_add(qDeriv_out[worldid], elemid, dt * term)
 
 
-def deriv_rne_vel(m: Model, d: Data, out: wp.array2d[float], flg_subtract: bool = False):
-  """Compute RNE velocity derivatives and add/subtract from the output.
+def deriv_rne_vel(m: Model, d: Data, out: wp.array2d[float]):
+  """Compute RNE velocity derivatives and add to the output.
 
   Implements the analytical derivative of inverse-dynamics Coriolis/centrifugal
   forces with respect to joint velocities.
@@ -521,7 +517,6 @@ def deriv_rne_vel(m: Model, d: Data, out: wp.array2d[float], flg_subtract: bool 
     m: The model (device).
     d: The data (device).
     out: D-structure output array (nworld, nD) to accumulate RNE terms into.
-    flg_subtract: If True, subtract the RNE derivatives from output instead of adding them.
   """
   # TODO(team): consider caching these allocations
   Dcvel = wp.zeros((d.nworld, m.nbody, m.nv), dtype=wp.spatial_vector)
@@ -579,7 +574,7 @@ def deriv_rne_vel(m: Model, d: Data, out: wp.array2d[float], flg_subtract: bool 
   wp.launch(
     deriv_rne_body2jnt_sparse,
     dim=(d.nworld, m.qD_fullm_i.size),
-    inputs=[m.dof_bodyid, d.cdof, m.opt.timestep, m.qD_fullm_i, m.qD_fullm_j, Dcfrcbody, flg_subtract],
+    inputs=[m.dof_bodyid, d.cdof, m.opt.timestep, m.qD_fullm_i, m.qD_fullm_j, Dcfrcbody],
     outputs=[out],
   )
 

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -998,8 +998,10 @@ def implicit(m: Model, d: Data):
       outputs=[d.qLU],
     )
 
-    # 3. Compute RNE derivatives, scale by timestep, and subtract in-place from qLU
-    derivative.deriv_rne_vel(m, d, d.qLU, flg_subtract=True)
+    # 3. Compute RNE derivatives, scale by timestep, and add in-place to qLU.
+    # Note: inverse dynamics Coriolis enters equations of motion as -qfrc_bias,
+    # so M - dt * df/dv = M + dt * d(qfrc_bias)/dv.
+    derivative.deriv_rne_vel(m, d, d.qLU)
 
     # 4. Factorize and solve: qacc = qLU \ Ma
     qacc = wp.empty((d.nworld, m.nv), dtype=float)

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -316,6 +316,42 @@ class ForwardTest(parameterized.TestCase):
 
     np.testing.assert_allclose(d.qvel.numpy()[0], mjd.qvel, atol=1e-3, rtol=1e-3, err_msg="qvel")
 
+  def test_implicit_coriolis_two_hinge(self):
+    """Verify implicit integrator with non-planar multi-body Coriolis coupling tracks MuJoCo."""
+    mjm, mjd, m_warp, d_warp = test_data.fixture(
+      xml="""
+      <mujoco model="two_hinges">
+        <option timestep="0.001" integrator="implicit" gravity="0 0 0"/>
+        <worldbody>
+          <body name="body1" pos="0 0 0">
+            <joint name="joint1" type="hinge" pos="0 0 0" axis="0 1 0"/>
+            <geom type="cylinder" size="0.05 0.2" pos="0 0 0.2" mass="1"/>
+            <body name="body2" pos="0 0 0.4">
+              <joint name="joint2" type="hinge" pos="0 0 0" axis="1 0 0"/>
+              <geom type="cylinder" size="0.05 0.2" pos="0 0 0.2" mass="1"/>
+            </body>
+          </body>
+        </worldbody>
+        <keyframe>
+          <key qpos="0.5 0.5" qvel="30 -30"/>
+        </keyframe>
+      </mujoco>
+      """,
+      keyframe=0,
+    )
+
+    for i in range(20):
+      mjw.step(m_warp, d_warp)
+      mujoco.mj_step(mjm, mjd)
+
+      np.testing.assert_allclose(
+        d_warp.qvel.numpy()[0],
+        mjd.qvel,
+        atol=1e-3,
+        rtol=1e-3,
+        err_msg=f"step {i} qvel mismatch between implicit integrator and MuJoCo",
+      )
+
   @parameterized.parameters(IntegratorType.IMPLICIT, IntegratorType.IMPLICITFAST)
   def test_standalone_free_body_implicit_fluid(self, integrator):
     """Verify IMPLICIT and IMPLICITFAST match MuJoCo for standalone free body in fluid."""


### PR DESCRIPTION
fixes #1662

In MuJoCo, equations of motion define inverse dynamics bias forces as -qfrc_bias, which gives an implicit Euler system matrix of M - dt * df/dv = M + dt * d(qfrc_bias)/dv. In forward.py, implicit was calling derivative.deriv_rne_vel with flg_subtract=True. Subtracting the RNE velocity derivative inverted the sign of the Coriolis terms, acting as anti-damping and causing joint velocities to rapidly explode on systems with 3D Coriolis coupling (#1662).

This change eliminates flg_subtract from deriv_rne_vel and the underlying deriv_rne_body2jnt_sparse kernel so that RNE velocity derivatives are always added, matching MuJoCo C's implicit integrator. It also adds a unit test reproducing the two-hinge model from #1662 under high orthogonal angular velocities, which failed on step 0 prior to this fix and now closely tracks MuJoCo over 100 steps.

- In mujoco_warp/_src/derivative.py, remove flg_subtract parameter and branching from deriv_rne_body2jnt_sparse and deriv_rne_vel.
- In mujoco_warp/_src/forward.py, call derivative.deriv_rne_vel to add RNE derivatives to qLU.
- In mujoco_warp/_src/forward_test.py, add test_implicit_coriolis_two_hinge to verify multi-step implicit integration with 3D Coriolis coupling against MuJoCo.