### PR TITLE
fix thermal dc motor velocity derivatives

### DIFF
--- a/mujoco_warp/_src/derivative.py
+++ b/mujoco_warp/_src/derivative.py
@@ -64,35 +64,48 @@ def _qderiv_actuator_passive_vel(
 
   actuator_gainprm_id = worldid % actuator_gainprm.shape[0]
   actuator_biasprm_id = worldid % actuator_biasprm.shape[0]
+  actuator_dynprm_id = worldid % actuator_dynprm.shape[0]
+  opt_timestep_id = worldid % opt_timestep.shape[0]
 
   bias = float(0.0)
+  R_dcmotor = float(0.0)
+  K_dcmotor = float(0.0)
+  te_dcmotor = float(0.0)
 
   if actuator_gaintype[actid] == GainType.AFFINE:
     gain = actuator_gainprm[actuator_gainprm_id, actid][2]
   elif actuator_gaintype[actid] == GainType.DCMOTOR:
     gain = 0.0
-    dynprm = actuator_dynprm[worldid % actuator_dynprm.shape[0], actid]
+    dynprm = actuator_dynprm[actuator_dynprm_id, actid]
     gainprm = actuator_gainprm[actuator_gainprm_id, actid]
     te = dynprm[0]
+    K = gainprm[1]
+    R0 = wp.max(MJ_MINVAL, gainprm[0])
 
-    # controller velocity derivative: dV/dω
+    # controller velocity derivative dV/dω using nameplate resistance
     dVdw = 0.0
     if (actuator_ctrlspec[actid] & 7) != 0:
-      R = wp.max(MJ_MINVAL, gainprm[0])
-      K = gainprm[1]
-      dVdw = -gainprm[6] * R / K + K
+      dVdw = -gainprm[6] * R0 / K + K
+
+    # winding resistance at current temperature
+    R = R0
+    if dynprm[2] > 0.0:
+      slots = util_misc.dcmotor_slots(dynprm, gainprm)
+      if slots[2] >= 0:
+        adr = actuator_actadr[actid] + slots[2]
+        T = act_in[worldid, adr]
+        alpha = gainprm[2]
+        T0 = gainprm[3]
+        Ta = dynprm[4]
+        R = wp.max(MJ_MINVAL, gainprm[0] * (1.0 + alpha * (T + Ta - T0)))
 
     if te > 0.0:
       # stateful current with actearly: d(K*next_act)/dω
       # includes both back-EMF (-K) and controller (dVdw) through act_dot
-      R = wp.max(MJ_MINVAL, gainprm[0])
-      K = gainprm[1]
-      s = 1.0 - wp.exp(-opt_timestep[worldid % opt_timestep.shape[0]] / te)
+      s = 1.0 - wp.exp(-opt_timestep[opt_timestep_id] / te)
       bias += K * (dVdw - K) * s / R
     elif dVdw != 0.0:
       # stateless: controller terms only (back-EMF handled in bias block)
-      R = wp.max(MJ_MINVAL, gainprm[0])
-      K = gainprm[1]
       bias += K * dVdw / R
 
     # LuGre: force includes -sigma1*z_dot, z_dot = a*z + v
@@ -100,31 +113,36 @@ def _qderiv_actuator_passive_vel(
     sigma1 = dynprm[6]
     if sigma1 > 0.0:
       bias -= sigma1
+
+    R_dcmotor = R
+    K_dcmotor = K
+    te_dcmotor = te
   else:
     gain = 0.0
 
   if actuator_biastype[actid] == BiasType.AFFINE:
     bias += actuator_biasprm[actuator_biasprm_id, actid][2]
   elif actuator_biastype[actid] == BiasType.DCMOTOR:
-    dynprm = actuator_dynprm[worldid % actuator_dynprm.shape[0], actid]
-    te = dynprm[0]
-    if te <= 0.0:
-      gainprm = actuator_gainprm[actuator_gainprm_id, actid]
-      R = gainprm[0]
-      K = gainprm[1]
-
-      slots = util_misc.dcmotor_slots(dynprm, gainprm)
-      slot_Ta = slots[2]
-
-      if slot_Ta >= 0:
-        adr = actuator_actadr[actid] + slot_Ta
-        T = act_in[worldid, adr]
-        alpha = gainprm[2]
-        T0 = gainprm[3]
-        Ta = dynprm[4]
-        R *= 1.0 + alpha * (T + Ta - T0)
-
-      bias += -K * K / wp.max(MJ_MINVAL, R)
+    if R_dcmotor > 0.0:
+      if te_dcmotor <= 0.0:
+        bias += -K_dcmotor * K_dcmotor / R_dcmotor
+    else:
+      dynprm = actuator_dynprm[actuator_dynprm_id, actid]
+      te = dynprm[0]
+      if te <= 0.0:
+        gainprm = actuator_gainprm[actuator_gainprm_id, actid]
+        K = gainprm[1]
+        R = wp.max(MJ_MINVAL, gainprm[0])
+        if dynprm[2] > 0.0:
+          slots = util_misc.dcmotor_slots(dynprm, gainprm)
+          if slots[2] >= 0:
+            adr = actuator_actadr[actid] + slots[2]
+            T = act_in[worldid, adr]
+            alpha = gainprm[2]
+            T0 = gainprm[3]
+            Ta = dynprm[4]
+            R = wp.max(MJ_MINVAL, gainprm[0] * (1.0 + alpha * (T + Ta - T0)))
+        bias += -K * K / R
 
   if bias == 0.0 and gain == 0.0:
     vel_out[worldid, actid] = 0.0
@@ -146,9 +164,9 @@ def _qderiv_actuator_passive_vel(
       # use next activation if actearly is set (matching forward pass)
       if actuator_actearly[actid]:
         act = next_act(
-          opt_timestep[worldid % opt_timestep.shape[0]],
+          opt_timestep[opt_timestep_id],
           actuator_dyntype[actid],
-          actuator_dynprm[worldid % actuator_dynprm.shape[0], actid],
+          actuator_dynprm[actuator_dynprm_id, actid],
           actuator_actrange[worldid % actuator_actrange.shape[0], actid],
           act_in[worldid, act_adr],
           act_dot_in[worldid, act_adr],

--- a/mujoco_warp/_src/derivative_test.py
+++ b/mujoco_warp/_src/derivative_test.py
@@ -1108,6 +1108,85 @@ class DerivativeTest(parameterized.TestCase):
       err_msg="stateful should converge to stateless as te->0",
     )
 
+  def test_dcmotor_thermal_derivative(self):
+    """Verify hot winding resistance is used for stateless and stateful DC motor derivatives."""
+    mjm, mjd, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option timestep="0.002"/>
+        <worldbody>
+          <body>
+            <joint name="sl_bemf" type="slide"/>
+            <geom type="sphere" size="0.1" mass="1"/>
+          </body>
+          <body>
+            <joint name="sf_bemf" type="slide"/>
+            <geom type="sphere" size="0.1" mass="1"/>
+          </body>
+          <body>
+            <joint name="sl_ctrl" type="slide"/>
+            <geom type="sphere" size="0.1" mass="1"/>
+          </body>
+          <body>
+            <joint name="sf_ctrl" type="slide"/>
+            <geom type="sphere" size="0.1" mass="1"/>
+          </body>
+        </worldbody>
+        <actuator>
+          <dcmotor joint="sl_bemf" motorconst="1" resistance="1"
+                   thermal="1 1 0 0.004 25 25"/>
+          <dcmotor joint="sf_bemf" motorconst="1" resistance="1"
+                   inductance="0 0.01" thermal="1 1 0 0.004 25 25"/>
+          <dcmotor joint="sl_ctrl" motorconst="1" resistance="1"
+                   input="vel" controller="0 0 5"
+                   thermal="1 1 0 0.004 25 25"/>
+          <dcmotor joint="sf_ctrl" motorconst="1" resistance="1"
+                   input="vel" controller="0 0 5"
+                   inductance="0 0.01" thermal="1 1 0 0.004 25 25"/>
+        </actuator>
+      </mujoco>
+      """
+    )
+
+    # A 250-degree rise doubles winding resistance from 1.0 to 2.0.
+    for i in range(4):
+      mjd.act[mjm.actuator_actadr[i]] = 250
+      mjd.qvel[i] = 0.5
+
+    mujoco.mj_forward(mjm, mjd)
+    d = mjw.put_data(mjm, mjd)
+
+    out = wp.empty((1, m.nC), dtype=float)
+    out.fill_(wp.inf)
+
+    forward.fwd_position(m, d, factorize=False)
+    forward.fwd_velocity(m, d)
+    derivative.deriv_smooth_vel(m, d, out)
+
+    dt = mjm.opt.timestep
+    te = 0.01
+    h = 0.002
+    s = 1.0 - np.exp(-h / te)
+
+    expected_qderiv = np.array(
+      [
+        -1.0 / 2.0,  # stateless back-EMF: -K^2 / R
+        -1.0 * s / 2.0,  # stateful back-EMF: -K^2 * s / R
+        -5.0 * (1.0 / 2.0),  # stateless ctrl: -kd * (R0 / R)
+        -5.0 * (1.0 / 2.0) * s,  # stateful ctrl: -kd * (R0 / R) * s
+      ]
+    )
+
+    out_arr = out.numpy()[0]
+    actual_qderiv = (1.0 - out_arr[:4]) / dt
+
+    np.testing.assert_allclose(
+      actual_qderiv,
+      expected_qderiv,
+      atol=1e-4,
+      err_msg="thermal DCMotor velocity derivative vs expected",
+    )
+
   _FLUID_SCENARIOS = {
     "basic": """
       <mujoco>


### PR DESCRIPTION
### Fix thermal DC motor velocity derivatives

This PR fixes an issue in `_qderiv_actuator_passive_vel` where DC motor velocity derivatives were evaluated using the nominal (cold) winding resistance $R_0$ rather than the operating winding resistance $R(T)$ at the current temperature. This brings MuJoCo Warp into parity with core MuJoCo ([google-deepmind/mujoco#3531](https://github.com/google-deepmind/mujoco/pull/3531)).

### Mathematical Background

When a DC motor includes thermal dynamics (`dynprm[2] > 0`), the winding resistance changes with temperature:
$$R(T) = \max\left(R_{\min}, R_0 \left(1 + \alpha (T + T_a - T_0)\right)\right)$$

1. **Controller Velocity Derivative ($dV/d\omega$)**:
   The controller maps commanded velocity error to drive voltage using nameplate parameters:
   $$dV/d\omega = -k_d \frac{R_0}{K} + K$$
   This correctly continues to use the nominal resistance $R_0$.

2. **Damping Derivatives ($\partial \text{force} / \partial \omega$)**:
   The physical torque generated by back-EMF and applied voltage depends on the actual armature current $i = V / R(T)$. Consequently, the velocity derivatives must scale with the hot resistance $R(T)$:
   - **Stateless back-EMF bias**:
     $$\frac{\partial \text{bias}}{\partial \omega} = -\frac{K^2}{R(T)}$$
   - **Stateless velocity controller**:
     $$\frac{\partial (\text{gain} \cdot V)}{\partial \omega} = \frac{K \cdot dV/d\omega}{R(T)} = -k_d \frac{R_0}{R(T)} + \frac{K^2}{R(T)}$$
     *(Note that the $+K^2/R(T)$ term cancels the back-EMF bias term, yielding net damping $-k_d \frac{R_0}{R(T)}$.)*
   - **Stateful current filter** ($t_e > 0$, $s = 1 - e^{-h/t_e}$):
     $$\frac{\partial \text{force}}{\partial \omega} = \frac{K (dV/d\omega - K) s}{R(T)}$$

### Optimizations

To avoid unnecessary GPU register pressure and global memory traffic:
- **Fast path for non-thermal motors**: If `dynprm[2] <= 0.0`, $R$ is assigned directly from $R_0$, bypassing `dcmotor_slots` evaluation, activation address resolution, and global loads from `act_in`.
- **Register reuse across gain and bias blocks**: In standard DC motors with both `GainType.DCMOTOR` and `BiasType.DCMOTOR`, computed values for $R$, $K$, and $t_e$ are cached in registers. The subsequent `BiasType.DCMOTOR` block reuses them directly without re-reading `actuator_dynprm`, `actuator_gainprm`, or `act_in`.
- **Index caching**: Cached `worldid % opt_timestep.shape[0]` and `worldid % actuator_dynprm.shape[0]` at kernel entry.

### Tests

- Added `test_dcmotor_thermal_derivative` in `derivative_test.py` covering all four DC motor variants with thermal model (stateless/stateful back-EMF, stateless/stateful velocity controller).
- Model XML is inlined directly in `test_data.fixture`.
- The output derivative buffer is initialized with `out.fill_(wp.inf)` before kernel execution to verify complete write coverage.
