### PR TITLE
Support free rigid subtrees for gyroscopic stabilization

### DIFF
--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -751,6 +751,7 @@ def _implicit_free_body_solve(
   geom_xmat_in: wp.array2d[wp.mat33],
   subtree_com_in: wp.array2d[wp.vec3],
   cdof_in: wp.array2d[wp.spatial_vector],
+  crb_in: wp.array2d[vec10],
   M_in: wp.array2d[float],
   tree_awake_in: wp.array2d[int],
   cvel_in: wp.array2d[wp.spatial_vector],
@@ -794,17 +795,28 @@ def _implicit_free_body_solve(
 
   # 3. Add gyroscopic bias velocity derivative
   mass = body_mass[worldid % body_mass.shape[0], bodyid]
+  crb = crb_in[worldid, bodyid]
+  subtree_mass = crb[9]
   R = xmat_in[worldid, bodyid]
-  Xi = ximat_in[worldid, bodyid]
-  inertia = body_inertia[worldid % body_inertia.shape[0], bodyid]
-  s = xipos_in[worldid, bodyid] - xpos_in[worldid, bodyid]
+  Iw = wp.mat33(
+    crb[0],
+    crb[3],
+    crb[4],
+    crb[3],
+    crb[1],
+    crb[5],
+    crb[4],
+    crb[5],
+    crb[2],
+  )
+  s = subtree_com_in[worldid, bodyid] - xpos_in[worldid, bodyid]
   qvel_rot = wp.vec3(
     qvel_in[worldid, dof_adr + 3],
     qvel_in[worldid, dof_adr + 4],
     qvel_in[worldid, dof_adr + 5],
   )
-  lin, rot = math.free_bias_vel_blocks(mass, R, Xi, inertia, s, qvel_rot)
-  h_mass = -timestep * mass
+  lin, rot = math.free_bias_vel_blocks(subtree_mass, R, Iw, s, qvel_rot)
+  h_mass = -timestep * subtree_mass
   for r in range(3):
     for c in range(3):
       A[r, 3 + c] += h_mass * lin[r, c]
@@ -973,6 +985,7 @@ def _launch_implicit_free_body_solve(m: Model, d: Data, qacc: wp.array2d[float])
       d.geom_xmat,
       d.subtree_com,
       d.cdof,
+      d.crb,
       d.M,
       d.tree_awake,
       d.cvel,

--- a/mujoco_warp/_src/forward_test.py
+++ b/mujoco_warp/_src/forward_test.py
@@ -448,6 +448,43 @@ class ForwardTest(parameterized.TestCase):
         err_msg=f"step {i} qvel mismatch for free root + massless child ({integrator})",
       )
 
+  def test_free_rigid_subtree_gyro_stable(self):
+    """Verify free root with inertial child remains stable under implicitfast."""
+    _, _, m, d = test_data.fixture(
+      xml="""
+      <mujoco>
+        <option integrator="implicitfast" timestep="0.001" gravity="0 0 0">
+          <flag energy="enable"/>
+        </option>
+        <worldbody>
+          <body>
+            <freejoint/>
+            <body>
+              <inertial pos="0 0 0" mass="0.12"
+                        diaginertia="0.00017231 0.00000658 0.00017243"/>
+            </body>
+          </body>
+        </worldbody>
+        <keyframe>
+          <key qvel="0 0 0 100 30 100"/>
+        </keyframe>
+      </mujoco>
+      """,
+      keyframe=0,
+    )
+
+    self.assertTrue(bool(m.body_is_free.numpy().any()))
+
+    d.energy.fill_(wp.inf)
+    mjw.forward(m, d)
+    initial_energy = float(d.energy.numpy()[0, 1])
+
+    for i in range(20):
+      d.energy.fill_(wp.inf)
+      mjw.step(m, d)
+      energy = float(d.energy.numpy()[0, 1])
+      self.assertLess(energy, 1.01 * initial_energy, f"step {i}")
+
   @parameterized.parameters(mujoco.mjtJacobian.mjJAC_SPARSE, mujoco.mjtJacobian.mjJAC_DENSE)
   def test_implicit_tendon_damping(self, jacobian):
     mjm, mjd, m, d = test_data.fixture(

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -499,8 +499,7 @@ def put_model(mjm: mujoco.MjModel, batch_sizes: dict[str, int] | None = None) ->
       dof_adrs = mjm.jnt_dofadr[jnt_free_adrs]
       tree_ids = mjm.dof_treeid[dof_adrs]
       tree_dof6 = mjm.tree_dofnum[tree_ids] == 6
-      mass_match = mjm.body_subtreemass[b_free] == mjm.body_mass[b_free]
-      body_is_free[b_free] = tree_dof6 & mass_match
+      body_is_free[b_free] = tree_dof6
   m.body_is_free = body_is_free
   m.body_freeadr = np.nonzero(m.body_is_free)[0]
   body_fluid_box = np.zeros(mjm.nbody, dtype=bool)

--- a/mujoco_warp/_src/math.py
+++ b/mujoco_warp/_src/math.py
@@ -338,16 +338,12 @@ def free_bias_vel_blocks(
   # In:
   mass: float,
   R: wp.mat33,
-  Xi: wp.mat33,
-  inertia: wp.vec3,
+  Iw: wp.mat33,
   s: wp.vec3,
   qvel_rot: wp.vec3,
 ) -> tuple[wp.mat33, wp.mat33]:
-  """3x3 sub-blocks of (d qfrc_bias / d qvel) for a standalone free body."""
+  """3x3 sub-blocks of (d qfrc_bias / d qvel) for a free rigid subtree."""
   w = R @ qvel_rot
-
-  diag_inertia = wp.diag(inertia)
-  Iw = Xi @ diag_inertia @ wp.transpose(Xi)
 
   ws = wp.cross(w, s)
   Iww = Iw @ w

--- a/mujoco_warp/_src/math_test.py
+++ b/mujoco_warp/_src/math_test.py
@@ -56,15 +56,14 @@ def _free_bias_vel_blocks_kernel(
   # In:
   mass: float,
   R: wp.mat33,
-  Xi: wp.mat33,
-  inertia: wp.vec3,
+  Iw: wp.mat33,
   s: wp.vec3,
   qvel_rot: wp.vec3,
   # Out:
   lin_out: wp.array2d[float],
   rot_out: wp.array2d[float],
 ):
-  lin, rot = free_bias_vel_blocks(mass, R, Xi, inertia, s, qvel_rot)
+  lin, rot = free_bias_vel_blocks(mass, R, Iw, s, qvel_rot)
   for r in range(3):
     for c in range(3):
       lin_out[r, c] = lin[r, c]
@@ -291,8 +290,7 @@ class FreeBiasVelTest(absltest.TestCase):
       inputs=[
         mass,
         wp.mat33(R_np),
-        wp.mat33(Xi_np),
-        wp.vec3(inertia_np),
+        wp.mat33(Iw),
         wp.vec3(s_np),
         wp.vec3(qvel_rot_np),
       ],

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -1444,7 +1444,7 @@ class Model:
     body_branch_start: start index in body_branches for each branch   (nbranch + 1,)
     mocap_bodyid: id of body for mocap                       (nmocap,)
     body_fluid_ellipsoid: does body use ellipsoid fluid      (nbody,)
-    body_is_free: is body a standalone free body             (nbody,)
+    body_is_free: is body root of a free rigid subtree       (nbody,)
     body_fluid_ellipsoid_adr: body ids with ellipsoid fluid  (nbody_fluid_ellipsoid,)
     body_fluid_box_adr: body ids with box fluid              (nbody_fluid_box,)
     body_freeadr: body ids of free bodies                    (nbodyfree,)


### PR DESCRIPTION
### Summary

Generalizes gyroscopic stabilization in implicit integrators (`implicit`, `implicitfast`) to support free rigid subtrees (composite bodies with a free root and no internal joints).

### Context & Motivation

Previously, `body_is_free` required `mjm.body_subtreemass == mjm.body_mass`, which restricted gyroscopic velocity derivatives to single, standalone free bodies. For free-floating bodies composed of multiple child links (such as a massless root body with inertial children), this term was omitted, leading to artificial energy growth and numerical instability under `implicitfast`.

### Changes

- **`io.py`**: Relax `body_is_free` condition to check `tree_dofnum == 6`, allowing free root bodies with rigid descendants.
- **`forward.py`**: Pass `d.crb` to `_implicit_free_body_solve`. Compute composite inertia `Iw` and subtree mass directly from `d.crb` (and leverage `d.subtree_com` for the COM lever arm `s`).
- **`math.py`**: Update `free_bias_vel_blocks` to accept the composite inertia matrix `Iw: wp.mat33` directly in world frame.
- **`forward_test.py`**: Add `test_free_rigid_subtree_gyro_stable` to verify energy stability under `implicitfast` for a free root body with an inertial child.
- **`math_test.py`**: Update unit tests for `free_bias_vel_blocks`.